### PR TITLE
Fix dataframe emptiness check

### DIFF
--- a/src/nv_ingest/modules/sinks/redis_task_sink.py
+++ b/src/nv_ingest/modules/sinks/redis_task_sink.py
@@ -307,13 +307,13 @@ def process_and_forward(message: ControlMessage, redis_client: RedisClient) -> C
         annotate_cm(message, message="Pushed")
         push_to_redis(redis_client, response_channel, json_payloads)
     except RedisError as e:
-        mdf_size = len(mdf) if mdf else 0
+        mdf_size = len(mdf) if not mdf.empty else 0
         handle_failure(redis_client, response_channel, json_result_fragments, e, mdf_size)
     except Exception as e:
         traceback.print_exc()
         logger.error(f"Critical error processing message: {e}")
 
-        mdf_size = len(mdf) if mdf else 0
+        mdf_size = len(mdf) if not mdf.empty else 0
         handle_failure(redis_client, response_channel, json_result_fragments, e, mdf_size)
 
     return message


### PR DESCRIPTION
## Description
Fixes
```
nv-ingest-ms-runtime-1  | E20241015 00:55:19.766779 132771194340928 context.cpp:124] /main/mrc::pymrc::PythonSegmentModule::redis_task_sink/process_and_forward; rank: 5; size: 6; tid: 132771
194340928: set_exception issued; issuing kill to current runnable. Exception msg: ValueError: The truth value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all()
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
