### PR TITLE
Add tip to run `docker compose up --build` to build from source into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ NV_INGEST_ROOT=<PATH_TO_THIS_REPO>
 > By default we have [configured log levels to be verbose](docker-compose.yaml#L27).
 >
 > It's possible to observe service startup proceeding: you will notice _many_ log messages. Disable verbose logging by configuring `NIM_TRITON_LOG_VERBOSE=0` for each NIM in [docker-compose.yaml](docker-compose.yaml).
+> 
+> If you want to build from source, use `docker compose up --build` instead. This will build from your repo's code rather than from an already published container.
 
 6. When all services have fully started, `nvidia-smi` should show processes like the following:
 ```


### PR DESCRIPTION
## Description
Currently in the README, the recommended way to run `docker compose` is:

```
docker compose up
```

this means that the command will use an already published container, rather than building from source. 
I've add a tip to use:

```
docker compose up --build
```

Since sometimes the published containers might have bugs that have only been fixed in the `main` branch and hence users would benefit from being "reminded" to build from source.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
