### PR TITLE
Install curl for healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y \
       wget \
       bzip2 \
       ca-certificates \
+      curl \
     && apt-get clean
 
 # Install miniconda
@@ -62,7 +63,7 @@ WORKDIR /workspace
 # Copy custom entrypoint script
 COPY ./docker/scripts/entrypoint.sh /workspace/docker/entrypoint.sh
 
-FROM base as nv_ingest_install
+FROM base AS nv_ingest_install
 # Copy the module code
 COPY setup.py setup.py
 COPY ci ci


### PR DESCRIPTION
## Description
Installs curl for [healthcheck](https://github.com/NVIDIA/nv-ingest/blob/main/docker-compose.yaml#L161).

```
$ docker ps
CONTAINER ID   IMAGE                                                                      COMMAND                  CREATED          STATUS                      PORTS                                                                                                                                                                                                                                                                                NAMES
d0d78f932ffe   nvcr.io/ohlfw0olaadg/ea-participants/nv-ingest:24.08                       "/opt/conda/envs/nv_…"   38 seconds ago   Up 38 seconds (healthy)     0.0.0.0:7670->7670/tcp, :::7670->7670/tcp                                                                                                                                                                                                                                            nv-ingest-nv-ingest-ms-runtime-1
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
