### PR TITLE
Add conda cache cleanup to dockerfile to reduce final image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN conda install -y mamba -n base -c conda-forge
 
 COPY ./docker/environments/nv_ingest_environment.yml /workspace/nv_ingest_environment.yml
 # Create nv_ingest base environment
-RUN mamba env create -f /workspace/nv_ingest_environment.yml
+RUN mamba env create -f /workspace/nv_ingest_environment.yml \
+    && conda clean --all --yes
 
 # Set default shell to bash
 SHELL ["/bin/bash", "-c"]
@@ -44,7 +45,8 @@ RUN echo "source activate nv_ingest_runtime" >> ~/.bashrc
 
 # Install Tini via conda from the conda-forge channel
 RUN source activate nv_ingest_runtime \
-    && mamba install -y -c conda-forge tini
+    && mamba install -y -c conda-forge tini \
+    && conda clean --all --yes
 
 # Set the working directory in the container
 WORKDIR /workspace

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-# TODO(Devin): This is duplicated in nv_ingest_client's setup.py, should be moved to common once Jermey's PR is merged
 def get_version():
     release_type = os.getenv("NV_INGEST_RELEASE_TYPE", "dev")
     version = os.getenv("NV_INGEST_VERSION")


### PR DESCRIPTION
Drops us from 20.4 GB to 17 GB


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
