### PR TITLE
Github Action to build and publish nightly nv-ingest Conda packages

### DIFF
--- a/.github/workflows/conda-nightly-publish.yml
+++ b/.github/workflows/conda-nightly-publish.yml
@@ -12,7 +12,8 @@ on:
 jobs:
   build:
     runs-on: linux-large-disk
-
+    container:
+      image: rapidsai/ci-conda:cuda12.5.1-ubuntu22.04-py3.10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -23,5 +24,5 @@ jobs:
           ./conda/build_conda_packages.sh
 
       # Publish nv-ingest conda packages
-      - name: Publish nv-ingest package
-        run: anaconda -t "$NVIDIA_CONDA_TOKEN" upload --label dev ./conda/output_conda_channel/linux-64/*.conda
+      - name: Publish conda package
+        run: anaconda -t "${{ secrets.NVIDIA_CONDA_TOKEN }}" upload --label dev ./conda/output_conda_channel/linux-64/*.conda

--- a/.github/workflows/conda-nightly-publish.yml
+++ b/.github/workflows/conda-nightly-publish.yml
@@ -1,0 +1,27 @@
+name: Nv-Ingest Nightly Conda Package Publish
+
+# Trigger for pull requests and pushing to main
+on:
+  schedule:
+    # Runs every day at 11:30PM (UTC)
+    - cron: "30 23 * * *"
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: linux-large-disk
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Build the Conda packages
+      - name: Build Conda Packages
+        run: |
+          ./conda/build_conda_packages.sh
+
+      # Publish nv-ingest conda packages
+      - name: Publish nv-ingest package
+        run: anaconda -t "$NVIDIA_CONDA_TOKEN" upload --label dev ./conda/output_conda_channel/linux-64/*.conda

--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,6 @@ processed_docs
 
 # Ignore devcontainer volumes
 .volumes
+
+# Ignore conda build output
+conda/output_conda_channel

--- a/conda/build_conda_packages.sh
+++ b/conda/build_conda_packages.sh
@@ -47,7 +47,7 @@ if [[ "${BUILD_NV_INGEST}" -eq 1 ]]; then
     echo "Building nv_ingest..."
     GIT_ROOT="${GIT_ROOT}" conda build "${NV_INGEST_DIR}" \
         -c nvidia/label/dev -c rapidsai -c nvidia -c conda-forge -c pytorch \
-        --pkg-format=conda --output-folder "${OUTPUT_DIR}" --no-anaconda-upload
+        --output-folder "${OUTPUT_DIR}" --no-anaconda-upload
 else
     echo "Skipping nv_ingest build."
 fi
@@ -56,7 +56,7 @@ if [[ "${BUILD_NV_INGEST_CLIENT}" -eq 1 ]]; then
     echo "Building nv_ingest_client..."
     GIT_ROOT="${GIT_ROOT}/client" conda build "${NV_INGEST_CLIENT_DIR}" \
         -c conda-forge \
-        --pkg-format=conda --output-folder "${OUTPUT_DIR}" --no-anaconda-upload
+        --output-folder "${OUTPUT_DIR}" --no-anaconda-upload
 else
     echo "Skipping nv_ingest_client build."
 fi

--- a/conda/build_conda_packages.sh
+++ b/conda/build_conda_packages.sh
@@ -45,18 +45,18 @@ mkdir -p "${OUTPUT_DIR}/linux-64"
 ##############################
 if [[ "${BUILD_NV_INGEST}" -eq 1 ]]; then
     echo "Building nv_ingest..."
-    GIT_ROOT="${GIT_ROOT}" conda build "${NV_INGEST_DIR}" \
+    GIT_ROOT="${GIT_ROOT}" conda-build "${NV_INGEST_DIR}" \
         -c nvidia/label/dev -c rapidsai -c nvidia -c conda-forge -c pytorch \
-        --output-folder "${OUTPUT_DIR}"
+        --package-format=conda --output-folder "${OUTPUT_DIR}" --no-anaconda-upload
 else
     echo "Skipping nv_ingest build."
 fi
 
 if [[ "${BUILD_NV_INGEST_CLIENT}" -eq 1 ]]; then
     echo "Building nv_ingest_client..."
-    GIT_ROOT="${GIT_ROOT}/client" conda build "${NV_INGEST_CLIENT_DIR}" \
+    GIT_ROOT="${GIT_ROOT}/client" conda-build "${NV_INGEST_CLIENT_DIR}" \
         -c conda-forge \
-        --output-folder "${OUTPUT_DIR}"
+        --package-format=conda --output-folder "${OUTPUT_DIR}" --no-anaconda-upload
 else
     echo "Skipping nv_ingest_client build."
 fi

--- a/conda/build_conda_packages.sh
+++ b/conda/build_conda_packages.sh
@@ -45,18 +45,18 @@ mkdir -p "${OUTPUT_DIR}/linux-64"
 ##############################
 if [[ "${BUILD_NV_INGEST}" -eq 1 ]]; then
     echo "Building nv_ingest..."
-    GIT_ROOT="${GIT_ROOT}" conda-build "${NV_INGEST_DIR}" \
+    GIT_ROOT="${GIT_ROOT}" conda build "${NV_INGEST_DIR}" \
         -c nvidia/label/dev -c rapidsai -c nvidia -c conda-forge -c pytorch \
-        --package-format=conda --output-folder "${OUTPUT_DIR}" --no-anaconda-upload
+        --pkg-format=conda --output-folder "${OUTPUT_DIR}" --no-anaconda-upload
 else
     echo "Skipping nv_ingest build."
 fi
 
 if [[ "${BUILD_NV_INGEST_CLIENT}" -eq 1 ]]; then
     echo "Building nv_ingest_client..."
-    GIT_ROOT="${GIT_ROOT}/client" conda-build "${NV_INGEST_CLIENT_DIR}" \
+    GIT_ROOT="${GIT_ROOT}/client" conda build "${NV_INGEST_CLIENT_DIR}" \
         -c conda-forge \
-        --package-format=conda --output-folder "${OUTPUT_DIR}" --no-anaconda-upload
+        --pkg-format=conda --output-folder "${OUTPUT_DIR}" --no-anaconda-upload
 else
     echo "Skipping nv_ingest_client build."
 fi


### PR DESCRIPTION
## Description
Introduces a new Github action that builds the `nv-ingest` and `nv-ingest-client` anaconda packages and publishes them to the Nvidia Anaconda repo as nightly packages.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
