### PR TITLE
Adjust spec.ports[1].name to nv-ingest-http from http

### DIFF
--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -19,7 +19,7 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
-      name: http
+      name: nv-ingest-http
     {{- end }}
     {{- if .Values.service.nodePort }}
       {{- with .Values.service.nodePort }}


### PR DESCRIPTION
## Description
Adjust helm spec.ports[1].name from `http` -> `nv-ingest-http` which was conflicting with other NIM services and causing deployment issues.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
