### PR TITLE
instantiate client config schema

### DIFF
--- a/client/src/nv_ingest_client/util/milvus.py
+++ b/client/src/nv_ingest_client/util/milvus.py
@@ -882,10 +882,11 @@ def nvingest_retrieval(
     List
         Nested list of top_k results per query.
     """
-    nvidia_api_key = ClientConfigSchema.nvidia_build_api_key
+    client_config = ClientConfigSchema()
+    nvidia_api_key = client_config.nvidia_build_api_key
     # required for NVIDIAEmbedding call if the endpoint is Nvidia build api.
-    embedding_endpoint = embedding_endpoint if embedding_endpoint else ClientConfigSchema.embedding_nim_endpoint
-    model_name = model_name if model_name else ClientConfigSchema.embedding_nim_model_name
+    embedding_endpoint = embedding_endpoint if embedding_endpoint else client_config.embedding_nim_endpoint
+    model_name = model_name if model_name else client_config.embedding_nim_model_name
     local_index = False
     embed_model = NVIDIAEmbedding(base_url=embedding_endpoint, model=model_name, nvidia_api_key=nvidia_api_key)
     client = MilvusClient(milvus_uri)


### PR DESCRIPTION
## Description
This fixes a bug where the ClientConfigSchema was not instantiated before reference. We want to instantiate so that we can pick up any changes to environment variables that happen before calling this function. See test cases in `tests/nv_ingest_client/util/test_util.py`
 
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
