### PR TITLE
Add docker compose override file for RTX deployments

### DIFF
--- a/docker-compose.rtx.yaml
+++ b/docker-compose.rtx.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+services:
+
+  yolox:
+    image: ${YOLOX_IMAGE:-nvcr.io/ohlfw0olaadg/ea-participants/nv-yolox-page-elements-v1}:${YOLOX_TAG:-1.0.0}
+
+  paddle:
+    image: ${PADDLE_IMAGE:-nvcr.io/ohlfw0olaadg/ea-participants/paddleocr}:${PADDLE_TAG:-1.0.0}
+
+  embedding:
+    image: ${EMBEDDING_IMAGE:-nvcr.io/nim/nvidia/nv-embedqa-e5-v5}:${EMBEDDING_TAG:-1.1.0}


### PR DESCRIPTION
## Description
Provides a Docker compose override file for RTX deployments. This allows for specific NIM versions to be deployed that are optimized to save VRAM usage on RTX cards.

This allows nv-ingest to be deployed like so ...

`docker compose -f docker-compose.yaml -f docker-compose.rtx.yaml up`

* Note as of writing the actual NIM URLs have not been determined and this is serving more as a placeholder for when those URLs are ready.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
