### PR TITLE
Update conda build script to include date

### DIFF
--- a/conda/build_conda_packages.sh
+++ b/conda/build_conda_packages.sh
@@ -40,12 +40,14 @@ NV_INGEST_CLIENT_DIR="${BUILD_SCRIPT_BASE}/packages/nv_ingest_client"
 echo "Using OUTPUT_DIR: $OUTPUT_DIR"
 mkdir -p "${OUTPUT_DIR}/linux-64"
 
+DATE_STRING="$(date +%y%m%d)"
+
 ##############################
 # Build Packages
 ##############################
 if [[ "${BUILD_NV_INGEST}" -eq 1 ]]; then
     echo "Building nv_ingest..."
-    GIT_ROOT="${GIT_ROOT}" conda build "${NV_INGEST_DIR}" \
+    GIT_ROOT="${GIT_ROOT}" DATE_STRING="${DATE_STRING}" conda build "${NV_INGEST_DIR}" \
         -c nvidia/label/dev -c rapidsai -c nvidia -c conda-forge -c pytorch \
         --output-folder "${OUTPUT_DIR}" --no-anaconda-upload
 else
@@ -54,7 +56,7 @@ fi
 
 if [[ "${BUILD_NV_INGEST_CLIENT}" -eq 1 ]]; then
     echo "Building nv_ingest_client..."
-    GIT_ROOT="${GIT_ROOT}/client" conda build "${NV_INGEST_CLIENT_DIR}" \
+    GIT_ROOT="${GIT_ROOT}/client" DATE_STRING="${DATE_STRING}" conda build "${NV_INGEST_CLIENT_DIR}" \
         -c conda-forge \
         --output-folder "${OUTPUT_DIR}" --no-anaconda-upload
 else


### PR DESCRIPTION
## Description
Update the conda build script to pass along the DATE_STRING for the conda meta packaging to use.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
