### PR TITLE
Page reconstruction

### DIFF
--- a/client/src/nv_ingest_client/util/milvus.py
+++ b/client/src/nv_ingest_client/util/milvus.py
@@ -1078,6 +1078,23 @@ def nv_rerank(
 
 
 def reconstruct_pages(anchor_record, records_list, page_signum: int = 0):
+    """
+    This function allows a user reconstruct the pages for a retrieved chunk.
+
+    Parameters
+    ----------
+    anchor_record : dict
+        Query the candidates are supposed to answer.
+    records_list : list
+        List of the candidates to rerank.
+    page_signum : int
+        The endpoint to the nvidia reranker
+
+    Returns
+    -------
+    String
+        Full page(s) corresponding to anchor record.
+    """
     source_file = anchor_record["entity"]["source"]["source_name"]
     page_number = anchor_record["entity"]["content_metadata"]["page_number"]
     min_page = page_number - page_signum

--- a/tests/nv_ingest_client/util/test_milvus_util.py
+++ b/tests/nv_ingest_client/util/test_milvus_util.py
@@ -1,5 +1,5 @@
 import pytest
-from nv_ingest_client.util.milvus import MilvusOperator, _dict_to_params
+from nv_ingest_client.util.milvus import MilvusOperator, _dict_to_params, reconstruct_pages
 
 
 @pytest.fixture
@@ -65,3 +65,112 @@ def test_op_dict_to_params(collection_name, expected_results):
         for k, v in expected_results.items():
             assert write_params[k] == v
         coll_name in collection_name.keys()
+
+
+def test_page_reconstruction():
+    records = [
+        [
+            {
+                "document_type": "text",
+                "metadata": {
+                    "content": "roses are red.",
+                    "source_metadata": {
+                        "source_name": "file_1.pdf",
+                    },
+                    "content_metadata": {
+                        "type": "text",
+                        "page_number": 0,
+                    },
+                },
+            },
+            {
+                "document_type": "text",
+                "metadata": {
+                    "content": "violets are blue.",
+                    "source_metadata": {
+                        "source_name": "file_1.pdf",
+                    },
+                    "content_metadata": {
+                        "type": "text",
+                        "page_number": 0,
+                    },
+                },
+            },
+            {
+                "document_type": "text",
+                "metadata": {
+                    "content": "sunflowers are yellow.",
+                    "source_metadata": {
+                        "source_name": "file_1.pdf",
+                    },
+                    "content_metadata": {
+                        "type": "text",
+                        "page_number": 0,
+                    },
+                },
+            },
+        ],
+        [
+            {
+                "document_type": "text",
+                "metadata": {
+                    "content": "two time two is four.",
+                    "source_metadata": {
+                        "source_name": "file_2.pdf",
+                    },
+                    "content_metadata": {
+                        "type": "text",
+                        "page_number": 0,
+                    },
+                },
+            },
+            {
+                "document_type": "text",
+                "metadata": {
+                    "content": "four times four is sixteen.",
+                    "source_metadata": {
+                        "source_name": "file_2.pdf",
+                    },
+                    "content_metadata": {
+                        "type": "text",
+                        "page_number": 1,
+                    },
+                },
+            },
+        ],
+    ]
+    candidates = [
+        {
+            "id": 456331433807935937,
+            "distance": 0.016393441706895828,
+            "entity": {
+                "text": "roses are red.",
+                "source": {
+                    "source_name": "file_1.pdf",
+                },
+                "content_metadata": {
+                    "type": "text",
+                    "page_number": 0,
+                },
+            },
+        },
+        {
+            "id": 456331433807935937,
+            "distance": 0.016393441706895828,
+            "entity": {
+                "text": "two time two is four.",
+                "source": {
+                    "source_name": "file_2.pdf",
+                },
+                "content_metadata": {
+                    "type": "text",
+                    "page_number": 0,
+                },
+            },
+        },
+    ]
+    pages = []
+    pages.append(reconstruct_pages(candidates[0], records))
+    pages.append(reconstruct_pages(candidates[1], records, page_signum=1))
+    assert pages[0] == "roses are red.\nviolets are blue.\nsunflowers are yellow.\n"
+    assert pages[1] == "two time two is four.\nfour times four is sixteen.\n"


### PR DESCRIPTION
## Description
This PR allows a user to reconstruct the full page that belongs to a retrieved chunk. It can also pull surrounding pages based on user page_signum input. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
