### PR TITLE
Fix bug causing last token in text splits to get dropped

### DIFF
--- a/src/nv_ingest/modules/transforms/text_splitter.py
+++ b/src/nv_ingest/modules/transforms/text_splitter.py
@@ -61,7 +61,7 @@ def _split_into_chunks(text, tokenizer, chunk_size=1024, chunk_overlap=20):
     # Convert token chunks back to text while preserving original spacing and case
     text_chunks = []
     for chunk in chunks:
-        text_chunk = text[chunk[0][0] : chunk[-1][0]]
+        text_chunk = text[chunk[0][0] : chunk[-1][1]]
         text_chunks.append(text_chunk)
 
     return text_chunks


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This fixes a bug that causes the Split task to drop the last token

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
