### PR TITLE
Use full container for generating api docs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -32,27 +32,33 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
-      - name: Install system deps
-        run: |
-          apt-get update && apt-get install -y make git python3-full
+      # Set up Docker Buildx, useful for building multi-platform images
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      # Install dependencies from docs/requirements.txt
-      - name: Install mkdocs dependencies
+      # Build the Docker image using the Dockerfile
+      - name: Build Docker image
         run: |
-          python3 -m venv venv
-          . venv/bin/activate
-          pip install -r docs/requirements.txt
+          docker build --target docs --build-arg GIT_COMMIT=${GITHUB_SHA} -t nv-ingest-docs:latest .
 
-      - name: Build Docs using Makefile
+      - name: Run the container
         run: |
-          . venv/bin/activate
-          cd docs
-          make docs
+          CONTAINER_ID=$(docker run -d nv-ingest-docs:latest)
+          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_ENV
+
+      - name: Wait for the docs generation to complete in the container
+        run: docker wait $CONTAINER_ID
+
+      - name: Copy generated docs site from the container
+        run: docker cp $CONTAINER_ID:/workspace/docs ./generated-site
+
+      - name: Stop and remove the container
+        run: docker rm $CONTAINER_ID
 
       - name: Upload Site Artifacts
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./docs/site
+          path: ./generated-site
 
   deploy:
     needs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,3 +144,24 @@ RUN source activate nv_ingest_runtime && \
     pip install -e ./client
 
 CMD ["/bin/bash"]
+
+
+FROM nv_ingest_install AS docs
+
+# Install dependencies needed for docs generation
+RUN apt-get update && apt-get install -y \
+      make \
+    && apt-get clean
+
+COPY docs docs
+
+# Docs needs all the source code present so add it to the container
+COPY src src
+COPY api api
+COPY client client
+
+RUN source activate nv_ingest_runtime && \
+    pip install -r ./docs/requirements.txt
+
+# Default command: Run `make docs`
+CMD ["bash", "-c", "cd /workspace/docs && source activate nv_ingest_runtime && make docs"]


### PR DESCRIPTION
## Description
Use the full nv-ingest container for building the api docs. This is needed due to sphinx autodoc needed the dependencies installed for our template.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
