### PR TITLE
enable traces for yolox, cached, and deplot

### DIFF
--- a/src/nv_ingest/extraction_workflows/pdf/pdfium_helper.py
+++ b/src/nv_ingest/extraction_workflows/pdf/pdfium_helper.py
@@ -97,6 +97,8 @@ def extract_tables_and_charts_using_image_ensemble(
                 iou_thresh=YOLOX_IOU_THRESHOLD,
                 min_score=YOLOX_MIN_SCORE,
                 final_thresh=YOLOX_FINAL_SCORE,
+                trace_info=trace_info,  # traceable_func arg
+                stage_name="pdf_content_extractor",  # traceable_func arg
             )
 
             # Process results

--- a/src/nv_ingest/stages/nim/chart_extraction.py
+++ b/src/nv_ingest/stages/nim/chart_extraction.py
@@ -75,8 +75,18 @@ def _update_metadata(row: pd.Series, cached_client: NimClient, deplot_client: Ni
         data = {"base64_image": base64_image}
 
         # Perform inference using the NimClients
-        deplot_result = deplot_client.infer(data, model_name="deplot")
-        cached_result = cached_client.infer(data, model_name="cached")
+        deplot_result = deplot_client.infer(
+            data,
+            model_name="deplot",
+            trace_info=trace_info,  # traceable_func arg
+            stage_name="chart_data_extraction",  # traceable_func arg
+        )
+        cached_result = cached_client.infer(
+            data,
+            model_name="cached",
+            stage_name="chart_data_extraction",  # traceable_func arg
+            trace_info=trace_info,  # traceable_func arg
+        )
 
         chart_content = join_cached_and_deplot_output(cached_result, deplot_result)
 
@@ -174,7 +184,7 @@ def _extract_chart_data(
         # Apply the _update_metadata function to each row in the DataFrame
         df["metadata"] = df.apply(_update_metadata, axis=1, args=(cached_client, deplot_client, trace_info))
 
-        return df, trace_info
+        return df, {"trace_info": trace_info}
 
     except Exception as e:
         logger.error("Error occurred while extracting chart data.", exc_info=True)

--- a/src/nv_ingest/stages/nim/table_extraction.py
+++ b/src/nv_ingest/stages/nim/table_extraction.py
@@ -83,6 +83,8 @@ def _update_metadata(row: pd.Series, paddle_client: NimClient, trace_info: Dict)
                 data,
                 model_name="paddle",
                 table_content_format=table_metadata.get("table_content_format"),
+                trace_info=trace_info,  # traceable_func arg
+                stage_name="table_data_extraction",  # traceable_func arg
             )
 
         table_content, table_content_format = paddle_result
@@ -165,7 +167,7 @@ def _extract_table_data(
         # Apply the _update_metadata function to each row in the DataFrame
         df["metadata"] = df.apply(_update_metadata, axis=1, args=(paddle_client, trace_info))
 
-        return df, trace_info
+        return df, {"trace_info": trace_info}
 
     except Exception as e:
         logger.error("Error occurred while extracting table data.", exc_info=True)

--- a/src/nv_ingest/util/nim/helpers.py
+++ b/src/nv_ingest/util/nim/helpers.py
@@ -157,6 +157,7 @@ class NimClient:
         else:
             raise ValueError("Invalid protocol specified. Must be 'grpc' or 'http'.")
 
+    @traceable_func(trace_name="{stage_name}::{model_name}")
     def infer(self, data: dict, model_name: str, **kwargs) -> Any:
         """
         Perform inference using the specified model and input data.

--- a/src/nv_ingest/util/tracing/tagging.py
+++ b/src/nv_ingest/util/tracing/tagging.py
@@ -163,7 +163,7 @@ def traceable_func(trace_name=None, dedupe=True):
                     elif name in kwargs:
                         arg_val = kwargs.get(name)
                     else:
-                        continue
+                        arg_val = name
                     format_kwargs[name] = arg_val
                 trace_prefix = trace_prefix.format(**format_kwargs)
 

--- a/src/nv_ingest/util/tracing/tagging.py
+++ b/src/nv_ingest/util/tracing/tagging.py
@@ -149,15 +149,17 @@ def traceable_func(trace_name=None, dedupe=True):
                 trace_info = {}
             trace_prefix = trace_name if trace_name else func.__name__
 
+            arg_names = list(inspect.signature(func).parameters)
+            args_name_to_val = dict(zip(arg_names, args))
+
             # If `trace_name` is a formattable string, e.g., "pdf_extractor::{model_name}",
             # search `args` and `kwargs` to replace the placeholder.
             placeholders = [x[1] for x in string.Formatter().parse(trace_name) if x[1] is not None]
             if placeholders:
                 format_kwargs = {}
                 for name in placeholders:
-                    arg_names = inspect.signature(func).parameters
-                    if name in arg_names:
-                        arg_val = dict(zip(arg_names, args))[name]
+                    if name in args_name_to_val:
+                        arg_val = args_name_to_val[name]
                     elif name in kwargs:
                         arg_val = kwargs.get(name)
                     else:

--- a/tests/nv_ingest/stages/nims/test_chart_extraction.py
+++ b/tests/nv_ingest/stages/nims/test_chart_extraction.py
@@ -211,7 +211,7 @@ def test_extract_chart_data_successful(sample_dataframe, mock_clients_and_reques
     # Expected content from the combined results
     expected_content = "Combined content: cached_result_content + deplot_result_content"
     assert updated_df.loc[0, "metadata"]["table_metadata"]["table_content"] == expected_content
-    assert trace_info_out == trace_info
+    assert trace_info_out == {"trace_info": trace_info}
 
     # Verify that the mocked methods were called
     assert mock_create_client.call_count == 2  # deplot and cached clients created

--- a/tests/nv_ingest/stages/nims/test_table_extraction.py
+++ b/tests/nv_ingest/stages/nims/test_table_extraction.py
@@ -312,7 +312,7 @@ def test_extract_table_data_successful(sample_dataframe, mock_paddle_client_and_
         "desk fan Cost"
     )
     assert updated_df.loc[0, "metadata"]["table_metadata"]["table_content"] == expected_content
-    assert trace_info_out == trace_info
+    assert trace_info_out == {"trace_info": trace_info}
 
     # Verify that the mocked methods were called
     mock_create_client.assert_called_once()


### PR DESCRIPTION
## Description
Tracing mechanism from #109 was lost during a recent refactor. This PR retores the finer-grained traces at the NIM level (`yolox_0`, ..., `paddle_0`, ..., `deplot_0`, ... below).

![image](https://github.com/user-attachments/assets/9c3436e7-62fb-48c8-92db-8d07b50997b3)

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
