### PR TITLE
Remove Legacy Version Variables and Code Cleanup

### DIFF
--- a/src/nv_ingest/extraction_workflows/pdf/pdfium_helper.py
+++ b/src/nv_ingest/extraction_workflows/pdf/pdfium_helper.py
@@ -34,7 +34,6 @@ from nv_ingest.schemas.pdf_extractor_schema import PDFiumConfigSchema
 from nv_ingest.util.image_processing.transforms import crop_image
 from nv_ingest.util.image_processing.transforms import numpy_to_base64
 from nv_ingest.util.nim.helpers import create_inference_client
-from nv_ingest.util.nim.helpers import get_version
 from nv_ingest.util.pdf.metadata_aggregators import Base64Image
 from nv_ingest.util.pdf.metadata_aggregators import CroppedImageWithContent
 from nv_ingest.util.pdf.metadata_aggregators import construct_image_metadata_from_pdf_image
@@ -64,22 +63,8 @@ def extract_tables_and_charts_using_image_ensemble(
 ) -> List[Tuple[int, object]]:  # List[Tuple[int, CroppedImageWithContent]]
     tables_and_charts = []
 
-    # Obtain yolox_version
-    # Assuming that the grpc endpoint is at index 0
-    yolox_http_endpoint = config.yolox_endpoints[1]
     try:
-        yolox_version = get_version(yolox_http_endpoint)
-        if not yolox_version:
-            logger.warning(
-                "Failed to obtain yolox-page-elements version from the endpoint. Falling back to the latest version."
-            )
-            yolox_version = None  # Default to the latest version
-    except Exception:
-        logger.waring("Failed to get yolox-page-elements version after 30 seconds. Falling back to the latest version.")
-        yolox_version = None  # Default to the latest version
-
-    try:
-        model_interface = yolox_utils.YoloxPageElementsModelInterface(yolox_version=yolox_version)
+        model_interface = yolox_utils.YoloxPageElementsModelInterface()
         yolox_client = create_inference_client(
             config.yolox_endpoints, model_interface, config.auth_token, config.yolox_infer_protocol
         )

--- a/src/nv_ingest/stages/nim/table_extraction.py
+++ b/src/nv_ingest/stages/nim/table_extraction.py
@@ -19,7 +19,6 @@ from nv_ingest.util.image_processing.transforms import base64_to_numpy
 from nv_ingest.util.image_processing.transforms import check_numpy_image_size
 from nv_ingest.util.nim.helpers import create_inference_client
 from nv_ingest.util.nim.helpers import NimClient
-from nv_ingest.util.nim.helpers import get_version
 from nv_ingest.util.nim.paddle import PaddleOCRModelInterface
 
 logger = logging.getLogger(f"morpheus.{__name__}")
@@ -139,20 +138,8 @@ def _extract_table_data(
 
     stage_config = validated_config.stage_config
 
-    # Obtain paddle_version
-    # Assuming that the grpc endpoint is at index 0
-    paddle_endpoint = stage_config.paddle_endpoints[1]
-    try:
-        paddle_version = get_version(paddle_endpoint)
-        if not paddle_version:
-            logger.warning("Failed to obtain PaddleOCR version from the endpoint. Falling back to the latest version.")
-            paddle_version = None  # Default to the latest version
-    except Exception:
-        logger.warning("Failed to get PaddleOCR version after 30 seconds. Falling back to the latest verrsion.")
-        paddle_version = None  # Default to the latest version
-
-    # Create the PaddleOCRModelInterface with paddle_version
-    paddle_model_interface = PaddleOCRModelInterface(paddle_version=paddle_version)
+    # Create the PaddleOCRModelInterface
+    paddle_model_interface = PaddleOCRModelInterface()
 
     # Create the NimClient for PaddleOCR
     paddle_client = create_inference_client(

--- a/src/nv_ingest/util/nim/helpers.py
+++ b/src/nv_ingest/util/nim/helpers.py
@@ -14,7 +14,6 @@ import cv2
 import numpy as np
 import requests
 import tritonclient.grpc as grpcclient
-from packaging import version as pkgversion
 
 from nv_ingest.util.image_processing.transforms import normalize_image
 from nv_ingest.util.image_processing.transforms import pad_image
@@ -362,7 +361,7 @@ def create_inference_client(
     return NimClient(model_interface, infer_protocol, endpoints, auth_token)
 
 
-def preprocess_image_for_paddle(array: np.ndarray, paddle_version: Optional[str] = None) -> np.ndarray:
+def preprocess_image_for_paddle(array: np.ndarray) -> np.ndarray:
     """
     Preprocesses an input image to be suitable for use with PaddleOCR by resizing, normalizing, padding,
     and transposing it into the required format.
@@ -395,9 +394,6 @@ def preprocess_image_for_paddle(array: np.ndarray, paddle_version: Optional[str]
       a requirement for PaddleOCR.
     - The normalized pixel values are scaled between 0 and 1 before padding and transposing the image.
     """
-    if (not paddle_version) or (pkgversion.parse(paddle_version) < pkgversion.parse("0.2.0-rc1")):
-        return array
-
     height, width = array.shape[:2]
     scale_factor = 960 / max(height, width)
     new_height = int(height * scale_factor)

--- a/tests/nv_ingest/stages/nims/test_table_extraction.py
+++ b/tests/nv_ingest/stages/nims/test_table_extraction.py
@@ -24,8 +24,8 @@ MODULE_UNDER_TEST = "nv_ingest.stages.nim.table_extraction"
 
 # Mocked PaddleOCRModelInterface
 class MockPaddleOCRModelInterface:
-    def __init__(self, paddle_version=None):
-        self.paddle_version = paddle_version
+    def __init__(self):
+        pass
 
     def prepare_data_for_inference(self, data):
         return data
@@ -147,9 +147,7 @@ def test_extract_table_data_image_too_small(base64_encoded_small_image):
     mock_nim_client.infer.side_effect = mock_infer
 
     # Patch 'create_inference_client' to return the mocked NimClient
-    with patch(f"{MODULE_UNDER_TEST}.create_inference_client", return_value=mock_nim_client), patch(
-        f"{MODULE_UNDER_TEST}.get_version", return_value="0.1.0"
-    ):
+    with patch(f"{MODULE_UNDER_TEST}.create_inference_client", return_value=mock_nim_client):
         # Since the image is too small, we expect the table_content to remain unchanged
         updated_df, _ = _extract_table_data(df, {}, validated_config, trace_info)
 
@@ -298,8 +296,7 @@ def test_extract_table_data_successful(sample_dataframe, mock_paddle_client_and_
 
     trace_info = {}
 
-    with patch(f"{MODULE_UNDER_TEST}.get_version", return_value="0.3.3"):
-        updated_df, trace_info_out = _extract_table_data(sample_dataframe, {}, validated_config, trace_info)
+    updated_df, trace_info_out = _extract_table_data(sample_dataframe, {}, validated_config, trace_info)
 
     # Expected content from the mocked response
     expected_content = (
@@ -326,9 +323,8 @@ def test_extract_table_data_missing_metadata(dataframe_missing_metadata, mock_pa
 
     trace_info = {}
 
-    with patch(f"{MODULE_UNDER_TEST}.get_version", return_value="0.2.1"):
-        with pytest.raises(ValueError, match="Row does not contain 'metadata'."):
-            _extract_table_data(dataframe_missing_metadata, {}, validated_config, trace_info)
+    with pytest.raises(ValueError, match="Row does not contain 'metadata'."):
+        _extract_table_data(dataframe_missing_metadata, {}, validated_config, trace_info)
 
     # Verify that the mocked methods were called
     mock_create_client.assert_called_once()
@@ -344,9 +340,8 @@ def test_extract_table_data_inference_failure(sample_dataframe, mock_paddle_clie
 
     trace_info = {}
 
-    with patch(f"{MODULE_UNDER_TEST}.get_version", return_value="0.1.0"):
-        with pytest.raises(Exception, match="Inference error"):
-            _extract_table_data(sample_dataframe, {}, validated_config, trace_info)
+    with pytest.raises(Exception, match="Inference error"):
+        _extract_table_data(sample_dataframe, {}, validated_config, trace_info)
 
 
 def test_extract_table_data_image_too_small_2(base64_encoded_small_image):
@@ -396,8 +391,8 @@ def test_extract_table_data_image_too_small_2(base64_encoded_small_image):
     }
 
     with patch(f"{MODULE_UNDER_TEST}.create_inference_client", side_effect=mock_create_inference_client), patch(
-        f"{MODULE_UNDER_TEST}.get_version", return_value="0.1.0"
-    ), patch("requests.post", return_value=mock_response):
+        "requests.post", return_value=mock_response
+    ):
         updated_df, _ = _extract_table_data(df, {}, validated_config, trace_info)
 
     # The table_content should remain unchanged because the image is too small


### PR DESCRIPTION
## Description
This PR removes the `paddle_version` and `yolox_version` variables from the codebase, along with any associated code that handled legacy model versions. These variables and the related logic are unnecessary and prone to errors. Since we are currently in the EA phase, we have the flexibility to break backward compatibility. We are able to make this change because in `main` both the container versions in docker-compose.yaml and the Preview endpoints have been updated to the latest versions.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
