### PR TITLE
Update action versions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,11 +14,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Set up Docker Buildx, useful for building multi-platform images
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # Build the Docker image using the Dockerfile
       - name: Build Docker image
@@ -30,7 +30,7 @@ jobs:
           docker run nv-ingest:latest pytest -rs --cov nv_ingest --cov nv_ingest_client --cov-report term --cov-report xml:coverage.xml tests/nv_ingest tests/nv_ingest_client
   
       - name: Upload test report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-report
           path: report.xml


### PR DESCRIPTION
## Description
I noticed [some warnings on our new CI actions](https://github.com/NVIDIA/nv-ingest/actions/runs/11001410068) and am making a small PR to bump our versions which should remove the warnings and make sure we're on a supported version.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] ~New or existing tests cover these changes.~
- [x] The documentation is up to date with these changes.
