### PR TITLE
Embedding module bug fix resolves #60

### DIFF
--- a/src/nv_ingest/modules/transforms/embed_extractions.py
+++ b/src/nv_ingest/modules/transforms/embed_extractions.py
@@ -560,6 +560,9 @@ def _embed_extractions(builder: mrc.Builder):
                     embedding_dataframes.append(df_tables)
                     content_masks.append(table_mask)
 
+            if len(content_masks) == 0:
+                return message
+
             message = _concatenate_extractions(message, embedding_dataframes, content_masks)
 
             return message

--- a/src/nv_ingest/modules/transforms/embed_extractions.py
+++ b/src/nv_ingest/modules/transforms/embed_extractions.py
@@ -468,14 +468,13 @@ def _concatenate_extractions(ctrl_msg: ControlMessage, dataframes: List[pd.DataF
         An updated control message with metadata enriched with embeddings.
     """
 
-    # build unified mask
-    for idx, mask in enumerate(masks):
-        if idx == 0:
-            unified_mask = mask
-        else:
+    with ctrl_msg.payload().mutable_dataframe() as mdf:
+
+        # build unified mask
+        unified_mask = cudf.Series(False, index=mdf.index)
+        for mask in masks:
             unified_mask = unified_mask | mask
 
-    with ctrl_msg.payload().mutable_dataframe() as mdf:
         df_no_text = mdf.loc[~unified_mask].to_pandas()
         df_no_text["_contains_embeddings"] = False
 


### PR DESCRIPTION
## Description

This PR resolves #60 by handling cases where embedding tasks flags are all set to false and/or no extracted content is a candidate for embedding.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

