### PR TITLE
use default task and task properties in audio extraction stage

### DIFF
--- a/src/nv_ingest/util/pipeline/stage_builders.py
+++ b/src/nv_ingest/util/pipeline/stage_builders.py
@@ -396,8 +396,6 @@ def add_audio_extractor_stage(pipe, morpheus_pipeline_config, ingest_config, def
             morpheus_pipeline_config,
             stage_config=audio_extractor_config,
             pe_count=8,
-            task="extract",
-            task_desc="audio_content_extractor",
         )
     )
     return audio_extractor_stage


### PR DESCRIPTION
## Description
This PR removes the incorrectly overridden task type `task="extract"` (task should be `audio_data_extract` not extract) in the audio extraction builder. By removing, this stage will use the default value `audio_data_extract` in
https://github.com/NVIDIA/nv-ingest/blob/14a859f2e825a7c7442874523e1817a1af533077/src/nv_ingest/stages/nim/audio_extraction.py#L158-L159

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
