### PR TITLE
Skip extractions if there is nothing to extract

### DIFF
--- a/src/nv_ingest/modules/transforms/embed_extractions.py
+++ b/src/nv_ingest/modules/transforms/embed_extractions.py
@@ -405,6 +405,9 @@ def _generate_embeddings(
     """
 
     with ctrl_msg.payload().mutable_dataframe() as mdf:
+        if mdf.empty:
+            return None, None
+
         # generate table text mask
         if content_type == ContentTypeEnum.TEXT:
             content_mask = (mdf["document_type"] == content_type.value) & (

--- a/src/nv_ingest/stages/nim/chart_extraction.py
+++ b/src/nv_ingest/stages/nim/chart_extraction.py
@@ -113,6 +113,13 @@ def _extract_chart_data(df: pd.DataFrame, task_props: Dict[str, Any],
 
     _ = task_props  # unused
 
+    if trace_info is None:
+        trace_info = {}
+        logger.debug("No trace_info provided. Initialized empty trace_info dictionary.")
+
+    if df.empty:
+        return df, trace_info
+
     deplot_client = create_inference_client(
         validated_config.stage_config.deplot_endpoints,
         validated_config.stage_config.auth_token,
@@ -124,10 +131,6 @@ def _extract_chart_data(df: pd.DataFrame, task_props: Dict[str, Any],
         validated_config.stage_config.auth_token,
         validated_config.stage_config.cached_infer_protocol
     )
-
-    if trace_info is None:
-        trace_info = {}
-        logger.debug("No trace_info provided. Initialized empty trace_info dictionary.")
 
     try:
         # Apply the _update_metadata function to each row in the DataFrame

--- a/src/nv_ingest/stages/nim/table_extraction.py
+++ b/src/nv_ingest/stages/nim/table_extraction.py
@@ -117,15 +117,18 @@ def _extract_table_data(df: pd.DataFrame, task_props: Dict[str, Any],
 
     _ = task_props  # unused
 
+    if trace_info is None:
+        trace_info = {}
+        logger.debug("No trace_info provided. Initialized empty trace_info dictionary.")
+
+    if df.empty:
+        return df, trace_info
+
     paddle_client = create_inference_client(
         validated_config.stage_config.paddle_endpoints,
         validated_config.stage_config.auth_token,
         validated_config.stage_config.paddle_infer_protocol
     )
-
-    if trace_info is None:
-        trace_info = {}
-        logger.debug("No trace_info provided. Initialized empty trace_info dictionary.")
 
     try:
         # Apply the _update_metadata function to each row in the DataFrame


### PR DESCRIPTION
## Description

Some documents have nothing to extract. This PR proposes to skip extraction stages if there is no data in the dataframes.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
