### PR TITLE
Increase Redis master and replica memory for k8s

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -238,8 +238,17 @@ redis:
     enabled: false
   replica:
     replicaCount: 1
+    resources:
+      requests:
+        memory: "6Gi"
+      limits:
+        memory: "12Gi"
   master:
-      resourcesPreset: xlarge
+    resources:
+      requests:
+        memory: "6Gi"
+      limits:
+        memory: "12Gi"
 
 ## @section Environment Variables
 ## @descriptionStart


### PR DESCRIPTION
## Description
Increase the requested memory to 6Gi and the limit memory to 12Gi for both Redis Master and Replicas

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
