### PR TITLE
Add nvidia-nim-llama-32-nv-embedqa-1b-v2 to Helm chart

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Build MkDocs Site
         run: mkdocs build --config-file docs/mkdocs.yml
 
+      - name: Check permissions
+        run: |
+          echo "Current Git user:"
+          git config --global user.name
+          git
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -40,12 +40,6 @@ jobs:
       - name: Build MkDocs Site
         run: mkdocs build --config-file docs/mkdocs.yml
 
-      - name: Check permissions
-        run: |
-          echo "Current Git user:"
-          git config --global user.name
-          git
-
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.29.1
+  version: 2.30.0
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 19.1.3
@@ -26,8 +26,11 @@ dependencies:
 - name: text-embedding-nim
   repository: https://helm.ngc.nvidia.com/nim/nvidia
   version: 1.1.0
+- name: nvidia-nim-llama-32-nv-embedqa-1b-v2
+  repository: https://helm.ngc.nvidia.com/nim/nvidia
+  version: 1.3.0
 - name: milvus
   repository: https://zilliztech.github.io/milvus-helm
   version: 4.1.11
-digest: sha256:e185b88c9f0f5bfde2f0bf4195516f0b0f15dc4ec3af1b2ceecbc8a8846e632e
-generated: "2025-01-29T15:33:16.951828-05:00"
+digest: sha256:6571e9d143f8b94f4cfa0e1edca3f2ac23189c07315f4908ecb6af80c5901cb4
+generated: "2025-02-19T11:00:07.532041109-05:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -46,6 +46,10 @@ dependencies:
     repository: "alias:nvidia-nim"
     version: 1.1.0
     condition: embedqaDeployed
+  - name: nvidia-nim-llama-32-nv-embedqa-1b-v2
+    repository: "alias:nvidia-nim"
+    version: 1.3.0
+    condition: nvEmbedqaDeployed
   - name: milvus
     repository: https://zilliztech.github.io/milvus-helm
     version: 4.1.11

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -173,12 +173,31 @@ deplot-nim:
 ## @skip embedqa-nim
 ## @extra embedqa-nim.image.repository The repository to override the location of the embedqa NIM
 ## @extra embedqa-nim.image.tag The tag override for embedqa NIM
-embedqaDeployed: true
+embedqaDeployed: false
 text-embedding-nim:
   fullnameOverride: nv-ingest-embedqa
   image:
     repository: nvcr.io/nim/nvidia/nv-embedqa-e5-v5
     tag: "1.1.0"
+  service:
+    name: nv-ingest-embedqa
+    grpcPort: 8001
+  nim:
+    grpcPort: 8001
+  env:
+    - name: NIM_HTTP_API_PORT
+      value: "8000"
+
+## @skip nvEmbedqaDeployed
+## @skip nvidia-nim-llama-32-nv-embedqa-1b-v2
+## @extra nvidia-nim-llama-32-nv-embedqa-1b-v2.image.repository The repository to override the location of the nvEmbedqa NIM
+## @extra nvidia-nim-llama-32-nv-embedqa-1b-v2.image.tag The tag override for nvEmbedqa NIM
+nvEmbedqaDeployed: true
+nvidia-nim-llama-32-nv-embedqa-1b-v2:
+  fullnameOverride: nv-ingest-embedqa
+  image:
+    repository: nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2
+    tag: "1.3.1"
   service:
     name: nv-ingest-embedqa
     grpcPort: 8001


### PR DESCRIPTION
## Description
This PR add the `nvidia-nim-llama-32-nv-embedqa-1b-v2` NIM to the Helm chart in favor of the previous `nv-embedqa-e5-v5` NIM.

`nv-embedqa-e5-v5` is still left in the chart but is disabled by default. Both of these NIMs deploy under the same fullname of `nv-ingest-embedqa`.

If you would prefer to continue using the `nv-ingest-embedqa` NIM you can add these `--set` commands to your helm command to deploy `nv-ingest-embedqa`

Note:
embedqaDeployed = `nv-embedqa-e5-v5`
nvEmbedqaDeployed = `nvidia-nim-llama-32-nv-embedqa-1b-v2`

Note:
Both values cannot be set to true

```bash
--set embedqaDeployed=true \
--set nvEmbedqaDeployed=false
```

Apologies for the confusing names but they were inherited.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
