### PR TITLE
add dense_dim parameter to client notebook and change default param on MilvusOperator

### DIFF
--- a/client/client_examples/examples/python_client_usage.ipynb
+++ b/client/client_examples/examples/python_client_usage.ipynb
@@ -480,7 +480,7 @@
     "        }\n",
     "    )\n",
     "    .embed()\n",
-    "    .vdb_upload()\n",
+    "    .vdb_upload(dense_dim=2048)\n",
     ")"
    ]
   },

--- a/client/src/nv_ingest_client/util/milvus.py
+++ b/client/src/nv_ingest_client/util/milvus.py
@@ -56,7 +56,7 @@ class MilvusOperator:
         recreate: bool = True,
         gpu_index: bool = True,
         gpu_search: bool = True,
-        dense_dim: int = 1024,
+        dense_dim: int = 2048,
         minio_endpoint: str = "localhost:9000",
         enable_text: bool = True,
         enable_charts: bool = True,


### PR DESCRIPTION
## Description
The example notebook does not mention the `dense_dim` parameter and because of the default parameter passed to MilvusOperator is 1024, this means that new embedding models like Llama 3.2 which have embedding dimensions 2048 do not work. For user-friendliness and clarity, it's best to leave the parameter in the notebook example

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
