### PR TITLE
match results from ingest and ingest-async

### DIFF
--- a/client/src/nv_ingest_client/client/interface.py
+++ b/client/src/nv_ingest_client/client/interface.py
@@ -293,15 +293,15 @@ class Ingestor:
         for future in future_to_job_id:
             future.add_done_callback(_done_callback)
 
+        results = []
+        for res in combined_future.result():
+            results += res
         if self._vdb_bulk_upload:
-            results = []
-            for res in combined_future.result():
-                results += res
             self._vdb_bulk_upload.run(results)
             # only upload as part of jobs user specified this action
             self._vdb_bulk_upload = None
 
-        return combined_future
+        return results
 
     @ensure_job_specs
     def _prepare_ingest_run(self):

--- a/client/src/nv_ingest_client/client/interface.py
+++ b/client/src/nv_ingest_client/client/interface.py
@@ -286,16 +286,14 @@ class Ingestor:
                 if job_state.state != JobStateEnum.FAILED:
                     job_state.state = JobStateEnum.FAILED
             completed_futures.add(future)
-            future_results.append(result)
+            future_results.extend(result)
             if completed_futures == submitted_futures:
                 combined_future.set_result(future_results)
 
         for future in future_to_job_id:
             future.add_done_callback(_done_callback)
 
-        results = []
-        for res in combined_future.result():
-            results += res
+        results = combined_future.result()
         if self._vdb_bulk_upload:
             self._vdb_bulk_upload.run(results)
             # only upload as part of jobs user specified this action

--- a/tests/nv_ingest_client/client/test_interface.py
+++ b/tests/nv_ingest_client/client/test_interface.py
@@ -262,8 +262,7 @@ def test_ingest_async(ingestor, mock_client):
         "result_1" if job_id == "job_id_1" else "result_2"
     )
 
-    combined_future = ingestor.ingest_async(timeout=15)
-    combined_result = combined_future.result()
+    combined_result = ingestor.ingest_async(timeout=15)
 
     assert combined_result == ["result_1", "result_2"]
 

--- a/tests/nv_ingest_client/client/test_interface.py
+++ b/tests/nv_ingest_client/client/test_interface.py
@@ -259,11 +259,10 @@ def test_ingest_async(ingestor, mock_client):
     ingestor._job_states["job_id_2"] = MagicMock(state=JobStateEnum.FAILED)
 
     mock_client.fetch_job_result.side_effect = lambda job_id, *args, **kwargs: (
-        "result_1" if job_id == "job_id_1" else "result_2"
+        ["result_1"] if job_id == "job_id_1" else ["result_2"]
     )
 
     combined_result = ingestor.ingest_async(timeout=15)
-
     assert combined_result == ["result_1", "result_2"]
 
 


### PR DESCRIPTION
## Description
This PR ensures that users get the same results format whether using ingest or ingest_async.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
