### PR TITLE
fix to get all records from results in ingest_async for milvus

### DIFF
--- a/client/src/nv_ingest_client/client/interface.py
+++ b/client/src/nv_ingest_client/client/interface.py
@@ -294,7 +294,10 @@ class Ingestor:
             future.add_done_callback(_done_callback)
 
         if self._vdb_bulk_upload:
-            self._vdb_bulk_upload.run(combined_future.result()[0])
+            results = []
+            for res in combined_future.result():
+                results += res
+            self._vdb_bulk_upload.run(results)
             # only upload as part of jobs user specified this action
             self._vdb_bulk_upload = None
 


### PR DESCRIPTION
## Description
This PR fixes a bug with the ingest_async call that I introduced in a previous PR when passing records to milvus. Before you only grabbed the first document, this change fixes this so that all documents are ingested by milvus. 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
