### PR TITLE
Add back yolox grpc endpoint for backward compatibility

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -154,6 +154,7 @@ services:
       - PADDLE_INFER_PROTOCOL=grpc
       - READY_CHECK_ALL_COMPONENTS=True
       - REDIS_MORPHEUS_TASK_QUEUE=morpheus_task_queue
+      - TABLE_DETECTION_GRPC_TRITON=yolox:8001  # Kept for backward comptability. Only used in legacy EA container.
       - YOLOX_GRPC_ENDPOINT=yolox:8001
       - YOLOX_HTTP_ENDPOINT=http://yolox:8000/v1/infer
       - YOLOX_INFER_PROTOCOL=grpc


### PR DESCRIPTION
## Description
Fixes #165.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
