### PR TITLE
add streaming milvus capability, output_fields param, and pin pacakges

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -13,6 +13,6 @@ requests
 fsspec
 pymilvus==2.4.9
 pymilvus[bulk_writer,model]
-azure-storage-blob
-llama-index-embeddings-nvidia
-openai
+azure-storage-blob==12.24.0
+llama-index-embeddings-nvidia==0.1.5
+openai==1.40.6


### PR DESCRIPTION
## Description
This PR adds support for milvus lite, it checks for the version of milvus and if you are using the embedded version, ensures you use the correct index params (no GPU CAGRA) and it uses streaming insert. Also added output_fields as a param for searches. Pinned versions of packages to ensure pypi only downloads one version of each package instead of download all of them.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
