### PR TITLE
Add embedding nim endpoint and model name env variables to client

### DIFF
--- a/client/src/nv_ingest_client/primitives/tasks/embed.py
+++ b/client/src/nv_ingest_client/primitives/tasks/embed.py
@@ -63,7 +63,7 @@ class EmbedTask(Task):
         embedding_nim_endpoint = os.getenv("EMBEDDING_NIM_ENDPOINT", "https://integrate.api.nvidia.com/v1")
         if embedding_nim_endpoint == "":
             self._embedding_nim_endpoint = "https://integrate.api.nvidia.com/v1"
-        elif embedding_nim_endpoint[:7] != "http://" and embedding_nim_endpoint[:8] != "https://":
+        elif not(embedding_nim_endpoint.startswith("http://") or embedding_nim_endpoint.startswith("https://")):
             self._embedding_nim_endpoint = "http://" + embedding_nim_endpoint + "/v1"
         else:
             self._embedding_nim_endpoint = embedding_nim_endpoint

--- a/client/src/nv_ingest_client/primitives/tasks/embed.py
+++ b/client/src/nv_ingest_client/primitives/tasks/embed.py
@@ -91,7 +91,7 @@ class EmbedTask(Task):
         """
 
         task_properties = {
-            "filter_errors": False,
+            "filter_errors": self._filter_errors,
         }
 
         if self._embedding_nim_endpoint is not None:

--- a/client/src/nv_ingest_client/primitives/tasks/embed.py
+++ b/client/src/nv_ingest_client/primitives/tasks/embed.py
@@ -63,7 +63,7 @@ class EmbedTask(Task):
         embedding_nim_endpoint = os.getenv("EMBEDDING_NIM_ENDPOINT", "https://integrate.api.nvidia.com/v1")
         if embedding_nim_endpoint == "":
             self._embedding_nim_endpoint = "https://integrate.api.nvidia.com/v1"
-        elif not(embedding_nim_endpoint.startswith("http://") or embedding_nim_endpoint.startswith("https://")):
+        elif not (embedding_nim_endpoint.startswith("http://") or embedding_nim_endpoint.startswith("https://")):
             self._embedding_nim_endpoint = "http://" + embedding_nim_endpoint + "/v1"
         else:
             self._embedding_nim_endpoint = embedding_nim_endpoint

--- a/client/src/nv_ingest_client/primitives/tasks/embed.py
+++ b/client/src/nv_ingest_client/primitives/tasks/embed.py
@@ -6,6 +6,8 @@
 # pylint: disable=too-few-public-methods
 # pylint: disable=too-many-arguments
 
+import os
+
 import logging
 from typing import Dict
 
@@ -58,6 +60,17 @@ class EmbedTask(Task):
                 "'tables' parameter is deprecated and will be ignored. Future versions will remove this argument."
             )
 
+        embedding_nim_endpoint = os.getenv("EMBEDDING_NIM_ENDPOINT", "https://integrate.api.nvidia.com/v1")
+        if embedding_nim_endpoint == "":
+            self._embedding_nim_endpoint = "https://integrate.api.nvidia.com/v1"
+        elif embedding_nim_endpoint[:7] != "http://" and embedding_nim_endpoint[:8] != "https://":
+            self._embedding_nim_endpoint = "http://" + embedding_nim_endpoint + "/v1"
+        else:
+            self._embedding_nim_endpoint = embedding_nim_endpoint
+
+        self._embedding_nim_model_name = os.getenv("EMBEDDING_NIM_MODEL_NAME", "nvidia/llama-3.2-nv-embedqa-1b-v2")
+        self._nvidia_build_api_key = os.getenv("NVIDIA_BUILD_API_KEY", "")
+
         self._filter_errors = filter_errors
 
     def __str__(self) -> str:
@@ -66,6 +79,9 @@ class EmbedTask(Task):
         """
         info = ""
         info += "Embed Task:\n"
+        info += f"  embedding_nim_endpoint: {self._embedding_nim_endpoint}\n"
+        info += f"  embedding_nim_model_name: {self._embedding_nim_model_name}\n"
+        info += "  nvidia_build_api_key: [redacted]\n"
         info += f"  filter_errors: {self._filter_errors}\n"
         return info
 
@@ -77,5 +93,12 @@ class EmbedTask(Task):
         task_properties = {
             "filter_errors": False,
         }
+
+        if self._embedding_nim_endpoint is not None:
+            task_properties["embedding_nim_endpoint"] = self._embedding_nim_endpoint
+        if self._embedding_nim_model_name is not None:
+            task_properties["embedding_nim_model_name"] = self._embedding_nim_model_name
+        if self._nvidia_build_api_key is not None:
+            task_properties["nvidia_build_api_key"] = self._nvidia_build_api_key
 
         return {"type": "embed", "task_properties": task_properties}

--- a/src/nv_ingest/modules/transforms/embed_extractions.py
+++ b/src/nv_ingest/modules/transforms/embed_extractions.py
@@ -353,14 +353,18 @@ def _embed_extractions(builder: mrc.Builder):
         try:
             task_props = remove_task_by_type(message, "embed")
             model_dump = task_props.model_dump()
+
+            embedding_nim_endpoint = model_dump.get("embedding_nim_endpoint", validated_config.embedding_nim_endpoint)
+            embedding_model = model_dump.get("embedding_nim_model_name", validated_config.embedding_model)
+            api_key = model_dump.get("nvidia_build_api_key", validated_config.api_key)
             filter_errors = model_dump.get("filter_errors", False)
 
             return _generate_embeddings(
                 message,
                 validated_config.batch_size,  # This parameter is now ignored in _generate_embeddings.
-                validated_config.api_key,
-                validated_config.embedding_nim_endpoint,
-                validated_config.embedding_model,
+                api_key,
+                embedding_nim_endpoint,
+                embedding_model,
                 validated_config.encoding_format,
                 validated_config.input_type,
                 validated_config.truncate,

--- a/src/nv_ingest/schemas/ingest_job_schema.py
+++ b/src/nv_ingest/schemas/ingest_job_schema.py
@@ -132,6 +132,9 @@ class IngestTaskDedupSchema(BaseModelNoExt):
 
 
 class IngestTaskEmbedSchema(BaseModelNoExt):
+    embedding_nim_endpoint: str = "http://embedding:8000/v1"
+    embedding_nim_model_name: str = "nvidia/llama-3.2-nv-embedqa-1b-v2"
+    nvidia_build_api_key: Optional[str] = None
     filter_errors: bool = False
 
 

--- a/src/nv_ingest/stages/embeddings/text_embeddings.py
+++ b/src/nv_ingest/stages/embeddings/text_embeddings.py
@@ -288,6 +288,15 @@ def _generate_text_embeddings_df(
         ContentTypeEnum.VIDEO: lambda x: None,  # Not supported yet.
     }
 
+    embedding_nim_endpoint = task_props.get("embedding_nim_endpoint", validated_config.embedding_nim_endpoint)
+    embedding_model = task_props.get("embedding_nim_model_name", validated_config.embedding_model)
+    api_key = task_props.get("nvidia_build_api_key", validated_config.api_key)
+    filter_errors = task_props.get("filter_errors", False)
+
+    logger.info(embedding_nim_endpoint)
+    logger.info(embedding_model)
+    logger.info(api_key)
+
     logger.debug("Generating text embeddings for supported content types: TEXT, STRUCTURED, IMAGE.")
 
     # Process each supported content type.
@@ -316,13 +325,13 @@ def _generate_text_embeddings_df(
         # Run asynchronous embedding requests.
         content_embeddings = _async_runner(
             filtered_content_batches,
-            validated_config.api_key,
-            validated_config.embedding_nim_endpoint,
-            validated_config.embedding_model,
+            api_key,
+            embedding_nim_endpoint,
+            embedding_model,
             validated_config.encoding_format,
             validated_config.input_type,
             validated_config.truncate,
-            False,  # task_props.get("filter_errors", False),
+            filter_errors,
         )
         # Apply the embeddings (and any error info) to each row.
         df_content[["metadata", "document_type", "_contains_embeddings"]] = df_content.apply(

--- a/tests/nv_ingest_client/primitives/tasks/test_embed.py
+++ b/tests/nv_ingest_client/primitives/tasks/test_embed.py
@@ -19,14 +19,14 @@ def test_embed_task_initialization():
         filter_errors=True,
     )
 
-    del os.environ['EMBEDDING_NIM_ENDPOINT']
-    del os.environ['EMBEDDING_NIM_MODEL_NAME']
+    del os.environ["EMBEDDING_NIM_ENDPOINT"]
+    del os.environ["EMBEDDING_NIM_MODEL_NAME"]
     del os.environ["NVIDIA_BUILD_API_KEY"]
 
     assert task._embedding_nim_endpoint == "http://embedding-ms:8000/v1"
     assert task._embedding_nim_model_name == "nvidia/test-model"
     assert task._nvidia_build_api_key == "api-key"
-    assert task._filter_errors == True
+    assert task._filter_errors
 
 
 # Dictionary Representation Tests
@@ -50,19 +50,20 @@ def test_embed_task_to_dict(
     os.environ["EMBEDDING_NIM_MODEL_NAME"] = embedding_nim_model_name
     os.environ["NVIDIA_BUILD_API_KEY"] = nvidia_build_api_key
 
-    task = EmbedTask(
-        filter_errors = filter_errors
-    )
+    task = EmbedTask(filter_errors=filter_errors)
 
-    del os.environ['EMBEDDING_NIM_ENDPOINT']
-    del os.environ['EMBEDDING_NIM_MODEL_NAME']
+    del os.environ["EMBEDDING_NIM_ENDPOINT"]
+    del os.environ["EMBEDDING_NIM_MODEL_NAME"]
     del os.environ["NVIDIA_BUILD_API_KEY"]
 
-    expected_dict = {"type": "embed", "task_properties": {
-        "embedding_nim_model_name": embedding_nim_model_name,
-        "nvidia_build_api_key": nvidia_build_api_key,
-        "filter_errors": filter_errors,
-    }}
+    expected_dict = {
+        "type": "embed",
+        "task_properties": {
+            "embedding_nim_model_name": embedding_nim_model_name,
+            "nvidia_build_api_key": nvidia_build_api_key,
+            "filter_errors": filter_errors,
+        },
+    }
 
     if embedding_nim_endpoint == "":
         expected_dict["task_properties"]["embedding_nim_endpoint"] = "https://integrate.api.nvidia.com/v1"
@@ -70,7 +71,7 @@ def test_embed_task_to_dict(
         expected_dict["task_properties"]["embedding_nim_endpoint"] = "http://" + embedding_nim_endpoint + "/v1"
     else:
         expected_dict["task_properties"]["embedding_nim_endpoint"] = embedding_nim_endpoint
-    
+
     print(expected_dict)
     print(task.to_dict())
 
@@ -86,7 +87,7 @@ def test_embed_task_default_params():
         "embedding_nim_endpoint: https://integrate.api.nvidia.com/v1",
         "embedding_nim_model_name: nvidia/llama-3.2-nv-embedqa-1b-v2",
         "nvidia_build_api_key: [redacted]",
-        "filter_errors: False"
+        "filter_errors: False",
     ]
     for expected_part in expected_str_contains:
         assert expected_part in str(task)

--- a/tests/nv_ingest_client/primitives/tasks/test_embed.py
+++ b/tests/nv_ingest_client/primitives/tasks/test_embed.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+import pytest
+from nv_ingest_client.primitives.tasks.embed import EmbedTask
+
+# Initialization and Property Setting
+
+
+def test_embed_task_initialization():
+    os.environ["EMBEDDING_NIM_ENDPOINT"] = "embedding-ms:8000"
+    os.environ["EMBEDDING_NIM_MODEL_NAME"] = "nvidia/test-model"
+    os.environ["NVIDIA_BUILD_API_KEY"] = "api-key"
+
+    task = EmbedTask(
+        filter_errors=True,
+    )
+
+    del os.environ['EMBEDDING_NIM_ENDPOINT']
+    del os.environ['EMBEDDING_NIM_MODEL_NAME']
+    del os.environ["NVIDIA_BUILD_API_KEY"]
+
+    assert task._embedding_nim_endpoint == "http://embedding-ms:8000/v1"
+    assert task._embedding_nim_model_name == "nvidia/test-model"
+    assert task._nvidia_build_api_key == "api-key"
+    assert task._filter_errors == True
+
+
+# Dictionary Representation Tests
+
+
+@pytest.mark.parametrize(
+    "embedding_nim_endpoint, embedding_nim_model_name, nvidia_build_api_key, filter_errors",
+    [
+        ("localhost:8000", "nvidia/embedding-model", "", True),
+        ("http://embedding-ms:8000/v1", "nvidia/llama-3.2-nv-embedqa-1b-v2", "test-key", False),
+        ("", "nvidia/nv-embedqa-e5-v5", "42", True),
+    ],
+)
+def test_embed_task_to_dict(
+    embedding_nim_endpoint,
+    embedding_nim_model_name,
+    nvidia_build_api_key,
+    filter_errors,
+):
+    os.environ["EMBEDDING_NIM_ENDPOINT"] = embedding_nim_endpoint
+    os.environ["EMBEDDING_NIM_MODEL_NAME"] = embedding_nim_model_name
+    os.environ["NVIDIA_BUILD_API_KEY"] = nvidia_build_api_key
+
+    task = EmbedTask(
+        filter_errors = filter_errors
+    )
+
+    del os.environ['EMBEDDING_NIM_ENDPOINT']
+    del os.environ['EMBEDDING_NIM_MODEL_NAME']
+    del os.environ["NVIDIA_BUILD_API_KEY"]
+
+    expected_dict = {"type": "embed", "task_properties": {
+        "embedding_nim_model_name": embedding_nim_model_name,
+        "nvidia_build_api_key": nvidia_build_api_key,
+        "filter_errors": filter_errors,
+    }}
+
+    if embedding_nim_endpoint == "":
+        expected_dict["task_properties"]["embedding_nim_endpoint"] = "https://integrate.api.nvidia.com/v1"
+    elif embedding_nim_endpoint[:7] != "http://" and embedding_nim_endpoint[:8] != "https://":
+        expected_dict["task_properties"]["embedding_nim_endpoint"] = "http://" + embedding_nim_endpoint + "/v1"
+    else:
+        expected_dict["task_properties"]["embedding_nim_endpoint"] = embedding_nim_endpoint
+    
+    print(expected_dict)
+    print(task.to_dict())
+
+    assert task.to_dict() == expected_dict, "The to_dict method did not return the expected dictionary representation"
+
+
+# Default Parameter Handling
+
+
+def test_embed_task_default_params():
+    task = EmbedTask()
+    expected_str_contains = [
+        "embedding_nim_endpoint: https://integrate.api.nvidia.com/v1",
+        "embedding_nim_model_name: nvidia/llama-3.2-nv-embedqa-1b-v2",
+        "nvidia_build_api_key: [redacted]",
+        "filter_errors: False"
+    ]
+    for expected_part in expected_str_contains:
+        assert expected_part in str(task)
+
+    expected_dict = {
+        "type": "embed",
+        "task_properties": {
+            "embedding_nim_endpoint": "https://integrate.api.nvidia.com/v1",
+            "embedding_nim_model_name": "nvidia/llama-3.2-nv-embedqa-1b-v2",
+            "nvidia_build_api_key": "",
+            "filter_errors": False,
+        },
+    }
+    assert task.to_dict() == expected_dict


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

This introduces the `EMBEDDING_NIM_ENDPOINT` env variable to the client which will default to https://integrate.api.nvidia.com/v1 if unset or empty string, and will convert urls that don’t start with http:// or https:// to the format `http://<EMBEDDING_NIM_ENDPOINT>/v1`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
