### PR TITLE
Remove time from the revision string

### DIFF
--- a/client/src/version.py
+++ b/client/src/version.py
@@ -26,7 +26,7 @@ def get_version():
         # If rev is not specified and defaults to 0 lets create a more meaningful development
         # identifier that is pep440 compliant
         if int(rev) == 0:
-            rev = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+            rev = datetime.datetime.now().strftime("%Y%m%d")
         final_version = f"{version}.dev{rev}"
     elif release_type == "release":
         final_version = f"{version}.post{rev}" if int(rev) > 0 else version


### PR DESCRIPTION
## Description
Fixes errors like:
```
  WARNING: Built wheel for nv-ingest-client is invalid: Wheel has unexpected file name: expected '2025.2.13.dev20250213110023', got '2025.2.13.dev20250213110039'
Failed to build nv-ingest-client
ERROR: Failed to build installable wheels for some pyproject.toml based projects (nv-ingest-client)
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
