### PR TITLE
Embed git rev-parse in docker metadata labels

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -29,7 +29,7 @@ jobs:
       # Build the Docker image using the Dockerfile
       - name: Build Docker image
         run: |
-          docker build --target runtime -t nv-ingest:latest .
+          docker build --target runtime --build-arg GIT_COMMIT=${GITHUB_SHA} -t nv-ingest:latest .
 
       - name: Run Pytest inside Docker container
         run: |

--- a/.github/workflows/docker-nightly-publish.yml
+++ b/.github/workflows/docker-nightly-publish.yml
@@ -27,7 +27,7 @@ jobs:
       # Build the Docker image using the Dockerfile
       - name: Build Docker image
         run: |
-          docker build --target runtime -t ${{ secrets.DOCKER_REGISTRY }}/nv-ingest:${{ env.CURRENT_DATE }} .
+          docker build --target runtime --build-arg GIT_COMMIT=${GITHUB_SHA} -t ${{ secrets.DOCKER_REGISTRY }}/nv-ingest:${{ env.CURRENT_DATE }} .
 
       # Login to NGC
       - name: Log in to NGC Registry

--- a/.github/workflows/docker-release-publish.yml
+++ b/.github/workflows/docker-release-publish.yml
@@ -27,7 +27,7 @@ jobs:
       # Build the Docker image using the Dockerfile
       - name: Build Docker image
         run: |
-          docker build --target runtime -t ${{ secrets.DOCKER_REGISTRY }}/nv-ingest:${{ env.SHORT_BRANCH_NAME }} .
+          docker build --target runtime --build-arg GIT_COMMIT=${GITHUB_SHA} -t ${{ secrets.DOCKER_REGISTRY }}/nv-ingest:${{ env.SHORT_BRANCH_NAME }} .
 
       # Login to NGC
       - name: Log in to NGC Registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,12 @@ ARG RELEASE_TYPE="dev"
 ARG VERSION=""
 ARG VERSION_REV="0"
 
+# Embed the `git rev-parse HEAD` as a Docker metadata label
+# Allows for linking container builds to git commits
+# docker inspect nv-ingest:latest | jq '.[0].Config.Labels.git_commit' -> GIT_SHA
+ARG GIT_COMMIT
+LABEL git_commit=$GIT_COMMIT
+
 # Install necessary dependencies using apt-get
 RUN apt-get update && apt-get install -y \
       wget \


### PR DESCRIPTION
## Description
Embeds the `git rev-parse HEAD` output as metadata in the Docker container labels. This makes it much easier for people to trace each container back to the git commit that was associated with it.

The data MUST be passed to the docker build command for this to work. Like so with the --build-arg "GIT_COMMIT"
```
docker build --target runtime --build-arg GIT_COMMIT=$(git rev-parse HEAD) -t nv-ingest:latest .
```

Docker containers can then be examine to view the git commit associated with them by running something like ....
```
docker inspect nv-ingest:latest | jq '.[0].Config.Labels.git_commit'
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
