### PR TITLE
Docs CI build changes

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -29,12 +29,12 @@ jobs:
         run: |
           pip install -r docs/requirements.txt
 
-      - name: Build Sphinx API Docs
-        run: |
-          cd docs/sphinx_docs
-          make html
-          cd ../../
-          mv docs/sphinx_docs/build/html docs/docs/user-guide/api_docs
+      # - name: Build Sphinx API Docs
+      #   run: |
+      #     cd docs/sphinx_docs
+      #     make html
+      #     cd ../../
+      #     mv docs/sphinx_docs/build/html docs/docs/user-guide/api_docs
 
       - name: Build MkDocs Site
         run: mkdocs build --config-file docs/mkdocs.yml

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install system deps
         run: |
-          apt-get update && apt-get install -y make
+          apt-get update && apt-get install -y make git
 
       # Install dependencies from docs/requirements.txt
       - name: Install mkdocs dependencies

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -11,6 +11,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write # gotta have this to push to gh-pages branch
+  pages: write
+  id-token: write
+
 jobs:
   build:
     runs-on: linux-large-disk
@@ -43,4 +48,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
+          publish_dir: ./docs/site

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -44,8 +44,27 @@ jobs:
       - name: Build MkDocs Site
         run: mkdocs build --config-file docs/mkdocs.yml
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload Site Artifacts
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/site
+          path: ./docs/site
+
+  deploy:
+    needs:
+      - build
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,14 +15,13 @@ jobs:
   build:
     runs-on: linux-large-disk
     container:
-      image: ubuntu:latest
+      image: python:3.11-slim
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Install system deps
         run: |
-          pip install --upgrade pip
           apt-get update && apt-get install -y make
 
       # Install dependencies from docs/requirements.txt

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -11,10 +11,10 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write # gotta have this to push to gh-pages branch
-  pages: write
-  id-token: write
+# permissions:
+#   contents: write # gotta have this to push to gh-pages branch
+#   pages: write
+#   id-token: write
 
 jobs:
   build:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -11,10 +11,10 @@ on:
     branches:
       - main
 
-# permissions:
-#   contents: write # gotta have this to push to gh-pages branch
-#   pages: write
-#   id-token: write
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
   build:
@@ -24,6 +24,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
 
       - name: Install system deps
         run: |
@@ -52,17 +55,9 @@ jobs:
   deploy:
     needs:
       - build
-
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-
-    # Deploy to the github-pages environment
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to GitHub Pages

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,6 +9,5 @@ mkdocs-include-dir-to-nav
 mkdocs-literate-nav
 mkdocs-site-urls
 sphinx
-sphinx-autodoc
 sphinx-markdown-builder
 sphinx-rtd-theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,4 +9,6 @@ mkdocs-include-dir-to-nav
 mkdocs-literate-nav
 mkdocs-site-urls
 sphinx
+sphinx-autodoc
+sphinx-markdown-builder
 sphinx-rtd-theme

--- a/docs/sphinx_docs/Makefile
+++ b/docs/sphinx_docs/Makefile
@@ -17,4 +17,6 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
+	pwd
+	ls -l
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/sphinx_docs/source/conf.py
+++ b/docs/sphinx_docs/source/conf.py
@@ -6,6 +6,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath("../../../api/src"))  # nv-ingest-api src
+print(f"!!!!!sys.path: {sys.path}")
 
 project = "nv-ingest"
 copyright = "2025, Nvidia"

--- a/docs/sphinx_docs/source/conf.py
+++ b/docs/sphinx_docs/source/conf.py
@@ -6,8 +6,6 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath("../../../api/src"))  # nv-ingest-api src
-sys.path.insert(1, os.path.abspath("../../api/src"))
-sys.path.insert(1, os.path.abspath("../../../../api/src"))
 print(f"!!!!!sys.path: {sys.path}")
 
 project = "nv-ingest"

--- a/docs/sphinx_docs/source/conf.py
+++ b/docs/sphinx_docs/source/conf.py
@@ -7,6 +7,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath("../../../api/src"))  # nv-ingest-api src
 sys.path.insert(1, os.path.abspath("../../api/src"))
+sys.path.insert(1, os.path.abspath("../../../../api/src"))
 print(f"!!!!!sys.path: {sys.path}")
 
 project = "nv-ingest"

--- a/docs/sphinx_docs/source/conf.py
+++ b/docs/sphinx_docs/source/conf.py
@@ -6,6 +6,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath("../../../api/src"))  # nv-ingest-api src
+sys.path.insert(1, os.path.abspath("../../api/src"))
 print(f"!!!!!sys.path: {sys.path}")
 
 project = "nv-ingest"


### PR DESCRIPTION
## Description
Change docs CI build container to python:3.11-slim from ubuntu:latest

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
