### PR TITLE
Documentation fix for 'extract_task'

### DIFF
--- a/client/src/nv_ingest_client/nv_ingest_cli.py
+++ b/client/src/nv_ingest_client/nv_ingest_cli.py
@@ -131,6 +131,10 @@ Tasks and Options:
     - extract_images (bool): Enables image extraction. Default: False.
     - extract_tables (bool): Enables table extraction. Default: False.
     - extract_charts (bool): Enables chart extraction. Default: False.
+    - text_depth (str): Text extraction granularity ('document', 'page'). Default: 'document'. 
+        Note: this will affect the granularity of text extraction, and the associated metadata. ie. 'page' will extract
+        text per page and you will get page-level metadata, 'document' will extract text for the entire document so
+        elements like page numbers will not be associated with individual text elements.
 \b
 - store: Stores any images extracted from documents.
     Options:


### PR DESCRIPTION
Add missing docstring for 'text_depth' extraction option.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
