### PR TITLE
Various compatitbility fixes for pyarrow 17 and cuda 12.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,8 +120,6 @@ RUN source activate nv_ingest \
 RUN source activate base \
     && conda install setuptools==70.0.0
 
-FROM nv_ingest_install AS runtime
-
 RUN source activate nv_ingest \
     && pip install ./client/dist/*.whl \
     ## Installations below can be removed after the next Morpheus release
@@ -133,6 +131,12 @@ RUN source activate nv_ingest \
     && pip install --no-input google-search-results==2.4 \
     && pip install --no-input nemollm==0.3.5 \
     && rm -rf client/dist
+
+# Install patched MRC version to circumvent NUMA node issue -- remove after Morpheus 10.24 release
+RUN source activate nv_ingest \
+    && conda install -y -c nvidia/label/dev mrc=24.10.00a=cuda_12.5_py310_h5ae46af_10
+
+FROM nv_ingest_install AS runtime
 
 COPY src/pipeline.py ./
 COPY pyproject.toml ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,10 +116,6 @@ RUN source activate nv_ingest \
 RUN source activate nv_ingest \
     && rm -rf src requirements.txt test-requirements.txt util-requirements.txt
 
-# Interim pyarrow backport until folded into upstream dependency tree
-RUN source activate nv_ingest \
-    && conda install https://anaconda.org/conda-forge/pyarrow/14.0.2/download/linux-64/pyarrow-14.0.2-py310h188ebfb_19_cuda.conda
-
 # Upgrade setuptools to mitigate https://github.com/advisories/GHSA-cx63-2mw6-8hw5
 RUN source activate base \
     && conda install setuptools==70.0.0

--- a/client/src/nv_ingest_client/cli/util/processing.py
+++ b/client/src/nv_ingest_client/cli/util/processing.py
@@ -400,11 +400,13 @@ def save_response_data(response, output_directory):
     """
 
     if ("data" not in response) or (not response["data"]):
+        logger.debug("Data is not in the response or response.data is empty")
         return
 
     response_data = response["data"]
 
     if not isinstance(response_data, list) or len(response_data) == 0:
+        logger.debug("Response data is not a list or the list is empty.")
         return
 
     doc_meta_base = response_data[0]["metadata"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -138,33 +138,34 @@ services:
       - sys_nice
     environment:
       - CACHED_GRPC_ENDPOINT=cached:8001
-      - CACHED_HTTP_ENDPOINT=""
       - CACHED_HEALTH_ENDPOINT=cached:8000
+      - CACHED_HTTP_ENDPOINT=""
+      - CUDA_VISIBLE_DEVICES=1
       - DEPLOT_GRPC_ENDPOINT=""
+      # self hosted deplot
+      - DEPLOT_HEALTH_ENDPOINT=deplot:8000
+      - DEPLOT_HTTP_ENDPOINT=http://deplot:8000/v1/chat/completions
       # build.nvidia.com hosted deplot
       #- DEPLOT_HTTP_ENDPOINT=https://ai.api.nvidia.com/v1/vlm/google/deplot
-      # self hosted deplot
-      - DEPLOT_HTTP_ENDPOINT=http://deplot:8000/v1/chat/completions
-      - DEPLOT_HEALTH_ENDPOINT=deplot:8000
       - DOUGHNUT_GRPC_TRITON=triton-doughnut:8001
       - INGEST_LOG_LEVEL=DEFAULT
       - MESSAGE_CLIENT_HOST=redis
       - MESSAGE_CLIENT_PORT=6379
       - MINIO_BUCKET=${MINIO_BUCKET:-nv-ingest}
+      - MRC_IGNORE_NUMA_CHECK=1
       - NGC_API_KEY=${NGC_API_KEY:-ngcapikey}
       - NVIDIA_BUILD_API_KEY=${NVIDIA_BUILD_API_KEY:-${NGC_API_KEY:-ngcapikey}}
       - OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317
       - PADDLE_GRPC_ENDPOINT=paddle:8001
-      - PADDLE_HTTP_ENDPOINT=""
       - PADDLE_HEALTH_ENDPOINT=paddle:8000
+      - PADDLE_HTTP_ENDPOINT=""
+      - READY_CHECK_ALL_COMPONENTS=True
       - REDIS_MORPHEUS_TASK_QUEUE=morpheus_task_queue
       - TABLE_DETECTION_GRPC_TRITON=yolox:8001
       - TABLE_DETECTION_HTTP_TRITON=""
       - YOLOX_GRPC_ENDPOINT=yolox:8001
-      - YOLOX_HTTP_ENDPOINT=""
       - YOLOX_HEALTH_ENDPOINT=yolox:8000
-      - CUDA_VISIBLE_DEVICES=1
-      - READY_CHECK_ALL_COMPONENTS=True
+      - YOLOX_HTTP_ENDPOINT=""
     healthcheck:
       test: curl --fail http://nv-ingest-ms-runtime:7670/v1/health/ready || exit 1
       interval: 10s

--- a/src/nv_ingest/modules/sinks/redis_task_sink.py
+++ b/src/nv_ingest/modules/sinks/redis_task_sink.py
@@ -50,8 +50,9 @@ def extract_data_frame(message: ControlMessage) -> Tuple[Any, Dict[str, Any]]:
         with message.payload().mutable_dataframe() as mdf:
             logger.debug(f"Redis Sink Received DataFrame with {len(mdf)} rows.")
             keep_cols = ["document_type", "metadata"]
-            return mdf, mdf[keep_cols].to_dict(orient="records")
-    except Exception:
+            return mdf, mdf[keep_cols].to_pandas().to_dict(orient="records")
+    except Exception as err:
+        logger.warning(f"Failed to extract DataFrame from message payload: {err}")
         return None, None
 
 

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -45,7 +45,7 @@ from nv_ingest.util.schema.schema_validator import validate_schema
 
 logger = logging.getLogger(__name__)
 local_log_level = os.getenv("INGEST_LOG_LEVEL", "INFO")
-if (local_log_level in ("DEFAULT")):
+if (local_log_level in ("DEFAULT",)):
     local_log_level = "INFO"
 configure_local_logging(logger, local_log_level)
 
@@ -672,7 +672,7 @@ def cli(
     env_log_level = os.getenv("INGEST_LOG_LEVEL")
     if env_log_level:
         log_level = env_log_level
-        if (log_level in ("DEFAULT")):
+        if (log_level in ("DEFAULT",)):
             log_level = "INFO"
 
     log_level = log_level_mapping.get(log_level.upper(), logging.INFO)


### PR DESCRIPTION
Resolves #155 

Adds:
- MRC_IGNORE_NUMA_CHECK env variable -- bypasses situations where GPUs are assigned to more than one NUMA node.  Which previously would cause MRC's NumaPlacement strategy to fail.
- Updates redis_task_sink to conver mdf to pandas before calling to_dict -- A bit hand-wavey on this, converting to Pandas works and the 'unexpected keyword value 'index'' error that comes out of cuDF is outside our control.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
