### PR TITLE
Adjust trailing-whitespace hook to ignore the docs/ directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v5.0.0
     hooks:
     -   id: trailing-whitespace
+        exclude: '^(docs)'
     -   id: end-of-file-fixer
     -   id: check-added-large-files
         args: [-- maxkb=1500]


### PR DESCRIPTION
## Description
This PR adjusts the pre-commit hooks to ignore the `docs/` directory for the `trailing-whitespace` hook.

I would recommend uninstalling, cleaning, and reinstall your local pre-commit hooks to validate this works.

```bash
pre-commit uninstall
pre-commit clean
pre-commit install
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
