### PR TITLE
Use extract method to add add audio extraction task

### DIFF
--- a/client/src/nv_ingest_client/primitives/jobs/job_spec.py
+++ b/client/src/nv_ingest_client/primitives/jobs/job_spec.py
@@ -174,7 +174,7 @@ class JobSpec:
             self._tasks.append(ChartExtractionTask())
         if isinstance(task, ExtractTask) and (task._extract_infographics is True):
             self._tasks.append(InfographicExtractionTask())
-        if isinstance(task, ExtractTask) and (_DEFAULT_EXTRACTOR_MAP[self._document_type] == "audio"):
+        if isinstance(task, ExtractTask) and (task._extract_method == "audio"):
             self._tasks.append(AudioExtractionTask())
 
 

--- a/client/src/nv_ingest_client/primitives/jobs/job_spec.py
+++ b/client/src/nv_ingest_client/primitives/jobs/job_spec.py
@@ -14,7 +14,6 @@ from uuid import UUID
 
 from nv_ingest_client.primitives.tasks import Task
 from nv_ingest_client.primitives.tasks import ExtractTask
-from nv_ingest_client.primitives.tasks.extract import _DEFAULT_EXTRACTOR_MAP
 from nv_ingest_client.primitives.tasks.audio_extraction import AudioExtractionTask
 from nv_ingest_client.primitives.tasks.table_extraction import TableExtractionTask
 from nv_ingest_client.primitives.tasks.chart_extraction import ChartExtractionTask

--- a/client/src/nv_ingest_client/primitives/tasks/__init__.py
+++ b/client/src/nv_ingest_client/primitives/tasks/__init__.py
@@ -2,6 +2,7 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from .audio_extraction import AudioExtractionTask
 from .caption import CaptionTask
 from .chart_extraction import ChartExtractionTask
 from .dedup import DedupTask
@@ -20,6 +21,7 @@ from .task_factory import task_factory
 from .vdb_upload import VdbUploadTask
 
 __all__ = [
+    "AudioExtractionTask",
     "CaptionTask",
     "ChartExtractionTask",
     "ExtractTask",


### PR DESCRIPTION
## Description
Updated `add_task` in `JobSpec` to check `task._extract_method` instead of `_DEFAULT_EXTRACTOR_MAP[self._document_type]` when determining if an `AudioExtractionTask` should be added. This improves encapsulation by relying on task properties rather than an external mapping.


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
