### PR TITLE
Fix docker compose changes

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -135,11 +135,11 @@ services:
       - CUDA_VISIBLE_DEVICES=0
       - DEPLOT_GRPC_ENDPOINT=""
       # self hosted deplot
-      #- DEPLOT_HEALTH_ENDPOINT=deplot:8000
-      #- DEPLOT_HTTP_ENDPOINT=http://deplot:8000/v1/chat/completions
+      - DEPLOT_HEALTH_ENDPOINT=deplot:8000
+      - DEPLOT_HTTP_ENDPOINT=http://deplot:8000/v1/chat/completions
       # build.nvidia.com hosted deplot
       - DEPLOT_INFER_PROTOCOL=http
-      - DEPLOT_HTTP_ENDPOINT=https://ai.api.nvidia.com/v1/vlm/google/deplot
+      #- DEPLOT_HTTP_ENDPOINT=https://ai.api.nvidia.com/v1/vlm/google/deplot
       - DOUGHNUT_GRPC_TRITON=triton-doughnut:8001
       - INGEST_LOG_LEVEL=DEFAULT
       - MESSAGE_CLIENT_HOST=redis


### PR DESCRIPTION
Default docker compose back to local deplot deployment.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
