### PR TITLE
Resolve issue 187

### DIFF
--- a/src/nv_ingest/modules/sinks/redis_task_sink.py
+++ b/src/nv_ingest/modules/sinks/redis_task_sink.py
@@ -119,7 +119,7 @@ def create_json_payload(message: ControlMessage, df_json: Dict[str, Any]) -> Lis
     df_json_size = sys.getsizeof(df_json_str)
 
     # 256 MB size limit (in bytes)
-    size_limit = 256 * 1024 * 1024
+    size_limit = 128 * 1024 * 1024
 
     # If df_json is larger than the size limit, split it into chunks
     if df_json_size > size_limit:


### PR DESCRIPTION
Resolves #187 

Updates the logic that creates and validates multi-part fragment sizes returned to the user. Here we just set the fragment size to 128 MB, and the maximum fragment size to 256 MB so there is a buffer.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
