### PR TITLE
Add missing receivers configuration for http protocol

### DIFF
--- a/config/otel-collector-config.yaml
+++ b/config/otel-collector-config.yaml
@@ -7,6 +7,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
 
 exporters:
   # NOTE: Prior to v0.86.0 use `logging` instead of `debug`.


### PR DESCRIPTION
## Description
Add the `http.endpoint` entry in the `receivers` section of the `config/otel-collector-config.yaml` configuration file. The `http` entry is needed by the `yolox` service. This PR closes #297 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
