### PR TITLE
Add empty setup.py file to pacify conda wanting a setup.py file

### DIFF
--- a/client/setup.py
+++ b/client/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()

--- a/conda/packages/nv_ingest_client/meta.yaml
+++ b/conda/packages/nv_ingest_client/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   build:
     - pip
     - python==3.10
-    - setuptools>=58.2.0
+    - setuptools>=75.8.0
   run:
     - click>=8.1.7
     - fsspec>=2024.10.0


### PR DESCRIPTION
## Description
Conda builds should be using the pyproject.toml built in setuptools plugin. For whatever reason that plugin is currently failing and general knowledge seems to be just add an empty setup.py file to pacify the broken plugin piece until a fix is made.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
