### PR TITLE
Adjust all calls to handle_future_result to unpack result and trace_id

### DIFF
--- a/client/src/nv_ingest_client/client/client.py
+++ b/client/src/nv_ingest_client/client/client.py
@@ -15,7 +15,6 @@ from concurrent.futures import Future
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import as_completed
 from typing import Any, Type
-from typing import Callable
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -415,7 +414,7 @@ class NvIngestClient:
             for future in as_completed(futures):
                 job_id = futures[future]
                 try:
-                    result = handle_future_result(future, timeout=timeout)
+                    result, _ = handle_future_result(future, timeout=timeout)
                     results.append(result.get("data"))
                     del self._job_index_to_job_spec[job_id]
                 except concurrent.futures.TimeoutError:

--- a/client/src/nv_ingest_client/util/processing.py
+++ b/client/src/nv_ingest_client/util/processing.py
@@ -58,7 +58,7 @@ def handle_future_result(
     and a directory for saving results:
 
     >>> future = concurrent.futures.Future()
-    >>> result = handle_future_result(future, timeout=60)
+    >>> result, trace_id = handle_future_result(future, timeout=60)
 
     In this example, the function processes the completed job and returns the result dictionary.
     If the job fails, it raises a `RuntimeError`.


### PR DESCRIPTION
## Description
The profiling PR https://github.com/NVIDIA/nv-ingest/pull/251 introduced a bug where a call to `handle_future_result` was not properly unpacking the resulting Tuple causing issues.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
