### PR TITLE
Change docs ci container to ubuntu latest to ensure make is present

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: linux-large-disk
     container:
-      image: python:3.11-slim
+      image: ubuntu:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description
Update CI container to ubuntu:latest for docs so that build utilities are present by default. This makes more sense than trying to manually install them on python:slim

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
