### PR TITLE
Add caching for conda packages to Dockerfile to speed up successive builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,7 @@ RUN --mount=type=cache,target=/opt/conda/pkgs \
     && ./ci/scripts/build_pip_packages.sh --type ${RELEASE_TYPE} --lib service
 
 RUN --mount=type=cache,target=/opt/conda/pkgs\
+    --mount=type=cache,target=/root/.cache/pip \
     source activate nv_ingest_runtime \
     && pip install ./dist/*.whl \
     && pip install ./client/dist/*.whl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-LicenseCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # syntax=docker/dockerfile:1.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-LicenseCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 # syntax=docker/dockerfile:1.3
@@ -30,12 +30,13 @@ RUN wget -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/lat
 ENV PATH=/opt/conda/bin:$PATH
 
 # Install Mamba, a faster alternative to conda, within the base environment
-RUN conda install -y mamba -n base -c conda-forge
+RUN --mount=type=cache,target=/opt/conda/pkgs \
+    conda install -y mamba conda-build==24.5.1 -n base -c conda-forge
 
 COPY conda/environments/nv_ingest_environment.yml /workspace/nv_ingest_environment.yml
 # Create nv_ingest base environment
-RUN mamba env create -f /workspace/nv_ingest_environment.yml \
-    && conda clean --all --yes
+RUN --mount=type=cache,target=/opt/conda/pkgs \
+    mamba env create -f /workspace/nv_ingest_environment.yml
 
 # Set default shell to bash
 SHELL ["/bin/bash", "-c"]
@@ -44,9 +45,9 @@ SHELL ["/bin/bash", "-c"]
 RUN echo "source activate nv_ingest_runtime" >> ~/.bashrc
 
 # Install Tini via conda from the conda-forge channel
-RUN source activate nv_ingest_runtime \
-    && mamba install -y -c conda-forge tini \
-    && conda clean --all --yes
+RUN --mount=type=cache,target=/opt/conda/pkgs \
+    source activate nv_ingest_runtime \
+    && mamba install -y -c conda-forge tini
 
 # Set the working directory in the container
 WORKDIR /workspace
@@ -64,15 +65,15 @@ ENV HAYSTACK_TELEMETRY_ENABLED=False
 
 # Ensure the NV_INGEST_VERSION is PEP 440 compatible
 RUN if [ -z "${VERSION}" ]; then \
-    export VERSION="$(date +'%Y.%m.%d')"; \
+        export VERSION="$(date +'%Y.%m.%d')"; \
     fi; \
     if [ "${RELEASE_TYPE}" = "dev" ]; then \
-    export NV_INGEST_VERSION_OVERRIDE="${VERSION}.dev${VERSION_REV}"; \
+        export NV_INGEST_VERSION_OVERRIDE="${VERSION}.dev${VERSION_REV}"; \
     elif [ "${RELEASE_TYPE}" = "release" ]; then \
-    export NV_INGEST_VERSION_OVERRIDE="${VERSION}.post${VERSION_REV}"; \
+        export NV_INGEST_VERSION_OVERRIDE="${VERSION}.post${VERSION_REV}"; \
     else \
-    echo "Invalid RELEASE_TYPE: ${RELEASE_TYPE}"; \
-    exit 1; \
+        echo "Invalid RELEASE_TYPE: ${RELEASE_TYPE}"; \
+        exit 1; \
     fi
 
 ENV NV_INGEST_RELEASE_TYPE=${RELEASE_TYPE}
@@ -87,12 +88,14 @@ COPY client client
 COPY src/nv_ingest src/nv_ingest
 RUN rm -rf ./src/nv_ingest/dist ./client/dist
 
-# Run the build_pip_packages.sh script with the specified build type and library
-RUN chmod +x ./ci/scripts/build_pip_packages.sh \
+# Add pip cache path to match conda's package cache
+RUN --mount=type=cache,target=/opt/conda/pkgs \
+    chmod +x ./ci/scripts/build_pip_packages.sh \
     && ./ci/scripts/build_pip_packages.sh --type ${RELEASE_TYPE} --lib client \
     && ./ci/scripts/build_pip_packages.sh --type ${RELEASE_TYPE} --lib service
 
-RUN source activate nv_ingest_runtime \
+RUN --mount=type=cache,target=/opt/conda/pkgs\
+    source activate nv_ingest_runtime \
     && pip install ./dist/*.whl \
     && pip install ./client/dist/*.whl
 
@@ -110,7 +113,8 @@ ENTRYPOINT ["/opt/conda/envs/nv_ingest_runtime/bin/tini", "--", "/workspace/dock
 
 FROM nv_ingest_install AS development
 
-RUN source activate nv_ingest && \
+RUN source activate nv_ingest_runtime && \
+    --mount=type=cache,target=/opt/conda/pkgs \
     pip install -e ./client
 
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,13 @@ ENV PATH=/opt/conda/bin:$PATH
 
 # Install Mamba, a faster alternative to conda, within the base environment
 RUN --mount=type=cache,target=/opt/conda/pkgs \
+    --mount=type=cache,target=/root/.cache/pip \
     conda install -y mamba conda-build==24.5.1 -n base -c conda-forge
 
 COPY conda/environments/nv_ingest_environment.yml /workspace/nv_ingest_environment.yml
 # Create nv_ingest base environment
 RUN --mount=type=cache,target=/opt/conda/pkgs \
+    --mount=type=cache,target=/root/.cache/pip \
     mamba env create -f /workspace/nv_ingest_environment.yml
 
 # Set default shell to bash
@@ -46,6 +48,7 @@ RUN echo "source activate nv_ingest_runtime" >> ~/.bashrc
 
 # Install Tini via conda from the conda-forge channel
 RUN --mount=type=cache,target=/opt/conda/pkgs \
+    --mount=type=cache,target=/root/.cache/pip \
     source activate nv_ingest_runtime \
     && mamba install -y -c conda-forge tini
 
@@ -90,6 +93,7 @@ RUN rm -rf ./src/nv_ingest/dist ./client/dist
 
 # Add pip cache path to match conda's package cache
 RUN --mount=type=cache,target=/opt/conda/pkgs \
+    --mount=type=cache,target=/root/.cache/pip \
     chmod +x ./ci/scripts/build_pip_packages.sh \
     && ./ci/scripts/build_pip_packages.sh --type ${RELEASE_TYPE} --lib client \
     && ./ci/scripts/build_pip_packages.sh --type ${RELEASE_TYPE} --lib service
@@ -115,6 +119,7 @@ FROM nv_ingest_install AS development
 
 RUN source activate nv_ingest_runtime && \
     --mount=type=cache,target=/opt/conda/pkgs \
+    --mount=type=cache,target=/root/.cache/pip \
     pip install -e ./client
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Add caching for conda packages to Dockerfile to speed up successive builds.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
