### PR TITLE
no create when already exists

### DIFF
--- a/client/src/nv_ingest_client/util/milvus.py
+++ b/client/src/nv_ingest_client/util/milvus.py
@@ -23,6 +23,7 @@ from urllib.parse import urlparse
 from typing import Union, Dict
 import requests
 from nv_ingest_client.util.util import ClientConfigSchema
+from nv_ingest_client.util.process_json_files import ingest_json_results_to_blob
 import logging
 
 
@@ -266,7 +267,8 @@ def create_collection(
     """
     if recreate and client.has_collection(collection_name):
         client.drop_collection(collection_name)
-    client.create_collection(collection_name=collection_name, schema=schema, index_params=index_params)
+    if not client.has_collection(collection_name):
+        client.create_collection(collection_name=collection_name, schema=schema, index_params=index_params)
 
 
 def create_nvingest_collection(
@@ -1074,3 +1076,21 @@ def nv_rerank(
         idx = rank_vals["index"]
         rank_results.append(map_candidates[idx])
     return rank_results
+
+
+def reconstruct_pages(anchor_record, records_list, page_signum: int = 0):
+    source_file = anchor_record["entity"]["source"]["source_name"]
+    page_number = anchor_record["entity"]["content_metadata"]["page_number"]
+    min_page = page_number - page_signum
+    max_page = page_number + 1 + page_signum 
+    page_numbers = list(range(min_page, max_page))
+
+    target_records = []
+    for sub_records in records_list:
+        for record in sub_records:
+            rec_src_file = record["metadata"]["source_metadata"]["source_name"]
+            rec_pg_num = record["metadata"]["content_metadata"]["page_number"]
+            if source_file == rec_src_file and rec_pg_num in page_numbers:
+                target_records.append(record)
+
+    return ingest_json_results_to_blob(target_records)

--- a/client/src/nv_ingest_client/util/milvus.py
+++ b/client/src/nv_ingest_client/util/milvus.py
@@ -1082,7 +1082,7 @@ def reconstruct_pages(anchor_record, records_list, page_signum: int = 0):
     source_file = anchor_record["entity"]["source"]["source_name"]
     page_number = anchor_record["entity"]["content_metadata"]["page_number"]
     min_page = page_number - page_signum
-    max_page = page_number + 1 + page_signum 
+    max_page = page_number + 1 + page_signum
     page_numbers = list(range(min_page, max_page))
 
     target_records = []


### PR DESCRIPTION
## Description
This PR fixes an issue with collections when you restart milvus, they seem to have some metadata attached that associates the collections with the instance of milvus that created them. So even though you have the index parameters and the same schema if you try to use the create collection api it will still say that you are trying to create a collection with a different set of parameters, instead of returning the already existing collection. This PR gives us the desired behavior where it uses the supplied collection. Now we no longer create a collection if the collection already exists (when recreate is false).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
