### PR TITLE
add llama-index-nvidia-embedding package to reqs for milvus search 

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -11,3 +11,4 @@ tqdm
 httpx==0.27.2
 requests
 fsspec
+llama-index-embeddings-nvidia


### PR DESCRIPTION
## Description
This PR adds the llama-index-nvidia-emebddings package to the reqs for the client. It allows users to leverage the search functions (dense & hybrid). The package is used to easily access the embedding NIM and get dense embeddings for queries.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
