### PR TITLE
move sleep to only run when using bulk ingestion for milvus

### DIFF
--- a/client/src/nv_ingest_client/util/milvus.py
+++ b/client/src/nv_ingest_client/util/milvus.py
@@ -694,7 +694,7 @@ def write_to_nvingest_collection(
         bulk_insert_milvus(collection_name, writer, milvus_uri)
         # this sleep is required, to ensure atleast this amount of time
         # passes before running a search against the collection.\
-    time.sleep(20)
+        time.sleep(20)
 
 
 def dense_retrieval(


### PR DESCRIPTION
## Description
PR moves the sleep for 20 seconds to only happen when bulk ingestion is used. This gives milvus the required administration setup time to get ready to handle retrieval calls on the recently created index. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
