### PR TITLE
add bounding box to content metadata on milvus

### DIFF
--- a/client/src/nv_ingest_client/util/milvus.py
+++ b/client/src/nv_ingest_client/util/milvus.py
@@ -382,16 +382,11 @@ def _insert_location_into_content_metadata(element, enable_charts: bool, enable_
     elif element["document_type"] == "image" and enable_images:
         location = element["metadata"]["image_metadata"]["image_location"]
         max_dimensions = element["metadata"]["image_metadata"]["image_location_max_dimensions"]
-    verify_emb = verify_embedding(element)
-    if (not location) or (not verify_emb):
+    if (not location) and (element["document_type"] != "text"):
         source_name = element["metadata"]["source_metadata"]["source_name"]
         pg_num = element["metadata"]["content_metadata"]["page_number"]
         doc_type = element["document_type"]
-        if not verify_emb:
-            logger.error(f"failed to find embedding for entity: {source_name} page: {pg_num} type: {doc_type}")
-        if not location:
-            logger.error(f"failed to find location for entity: {source_name} page: {pg_num} type: {doc_type}")
-        # if we do find location but no embedding remove anyway
+        logger.error(f"failed to find location for entity: {source_name} page: {pg_num} type: {doc_type}")
         location = max_dimensions = None
     element["metadata"]["content_metadata"]["location"] = location
     element["metadata"]["content_metadata"]["max_dimensions"] = max_dimensions


### PR DESCRIPTION
## Description
This PR adds the bounding boxes of images/tables/charts to the metadata stored on milvus. To avoid inflating the milvus usage unnecessarily, we only extract the necessary bounding box values and insert them into the existing `content_metadata` field.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
