### PR TITLE
Adjust helm docs to note interacting with Helm assets is possible

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -118,7 +118,7 @@ nv-ingest-cli \
   --client_port=7670
 ```
 
-Enjoy!
+You can also use nv-ingest's python client API to interact with the service running in the cluster. Use the same host and port as in the above nv-ingest-cli example.
 
 ## Parameters
 

--- a/skaffold/README.md
+++ b/skaffold/README.md
@@ -1,0 +1,7 @@
+# Skaffold - Dev Team
+
+Skaffold is intended to support the nv-ingest development team with kubernetes dev and testing. It is not meant to be used in production deployments or even for local testing.
+
+We offer k8s support via Helm and those instructions can be found at [Helm Documentation](../helm/README.md)
+
+For developers further documentation for using Skaffold can be found at [Skaffold Documentation](../docs/kubernetes-dev.md)


### PR DESCRIPTION
## Description
Update the Helm documentation with a note about accessing the services running on Helm with the nv-ingest-cli or python library

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
