### PR TITLE
async results reverted to future

### DIFF
--- a/client/src/nv_ingest_client/client/interface.py
+++ b/client/src/nv_ingest_client/client/interface.py
@@ -293,13 +293,12 @@ class Ingestor:
         for future in future_to_job_id:
             future.add_done_callback(_done_callback)
 
-        results = combined_future.result()
         if self._vdb_bulk_upload:
-            self._vdb_bulk_upload.run(results)
+            self._vdb_bulk_upload.run(combined_future.result())
             # only upload as part of jobs user specified this action
             self._vdb_bulk_upload = None
 
-        return results
+        return combined_future
 
     @ensure_job_specs
     def _prepare_ingest_run(self):

--- a/tests/nv_ingest_client/client/test_interface.py
+++ b/tests/nv_ingest_client/client/test_interface.py
@@ -262,7 +262,7 @@ def test_ingest_async(ingestor, mock_client):
         ["result_1"] if job_id == "job_id_1" else ["result_2"]
     )
 
-    combined_result = ingestor.ingest_async(timeout=15)
+    combined_result = ingestor.ingest_async(timeout=15).result()
     assert combined_result == ["result_1", "result_2"]
 
 


### PR DESCRIPTION
## Description
This PR reverts previous change, so that ingest_async returns the future instead of the results

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
