### PR TITLE
Update port number to match exposed port from container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ COPY src/pipeline.py ./
 COPY pyproject.toml ./
 COPY ./docker/scripts/entrypoint_source_ext.sh /opt/docker/bin/entrypoint_source
 
-# Start both the core nv-ingest pipeline service and teh FastAPI microservice in parallel
+# Start both the core nv-ingest pipeline service and the FastAPI microservice in parallel
 CMD ["sh", "-c", "python /workspace/pipeline.py & uvicorn nv_ingest.main:app --workers 32 --host 0.0.0.0 --port 7670 & wait"]
 
 FROM base AS development

--- a/helm/README.md
+++ b/helm/README.md
@@ -92,7 +92,7 @@ minikube addons enable storage-provisioner-rancher
 
 Jobs are submitted via the `nv-ingest-cli` command. See installation [here](https://github.com/NVIDIA/nv-ingest/tree/main/client)
 
-### Access To Redis
+### Access To NV Ingest API
 
 It is recommended that the end user provide a mechanism for [`Ingress`](https://kubernetes.io/docs/concepts/services-networking/ingress/) for the Redis pod.
 You can test outside of your Kuberenetes cluster by [port-forwarding](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_port-forward/) the Redis pod to your local environment.
@@ -100,7 +100,7 @@ You can test outside of your Kuberenetes cluster by [port-forwarding](https://ku
 Example:
 
 ```bash
-kubectl port-forward -n ${NAMESPACE} nv-ingest-redis-master-0 6379:6379
+kubectl port-forward -n ${NAMESPACE} service/nv-ingest 7670:7670
 ```
 
 ### Executing jobs

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -478,7 +478,7 @@ readinessProbe:
 ## @param service.labels [object] Specifies additional labels to be added to service.
 service:
   type: ClusterIP
-  port: 8000
+  port: 7670
   annotations: {}
   labels: {}
   name: ""  # override the default service name


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This MR aligns the default exposed port for the service with that of the Images port. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
