### PR TITLE
Bump Python version 3.10.14 -> 3.10.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ ARG RELEASE_TYPE="dev"
 ARG VERSION=""
 ARG VERSION_REV="0"
 
+# We require Python 3.10.15 but base image currently comes with 3.10.14, update here.
+RUN source activate morpheus \
+    && conda install python=3.10.15
+
 # Set the working directory in the container
 WORKDIR /workspace
 


### PR DESCRIPTION
## Description
Bump the Python version from 3.10.14 -> 3.10.15. The Morpheus base container currently ships with 3.10.14 so we perform that manual conda installation step in the Dockerfile.

This closes: #104 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
