### PR TITLE
Add Split Task to Job in Client Demo

### DIFF
--- a/client/client_examples/examples/python_client_usage.ipynb
+++ b/client/client_examples/examples/python_client_usage.ipynb
@@ -630,6 +630,7 @@
     "job_spec.add_task(extract_task)\n",
     "job_spec.add_task(dedup_task)\n",
     "job_spec.add_task(filter_task)\n",
+    "job_spec.add_task(split_task)\n",
     "job_spec.add_task(store_task)\n",
     "job_spec.add_task(embed_task)\n",
     "job_spec.add_task(vdb_upload_task)"


### PR DESCRIPTION
Add the split task to the job in the client example notebook (to prevent confusion).
