### PR TITLE
filter out null content before embedding

### DIFF
--- a/src/nv_ingest/stages/embeddings/text_embeddings.py
+++ b/src/nv_ingest/stages/embeddings/text_embeddings.py
@@ -303,7 +303,7 @@ def _generate_text_embeddings_df(
 
         # Extract content from metadata and filter out rows with empty content.
         extracted_content = df.loc[content_mask, "metadata"].apply(content_getter)
-        non_empty_mask = extracted_content.str.strip() != ""
+        non_empty_mask = extracted_content.notna() & (extracted_content.str.strip() != "")
         final_mask = content_mask & non_empty_mask
         if not final_mask.any():
             continue


### PR DESCRIPTION
## Description
This PR updates the content filtering logic to ensure null content fields are excluded from the embedding process.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
