### PR TITLE
Create CODEOWNERS file to support development

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Documentation and examples
+docs/                    @nv-ingest-docs
+README.md                @nv-ingest-docs
+examples/                @nv-ingest-docs
+
+# Devops
+.devcontainer/           @NVIDIA-nv-ingest-ops
+.github/                 @NVIDIA/nv-ingest-ops
+.ci/                     @NVIDIA/nv-ingest-ops
+
+# Global owners (required for all PRs)
+*                        @NVIDIA/nv-ingest-maintainers


### PR DESCRIPTION
## Description
This pull request includes updates to the `.github/CODEOWNERS` file to assign ownership of various files and directories to the appropriate teams.

Ownership assignments:

* Assigned `docs/`, `README.md`, and `examples/` to `@nv-ingest-docs` for documentation and examples.
* Assigned `.devcontainer/`, `.github/`, and `.ci/` to `@NVIDIA-nv-ingest-ops` for devops.
* Assigned global ownership to `@NVIDIA/nv-ingest-maintainers` for all other files.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
