### PR TITLE
introduce nv-ingest-api package

### DIFF
--- a/api/LICENSE
+++ b/api/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,10 @@
+# nv-ingest-api
+
+Provides a common set of
+
+- Pythonic Objects
+- Common Functions
+- Utilities
+- Core Logic
+
+Implemented in pure Python that can be imported and used directly or used as part of future frameworks and runtimes.

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools", "wheel"]  # Tools needed to build the project
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "nv-ingest-api"
+version = "24.12.dev0"
+description = "Python module with core document ingestion functions."
+readme = "README.md"
+authors = [
+    {name = "Jeremy Dyer", email = "jdyer@nvidia.com"}
+]
+license = {file = "LICENSE"}
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "pandas>=2.0",
+    "pydantic>2.0.0",
+    "pydantic-settings>2.0.0",
+]
+
+[project.urls]
+homepage = "https://github.com/NVIDIA/nv-ingest"
+repository = "https://github.com/NVIDIA/nv-ingest"
+documentation = "https://docs.nvidia.com/nv-ingest"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/conda/build_conda_packages.sh
+++ b/conda/build_conda_packages.sh
@@ -26,12 +26,14 @@ GIT_ROOT=$(determine_git_root)
 OUTPUT_DIR=${1:-"${BUILD_SCRIPT_BASE}/output_conda_channel"}
 CONDA_CHANNEL=${2:-""}
 BUILD_NV_INGEST=${BUILD_NV_INGEST:-1} # 1 = build by default, 0 = skip
+BUILD_NV_INGEST_API=${BUILD_NV_INGEST_API:-1} # 1 = build by default, 0 = skip
 BUILD_NV_INGEST_CLIENT=${BUILD_NV_INGEST_CLIENT:-1} # 1 = build by default, 0 = skip
 
 ##############################
 # Package Directories
 ##############################
 NV_INGEST_DIR="${BUILD_SCRIPT_BASE}/packages/nv_ingest"
+NV_INGEST_API_DIR="${BUILD_SCRIPT_BASE}/packages/nv_ingest_api"
 NV_INGEST_CLIENT_DIR="${BUILD_SCRIPT_BASE}/packages/nv_ingest_client"
 
 ##############################
@@ -45,6 +47,15 @@ GIT_SHA=$(git rev-parse --short HEAD)
 ##############################
 # Build Packages
 ##############################
+if [[ "${BUILD_NV_INGEST_API}" -eq 1 ]]; then
+    echo "Building nv_ingest_api..."
+    GIT_ROOT="${GIT_ROOT}" GIT_SHA="${GIT_SHA}" conda build "${NV_INGEST_API_DIR}" \
+        -c nvidia/label/dev -c rapidsai -c nvidia -c conda-forge -c pytorch \
+        --output-folder "${OUTPUT_DIR}" --no-anaconda-upload
+else
+    echo "Skipping nv_ingest_api build."
+fi
+
 if [[ "${BUILD_NV_INGEST}" -eq 1 ]]; then
     echo "Building nv_ingest..."
     GIT_ROOT="${GIT_ROOT}" GIT_SHA="${GIT_SHA}" conda build "${NV_INGEST_DIR}" \

--- a/conda/environments/nv_ingest_api_environment.yml
+++ b/conda/environments/nv_ingest_api_environment.yml
@@ -1,0 +1,17 @@
+name: nv_ingest_api
+channels:
+  - nvidia/label/dev
+  - rapidsai
+  - nvidia
+  - conda-forge
+  - pytorch
+dependencies:
+  - pydantic>2.0.0
+  - pydantic-settings>2.0.0
+  - pytest>=8.0.2
+  - pytest-mock>=3.14.0
+  - pytest-cov>=6.0.0
+  - python>=3.10
+  - python-build>=1.2.2
+  - setuptools>=58.2.0
+  - pip

--- a/conda/packages/nv_ingest_api/meta.yaml
+++ b/conda/packages/nv_ingest_api/meta.yaml
@@ -8,14 +8,14 @@
 {% set GIT_SHA = environ['GIT_SHA'] %}
 
 # Determine Git root, falling back to default path ../../.. if Git is not available or the directory is not a Git repo
-{% set git_root = environ.get('GIT_ROOT', '../../..') %}
+{% set git_root = environ.get('GIT_ROOT', '../../../api') %}
 
 package:
   name: nv_ingest_api
   version: {{ version }}
 
 source:
-  path: {{ git_root }}/api
+  path: {{ git_root }}
 
 build:
   number: 0

--- a/conda/packages/nv_ingest_api/meta.yaml
+++ b/conda/packages/nv_ingest_api/meta.yaml
@@ -3,26 +3,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {% set data = load_setup_py_data() %}
-{% set name = data.get('name', 'nv_ingest_client') | lower %}
 {% set version = data.get('version') %}
 {% set py_version = environ['CONDA_PY'] %}
 {% set GIT_SHA = environ['GIT_SHA'] %}
 
 # Determine Git root, falling back to default path ../../.. if Git is not available or the directory is not a Git repo
-{% set git_root = environ.get('GIT_ROOT', '../../../client') %}
+{% set git_root = environ.get('GIT_ROOT', '../../..') %}
 
 package:
-  name: {{ name }}
+  name: nv_ingest_api
   version: {{ version }}
 
 source:
-  path: {{ git_root }}/client
+  path: {{ git_root }}/api
 
 build:
   number: 0
   string: py{{ py_version }}_{{ GIT_SHA }}
   script:
-    - {{ PYTHON }} -m pip install ./ --no-deps -vv
+    - {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   build:
@@ -30,17 +29,31 @@ requirements:
     - python==3.10
     - setuptools>=58.2.0
   run:
-    - click>=8.1.7
+    - azure-core>=1.32.0
+    - fastparquet>=2024.11.0
     - fsspec>=2024.10.0
     - httpx>=0.28.1
+    - isodate>=0.7.2
+    - langdetect>=1.0.9
+    - openai>=1.57.1
     - pydantic>=2.0.0
     - pypdfium2>=4.30.0
+    - pytest>=8.0.2
+    - pytest-mock>=3.14.0
     - python>=3.10
     - python-docx>=1.1.2
+    - python-dotenv>=1.0.1
+    - python-magic>=0.4.27
     - python-pptx>=1.0.2
+    - pytorch
     - requests>=2.32.3
     - setuptools>=58.2.0
-    - tqdm>=4.67.1
+    - tabulate>=0.9.0
+    - torchaudio
+    - torchvision
+    - transformers>=4.47.0
+    - unstructured-client>=0.25.9
+    - wand>=0.6.10
 
   test:
     commands:
@@ -49,12 +62,16 @@ requirements:
 about:
   home: "https://github.com/NVIDIA/nv-ingest"
   license: "Apache-2.0"
-  summary: "Python module supporting document ingestion."
-  description: "Python module supporting document ingestion."
+  summary: "Python module with core document ingestion functions."
+  description: "Python module with core document ingestion functions."
 
 extra:
   recipe-maintainers:
-    - drobison@nvidia.com
+    - jdyer@nvidia.com
 
 channels:
+  - nvidia/label/dev
+  - rapidsai
+  - nvidia
   - conda-forge
+  - pytorch

--- a/conda/packages/nv_ingest_client/meta.yaml
+++ b/conda/packages/nv_ingest_client/meta.yaml
@@ -16,7 +16,7 @@ package:
   version: {{ version }}
 
 source:
-  path: {{ git_root }}/client
+  path: {{ git_root }}
 
 build:
   number: 0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths =
+    api/tests
+    tests


### PR DESCRIPTION
## Description
Introduce the `nv-ingest-api` package which will serve as the home for purely pythonic code from nv-ingest that is meant to be shared across several modules and runtimes.

This PR simply sets up the directory structure, conda build, and CI for building the package and deploying the nightly.

This package is currently empty on purpose as components will slowly be moved over to it from other locations.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
