### PR TITLE
Fix conda create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ To interact with the nv-ingest service, you can do so from the host, or by `dock
 To interact from the host, you'll need a Python environment and install the client dependencies:
 ```bash
 # conda not required, but makes it easy to create a fresh python environment
-conda create --name nv-ingest-dev --file ./conda/environments/nv_ingest_environment.yml
+conda env create --name nv-ingest-dev --file ./conda/environments/nv_ingest_environment.yml
 conda activate nv-ingest-dev
 
 cd client


### PR DESCRIPTION
## Description
The command as documented gives this error:
```
$ conda create --name nv-ingest-dev --file ./conda/environments/nv_ingest_environment.yml
conda activate nv-ingest-dev

CondaValueError: could not parse 'name: nv_ingest_runtime' in: ./conda/environments/nv_ingest_environment.yml


EnvironmentNameNotFound: Could not find conda environment: nv-ingest-dev
You can list all discoverable environments with `conda info --envs`.
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
