### PR TITLE
fix for ingest async in milvus

### DIFF
--- a/client/src/nv_ingest_client/client/interface.py
+++ b/client/src/nv_ingest_client/client/interface.py
@@ -294,7 +294,7 @@ class Ingestor:
             future.add_done_callback(_done_callback)
 
         if self._vdb_bulk_upload:
-            self._vdb_bulk_upload.run(combined_future)
+            self._vdb_bulk_upload.run(combined_future.result()[0])
             # only upload as part of jobs user specified this action
             self._vdb_bulk_upload = None
 


### PR DESCRIPTION
## Description
This PR fixes milvus ingestion when using the ingestor's `ingest_async` function. 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
