### PR TITLE
BugFix: Abort on certain response codes and retry on others

### DIFF
--- a/client/src/nv_ingest_client/message_clients/rest/rest_client.py
+++ b/client/src/nv_ingest_client/message_clients/rest/rest_client.py
@@ -209,7 +209,7 @@ class RestClient(MessageBrokerClientBase):
                 if response_code in _TERMINAL_RESPONSE_STATUSES:
                     # Terminal response code; return error ResponseSchema
                     return ResponseSchema(
-                        response_code=1,
+                        response_code=response_code,
                         response_reason=(
                             f"Terminal response code {response_code} received when fetching JobSpec: {job_id}"
                         ),


### PR DESCRIPTION
## Description
The previous logic grouped all possible HTTP response codes into the same "bucket". This meant that any response received from the server would result in a retry. Some HTTP response codes like 404 & 500 are unlikely to remediate themselves with a retry with the extra same input and conditions and therefore spam the client with nearly unlimited retries. This PR adjust that logic to instead through RuntimeErrors in those conditions and offer a placeholder where other conditions of that manner can later be added as well.

This closes #382 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
