### PR TITLE
Pin httpx to 0.27.2 to prevent OpenAI client from pulling in newer 0.…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ unstructured-client==0.23.3
 uvicorn==0.24.0-post.1
 s3fs
 Wand==0.6.13
+httpx==0.27.2


### PR DESCRIPTION
…28.0 version that has breaking changes

## Description
A newer version of httpx 0.28.0 was released on 11/28/2024 and in certain environments is causing issues. This PR pins our version of httpx to 0.27.2 which works with our OpenAI dependency version.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
