### PR TITLE
Add /v1/health/ready "ready" endpoint for nv-ingest

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -160,6 +160,7 @@ services:
       - YOLOX_GRPC_ENDPOINT=""
       - YOLOX_HTTP_ENDPOINT=yolox:8000
       - CUDA_VISIBLE_DEVICES=1
+      - READY_CHECK_ALL_COMPONENTS=True
     healthcheck:
       test: curl --fail http://nv-ingest-ms-runtime:7670/v1/health/ready || exit 1
       interval: 10s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -159,7 +159,6 @@ services:
       - TABLE_DETECTION_HTTP_TRITON=yolox:8000
       - YOLOX_GRPC_ENDPOINT=""
       - YOLOX_HTTP_ENDPOINT=yolox:8000
-      - EMBEDDING_HTTP_ENDPOINT=embedding:8000
       - CUDA_VISIBLE_DEVICES=1
     deploy:
       resources:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -137,8 +137,8 @@ services:
     cap_add:
       - sys_nice
     environment:
-      - CACHED_GRPC_ENDPOINT=cached:8001
-      - CACHED_HTTP_ENDPOINT=""
+      - CACHED_GRPC_ENDPOINT=""
+      - CACHED_HTTP_ENDPOINT=cached:8000
       - DEPLOT_GRPC_ENDPOINT=""
       # build.nvidia.com hosted deplot
       #- DEPLOT_HTTP_ENDPOINT=https://ai.api.nvidia.com/v1/vlm/google/deplot
@@ -152,13 +152,14 @@ services:
       - NGC_API_KEY=${NGC_API_KEY:-ngcapikey}
       - NVIDIA_BUILD_API_KEY=${NVIDIA_BUILD_API_KEY:-${NGC_API_KEY:-ngcapikey}}
       - OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317
-      - PADDLE_GRPC_ENDPOINT=paddle:8001
-      - PADDLE_HTTP_ENDPOINT=""
+      - PADDLE_GRPC_ENDPOINT=""
+      - PADDLE_HTTP_ENDPOINT=paddle:8000
       - REDIS_MORPHEUS_TASK_QUEUE=morpheus_task_queue
-      - TABLE_DETECTION_GRPC_TRITON=yolox:8001
-      - TABLE_DETECTION_HTTP_TRITON=""
-      - YOLOX_GRPC_ENDPOINT=yolox:8001
-      - YOLOX_HTTP_ENDPOINT=""
+      - TABLE_DETECTION_GRPC_TRITON=""
+      - TABLE_DETECTION_HTTP_TRITON=yolox:8000
+      - YOLOX_GRPC_ENDPOINT=""
+      - YOLOX_HTTP_ENDPOINT=yolox:8000
+      - EMBEDDING_HTTP_ENDPOINT=embedding:8000
       - CUDA_VISIBLE_DEVICES=1
     deploy:
       resources:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -160,6 +160,11 @@ services:
       - YOLOX_GRPC_ENDPOINT=""
       - YOLOX_HTTP_ENDPOINT=yolox:8000
       - CUDA_VISIBLE_DEVICES=1
+    healthcheck:
+      test: curl --fail http://nv-ingest-ms-runtime:7670/v1/health/ready || exit 1
+      interval: 10s
+      timeout: 5s
+      retries: 500
     deploy:
       resources:
         reservations:

--- a/src/nv_ingest/api/main.py
+++ b/src/nv_ingest/api/main.py
@@ -15,6 +15,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from fastapi import FastAPI
 
+from .v1.health import router as HealthApiRouter
 from .v1.ingest import router as IngestApiRouter
 
 # Set up the tracer provider and add a processor for exporting traces
@@ -29,6 +30,7 @@ trace.get_tracer_provider().add_span_processor(span_processor)
 app = FastAPI()
 
 app.include_router(IngestApiRouter)
+app.include_router(HealthApiRouter)
 
 # Instrument FastAPI with OpenTelemetry
 FastAPIInstrumentor.instrument_app(app)

--- a/src/nv_ingest/api/v1/health.py
+++ b/src/nv_ingest/api/v1/health.py
@@ -67,15 +67,9 @@ async def get_ready_state() -> dict:
     # the pipeline.
     morpheus_pipeline_ready = True
     yolox_ready = is_ready(os.getenv("YOLOX_HTTP_ENDPOINT", None), "/v1/health/ready")
-    # deplot_ready = is_ready(os.getenv("DEPLOT_HTTP_ENDPOINT", None), "/v1/health/ready")
-    deplot_ready = True
+    deplot_ready = is_ready(os.getenv("DEPLOT_HTTP_ENDPOINT", None), "/v1/health/ready")
     cached_ready = is_ready(os.getenv("CACHED_HTTP_ENDPOINT", None), "/v1/health/ready")
     paddle_ready = is_ready(os.getenv("PADDLE_HTTP_ENDPOINT", None), "/v1/health/ready")
-    
-    print(f"ingest_ready: {ingest_ready} - morpheus_pipeline_ready: \
-        {morpheus_pipeline_ready} - yolox_ready: {yolox_ready} - \
-            deplot_ready: {deplot_ready} - cached_ready: {cached_ready} - \
-                paddle_ready: {paddle_ready}")
 
     if (ingest_ready
             and morpheus_pipeline_ready
@@ -93,5 +87,5 @@ async def get_ready_state() -> dict:
             "cached_ready": cached_ready,
             "paddle_ready": paddle_ready,
         }
-        print(f"Ready Statuses: {ready_statuses}")
+        logger.debug(f"Ready Statuses: {ready_statuses}")
         return JSONResponse(content=ready_statuses, status_code=503)

--- a/src/nv_ingest/api/v1/health.py
+++ b/src/nv_ingest/api/v1/health.py
@@ -66,26 +66,32 @@ async def get_ready_state() -> dict:
     # for now to assume that if nv-ingest is running so is
     # the pipeline.
     morpheus_pipeline_ready = True
-    yolox_ready = is_ready(os.getenv("YOLOX_HTTP_ENDPOINT", None), "/v1/health/ready")
-    deplot_ready = is_ready(os.getenv("DEPLOT_HTTP_ENDPOINT", None), "/v1/health/ready")
-    cached_ready = is_ready(os.getenv("CACHED_HTTP_ENDPOINT", None), "/v1/health/ready")
-    paddle_ready = is_ready(os.getenv("PADDLE_HTTP_ENDPOINT", None), "/v1/health/ready")
+    
+    # We give the users an option to disable checking all distributed services for "readiness"
+    check_all_components = os.getenv("READY_CHECK_ALL_COMPONENTS", "True").lower()
+    if check_all_components in ['1', 'true', 'yes']:
+        yolox_ready = is_ready(os.getenv("YOLOX_HTTP_ENDPOINT", None), "/v1/health/ready")
+        deplot_ready = is_ready(os.getenv("DEPLOT_HTTP_ENDPOINT", None), "/v1/health/ready")
+        cached_ready = is_ready(os.getenv("CACHED_HTTP_ENDPOINT", None), "/v1/health/ready")
+        paddle_ready = is_ready(os.getenv("PADDLE_HTTP_ENDPOINT", None), "/v1/health/ready")
 
-    if (ingest_ready
-            and morpheus_pipeline_ready
-            and yolox_ready
-            and deplot_ready
-            and cached_ready
-            and paddle_ready):
-        return JSONResponse(content={"ready": True}, status_code=200)
+        if (ingest_ready
+                and morpheus_pipeline_ready
+                and yolox_ready
+                and deplot_ready
+                and cached_ready
+                and paddle_ready):
+            return JSONResponse(content={"ready": True}, status_code=200)
+        else:
+            ready_statuses = {
+                "ingest_ready": ingest_ready,
+                "morpheus_pipeline_ready": morpheus_pipeline_ready,
+                "yolox_ready": yolox_ready,
+                "deplot_ready": deplot_ready,
+                "cached_ready": cached_ready,
+                "paddle_ready": paddle_ready,
+            }
+            logger.debug(f"Ready Statuses: {ready_statuses}")
+            return JSONResponse(content=ready_statuses, status_code=503)
     else:
-        ready_statuses = {
-            "ingest_ready": ingest_ready,
-            "morpheus_pipeline_ready": morpheus_pipeline_ready,
-            "yolox_ready": yolox_ready,
-            "deplot_ready": deplot_ready,
-            "cached_ready": cached_ready,
-            "paddle_ready": paddle_ready,
-        }
-        logger.debug(f"Ready Statuses: {ready_statuses}")
-        return JSONResponse(content=ready_statuses, status_code=503)
+        return JSONResponse(content={"ready": True}, status_code=200)

--- a/src/nv_ingest/api/v1/health.py
+++ b/src/nv_ingest/api/v1/health.py
@@ -66,12 +66,12 @@ async def get_ready_state() -> dict:
     # for now to assume that if nv-ingest is running so is
     # the pipeline.
     morpheus_pipeline_ready = True
-    yolox_ready = is_ready(os.getenv("YOLOX_HTTP_ENDPOINT", "yolox:8000"), "/v1/health/ready")
+    yolox_ready = is_ready(os.getenv("YOLOX_HTTP_ENDPOINT", ""), "/v1/health/ready")
     # deplot_ready = is_ready(os.getenv("YOLOX_HTTP_ENDPOINT", "yolox:8000"), "/v1/health/ready")
     deplot_ready = True
-    cached_ready = is_ready(os.getenv("CACHED_HTTP_ENDPOINT", "cached:8000"), "/v1/health/ready")
-    paddle_ready = is_ready(os.getenv("PADDLE_HTTP_ENDPOINT", "paddle:8000"), "/v1/health/ready")
-    embedding_ready = is_ready(os.getenv("EMBEDDING_HTTP_ENDPOINT", "embedding:8000"), "/v1/health/ready")
+    cached_ready = is_ready(os.getenv("CACHED_HTTP_ENDPOINT", ""), "/v1/health/ready")
+    paddle_ready = is_ready(os.getenv("PADDLE_HTTP_ENDPOINT", ""), "/v1/health/ready")
+    embedding_ready = is_ready(os.getenv("EMBEDDING_HTTP_ENDPOINT", ""), "/v1/health/ready")
 
     if (ingest_ready
             and morpheus_pipeline_ready

--- a/src/nv_ingest/api/v1/health.py
+++ b/src/nv_ingest/api/v1/health.py
@@ -71,15 +71,13 @@ async def get_ready_state() -> dict:
     deplot_ready = True
     cached_ready = is_ready(os.getenv("CACHED_HTTP_ENDPOINT", ""), "/v1/health/ready")
     paddle_ready = is_ready(os.getenv("PADDLE_HTTP_ENDPOINT", ""), "/v1/health/ready")
-    embedding_ready = is_ready(os.getenv("EMBEDDING_HTTP_ENDPOINT", ""), "/v1/health/ready")
 
     if (ingest_ready
             and morpheus_pipeline_ready
             and yolox_ready
             and deplot_ready
             and cached_ready
-            and paddle_ready
-            and embedding_ready):
+            and paddle_ready):
         return JSONResponse(content={"ready": True}, status_code=200)
     else:
         ready_statuses = {

--- a/src/nv_ingest/api/v1/health.py
+++ b/src/nv_ingest/api/v1/health.py
@@ -81,12 +81,11 @@ async def get_ready_state() -> dict:
         return JSONResponse(content={"ready": True}, status_code=200)
     else:
         ready_statuses = {
-            ingest_ready: ingest_ready,
-            morpheus_pipeline_ready: morpheus_pipeline_ready,
-            yolox_ready: yolox_ready,
-            deplot_ready: deplot_ready,
-            cached_ready: cached_ready,
-            paddle_ready: paddle_ready,
-            embedding_ready: embedding_ready
+            "ingest_ready": ingest_ready,
+            "morpheus_pipeline_ready": morpheus_pipeline_ready,
+            "yolox_ready": yolox_ready,
+            "deplot_ready": deplot_ready,
+            "cached_ready": cached_ready,
+            "paddle_ready": paddle_ready,
         }
         return JSONResponse(content=ready_statuses, status_code=503)

--- a/src/nv_ingest/api/v1/health.py
+++ b/src/nv_ingest/api/v1/health.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+import logging
+
+from opentelemetry import trace
+from fastapi import APIRouter
+from fastapi import status
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger("uvicorn")
+tracer = trace.get_tracer(__name__)
+
+router = APIRouter()
+
+
+@router.get(
+    "/health/live",
+    tags=["Health"],
+    summary="Check if the service is running.",
+    description="""
+        Check if the service is running.
+    """,
+    status_code=status.HTTP_200_OK,
+)
+async def get_live_state() -> dict:
+    live_content = {"live": True}
+    return JSONResponse(content=live_content, status_code=200)
+
+
+@router.get(
+    "/health/ready",
+    tags=["Health"],
+    summary="Check if the service is ready to receive traffic.",
+    description="""
+        Check if the service is ready to receive traffic.
+    """,
+    status_code=status.HTTP_200_OK,
+)
+async def get_ready_state() -> dict:
+    ready_content = {"ready": True}
+    return JSONResponse(content=ready_content, status_code=200)

--- a/src/nv_ingest/api/v1/health.py
+++ b/src/nv_ingest/api/v1/health.py
@@ -66,11 +66,16 @@ async def get_ready_state() -> dict:
     # for now to assume that if nv-ingest is running so is
     # the pipeline.
     morpheus_pipeline_ready = True
-    yolox_ready = is_ready(os.getenv("YOLOX_HTTP_ENDPOINT", ""), "/v1/health/ready")
-    # deplot_ready = is_ready(os.getenv("YOLOX_HTTP_ENDPOINT", "yolox:8000"), "/v1/health/ready")
+    yolox_ready = is_ready(os.getenv("YOLOX_HTTP_ENDPOINT", None), "/v1/health/ready")
+    # deplot_ready = is_ready(os.getenv("DEPLOT_HTTP_ENDPOINT", None), "/v1/health/ready")
     deplot_ready = True
-    cached_ready = is_ready(os.getenv("CACHED_HTTP_ENDPOINT", ""), "/v1/health/ready")
-    paddle_ready = is_ready(os.getenv("PADDLE_HTTP_ENDPOINT", ""), "/v1/health/ready")
+    cached_ready = is_ready(os.getenv("CACHED_HTTP_ENDPOINT", None), "/v1/health/ready")
+    paddle_ready = is_ready(os.getenv("PADDLE_HTTP_ENDPOINT", None), "/v1/health/ready")
+    
+    print(f"ingest_ready: {ingest_ready} - morpheus_pipeline_ready: \
+        {morpheus_pipeline_ready} - yolox_ready: {yolox_ready} - \
+            deplot_ready: {deplot_ready} - cached_ready: {cached_ready} - \
+                paddle_ready: {paddle_ready}")
 
     if (ingest_ready
             and morpheus_pipeline_ready
@@ -88,4 +93,5 @@ async def get_ready_state() -> dict:
             "cached_ready": cached_ready,
             "paddle_ready": paddle_ready,
         }
+        print(f"Ready Statuses: {ready_statuses}")
         return JSONResponse(content=ready_statuses, status_code=503)

--- a/src/nv_ingest/api/v1/ingest.py
+++ b/src/nv_ingest/api/v1/ingest.py
@@ -17,7 +17,6 @@ import logging
 import time
 import traceback
 from typing import Annotated
-import uuid
 
 from opentelemetry import trace
 from nv_ingest_client.primitives.jobs.job_spec import JobSpec

--- a/src/nv_ingest/main.py
+++ b/src/nv_ingest/main.py
@@ -9,14 +9,42 @@
 # its affiliates is strictly prohibited.
 
 from fastapi import FastAPI
-from fastapi import status
+import datetime
+import os
+import re
 
 from .api.main import app as app_v1
+
+
+# TODO: Lets move this to a common utility, this is also used in both client and runtime setup.py files ...
+def get_version():
+    release_type = os.getenv("NV_INGEST_RELEASE_TYPE", "dev")
+    version = os.getenv("NV_INGEST_VERSION")
+    rev = os.getenv("NV_INGEST_REV", "0")
+
+    if not version:
+        version = f"{datetime.datetime.now().strftime('%Y.%m.%d')}"
+
+    # Ensure the version is PEP 440 compatible
+    pep440_regex = r"^\d{4}\.\d{1,2}\.\d{1,2}$"
+    if not re.match(pep440_regex, version):
+        raise ValueError(f"Version '{version}' is not PEP 440 compatible")
+
+    # Construct the final version string
+    if release_type == "dev":
+        final_version = f"{version}.dev{rev}"
+    elif release_type == "release":
+        final_version = f"{version}.post{rev}" if int(rev) > 0 else version
+    else:
+        raise ValueError(f"Invalid release type: {release_type}")
+
+    return final_version
+
 
 app = FastAPI(
     title="NV-Ingest Microservice",
     description="Service for ingesting heterogenous datatypes",
-    version="0.1.0",
+    version=get_version(),
     contact={
         "name": "NVIDIA Corporation",
         "url": "https://nvidia.com",
@@ -28,20 +56,3 @@ app = FastAPI(
 
 
 app.mount("/v1", app_v1)
-
-
-@app.get(
-    "/health",
-    tags=["Health"],
-    summary="Perform a Health Check",
-    description="""
-        Immediately returns 200 when service is up.
-        This does not check the health of downstream
-        services.
-    """,
-    response_description="Return HTTP Status Code 200 (OK)",
-    status_code=status.HTTP_200_OK,
-)
-def get_health() -> str:
-    # Perform a health check
-    return "OK"

--- a/src/nv_ingest/main.py
+++ b/src/nv_ingest/main.py
@@ -9,42 +9,13 @@
 # its affiliates is strictly prohibited.
 
 from fastapi import FastAPI
-import datetime
-import os
-import re
 
 from .api.main import app as app_v1
-
-
-# TODO: Lets move this to a common utility, this is also used in both client and runtime setup.py files ...
-def get_version():
-    release_type = os.getenv("NV_INGEST_RELEASE_TYPE", "dev")
-    version = os.getenv("NV_INGEST_VERSION")
-    rev = os.getenv("NV_INGEST_REV", "0")
-
-    if not version:
-        version = f"{datetime.datetime.now().strftime('%Y.%m.%d')}"
-
-    # Ensure the version is PEP 440 compatible
-    pep440_regex = r"^\d{4}\.\d{1,2}\.\d{1,2}$"
-    if not re.match(pep440_regex, version):
-        raise ValueError(f"Version '{version}' is not PEP 440 compatible")
-
-    # Construct the final version string
-    if release_type == "dev":
-        final_version = f"{version}.dev{rev}"
-    elif release_type == "release":
-        final_version = f"{version}.post{rev}" if int(rev) > 0 else version
-    else:
-        raise ValueError(f"Invalid release type: {release_type}")
-
-    return final_version
-
 
 app = FastAPI(
     title="NV-Ingest Microservice",
     description="Service for ingesting heterogenous datatypes",
-    version=get_version(),
+    version="0.1.0",
     contact={
         "name": "NVIDIA Corporation",
         "url": "https://nvidia.com",

--- a/src/nv_ingest/util/nim/helpers.py
+++ b/src/nv_ingest/util/nim/helpers.py
@@ -184,8 +184,7 @@ def generate_url(url) -> str:
     if not re.match(r'^https?://', url):
         # Add the default `http://` if its not already present in the URL
         url = f"http://{url}"
-    else:
-        url = f"{url}"
+
     return url
 
 

--- a/src/nv_ingest/util/nim/helpers.py
+++ b/src/nv_ingest/util/nim/helpers.py
@@ -189,6 +189,12 @@ def generate_url(url) -> str:
 
 
 def is_ready(http_endpoint, ready_endpoint) -> bool:
+    
+    # IF the url is empty or None that means the service was not configured
+    # and is therefore automatically marked as "ready"
+    if http_endpoint is None or http_endpoint == '':
+        return True
+    
     url = generate_url(http_endpoint)
 
     if not ready_endpoint.startswith('/') and not url.endswith('/'):


### PR DESCRIPTION
## Description
nv-ingest as a service should offer a "readiness" endpoint that both signals to end users or container orchestration technologies like k8s it is in a ready state for processing.

Since nv-ingest (in the service context) is comprised of several components this `/v1/health/ready` endpoint will reach out to all of those components via their "ready" endpoints and then aggregate the results. Once ALL of the configured components are ready nv-ingest will report that it is ready as well.

Ready = HTTP 200
Not Ready = HTTP 503  as well as a JSON payload describing the individual components that are ready or not ready.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
