### PR TITLE
Build nv-ingest docs with CI

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -29,4 +29,4 @@ jobs:
       # Builds docs site
       - name: Build docs site
         run: |
-          mkdocs build
+          mkdocs build --config-file docs/mkdocs.yml

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,32 @@
+name: Build NV-Ingest Documentation
+
+# Trigger for pull requests and pushing to main
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: linux-large-disk
+    container:
+      image: python:3.11-slim
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Install dependencies from docs/requirements.txt
+      - name: Install mkdocs dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r docs/requirements.txt
+
+      # Builds docs site
+      - name: Build docs site
+        run: |
+          mkdocs build

--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,6 @@ processed_docs
 
 # Ignore conda build output
 conda/output_conda_channel
+
+# Ignore generate docs site
+docs/site


### PR DESCRIPTION
## Description
Builds the nv-ingest documentation site on each merge to main and nightly. This PR currently does not physically push the site anywhere as we have yet to determine that location. A future PR will handle the actual publishing of the site.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
