### PR TITLE
Pin to langchain-nvidia-ai-endpoints >= 0.3.7

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -17,6 +17,6 @@ requests
 setuptools
 tqdm
 langchain-milvus
-langchain-nvidia-ai-endpoints
+langchain-nvidia-ai-endpoints>=0.3.7
 minio
 pyarrow

--- a/examples/langchain_multimodal_rag.ipynb
+++ b/examples/langchain_multimodal_rag.ipynb
@@ -39,7 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pip install -qU langchain langchain_community langchain-nvidia-ai-endpoints langchain_milvus pymilvus"
+    "pip install -qU langchain langchain_community langchain-nvidia-ai-endpoints>=0.3.7 langchain_milvus pymilvus"
    ]
   },
   {


### PR DESCRIPTION
## Description
Pin to langchain-nvidia-ai-endpoints >= 0.3.7 to allow for "prepended model names" to be used for custom model invocation.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
