### PR TITLE
Incremental shift towards dynamic batching

### DIFF
--- a/src/nv_ingest/extraction_workflows/image/image_handlers.py
+++ b/src/nv_ingest/extraction_workflows/image/image_handlers.py
@@ -225,6 +225,7 @@ def extract_tables_and_charts_from_images(
             inference_results = yolox_client.infer(
                 data,
                 model_name="yolox",
+                max_batch_size=YOLOX_MAX_BATCH_SIZE,
                 num_classes=YOLOX_NUM_CLASSES,
                 conf_thresh=YOLOX_CONF_THRESHOLD,
                 iou_thresh=YOLOX_IOU_THRESHOLD,

--- a/src/nv_ingest/extraction_workflows/pdf/pdfium_helper.py
+++ b/src/nv_ingest/extraction_workflows/pdf/pdfium_helper.py
@@ -90,6 +90,7 @@ def extract_tables_and_charts_using_image_ensemble(
             inference_results = yolox_client.infer(
                 data,
                 model_name="yolox",
+                max_batch_size=YOLOX_MAX_BATCH_SIZE,
                 num_classes=YOLOX_NUM_CLASSES,
                 conf_thresh=YOLOX_CONF_THRESHOLD,
                 iou_thresh=YOLOX_IOU_THRESHOLD,

--- a/src/nv_ingest/stages/nim/chart_extraction.py
+++ b/src/nv_ingest/stages/nim/chart_extraction.py
@@ -66,6 +66,7 @@ def _update_metadata(
                         data=data,
                         model_name="cached",
                         stage_name="chart_data_extraction",
+                        max_batch_size=1,
                         trace_info=trace_info,
                     )
                     cached_futures.append(fut)
@@ -77,6 +78,7 @@ def _update_metadata(
                     data=data,
                     model_name="cached",
                     stage_name="chart_data_extraction",
+                    max_batch_size=batch_size,
                     trace_info=trace_info,
                 )
 
@@ -90,6 +92,7 @@ def _update_metadata(
                     data=deplot_data,
                     model_name="deplot",
                     stage_name="chart_data_extraction",
+                    max_batch_size=1,
                     trace_info=trace_info,
                 )
                 deplot_futures.append(fut)

--- a/src/nv_ingest/stages/nim/table_extraction.py
+++ b/src/nv_ingest/stages/nim/table_extraction.py
@@ -76,8 +76,9 @@ def _update_metadata(
                     paddle_client.infer,
                     data=data,
                     model_name="paddle",
-                    trace_info=trace_info,
                     stage_name="table_data_extraction",
+                    max_batch_size=1,
+                    trace_info=trace_info,
                 )
                 future_to_index[future] = i
 
@@ -127,8 +128,9 @@ def _update_metadata(
                     paddle_client.infer,
                     data=data,
                     model_name="paddle",
-                    trace_info=trace_info,
                     stage_name="table_data_extraction",
+                    max_batch_size=batch_size,
+                    trace_info=trace_info,
                 )
 
                 try:

--- a/src/nv_ingest/util/nim/helpers.py
+++ b/src/nv_ingest/util/nim/helpers.py
@@ -148,6 +148,7 @@ class NimClient:
             If an invalid protocol is specified or if required endpoints are missing.
         """
 
+        self.client = None
         self.model_interface = model_interface
         self.protocol = protocol.lower()
         self.auth_token = auth_token
@@ -188,7 +189,8 @@ class NimClient:
                 return 1
 
             try:
-                model_config = self.client.get_model_config(model_name=model_name, model_version=model_version)
+                client = self.client if self.client else grpcclient.InferenceServerClient(url=self._grpc_endpoint)
+                model_config = client.get_model_config(model_name=model_name, model_version=model_version)
                 self._max_batch_sizes[model_name] = model_config.config.max_batch_size
                 logger.info(f"Max batch size for model '{model_name}': {self._max_batch_sizes[model_name]}")
             except Exception as e:

--- a/src/nv_ingest/util/nim/helpers.py
+++ b/src/nv_ingest/util/nim/helpers.py
@@ -100,17 +100,6 @@ class ModelInterface:
         """
         raise NotImplementedError("Subclasses should implement this method")
 
-    def model_name(self):
-        """
-        Get the model name for the interface.
-
-        Returns
-        -------
-        str
-            The name of the model.
-        """
-        raise NotImplementedError("Subclasses should implement this method")
-
 
 class NimClient:
     """

--- a/src/nv_ingest/util/nim/helpers.py
+++ b/src/nv_ingest/util/nim/helpers.py
@@ -4,6 +4,7 @@
 
 import logging
 import re
+import threading
 import time
 from typing import Any
 from typing import Optional
@@ -34,7 +35,7 @@ class ModelInterface:
     inference, parsing output, and processing inference results.
     """
 
-    def format_input(self, data: dict, protocol: str):
+    def format_input(self, data: dict, protocol: str, max_batch_size: int):
         """
         Format the input data for the specified protocol.
 
@@ -99,6 +100,17 @@ class ModelInterface:
         """
         raise NotImplementedError("Subclasses should implement this method")
 
+    def model_name(self):
+        """
+        Get the model name for the interface.
+
+        Returns
+        -------
+        str
+            The name of the model.
+        """
+        raise NotImplementedError("Subclasses should implement this method")
+
 
 class NimClient:
     """
@@ -107,7 +119,7 @@ class NimClient:
 
     def __init__(
         self,
-        model_interface: ModelInterface,
+        model_interface,
         protocol: str,
         endpoints: Tuple[str, str],
         auth_token: Optional[str] = None,
@@ -141,24 +153,53 @@ class NimClient:
         self.auth_token = auth_token
         self.timeout = timeout  # Timeout for HTTP requests
         self.max_retries = max_retries
-
-        grpc_endpoint, http_endpoint = endpoints
+        self._grpc_endpoint, self._http_endpoint = endpoints
+        self._max_batch_sizes = {}
+        self._lock = threading.Lock()
 
         if self.protocol == "grpc":
-            if not grpc_endpoint:
+            if not self._grpc_endpoint:
                 raise ValueError("gRPC endpoint must be provided for gRPC protocol")
-            logger.debug(f"Creating gRPC client with {grpc_endpoint}")
-            self.client = grpcclient.InferenceServerClient(url=grpc_endpoint)
+            logger.debug(f"Creating gRPC client with {self._grpc_endpoint}")
+            self.client = grpcclient.InferenceServerClient(url=self._grpc_endpoint)
         elif self.protocol == "http":
-            if not http_endpoint:
+            if not self._http_endpoint:
                 raise ValueError("HTTP endpoint must be provided for HTTP protocol")
-            logger.debug(f"Creating HTTP client with {http_endpoint}")
-            self.endpoint_url = generate_url(http_endpoint)
+            logger.debug(f"Creating HTTP client with {self._http_endpoint}")
+            self.endpoint_url = generate_url(self._http_endpoint)
             self.headers = {"accept": "application/json", "content-type": "application/json"}
             if self.auth_token:
                 self.headers["Authorization"] = f"Bearer {self.auth_token}"
         else:
             raise ValueError("Invalid protocol specified. Must be 'grpc' or 'http'.")
+
+    def _fetch_max_batch_size(self, model_name, model_version: str = "") -> int:
+        """Fetch the maximum batch size from the Triton model configuration in a thread-safe manner."""
+        if model_name in self._max_batch_sizes:
+            return self._max_batch_sizes[model_name]
+
+        with self._lock:
+            # Double check, just in case another thread set the value while we were waiting
+            if model_name in self._max_batch_sizes:
+                return self._max_batch_sizes[model_name]
+
+            if not self._grpc_endpoint:
+                self._max_batch_sizes[model_name] = 1
+                return 1
+
+            try:
+                model_config = self.client.get_model_config(model_name=model_name, model_version=model_version)
+                self._max_batch_sizes[model_name] = model_config.config.max_batch_size
+                logger.info(f"Max batch size for model '{model_name}': {self._max_batch_sizes[model_name]}")
+            except Exception as e:
+                self._max_batch_sizes[model_name] = 1
+                logger.warning(f"Failed to retrieve max batch size: {e}, defaulting to 1")
+
+            return self._max_batch_sizes[model_name]
+
+    def try_set_max_batch_size(self, model_name, model_version: str = ""):
+        """Attempt to set the max batch size for the model if it is not already set, ensuring thread safety."""
+        self._fetch_max_batch_size(model_name, model_version)
 
     @traceable_func(trace_name="{stage_name}::{model_name}")
     def infer(self, data: dict, model_name: str, **kwargs) -> Any:
@@ -186,38 +227,74 @@ class NimClient:
         """
 
         try:
-            # Prepare data for inference
+            # 1. Retrieve or default to the model's maximum batch size
+            batch_size = self._fetch_max_batch_size(model_name)
+            max_requested_batch_size = kwargs.get("max_batch_size", batch_size)
+            force_requested_batch_size = kwargs.get("force_max_batch_size", False)
+
+            # 1a. In some cases we can't use the absolute max batch size (or don't want to) so we allow override
+            # 1b. In some cases we can't reliably retrieve the max batch size so we default to 1 and allow forced
+            #   override
+            if not force_requested_batch_size:
+                max_batch_size = min(batch_size, max_requested_batch_size)
+            else:
+                max_batch_size = max_requested_batch_size
+
+            # 2. Prepare data for inference
             prepared_data = self.model_interface.prepare_data_for_inference(data)
 
-            # Format input based on protocol
-            formatted_input = self.model_interface.format_input(prepared_data, protocol=self.protocol)
-
-            # Perform inference
-            if self.protocol == "grpc":
-                logger.debug("Performing gRPC inference...")
-                response = self._grpc_infer(formatted_input, model_name)
-                logger.debug("gRPC inference received response")
-            elif self.protocol == "http":
-                logger.debug("Performing HTTP inference...")
-                response = self._http_infer(formatted_input)
-                logger.debug("HTTP inference received response")
-            else:
-                raise ValueError("Invalid protocol specified. Must be 'grpc' or 'http'.")
-
-            # Parse and process output
-            parsed_output = self.model_interface.parse_output(
-                response, protocol=self.protocol, data=prepared_data, **kwargs
+            # 3. Format the input based on protocol
+            #    NOTE: This now returns a list of batches.
+            formatted_batches = self.model_interface.format_input(
+                prepared_data, protocol=self.protocol, max_batch_size=max_batch_size
             )
-            results = self.model_interface.process_inference_results(
-                parsed_output, original_image_shapes=data.get("original_image_shapes"), protocol=self.protocol, **kwargs
-            )
+
+            # Container for all parsed outputs
+            all_parsed_outputs = []
+
+            # 4. Loop over each batch
+            for batch_input in formatted_batches:
+                if self.protocol == "grpc":
+                    logger.debug("Performing gRPC inference for a batch...")
+                    response = self._grpc_infer(batch_input, model_name)
+                    logger.debug("gRPC inference received response for a batch")
+                elif self.protocol == "http":
+                    logger.debug("Performing HTTP inference for a batch...")
+                    response = self._http_infer(batch_input)
+                    logger.debug("HTTP inference received response for a batch")
+                else:
+                    raise ValueError("Invalid protocol specified. Must be 'grpc' or 'http'.")
+
+                # Parse the output of this batch
+                parsed_output = self.model_interface.parse_output(
+                    response, protocol=self.protocol, data=prepared_data, **kwargs
+                )
+                # Accumulate parsed outputs
+                all_parsed_outputs.append(parsed_output)
+
+            # 5. Process the parsed outputs for each batch
+            all_results = []
+            for parsed_output in all_parsed_outputs:
+                batch_results = self.model_interface.process_inference_results(
+                    parsed_output,
+                    original_image_shapes=data.get("original_image_shapes"),
+                    protocol=self.protocol,
+                    **kwargs,
+                )
+                # Extend or append based on how `batch_results` is structured
+                # (assuming it's a list of result items):
+                if isinstance(batch_results, list):
+                    all_results.extend(batch_results)
+                else:
+                    all_results.append(batch_results)
+
         except Exception as err:
             error_str = f"Error during NimClient inference [{self.model_interface.name()}, {self.protocol}]: {err}"
             logger.error(error_str)
-
             raise RuntimeError(error_str)
 
-        return results
+        # 6. Return final accumulated results
+        return all_results
 
     def _grpc_infer(self, formatted_input: np.ndarray, model_name: str) -> np.ndarray:
         """

--- a/src/nv_ingest/util/nim/paddle.py
+++ b/src/nv_ingest/util/nim/paddle.py
@@ -96,7 +96,7 @@ class PaddleOCRModelInterface(ModelInterface):
 
         return data
 
-    def format_input(self, data: Dict[str, Any], protocol: str, **kwargs: Any) -> Any:
+    def format_input(self, data: Dict[str, Any], protocol: str, max_batch_size: int, **kwargs) -> Any:
         """
         Format input data for the specified protocol ("grpc" or "http"), supporting batched data.
 
@@ -106,28 +106,31 @@ class PaddleOCRModelInterface(ModelInterface):
             The input data dictionary, expected to contain "image_arrays" (list of np.ndarray).
         protocol : str
             The inference protocol, either "grpc" or "http".
-        **kwargs : Any
-            Additional keyword arguments for future use.
+        max_batch_size : int
+            The maximum batch size batching.
 
         Returns
         -------
         Any
-            The formatted data ready to be sent via the specified protocol. For gRPC,
-            a batched NumPy array of shape (B, H, W, C). For HTTP, a JSON-serializable
-            payload containing the base64 images in the format required by the PaddleOCR endpoint.
+            A list of formatted batches. For gRPC, each item is a batched NumPy array of shape (B, H, W, C)
+            where B <= max_batch_size. For HTTP, each item is a JSON-serializable payload containing the
+            base64 images in the format required by the PaddleOCR endpoint.
 
         Raises
         ------
         KeyError
             If "image_arrays" is not found in `data`.
         ValueError
-            If an invalid protocol is specified, or if the image shapes are inconsistent
-            for gRPC batching.
+            If an invalid protocol is specified, or if the image shapes are inconsistent for gRPC batching.
         """
         if "image_arrays" not in data:
             raise KeyError("Expected 'image_arrays' in data. Call prepare_data_for_inference first.")
 
         images = data["image_arrays"]
+
+        # Helper function to split a list into chunks of size up to chunk_size.
+        def chunk_list(lst, chunk_size):
+            return [lst[i : i + chunk_size] for i in range(0, len(lst), chunk_size)]
 
         if protocol == "grpc":
             logger.debug("Formatting input for gRPC PaddleOCR model (batched).")
@@ -143,15 +146,19 @@ class PaddleOCRModelInterface(ModelInterface):
             if not all(s == shapes[0] for s in shapes[1:]):
                 raise ValueError(f"All images must have the same dimensions for gRPC batching. Found: {shapes}")
 
-            # Concatenate along the batch dimension => shape (B, H, W, C)
-            batched_input = np.concatenate(processed, axis=0)
-            return batched_input
+            batches = []
+            for chunk in chunk_list(processed, max_batch_size):
+                # Concatenate arrays in the chunk along the batch dimension => shape (B, H, W, C)
+                batched_input = np.concatenate(chunk, axis=0)
+                batches.append(batched_input)
+
+            return batches
 
         elif protocol == "http":
             logger.debug("Formatting input for HTTP PaddleOCR model (batched).")
 
+            # Use legacy or new API based on the PaddleOCR version
             if self._is_version_early_access_legacy_api():
-                # Legacy => {"messages":[{"content":[imageObj, imageObj, ...]}]}
                 content_list: List[Dict[str, Any]] = []
                 base64_list = data.get("base64_images")
                 if base64_list is None and "base64_image" in data:
@@ -163,11 +170,14 @@ class PaddleOCRModelInterface(ModelInterface):
                     image_obj = {"type": "image_url", "image_url": {"url": image_url}}
                     content_list.append(image_obj)
 
-                message = {"content": content_list}
-                payload = {"messages": [message]}
+                batches = []
+                for chunk in chunk_list(content_list, max_batch_size):
+                    message = {"content": chunk}
+                    payload = {"messages": [message]}
+                    batches.append(payload)
+                return batches
 
             else:
-                # New => {"input":[ {"type":"image_url","url":...}, ... ]}
                 input_list: List[Dict[str, Any]] = []
                 base64_list = data.get("base64_images")
                 if base64_list is None and "base64_image" in data:
@@ -179,9 +189,11 @@ class PaddleOCRModelInterface(ModelInterface):
                     image_obj = {"type": "image_url", "url": image_url}
                     input_list.append(image_obj)
 
-                payload = {"input": input_list}
-
-            return payload
+                batches = []
+                for chunk in chunk_list(input_list, max_batch_size):
+                    payload = {"input": chunk}
+                    batches.append(payload)
+                return batches
 
         else:
             raise ValueError("Invalid protocol specified. Must be 'grpc' or 'http'.")

--- a/tests/nv_ingest/stages/nims/test_chart_extraction.py
+++ b/tests/nv_ingest/stages/nims/test_chart_extraction.py
@@ -99,16 +99,25 @@ def test_update_metadata_single_batch_single_worker(mocker):
         data={"base64_images": ["img1", "img2"]},
         model_name="cached",
         stage_name="chart_data_extraction",
+        max_batch_size=2,
         trace_info=trace_info,
     )
 
     # deplot.infer called once per image
     assert deplot_mock.infer.call_count == 2
     deplot_mock.infer.assert_any_call(
-        data={"base64_image": "img1"}, model_name="deplot", stage_name="chart_data_extraction", trace_info=trace_info
+        data={"base64_image": "img1"},
+        model_name="deplot",
+        stage_name="chart_data_extraction",
+        max_batch_size=1,
+        trace_info=trace_info,
     )
     deplot_mock.infer.assert_any_call(
-        data={"base64_image": "img2"}, model_name="deplot", stage_name="chart_data_extraction", trace_info=trace_info
+        data={"base64_image": "img2"},
+        model_name="deplot",
+        stage_name="chart_data_extraction",
+        max_batch_size=1,
+        trace_info=trace_info,
     )
 
     # join_cached_and_deplot_output called twice

--- a/tests/nv_ingest/stages/nims/test_table_extraction.py
+++ b/tests/nv_ingest/stages/nims/test_table_extraction.py
@@ -288,6 +288,7 @@ def test_update_metadata_all_valid(mocker, paddle_mock):
         data={"base64_images": ["b64imgA", "b64imgB"]},
         model_name="paddle",
         stage_name="table_data_extraction",
+        max_batch_size=2,
         trace_info=None,
     )
 
@@ -316,7 +317,11 @@ def test_update_metadata_skip_small(mocker, paddle_mock):
     assert res[1] == ("imgBig", ("valid_table", "valid_fmt"))
 
     paddle_mock.infer.assert_called_once_with(
-        data={"base64_images": ["imgBig"]}, model_name="paddle", stage_name="table_data_extraction", trace_info=None
+        data={"base64_images": ["imgBig"]},
+        model_name="paddle",
+        stage_name="table_data_extraction",
+        max_batch_size=2,
+        trace_info=None,
     )
 
 

--- a/tests/nv_ingest/util/nim/test_cached.py
+++ b/tests/nv_ingest/util/nim/test_cached.py
@@ -97,7 +97,7 @@ def test_format_input_grpc_with_ndim_3(model_interface):
     base64_img = create_base64_image()
     data = model_interface.prepare_data_for_inference({"base64_image": base64_img})
 
-    formatted_input = model_interface.format_input(data, "grpc")
+    formatted_input = model_interface.format_input(data, "grpc", max_batch_size=1)[0]
 
     assert isinstance(formatted_input, np.ndarray)
     assert formatted_input.dtype == np.float32
@@ -117,7 +117,7 @@ def test_format_input_grpc_with_ndim_other(model_interface):
 
     data = model_interface.prepare_data_for_inference({"base64_image": base64_img})
 
-    formatted_input = model_interface.format_input(data, "grpc")
+    formatted_input = model_interface.format_input(data, "grpc", max_batch_size=1)[0]
 
     assert isinstance(formatted_input, np.ndarray)
     assert formatted_input.dtype == np.float32
@@ -142,7 +142,7 @@ def test_format_input_http(model_interface):
     data = {"image_arrays": [arr]}  # single array for a single test image
 
     # 4) Call format_input
-    formatted_input = model_interface.format_input(data, "http")
+    formatted_input = model_interface.format_input(data, "http", max_batch_size=1)[0]
 
     # 5) Verify the structure of the HTTP payload
 
@@ -177,7 +177,7 @@ def test_format_input_invalid_protocol(model_interface):
     data = model_interface.prepare_data_for_inference({"base64_image": base64_img})
 
     with pytest.raises(ValueError, match="Invalid protocol specified. Must be 'grpc' or 'http'."):
-        model_interface.format_input(data, "invalid_protocol")
+        model_interface.format_input(data, "invalid_protocol", max_batch_size=1)
 
 
 def test_parse_output_grpc(model_interface):

--- a/tests/nv_ingest/util/nim/test_deplot.py
+++ b/tests/nv_ingest/util/nim/test_deplot.py
@@ -63,7 +63,7 @@ def test_prepare_data_for_inference_invalid_base64_image(model_interface):
 def test_format_input_grpc(model_interface):
     base64_img = create_base64_image()
     prepared = model_interface.prepare_data_for_inference({"base64_image": base64_img})
-    formatted = model_interface.format_input(prepared, "grpc")
+    formatted = model_interface.format_input(prepared, "grpc", max_batch_size=1)[0]
     assert isinstance(formatted, np.ndarray)
     assert formatted.dtype == np.float32
     assert formatted.ndim == 4
@@ -74,7 +74,9 @@ def test_format_input_grpc(model_interface):
 def test_format_input_http(model_interface):
     base64_img = create_base64_image()
     prepared = model_interface.prepare_data_for_inference({"base64_image": base64_img})
-    formatted = model_interface.format_input(prepared, "http", max_tokens=600, temperature=0.7, top_p=0.95)
+    formatted = model_interface.format_input(
+        prepared, "http", max_batch_size=1, max_tokens=600, temperature=0.7, top_p=0.95
+    )[0]
     assert isinstance(formatted, dict)
     assert formatted["model"] == "google/deplot"
     assert isinstance(formatted["messages"], list)
@@ -91,7 +93,7 @@ def test_format_input_http(model_interface):
 def test_format_input_http_defaults(model_interface):
     base64_img = create_base64_image()
     prepared = model_interface.prepare_data_for_inference({"base64_image": base64_img})
-    formatted = model_interface.format_input(prepared, "http")
+    formatted = model_interface.format_input(prepared, "http", max_batch_size=1)[0]
     assert formatted["max_tokens"] == 500
     assert formatted["temperature"] == 0.5
     assert formatted["top_p"] == 0.9
@@ -102,7 +104,7 @@ def test_format_input_invalid_protocol(model_interface):
     base64_img = create_base64_image()
     prepared = model_interface.prepare_data_for_inference({"base64_image": base64_img})
     with pytest.raises(ValueError, match="Invalid protocol specified. Must be 'grpc' or 'http'."):
-        model_interface.format_input(prepared, "invalid")
+        model_interface.format_input(prepared, "invalid", max_batch_size=1)
 
 
 def test_parse_output_grpc_simple(model_interface):

--- a/tests/nv_ingest/util/nim/test_paddle.py
+++ b/tests/nv_ingest/util/nim/test_paddle.py
@@ -125,7 +125,7 @@ def test_format_input_grpc(paddle_ocr_model):
 
         # For gRPC, we rely on 'image_arrays'
         data = {"image_arrays": [np.zeros((32, 32, 3))]}
-        result = paddle_ocr_model.format_input(data, protocol="grpc")
+        result = paddle_ocr_model.format_input(data, protocol="grpc", max_batch_size=1)[0]
 
         # shape => (batch_size, 32, 32, 3). We have batch_size=1.
         assert result.shape == (1, 32, 32, 3)
@@ -142,7 +142,7 @@ def test_format_input_http(paddle_ocr_model):
     # MUST call prepare_data_for_inference first, so data has "image_arrays"
     data = paddle_ocr_model.prepare_data_for_inference(data)
 
-    result = paddle_ocr_model.format_input(data, protocol="http")
+    result = paddle_ocr_model.format_input(data, protocol="http", max_batch_size=1)[0]
 
     # For non-legacy => {"input": [ {"type":"image_url","url": "..."} ]}
     assert "input" in result
@@ -162,7 +162,7 @@ def test_format_input_http_legacy(legacy_paddle_ocr_model):
     data = {"base64_image": valid_b64}
 
     data = legacy_paddle_ocr_model.prepare_data_for_inference(data)
-    result = legacy_paddle_ocr_model.format_input(data, protocol="http")
+    result = legacy_paddle_ocr_model.format_input(data, protocol="http", max_batch_size=1)[0]
 
     # Now we expect => {"messages":[{"content":[ { "type":"image_url",
     # "image_url":{"url":"data:image/png;base64,..."}}, ... ]}]}

--- a/tests/nv_ingest/util/nim/test_yolox.py
+++ b/tests/nv_ingest/util/nim/test_yolox.py
@@ -96,18 +96,22 @@ def test_format_input_grpc(model_interface):
     images = [create_test_image(), create_test_image()]
     input_data = {"images": images}
     prepared_data = model_interface.prepare_data_for_inference(input_data)
-    formatted_input = model_interface.format_input(prepared_data, "grpc")
-    assert isinstance(formatted_input, np.ndarray)
-    assert formatted_input.dtype == np.float32
-    assert formatted_input.shape[0] == len(images)
-    assert formatted_input.shape[1:] == (3, 1024, 1024)
+    formatted_input = model_interface.format_input(prepared_data, "grpc", max_batch_size=2)
+
+    assert isinstance(formatted_input, list)
+    assert isinstance(formatted_input[0], np.ndarray)
+    nparray = formatted_input[0]
+    assert nparray.dtype == np.float32
+    assert nparray.shape[0] == len(images)
+    assert nparray.shape[1:] == (3, 1024, 1024)
 
 
 def test_format_input_http(model_interface):
     images = [create_test_image(), create_test_image()]
     input_data = {"images": images}
     prepared_data = model_interface.prepare_data_for_inference(input_data)
-    formatted_input = model_interface.format_input(prepared_data, "http")
+    formatted_input = model_interface.format_input(prepared_data, "http", max_batch_size=2)[0]
+
     assert "input" in formatted_input
     assert isinstance(formatted_input["input"], list)
     for content in formatted_input["input"]:
@@ -122,7 +126,7 @@ def test_format_input_invalid_protocol(model_interface):
     input_data = {"images": images}
     prepared_data = model_interface.prepare_data_for_inference(input_data)
     with pytest.raises(ValueError, match="Invalid protocol specified. Must be 'grpc' or 'http'."):
-        model_interface.format_input(prepared_data, "invalid_protocol")
+        model_interface.format_input(prepared_data, "invalid_protocol", max_batch_size=1)
 
 
 def test_parse_output_grpc(model_interface):


### PR DESCRIPTION
Changes:

- Begins to shift batching responsibility to NimClient and ModelInterface abstractions
- Attempts to detect max batch size from the NIM if gRPC endpoint is available (HTTP API does not yet support)
- Defaults to batch size 1 if we can't detect the true batch size, but allows the caller to override.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
