### PR TITLE
Use paddle and cached http endpoints

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,8 +14,6 @@ services:
       - "8000:8000"
       - "8001:8001"
       - "8002:8002"
-    volumes:
-      - ${HOME}/.cache:/home/nvs/.cache
     user: root
     environment:
       - NIM_HTTP_API_PORT=8000
@@ -61,8 +59,6 @@ services:
       - "8006:8000"
       - "8007:8001"
       - "8008:8002"
-    volumes:
-      - ${HOME}/.cache:/home/nvs/.cache
     user: root
     environment:
       - NIM_HTTP_API_PORT=8000
@@ -85,8 +81,6 @@ services:
       - "8009:8000"
       - "8010:8001"
       - "8011:8002"
-    volumes:
-      - ${HOME}/.cache:/home/nvs/.cache
     user: root
     environment:
       - NIM_HTTP_API_PORT=8000
@@ -137,8 +131,8 @@ services:
     cap_add:
       - sys_nice
     environment:
-      - CACHED_GRPC_ENDPOINT=cached:8001
-      - CACHED_HTTP_ENDPOINT=""
+      - CACHED_GRPC_ENDPOINT=""
+      - CACHED_HTTP_ENDPOINT=http://cached:8000/v1/infer
       - CACHED_HEALTH_ENDPOINT=cached:8000
       - DEPLOT_GRPC_ENDPOINT=""
       # build.nvidia.com hosted deplot
@@ -154,8 +148,8 @@ services:
       - NGC_API_KEY=${NGC_API_KEY:-ngcapikey}
       - NVIDIA_BUILD_API_KEY=${NVIDIA_BUILD_API_KEY:-${NGC_API_KEY:-ngcapikey}}
       - OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317
-      - PADDLE_GRPC_ENDPOINT=paddle:8001
-      - PADDLE_HTTP_ENDPOINT=""
+      - PADDLE_GRPC_ENDPOINT=""
+      - PADDLE_HTTP_ENDPOINT=http://paddle:8000/v1/infer
       - PADDLE_HEALTH_ENDPOINT=paddle:8000
       - REDIS_MORPHEUS_TASK_QUEUE=morpheus_task_queue
       - TABLE_DETECTION_GRPC_TRITON=yolox:8001

--- a/src/nv_ingest/util/image_processing/table_and_chart.py
+++ b/src/nv_ingest/util/image_processing/table_and_chart.py
@@ -43,7 +43,13 @@ def join_cached_and_deplot_output(cached_text, deplot_text):
 
     if (cached_text is not None):
         try:
-            cached_text_dict = json.loads(cached_text)
+            if isinstance(cached_text, str):
+                cached_text_dict = json.loads(cached_text)
+            elif isinstance(cached_text, dict):
+                cached_text_dict = cached_text
+            else:
+                cached_text_dict = {}
+
             chart_content += cached_text_dict.get("chart_title", "")
 
             if (deplot_text is not None):


### PR DESCRIPTION
## Description
- Repalce GRPC endpoints with HTTP endpoints for PaddleOCR and Cached NIMs.
- We are not ready to use the HTTP endpoint yet because [this fix](https://github.com/NVIDIA/nv-ingest/pull/72) has not been moved to YOLOX yet.
- Remove cache directory mounts in docker compose since NIMs are not expected to be run a second time.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
