### PR TITLE
Adjust build.sh script to export DATE_STRING

### DIFF
--- a/conda/packages/nv_ingest/build.sh
+++ b/conda/packages/nv_ingest/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+DATE_STRING="$(date +%y%m%d)"
+export DATE_STRING

--- a/conda/packages/nv_ingest/meta.yaml
+++ b/conda/packages/nv_ingest/meta.yaml
@@ -6,7 +6,7 @@
 {% set name = data.get('name', 'nv_ingest') | lower %}
 {% set version = data.get('version') %}
 {% set py_version = environ['CONDA_PY'] %}
-{% set date_string = "$(date +%y%m%d)" %}
+{% set date_string = environ['DATE_STRING'] %}
 
 # Determine Git root, falling back to default path ../../.. if Git is not available or the directory is not a Git repo
 {% set git_root = environ.get('GIT_ROOT', '../../..') %}

--- a/conda/packages/nv_ingest_client/build.sh
+++ b/conda/packages/nv_ingest_client/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+DATE_STRING="$(date +%y%m%d)"
+export DATE_STRING

--- a/conda/packages/nv_ingest_client/meta.yaml
+++ b/conda/packages/nv_ingest_client/meta.yaml
@@ -6,7 +6,7 @@
 {% set name = data.get('name', 'nv_ingest_client') | lower %}
 {% set version = data.get('version') %}
 {% set py_version = environ['CONDA_PY'] %}
-{% set date_string = "$(date +%y%m%d)" %}
+{% set date_string = environ['DATE_STRING'] %}
 
 # Determine Git root, falling back to default path ../../.. if Git is not available or the directory is not a Git repo
 {% set git_root = environ.get('GIT_ROOT', '../../../client') %}


### PR DESCRIPTION
## Description
Add build.sh scripts and have them export the date_string environment variable for the conda meta.yaml to use.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
