### PR TITLE
Install python3 and pip with symlink on ubuntu latest image

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -22,8 +22,7 @@ jobs:
 
       - name: Install system deps
         run: |
-          apt update && apt install -y python3 python3-pip
-          ln -sf /usr/bin/python3 /usr/bin/python
+          apt-get update && apt-get install -y make
 
       # Install dependencies from docs/requirements.txt
       - name: Install mkdocs dependencies

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -22,6 +22,7 @@ jobs:
 
       - name: Install system deps
         run: |
+          pip install --upgrade pip
           apt-get update && apt-get install -y make
 
       # Install dependencies from docs/requirements.txt

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -20,10 +20,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install system deps
+        run: |
+          apt update && apt install -y python3 python3-pip
+          ln -sf /usr/bin/python3 /usr/bin/python
+
       # Install dependencies from docs/requirements.txt
       - name: Install mkdocs dependencies
         run: |
-          python -m pip install --upgrade pip
           pip install -r docs/requirements.txt
 
       - name: Build Sphinx API Docs


### PR DESCRIPTION
## Description
Install Python3 and pip on the ubuntu latest image since they are not present at CI runtime.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
