### PR TITLE
add bounding box to milvus metadata in streaming mode

### DIFF
--- a/client/src/nv_ingest_client/util/milvus.py
+++ b/client/src/nv_ingest_client/util/milvus.py
@@ -570,6 +570,7 @@ def stream_insert_milvus(
     for result in records:
         for element in result:
             text = _pull_text(element, enable_text, enable_charts, enable_tables, enable_images)
+            _insert_location_into_content_metadata(element, enable_charts, enable_tables, enable_images)
             if text:
                 if sparse_model is not None:
                     data.append(record_func(text, element, sparse_model.encode_documents([text])))


### PR DESCRIPTION
## Description
This PR adds bounding box information in streaming mode to mirror the bulk upload mode:

https://github.com/NVIDIA/nv-ingest/blob/e1802b25eabd873fb6c6c45ebbf7724faaf87df6/client/src/nv_ingest_client/util/milvus.py#L438-L441

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
