### PR TITLE
Use build api key as backup in embedding extraction

### DIFF
--- a/src/nv_ingest/util/pipeline/stage_builders.py
+++ b/src/nv_ingest/util/pipeline/stage_builders.py
@@ -384,7 +384,13 @@ def add_image_caption_stage(pipe, morpheus_pipeline_config, ingest_config, defau
 
 
 def add_embed_extractions_stage(pipe, morpheus_pipeline_config, ingest_config):
-    api_key = os.getenv("NGC_API_KEY", "ngc_api_key")
+    api_key = os.environ.get(
+        "NVIDIA_BUILD_API_KEY",
+        "",
+    ) or os.environ.get(
+        "NGC_API_KEY",
+        "",
+    )
     embedding_nim_endpoint = os.getenv("EMBEDDING_NIM_ENDPOINT", "http://embedding:8000/v1")
     embedding_model = os.getenv("EMBEDDING_NIM_MODEL_NAME", "nvidia/nv-embedqa-e5-v5")
 


### PR DESCRIPTION
## Description
This PR proposes to use the build api key when we use the build api endpoints in embedding extraction, similarly to image NIMs.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
