### PR TITLE
Adjust otel-collector docker-compose user argument

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -276,6 +276,7 @@ services:
     image: otel/opentelemetry-collector-contrib:0.91.0
     hostname: otel-collector
     command: ["--config=/etc/otel-collector-config.yaml"]
+    user: "${UID}:${GID}"
     volumes:
       - ./config/otel-collector-config.yaml:/etc/otel-collector-config.yaml
     ports:


### PR DESCRIPTION
## Description
Adjust the docker-compose.yaml `user` argument for otel-collector to avoid permissions issues with the otel config file in certain situations inside the container.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
