### PR TITLE
Add note to set NVIDIA as default container runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ NV_INGEST_ROOT=<PATH_TO_THIS_REPO>
 > Change the `CUDA_VISIBLE_DEVICES` pinnings as desired for your system within docker-compose.yaml.
 
 > [!IMPORTANT]
-> Make sure nvidia is set as your default container runtime before running the docker compose command:
+> Make sure NVIDIA is set as your default container runtime before running the docker compose command with the command:
 > `sudo nvidia-ctk runtime configure --runtime=docker --set-as-default`
 
 5. Start all services:

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ NV_INGEST_ROOT=<PATH_TO_THIS_REPO>
 >
 > Change the `CUDA_VISIBLE_DEVICES` pinnings as desired for your system within docker-compose.yaml.
 
+> [!IMPORTANT]
+> Make sure nvidia is set as your default container runtime before running the docker compose command:
+> `sudo nvidia-ctk runtime configure --runtime=docker --set-as-default`
+
 5. Start all services:
 `docker compose up`
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Adds a note set NVIDIA as default container runtime before running docker compose. Closes #101 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
