### PR TITLE
Check if return value of extractor functions is unpackable

### DIFF
--- a/src/nv_ingest/stages/multiprocessing_stage.py
+++ b/src/nv_ingest/stages/multiprocessing_stage.py
@@ -243,7 +243,10 @@ class MultiProcessingBaseStage(SinglePortStage):
                     future = process_pool.submit_task(process_fn, (df, task_props))
 
                     # This can return/raise an exception
-                    result, *extra_results = future.result()
+                    result = future.result()
+                    extra_results = []
+                    if isinstance(result, tuple):
+                        result, *extra_results = result
 
                     work_package["payload"] = result
                     if extra_results:


### PR DESCRIPTION
## Description
This PR is a bug fix, following up on https://github.com/NVIDIA/nv-ingest/pull/109, where the return value of `process_fn` was unpacked. It was an attempt at having the PDF extraction functions return a tuple of `(extracted_data, {"trace_info": trace_info}` and making it compatible with other extration functions (pptx, docx, etc.) which does not return the `trace_info`. This PR adds an extra check to ensure that the return value is unpackable. Without this check, since `extracted_data` is a data frame, the data frame will be unpacked.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
