### PR TITLE
Github Action: Build nv-ingest-client wheel and publish to artifactory

### DIFF
--- a/.github/workflows/pypi-nightly-publish.yml
+++ b/.github/workflows/pypi-nightly-publish.yml
@@ -1,0 +1,35 @@
+name: Nv-Ingest Nightly PyPi Wheel Publish
+
+# Trigger for pull requests and pushing to main
+on:
+  schedule:
+    # Runs every day at 11:30PM (UTC)
+    - cron: "30 23 * * *"
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: linux-large-disk
+    container:
+      image: rapidsai/ci-conda:cuda12.5.1-ubuntu22.04-py3.10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          pip install build twine
+
+      - name: Build wheel
+        run: |
+          cd client && python -m build
+
+      - name: Publish to Artifactory
+        env:
+          ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+        run: |
+          twine upload --repository-url $ARTIFACTORY_URL -u $ARTIFACTORY_USERNAME -p $ARTIFACTORY_PASSWORD dist/*

--- a/client/setup.py
+++ b/client/setup.py
@@ -10,20 +10,11 @@ import re
 from setuptools import find_packages
 from setuptools import setup
 
-import subprocess
-
-
-def git_revision():
-    try:
-        return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("utf-8").strip()
-    except Exception:
-        return "unknown"
-
 
 def get_version():
     release_type = os.getenv("NV_INGEST_RELEASE_TYPE", "dev")
     version = os.getenv("NV_INGEST_CLIENT_VERSION")
-    rev = git_revision()[:7]  # Use short in favor of full sha
+    rev = os.getenv("NV_INGEST_REV", "0")
 
     if not version:
         version = f"{datetime.datetime.now().strftime('%Y.%m.%d')}"

--- a/client/setup.py
+++ b/client/setup.py
@@ -10,11 +10,20 @@ import re
 from setuptools import find_packages
 from setuptools import setup
 
+import subprocess
+
+
+def git_revision():
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode("utf-8").strip()
+    except Exception:
+        return "unknown"
+
 
 def get_version():
     release_type = os.getenv("NV_INGEST_RELEASE_TYPE", "dev")
     version = os.getenv("NV_INGEST_CLIENT_VERSION")
-    rev = os.getenv("NV_INGEST_REV", "0")
+    rev = git_revision()[:7]  # Use short in favor of full sha
 
     if not version:
         version = f"{datetime.datetime.now().strftime('%Y.%m.%d')}"


### PR DESCRIPTION
## Description
Builds the python wheel for `nv-ingest-client` and publishes that wheel to the upstream artifactory repository.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
