### PR TITLE
adds 2.5.3 bm25 support while keeping previous support for milvus lite

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -296,7 +296,7 @@ services:
     # Turn on to leverage the `vdb_upload` task
     restart: always
     container_name: milvus-standalone
-    image: milvusdb/milvus:v2.4.17-gpu
+    image: milvusdb/milvus:v2.5.3-gpu
     command: [ "milvus", "run", "standalone" ]
     hostname: milvus
     security_opt:


### PR DESCRIPTION
## Description
updates the milvus container and adds support for continuous update on bm25 while adding new data points when using container. Still allows Embedding functionality previously available when using milvus-lite.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
