### PR TITLE
Simplify Python SDK example and offer a convenience function that transparently handles fetch retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,7 @@ You can submit jobs programmatically in Python or via the nv-ingest-cli tool.
 Note that `extract_tables` controls extraction for both tables and charts.
 
 In Python (you can find more documentation and examples [here](./client/client_examples/examples/python_client_usage.ipynb)):
-```
 import logging, time
-import concurrent.futures
 
 from nv_ingest_client.client import NvIngestClient
 from nv_ingest_client.primitives import JobSpec
@@ -185,31 +183,8 @@ client = NvIngestClient(
 )
 job_id = client.add_job(job_spec)
 client.submit_job(job_id, "morpheus_task_queue")
-
-
-# Nv-Ingest jobs are often "long running". Therefore after
-# submission we intermittently check if the job is completed.
-def fetch_wait_completed_results(job_id):
-  while True:
-    try:
-      result = client.fetch_job_result(job_id, timeout=60)
-      return result
-    except TimeoutError:
-      print("Job still processing ... aka HTTP 202 received")
-
-# Results are fetched in an async manner. If the job is still running a
-# HTTP 202 response is returned and interpreted as a TimeoutError.
-# We continue retrying here until our timeout is reached
-timeout_seconds = 60
-with concurrent.futures.ThreadPoolExecutor() as executor:
-  future = executor.submit(fetch_wait_completed_results, job_id)
-  
-  try:
-      # Wait for the result within the specified timeout
-      result = future.result(timeout=timeout_seconds)
-      print(f"Got {len(result)} results")
-  except concurrent.futures.TimeoutError:
-      print(f"Job processing did not complete within the specified {timeout_seconds} seconds")
+result = client.fetch_job_result(job_id, timeout=60)
+print(f"Got {len(result)} results")
 ```
 
 Using the the `nv-ingest-cli` (find the complete example [here](./client/client_examples/examples/cli_client_usage.ipynb)):

--- a/client/src/nv_ingest_client/client/client.py
+++ b/client/src/nv_ingest_client/client/client.py
@@ -314,7 +314,7 @@ class NvIngestClient:
     
     # Nv-Ingest jobs are often "long running". Therefore after
     # submission we intermittently check if the job is completed.
-    def _fetch_job_result_wait(job_id: str, timeout: float = 60, data_only: bool = True):
+    def _fetch_job_result_wait(self, job_id: str, timeout: float = 60, data_only: bool = True):
         while True:
             try:
                 return self._fetch_job_result(job_id, timeout, data_only)
@@ -324,13 +324,10 @@ class NvIngestClient:
     # This is the direct Python approach function for retrieving jobs which handles the timeouts directly
     # in the function itself instead of expecting the user to handle it themselves
     # Note this method only supports fetching a single job result synchronously
-    def fetch_job_result(self, job_ids: Union[str, List[str]], timeout: float = 100, data_only: bool = True):
-        if isinstance(job_ids, str):
-            job_ids = [job_ids]
-        
+    def fetch_job_result(self, job_id: str, timeout: float = 100, data_only: bool = True):        
         # A thread pool executor is a simple approach to performing an action with a timeout
         with ThreadPoolExecutor() as executor:
-            future = executor.submit(_fetch_job_result_wait, job_id, timeout, data_only)
+            future = executor.submit(self._fetch_job_result_wait, job_id, timeout, data_only)
             try:
                 # Wait for the result within the specified timeout
                 return future.result(timeout=timeout)


### PR DESCRIPTION
## Description
Simplify Python SDK example and offer a convenience function that transparently handles fetch retries. This approach takes the existing `fetch_job_result` and renames it to `fetch_job_result_cli`. That function is then only used exclusively from the CLI codebase. The reasoning for this is because the timeout approaches and how they are handled are different between the CLI and how users wish to have them transparently handled for them.

This approach was chosen since there are several examples and notebooks using the `fetch_job_result` function and this helps ensure those existing examples need not be changed.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
