### PR TITLE
Fix task_id and task tuple bug in client

### DIFF
--- a/client/src/nv_ingest_client/cli/util/click.py
+++ b/client/src/nv_ingest_client/cli/util/click.py
@@ -127,7 +127,7 @@ def click_validate_task(ctx, param, value):
             elif task_id == "store":
                 task_options = check_schema(StoreTaskSchema, options, task_id, json_options)
                 new_task_id = f"{task_id}"
-                new_task = StoreTask(**task_options.dict())
+                new_task = [(new_task_id, StoreTask(**task_options.dict()))]
             elif task_id == "store_embedding":
                 task_options = check_schema(StoreEmbedTaskSchema, options, task_id, json_options)
                 new_task_id = f"{task_id}"

--- a/tests/nv_ingest_client/cli/util/test_click.py
+++ b/tests/nv_ingest_client/cli/util/test_click.py
@@ -118,7 +118,7 @@ def test_validate_task_with_valid_store_task():
     assert isinstance(result["store"], StoreTask)
 
 
-def test_validate_task_with_valid_store_task():
+def test_validate_task_with_valid_store_embed_task():
     """Test with valid stor task options."""
     value = ['store_embedding:{"endpoint": "localhost:9000"}']
     result = click_validate_task(None, None, value)


### PR DESCRIPTION
## Description
Tasks should be combined with `task_id`. This bug didn't get noticed because two unit tests shared the same name, and the second test overwrote the first one.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
