### PR TITLE
Add missing requirements for Python client

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -10,3 +10,4 @@ python-pptx==0.6.23
 tqdm
 httpx
 requests
+fsspec


### PR DESCRIPTION
## Description
If you follow the instructions in the main README of doing

```
# conda not required, but makes it easy to create a fresh python environment
conda create --name nv-ingest-dev python=3.10
conda activate nv-ingest-dev
cd client
pip install -r ./requirements.txt
pip install .
```

Then if you run the notebook examples in:

```
client/client_examples/examples/python_client_usage.ipynb
```

you'll get an Import Error saying that the `fsspec` is required. A simple pip install of the library fixes the issue and hence I've added it to the requirements.txt file.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
