### PR TITLE
Cache nim version metadata calls and invalidate periodically

### DIFF
--- a/src/nv_ingest/util/nim/decorators.py
+++ b/src/nv_ingest/util/nim/decorators.py
@@ -1,0 +1,52 @@
+import logging
+from functools import wraps
+from multiprocessing import Lock
+from multiprocessing import Manager
+
+logger = logging.getLogger(__name__)
+
+# Create a shared manager and lock for thread-safe access
+manager = Manager()
+global_cache = manager.dict()
+lock = Lock()
+
+
+def multiprocessing_cache(max_calls):
+    """
+    A decorator that creates a global cache shared between multiple processes.
+    The cache is invalidated after `max_calls` number of accesses.
+
+    Args:
+        max_calls (int): The number of calls after which the cache is cleared.
+
+    Returns:
+        function: The decorated function with global cache and invalidation logic.
+    """
+
+    def decorator(func):
+        call_count = manager.Value("i", 0)  # Shared integer for call counting
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            key = (func.__name__, args, frozenset(kwargs.items()))
+
+            with lock:
+                call_count.value += 1
+
+                if call_count.value > max_calls:
+                    global_cache.clear()
+                    call_count.value = 0
+
+                if key in global_cache:
+                    return global_cache[key]
+
+            result = func(*args, **kwargs)
+
+            with lock:
+                global_cache[key] = result
+
+            return result
+
+        return wrapper
+
+    return decorator

--- a/src/nv_ingest/util/nim/helpers.py
+++ b/src/nv_ingest/util/nim/helpers.py
@@ -19,6 +19,7 @@ import tritonclient.grpc as grpcclient
 from nv_ingest.util.image_processing.transforms import normalize_image
 from nv_ingest.util.image_processing.transforms import numpy_to_base64
 from nv_ingest.util.image_processing.transforms import pad_image
+from nv_ingest.util.nim.decorators import multiprocessing_cache
 from nv_ingest.util.tracing.tagging import traceable_func
 
 logger = logging.getLogger(__name__)
@@ -393,6 +394,7 @@ def is_ready(http_endpoint, ready_endpoint) -> bool:
 
 
 @backoff.on_predicate(backoff.expo, max_value=5)
+@multiprocessing_cache(max_calls=100)
 def get_version(http_endpoint, metadata_endpoint="/v1/metadata", version_field="version") -> str:
     if http_endpoint is None or http_endpoint == "":
         return ""

--- a/tests/nv_ingest/util/nim/test_decorators.py
+++ b/tests/nv_ingest/util/nim/test_decorators.py
@@ -1,0 +1,78 @@
+from multiprocessing import Manager
+from multiprocessing import Process
+from multiprocessing import Queue
+
+import pytest
+
+from nv_ingest.util.nim.decorators import multiprocessing_cache
+
+
+@pytest.fixture
+def shared_manager():
+    """Fixture to create a shared multiprocessing manager."""
+    return Manager()
+
+
+def test_global_cache_with_same_arguments(shared_manager):
+    queue = Queue()
+
+    @multiprocessing_cache(3)
+    def add(x, y):
+        queue.put(1)  # Track each function call
+        return x + y
+
+    def worker(val1, val2):
+        add(val1, val2)
+
+    processes = [
+        Process(target=worker, args=(1, 2)),  # called 1st time
+        Process(target=worker, args=(1, 2)),
+        Process(target=worker, args=(1, 2)),
+        Process(target=worker, args=(1, 2)),  # called 2nd time
+    ]
+
+    for p in processes:
+        p.start()
+
+    for p in processes:
+        p.join()
+
+    total_calls = 0
+    while not queue.empty():
+        total_calls += queue.get()
+
+    assert total_calls == 2
+
+
+def test_global_cache_with_different_arguments(shared_manager):
+    queue = Queue()
+
+    @multiprocessing_cache(3)
+    def add(x, y):
+        queue.put(1)  # Track each function call
+        return x + y
+
+    def worker(val1, val2):
+        add(val1, val2)
+
+    processes = [
+        Process(target=worker, args=(1, 2)),  # called 1st time
+        Process(target=worker, args=(3, 4)),  # called 2nd time
+        Process(target=worker, args=(1, 2)),
+        Process(target=worker, args=(3, 4)),
+        Process(target=worker, args=(1, 2)),
+        Process(target=worker, args=(3, 4)),
+        Process(target=worker, args=(3, 4)),  # called 3rd time
+    ]
+
+    for p in processes:
+        p.start()
+
+    for p in processes:
+        p.join()
+
+    total_calls = 0
+    while not queue.empty():
+        total_calls += queue.get()
+
+    assert total_calls == 3


### PR DESCRIPTION
## Description
This PR adds a caching mechanism to the http call to /v1/metadata (which gives us version info). A simple approach such as `functools.lru_cache` is not effective because these http calls are currently used in the extractor stage and extractor stages are multiprocessing stages. To prevent overladoing workers with highly concurrent requests, we introduce a cache that is invalidated after n calls, where the total call count is shared across multiple processes.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
