### PR TITLE
Fix a broken link from the Skaffold readme page to a doc page

### DIFF
--- a/skaffold/README.md
+++ b/skaffold/README.md
@@ -2,6 +2,6 @@
 
 Skaffold is intended to support the nv-ingest development team with kubernetes dev and testing. It is not meant to be used in production deployments or even for local testing.
 
-We offer k8s support via Helm and those instructions can be found at [Helm Documentation](../helm/README.md)
+We offer k8s support via Helm and those instructions can be found at [Helm Documentation](../helm/README.md).
 
-For developers further documentation for using Skaffold can be found at [Skaffold Documentation](../docs/kubernetes-dev.md)
+For developers further documentation for using Skaffold can be found at [Skaffold Documentation](/docs/docs/user-guide/developer-guide/kubernetes-dev.md).


### PR DESCRIPTION
Fix a broken link from the Skaffold readme page to a doc page.

Closes #322 