### PR TITLE
Fix broken links, table-fy environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Password: <Your Key>
 > During the early access (EA) phase, you must apply for early access here: https://developer.nvidia.com/nemo-microservices-early-access/join.
 > When your early access is approved, follow the instructions in the email to create an organization and team, link your profile, and generate your NGC API key.
 
-4. Create a .env file that contains your NGC API keys. For more information, refer to [](docs/docs/user-guide/developer-guide/environment-config.md).
+4. Create a .env file that contains your NGC API keys. For more information, refer to [Environment Configuration Variables](docs/docs/user-guide/developer-guide/environment-config.md).
 
 ```
 # Container images must access resources from NGC.

--- a/docs/docs/user-guide/developer-guide/environment-config.md
+++ b/docs/docs/user-guide/developer-guide/environment-config.md
@@ -1,68 +1,20 @@
 # Environment Configuration Variables
 
+The following are the environment configuration variables that you can specify in your .env file.
 
-- **`MESSAGE_CLIENT_HOST`**:
 
-  - **Description**: Specifies the hostname or IP address of the message broker used for communication between
-    services.
-  - **Example**: `redis`, `localhost`, `192.168.1.10`
-
-- **`MESSAGE_CLIENT_PORT`**:
-
-  - **Description**: Specifies the port number on which the message broker is listening.
-  - **Example**: `7670`, `6379`
-
-- **`CAPTION_CLASSIFIER_GRPC_TRITON`**:
-
-  - **Description**: The endpoint where the caption classifier model is hosted using gRPC for communication. This is
-    used to send requests for caption classification.
-    You must specify only ONE of an http or gRPC endpoint. If both are specified gRPC will take precedence.
-  - **Example**: `triton:8001`
-
-- **`CAPTION_CLASSIFIER_MODEL_NAME`**:
-
-  - **Description**: The name of the caption classifier model.
-  - **Example**: `deberta_large`
-
-- **`REDIS_MORPHEUS_TASK_QUEUE`**:
-
-  - **Description**: The name of the task queue in Redis where tasks are stored and processed.
-  - **Example**: `morpheus_task_queue`
-
-- **`DOUGHNUT_TRITON_HOST`**:
-
-  - **Description**: The hostname or IP address of the DOUGHNUT model service.
-  - **Example**: `triton-doughnut`
-
-- **`DOUGHNUT_TRITON_PORT`**:
-
-  - **Description**: The port number on which the DOUGHNUT model service is listening.
-  - **Example**: `8001`
-
-- **`OTEL_EXPORTER_OTLP_ENDPOINT`**:
-
-  - **Description**: The endpoint for the OpenTelemetry exporter, used for sending telemetry data.
-  - **Example**: `http://otel-collector:4317`
-
-- **`NGC_API_KEY`**:
-
-  - **Description**: An authorized NGC API key, used to interact with hosted NIMs and can be generated here: https://org.ngc.nvidia.com/setup/personal-keys.
-  - **Example**: `nvapi-*************`
-
-- **`MINIO_BUCKET`**:
-
-  - **Description**: Name of MinIO bucket, used to store image, table, and chart extractions.
-  - **Example**: `nv-ingest`
-
-- **`INGEST_LOG_LEVEL`**:
-
-  - **Description**: The log level for the ingest service, which controls the verbosity of the logging output.
-  - **Example**: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`
-
-- **`NVIDIA_BUILD_API_KEY`**:
-  - **Description**: This key is for when you are using the build.nvidia.com endpoint instead of a self hosted Deplot NIM.
-    This is necessary only in some cases when it is different from `NGC_API_KEY`. If this is not specified, `NGC_API_KEY` is used for build.nvidia.com.
-
-- **`NIM_NGC_API_KEY`**:
-  - **Description**: This key is by NIM microservices inside docker containers to access NGC resources.
-    This is necessary only in some cases when it is different from `NGC_API_KEY`. If this is not specified, `NGC_API_KEY` is used to access NGC resources.
+| Name                             | Example                   | Description                                                             |
+|----------------------------------|---------------------------|-------------------------------------------------------------------------|
+| `CAPTION_CLASSIFIER_GRPC_TRITON` | - `triton:8001` <br/>                                      | The endpoint where the caption classifier model is hosted using gRPC for communication. This is used to send requests for caption classification. You must specify only ONE of an http or gRPC endpoint. If both are specified gRPC will take precedence. |
+| `CAPTION_CLASSIFIER_MODEL_NAME`  | - `deberta_large` <br/>                                    | The name of the caption classifier model. |
+| `DOUGHNUT_TRITON_HOST`           | - `triton-doughnut` <br/>                                  | The hostname or IP address of the DOUGHNUT model service. |
+| `DOUGHNUT_TRITON_PORT`           | - `8001` <br/>                                             | The port number on which the DOUGHNUT model service is listening. |
+| `INGEST_LOG_LEVEL`               | - `DEBUG` <br/> - `INFO` <br/> - `WARNING` <br/> - `ERROR` <br/> - `CRITICAL` <br/> | The log level for the ingest service, which controls the verbosity of the logging output. |
+| `MESSAGE_CLIENT_HOST`            | - `redis` <br/> - `localhost` <br/> - `192.168.1.10` <br/> | Specifies the hostname or IP address of the message broker used for communication between services. |
+| `MESSAGE_CLIENT_PORT`            | - `7670` <br/> - `6379` <br/>                              | Specifies the port number on which the message broker is listening. |
+| `MINIO_BUCKET`                   | - `nv-ingest` <br/>                                        | Name of MinIO bucket, used to store image, table, and chart extractions. |
+| `NGC_API_KEY`                    | - `nvapi-*************` <br/>                              | An authorized NGC API key, used to interact with hosted NIMs and can be generated here: https://org.ngc.nvidia.com/setup/personal-keys. |
+| `NIM_NGC_API_KEY`                | —                                                          | The key that NIM microservices inside docker containers use to access NGC resources. This is necessary only in some cases when it is different from `NGC_API_KEY`. If this is not specified, `NGC_API_KEY` is used to access NGC resources. |
+| `NVIDIA_BUILD_API_KEY`           | —                                                          | The key to access NIMs that are hosted on build.nvidia.com instead of a self-hosted NIM. This is necessary only in some cases when it is different from `NGC_API_KEY`. If this is not specified, `NGC_API_KEY` is used for build.nvidia.com. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`    | - `http://otel-collector:4317` <br/>                       | The endpoint for the OpenTelemetry exporter, used for sending telemetry data. |
+| `REDIS_MORPHEUS_TASK_QUEUE`      | - `morpheus_task_queue` <br/>                              | The name of the task queue in Redis where tasks are stored and processed. |

--- a/docs/docs/user-guide/developer-guide/environment-config.md
+++ b/docs/docs/user-guide/developer-guide/environment-config.md
@@ -3,8 +3,8 @@
 The following are the environment configuration variables that you can specify in your .env file.
 
 
-| Name                             | Example                   | Description                                                             |
-|----------------------------------|---------------------------|-------------------------------------------------------------------------|
+| Name                             | Example                        | Description                                                           |
+|----------------------------------|--------------------------------|-----------------------------------------------------------------------|
 | `CAPTION_CLASSIFIER_GRPC_TRITON` | - `triton:8001` <br/>                                      | The endpoint where the caption classifier model is hosted using gRPC for communication. This is used to send requests for caption classification. You must specify only ONE of an http or gRPC endpoint. If both are specified gRPC will take precedence. |
 | `CAPTION_CLASSIFIER_MODEL_NAME`  | - `deberta_large` <br/>                                    | The name of the caption classifier model. |
 | `DOUGHNUT_TRITON_HOST`           | - `triton-doughnut` <br/>                                  | The hostname or IP address of the DOUGHNUT model service. |

--- a/docs/docs/user-guide/getting-started/quickstart-guide.md
+++ b/docs/docs/user-guide/getting-started/quickstart-guide.md
@@ -33,7 +33,7 @@ Password: <Your Key>
 > When your early access is approved, follow the instructions in the email to create an organization and team, link your profile, and generate your NGC API key.
 
 
-4. Create a .env file containing your NGC API key and the following paths. For more information, refer to [](../developer-guide/environment-config.md).
+4. Create a .env file containing your NGC API key and the following paths. For more information, refer to [Environment Configuration Variables](../developer-guide/environment-config.md).
 
 ```
 # Container images must access resources from NGC.


### PR DESCRIPTION
- Fix broken links x2
- Table-fy environment variables: even though the environment variables page looks okay in the GitHub build, in the [docs.nvidia.com Environment page](https://docs.nvidia.com/nv-ingest/user-guide/developer-guide/environment-config/) build, it looks terrible.
