### PR TITLE
Github Action RC Release Action

### DIFF
--- a/.github/workflows/docker-release-publish.yml
+++ b/.github/workflows/docker-release-publish.yml
@@ -1,0 +1,38 @@
+name: Build and Push Docker Image
+
+on:
+  create:
+    branches:
+      - release/*
+
+jobs:
+  build:
+    runs-on: linux-large-disk
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Extract branch name after "release/"
+      - name: Extract branch name
+        id: extract_branch
+        run: |
+          BRANCH_NAME=${GITHUB_REF#refs/heads/release/}
+          echo "SHORT_BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_ENV
+
+      # Set up Docker Buildx, useful for building multi-platform images
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build the Docker image using the Dockerfile
+      - name: Build Docker image
+        run: |
+          docker build --target runtime -t ${{ secrets.DOCKER_REGISTRY }}/nv-ingest:${{ env.SHORT_BRANCH_NAME }} .
+
+      # Login to NGC
+      - name: Log in to NGC Registry
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login nvcr.io --username "\$oauthtoken" --password-stdin
+
+      # Push the container to NGC
+      - name: Upload nv-ingest container
+        run: docker push ${{ secrets.DOCKER_REGISTRY }}/nv-ingest:${{ env.SHORT_BRANCH_NAME }}


### PR DESCRIPTION
## Description
Create a github action that will build and publish the nv-ingest-ms-runtime container when a new branch named 'release/XX.YY-RCZ' is created and publish the container to NGC

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
