### PR TITLE
Handle the existance of HTTP/S pre-pended to the Rest server URL

### DIFF
--- a/tests/nv_ingest_client/client/test_rest_client.py
+++ b/tests/nv_ingest_client/client/test_rest_client.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nv_ingest_client.message_clients.rest.rest_client import RestClient
+
+
+class MockRestClient:
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+        self.counter = 0
+
+    def get_client(self):
+        return self
+
+
+@pytest.fixture
+def mock_rest_client_allocator():
+    return MagicMock(return_value=MockRestClient("localhost", 7670))
+
+
+@pytest.fixture
+def rest_client(mock_rest_client_allocator):
+    return RestClient(
+        host="localhost",
+        port=7670,
+        max_retries=0,
+        max_backoff=32,
+        connection_timeout=300,
+        http_allocator=mock_rest_client_allocator
+    )
+
+
+# Test generate_url function
+def test_generate_url(rest_client):
+    assert rest_client.generate_url("localhost", 7670) == "http://localhost:7670"
+    assert rest_client.generate_url("http://localhost", 7670) == "http://localhost:7670"
+    assert rest_client.generate_url("https://localhost", 7670) == "https://localhost:7670"
+    
+    # A few more complicated and possible tricks
+    assert rest_client.generate_url("localhost-https-else", 7670) == "http://localhost-https-else:7670"


### PR DESCRIPTION
## Description
Handles if a HTTP/S is pre-pended to the user provided URL. If it is the value is kept as is assuming the user knows what they are doing and would like to override the default behavior. If it is not then the URL is pre-pended with the default `http://` value.

This closes: #103 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
