### PR TITLE
Use the new ModelInterface in image handler

### DIFF
--- a/src/nv_ingest/extraction_workflows/image/image_handlers.py
+++ b/src/nv_ingest/extraction_workflows/image/image_handlers.py
@@ -318,7 +318,10 @@ def extract_tables_and_charts_from_image(
 
     yolox_client = None
     try:
-        yolox_client = create_inference_client(config.yolox_endpoints, config.auth_token)
+        model_interface = yolox_utils.YoloxModelInterface()
+        yolox_client = create_inference_client(
+            config.yolox_endpoints, model_interface, config.auth_token, config.yolox_infer_protocol
+        )
 
         data = {"images": [image]}
 


### PR DESCRIPTION
## Description
Interaction with NIMs was recently abstracted with `ModelInterface`. This PR updates the image extraction stage to use `ModelInterface`.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
