### PR TITLE
Filter out whitespace-only strings before embedding

### DIFF
--- a/src/nv_ingest/modules/transforms/embed_extractions.py
+++ b/src/nv_ingest/modules/transforms/embed_extractions.py
@@ -474,7 +474,9 @@ def _generate_embeddings(
                 continue
 
             cudf_content_getter = cudf_content_extractor[content_type]
-            content_mask = (content_mask & (cudf_content_getter(mdf["metadata"]) != "")).fillna(False)
+            # Embedding NIMs will complain if text has only whitespaces.
+            content_text_mask = cudf_content_getter(mdf["metadata"]).str.strip() != ""
+            content_mask = (content_mask & content_text_mask).fillna(False)
             if not content_mask.any():
                 continue
 


### PR DESCRIPTION
## Description
Embedding NIM services return errors if the input text is empty or all whitespace. This PR updates the content filtering logic to ensure strings with only whitespace are excluded from the embedding process.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
