### PR TITLE
Add extract_charts option for disabling chart extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,10 +192,11 @@ You can submit jobs programmatically in Python or via the nv-ingest-cli tool.
 In the below examples, we are doing text, chart, table, and image extraction:
 - `extract_text`, - uses [PDFium](https://github.com/pypdfium2-team/pypdfium2/) to find and extract text from pages
 - `extract_images` - uses [PDFium](https://github.com/pypdfium2-team/pypdfium2/) to extract images
-- `extract_tables` - uses [YOLOX](https://github.com/Megvii-BaseDetection/YOLOX) to find tables and charts. Uses [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR) for table extraction, and [Deplot](https://huggingface.co/google/deplot), CACHED, and [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR) for chart extraction
+- `extract_tables` - uses [YOLOX](https://github.com/Megvii-BaseDetection/YOLOX) to find tables and charts. Uses [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR) for table extraction, and [Deplot](https://huggingface.co/google/deplot) and CACHED for chart extraction
+- `extract_charts` - (optional) enables or disables the use of Deplot and CACHED for chart extraction.
 
 > [!IMPORTANT]
-> `extract_tables` controls extraction for both tables and charts.
+> `extract_tables` controls extraction for both tables and charts. You can optionally disable chart extraction by setting `extract_charts` to false.
 
 #### In Python (you can find more documentation and examples [here](./client/client_examples/examples/python_client_usage.ipynb)):
 

--- a/client/src/nv_ingest_client/nv_ingest_cli.py
+++ b/client/src/nv_ingest_client/nv_ingest_cli.py
@@ -130,6 +130,7 @@ Tasks and Options:
     - extract_text (bool): Enables text extraction. Default: False.
     - extract_images (bool): Enables image extraction. Default: False.
     - extract_tables (bool): Enables table extraction. Default: False.
+    - extract_charts (bool): Enables chart extraction. Default: False.
 \b
 - store: Stores any images extracted from documents.
     Options:
@@ -216,10 +217,8 @@ def main(
             logger.info(_msg)
 
         if not dry_run:
-            logging.debug(
-                f"Creating REST message client: {client_host} and port: {client_port} -> {client_kwargs}"
-            )
-            
+            logging.debug(f"Creating REST message client: {client_host} and port: {client_port} -> {client_kwargs}")
+
             client_allocator = RestClient
 
             ingest_client = NvIngestClient(

--- a/src/nv_ingest/extraction_workflows/pdf/pdfium_helper.py
+++ b/src/nv_ingest/extraction_workflows/pdf/pdfium_helper.py
@@ -188,11 +188,11 @@ def extract_tables_and_charts_using_image_ensemble(
         logger.error(f"Error during table/chart extraction: {str(e)}")
         raise
     finally:
-        if extract_tables and isinstance(paddle_client, grpcclient.InferenceServerClient):
+        if isinstance(paddle_client, grpcclient.InferenceServerClient):
             paddle_client.close()
-        if extract_charts and isinstance(cached_client, grpcclient.InferenceServerClient):
+        if isinstance(cached_client, grpcclient.InferenceServerClient):
             cached_client.close()
-        if extract_charts and isinstance(deplot_client, grpcclient.InferenceServerClient):
+        if isinstance(deplot_client, grpcclient.InferenceServerClient):
             deplot_client.close()
         if isinstance(yolox_client, grpcclient.InferenceServerClient):
             yolox_client.close()

--- a/src/nv_ingest/extraction_workflows/pdf/pdfium_helper.py
+++ b/src/nv_ingest/extraction_workflows/pdf/pdfium_helper.py
@@ -71,6 +71,8 @@ def extract_tables_and_charts_using_image_ensemble(
     iou_thresh: float = YOLOX_IOU_THRESHOLD,
     min_score: float = YOLOX_MIN_SCORE,
     final_thresh: float = YOLOX_FINAL_SCORE,
+    extract_tables: bool = True,
+    extract_charts: bool = True,
     trace_info: Optional[List] = None,
 ) -> List[Tuple[int, ImageTable]]:
     """
@@ -132,12 +134,18 @@ def extract_tables_and_charts_using_image_ensemble(
     """
     tables_and_charts = []
 
+    if not extract_tables and not extract_charts:
+        logger.debug("Nothing to do since both extract_tables and extract_charts are set to false.")
+        return tables_and_charts
+
     yolox_client = paddle_client = deplot_client = cached_client = None
     try:
-        cached_client = create_inference_client(config.cached_endpoints, config.auth_token)
-        deplot_client = create_inference_client(config.deplot_endpoints, config.auth_token)
-        paddle_client = create_inference_client(config.paddle_endpoints, config.auth_token)
         yolox_client = create_inference_client(config.yolox_endpoints, config.auth_token)
+        if extract_tables:
+            paddle_client = create_inference_client(config.paddle_endpoints, config.auth_token)
+        if extract_charts:
+            cached_client = create_inference_client(config.cached_endpoints, config.auth_token)
+            deplot_client = create_inference_client(config.deplot_endpoints, config.auth_token)
 
         batches = []
         i = 0
@@ -148,7 +156,9 @@ def extract_tables_and_charts_using_image_ensemble(
 
         page_idx = 0
         for batch in batches:
-            original_images, _ = pdfium_pages_to_numpy(batch, scale_tuple=(YOLOX_MAX_WIDTH, YOLOX_MAX_HEIGHT), trace_info=trace_info)
+            original_images, _ = pdfium_pages_to_numpy(
+                batch, scale_tuple=(YOLOX_MAX_WIDTH, YOLOX_MAX_HEIGHT), trace_info=trace_info
+            )
 
             original_image_shapes = [image.shape for image in original_images]
             input_array = prepare_images_for_inference(original_images)
@@ -168,6 +178,8 @@ def extract_tables_and_charts_using_image_ensemble(
                     deplot_client,
                     cached_client,
                     tables_and_charts,
+                    extract_tables=extract_tables,
+                    extract_charts=extract_charts,
                     trace_info=trace_info,
                 )
 
@@ -176,11 +188,11 @@ def extract_tables_and_charts_using_image_ensemble(
         logger.error(f"Error during table/chart extraction: {str(e)}")
         raise
     finally:
-        if isinstance(paddle_client, grpcclient.InferenceServerClient):
+        if extract_tables and isinstance(paddle_client, grpcclient.InferenceServerClient):
             paddle_client.close()
-        if isinstance(cached_client, grpcclient.InferenceServerClient):
+        if extract_charts and isinstance(cached_client, grpcclient.InferenceServerClient):
             cached_client.close()
-        if isinstance(deplot_client, grpcclient.InferenceServerClient):
+        if extract_charts and isinstance(deplot_client, grpcclient.InferenceServerClient):
             deplot_client.close()
         if isinstance(yolox_client, grpcclient.InferenceServerClient):
             yolox_client.close()
@@ -292,7 +304,16 @@ def process_inference_results(
 
 # Handle individual table/chart extraction and model inference
 def handle_table_chart_extraction(
-    annotation_dict, original_image, page_idx, paddle_client, deplot_client, cached_client, tables_and_charts, trace_info=None,
+    annotation_dict,
+    original_image,
+    page_idx,
+    paddle_client,
+    deplot_client,
+    cached_client,
+    tables_and_charts,
+    extract_tables=True,
+    extract_charts=True,
+    trace_info=None,
 ):
     """
     Handle the extraction of tables and charts from the inference results and run additional model inference.
@@ -339,7 +360,7 @@ def handle_table_chart_extraction(
             *bbox, _ = bboxes
             h1, w1, h2, w2 = bbox * np.array([height, width, height, width])
 
-            if label == "table":
+            if extract_tables and label == "table":
                 # PaddleOCR NIM enforces minimum dimensions for TRT engines.
                 cropped = crop_image(
                     original_image,
@@ -352,11 +373,13 @@ def handle_table_chart_extraction(
                 table_content = call_image_inference_model(paddle_client, "paddle", cropped, trace_info=trace_info)
                 table_data = ImageTable(table_content, base64_img, (w1, h1, w2, h2))
                 tables_and_charts.append((page_idx, table_data))
-            elif label == "chart":
+            elif extract_charts and label == "chart":
                 cropped = crop_image(original_image, (h1, w1, h2, w2))
                 base64_img = numpy_to_base64(cropped)
 
-                deplot_result = call_image_inference_model(deplot_client, "google/deplot", cropped, trace_info=trace_info)
+                deplot_result = call_image_inference_model(
+                    deplot_client, "google/deplot", cropped, trace_info=trace_info
+                )
                 cached_result = call_image_inference_model(cached_client, "cached", cropped, trace_info=trace_info)
                 chart_content = join_cached_and_deplot_output(cached_result, deplot_result)
                 chart_data = ImageChart(chart_content, base64_img, (w1, h1, w2, h2))
@@ -365,7 +388,15 @@ def handle_table_chart_extraction(
 
 # Define a helper function to use unstructured-io to extract text from a base64
 # encoded bytestram PDF
-def pdfium(pdf_stream, extract_text: bool, extract_images: bool, extract_tables: bool, trace_info = None, **kwargs):
+def pdfium(
+    pdf_stream,
+    extract_text: bool,
+    extract_images: bool,
+    extract_tables: bool,
+    extract_charts: bool,
+    trace_info=None,
+    **kwargs,
+):
     """
     Helper function to use pdfium to extract text from a bytestream PDF.
 
@@ -378,6 +409,8 @@ def pdfium(pdf_stream, extract_text: bool, extract_images: bool, extract_tables:
     extract_images : bool
         Specifies whether to extract images.
     extract_tables : bool
+        Specifies whether to extract tables.
+    extract_charts : bool
         Specifies whether to extract tables.
     **kwargs
         The keyword arguments are used for additional extraction parameters.
@@ -432,6 +465,7 @@ def pdfium(pdf_stream, extract_text: bool, extract_images: bool, extract_tables:
     logger.debug(f"Extract text: {extract_text}")
     logger.debug(f"extract images: {extract_images}")
     logger.debug(f"extract tables: {extract_tables}")
+    logger.debug(f"extract tables: {extract_charts}")
 
     # Pdfium does not support text extraction at the document level
     accumulated_text = []
@@ -489,7 +523,7 @@ def pdfium(pdf_stream, extract_text: bool, extract_images: bool, extract_tables:
                         pass  # Pdfium failed to extract the image associated with this object - corrupt or missing.
 
         # Table and chart collection
-        if extract_tables:
+        if extract_tables or extract_charts:
             pages.append(page)
 
     if extract_text and text_depth == TextTypeEnum.DOCUMENT:
@@ -508,11 +542,21 @@ def pdfium(pdf_stream, extract_text: bool, extract_images: bool, extract_tables:
 
         extracted_data.append(text_extraction)
 
-    if extract_tables:
-        for page_idx, table_and_charts in extract_tables_and_charts_using_image_ensemble(pages, pdfium_config, trace_info=trace_info):
+    if extract_tables or extract_charts:
+        for page_idx, table_and_charts in extract_tables_and_charts_using_image_ensemble(
+            pages,
+            pdfium_config,
+            extract_tables=extract_tables,
+            extract_charts=extract_charts,
+            trace_info=trace_info,
+        ):
             extracted_data.append(
                 construct_table_and_chart_metadata(
-                    table_and_charts, page_idx, pdf_metadata.page_count, source_metadata, base_unified_metadata,
+                    table_and_charts,
+                    page_idx,
+                    pdf_metadata.page_count,
+                    source_metadata,
+                    base_unified_metadata,
                 )
             )
 

--- a/tests/nv_ingest_client/primitives/tasks/test_extract.py
+++ b/tests/nv_ingest_client/primitives/tasks/test_extract.py
@@ -32,6 +32,42 @@ def test_extract_task_str_representation(document_type, extract_method, extract_
         f"extract text: {extract_text}",
         f"extract images: {extract_images}",
         f"extract tables: {extract_tables}",
+        f"extract charts: {extract_tables}",  # If extract_charts is not specified, it defaults to the same value as extract_tables.
+        "text depth: document",  # Assuming this is a fixed value for all instances
+    ]
+
+    for part in expected_parts:
+        assert part in task_str, f"Expected part '{part}' not found in task string representation"
+
+
+@pytest.mark.parametrize(
+    "document_type, extract_method, extract_text, extract_images, extract_tables, extract_charts",
+    [
+        ("pdf", "tika", True, False, True, False),
+        (None, "pdfium", False, True, None, False),
+        ("txt", None, None, None, False, False),
+    ],
+)
+def test_extract_task_str_representation_extract_charts_false(document_type, extract_method, extract_text, extract_images, extract_tables, extract_charts):
+    task = ExtractTask(
+        document_type=document_type,
+        extract_method=extract_method,
+        extract_text=extract_text,
+        extract_images=extract_images,
+        extract_tables=extract_tables,
+        extract_charts=extract_charts,
+    )
+
+    task_str = str(task)
+
+    expected_parts = [
+        "Extract Task:",
+        f"document type: {document_type}",
+        f"extract method: {extract_method}",
+        f"extract text: {extract_text}",
+        f"extract images: {extract_images}",
+        f"extract tables: {extract_tables}",
+        f"extract charts: {extract_charts}",
         "text depth: document",  # Assuming this is a fixed value for all instances
     ]
 
@@ -97,6 +133,46 @@ def test_extract_task_to_dict_basic(
                 "extract_images": extract_images,
                 "extract_tables": extract_tables,
                 "extract_tables_method": extract_tables_method,
+                "extract_charts": extract_tables,  # If extract_charts is not specified, it defaults to the same value as extract_tables.
+                "text_depth": "document",
+            },
+        },
+    }
+
+    assert task.to_dict() == expected_dict, "ExtractTask.to_dict() did not return the expected dictionary"
+
+
+@pytest.mark.parametrize(
+    "document_type, extract_method, extract_text, extract_images, extract_tables, extract_tables_method, extract_charts",
+    [
+        ("pdf", "tika", True, False, False, "yolox", False),
+        ("docx", "haystack", False, True, True, "python_docx", False),
+        ("txt", "llama_parse", True, True, False, None, False),
+    ],
+)
+def test_extract_task_to_dict_extract_charts_false(
+    document_type, extract_method, extract_text, extract_images, extract_tables, extract_tables_method, extract_charts,
+):
+    task = ExtractTask(
+        document_type=document_type,
+        extract_method=extract_method,
+        extract_text=extract_text,
+        extract_images=extract_images,
+        extract_tables=extract_tables,
+        extract_tables_method=extract_tables_method,
+        extract_charts=extract_charts,
+    )
+    expected_dict = {
+        "type": "extract",
+        "task_properties": {
+            "method": extract_method,
+            "document_type": document_type,
+            "params": {
+                "extract_text": extract_text,
+                "extract_images": extract_images,
+                "extract_tables": extract_tables,
+                "extract_tables_method": extract_tables_method,
+                "extract_charts": extract_charts,
                 "text_depth": "document",
             },
         },


### PR DESCRIPTION
## Description
This PR introduces an optional `extract_charts` parameter to both the CLI and Python client. When `extract_charts` is set to false, the process will skip the deplot and cached steps. If the parameter is not specified, the default behavior remains unchanged, ensuring backward compatibility by continuing to run both table and chart extraction as before.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
