### PR TITLE
Fix paddle version missing when extract_tables is false

### DIFF
--- a/src/nv_ingest/extraction_workflows/pdf/pdfium_helper.py
+++ b/src/nv_ingest/extraction_workflows/pdf/pdfium_helper.py
@@ -140,6 +140,7 @@ def extract_tables_and_charts_using_image_ensemble(
         return tables_and_charts
 
     yolox_client = paddle_client = deplot_client = cached_client = None
+    paddle_version = None
     try:
         yolox_client = create_inference_client(config.yolox_endpoints, config.auth_token, config.yolox_infer_protocol)
         if extract_tables:


### PR DESCRIPTION
## Description

Fixes
```
nv-ingest-ms-runtime-1  | 2024-10-16 21:31:52,923 - ERROR - Error during table/chart extraction: local variable 'paddle_version' referenced before assignment
nv-ingest-ms-runtime-1  | 2024-10-16 21:31:52,926 - ERROR - Future result failure - local variable 'paddle_version' referenced before assignment
nv-ingest-ms-runtime-1  |
nv-ingest-ms-runtime-1  | Unhandled exception in decode_and_extract for './data/multimodal_test.pdf':
nv-ingest-ms-runtime-1  | local variable 'paddle_version' referenced before assignment
nv-ingest-ms-runtime-1  | Unhandled exception in process_pdf_bytes: local variable 'paddle_version' referenced before assignment
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
