### PR TITLE
Revert embedding env variable changes

### DIFF
--- a/client/src/nv_ingest_client/primitives/tasks/embed.py
+++ b/client/src/nv_ingest_client/primitives/tasks/embed.py
@@ -6,10 +6,9 @@
 # pylint: disable=too-few-public-methods
 # pylint: disable=too-many-arguments
 
-import os
-
 import logging
 from typing import Dict
+from typing import Optional
 
 from pydantic import BaseModel, root_validator
 
@@ -19,6 +18,9 @@ logger = logging.getLogger(__name__)
 
 
 class EmbedTaskSchema(BaseModel):
+    endpoint_url: Optional[str] = None
+    model_name: Optional[str] = None
+    api_key: Optional[str] = None
     filter_errors: bool = False
 
     @root_validator(pre=True)
@@ -44,7 +46,15 @@ class EmbedTask(Task):
     Object for document embedding task
     """
 
-    def __init__(self, text: bool = None, tables: bool = None, filter_errors: bool = False) -> None:
+    def __init__(
+        self,
+        endpoint_url: str = None,
+        model_name: str = None,
+        api_key: str = None,
+        text: bool = None,
+        tables: bool = None,
+        filter_errors: bool = False,
+    ) -> None:
         """
         Setup Embed Task Config
         """
@@ -60,17 +70,9 @@ class EmbedTask(Task):
                 "'tables' parameter is deprecated and will be ignored. Future versions will remove this argument."
             )
 
-        embedding_nim_endpoint = os.getenv("EMBEDDING_NIM_ENDPOINT", "https://integrate.api.nvidia.com/v1")
-        if embedding_nim_endpoint == "":
-            self._embedding_nim_endpoint = "https://integrate.api.nvidia.com/v1"
-        elif not (embedding_nim_endpoint.startswith("http://") or embedding_nim_endpoint.startswith("https://")):
-            self._embedding_nim_endpoint = "http://" + embedding_nim_endpoint + "/v1"
-        else:
-            self._embedding_nim_endpoint = embedding_nim_endpoint
-
-        self._embedding_nim_model_name = os.getenv("EMBEDDING_NIM_MODEL_NAME", "nvidia/llama-3.2-nv-embedqa-1b-v2")
-        self._nvidia_build_api_key = os.getenv("NVIDIA_BUILD_API_KEY", "")
-
+        self._endpoint_url = endpoint_url
+        self._model_name = model_name
+        self._api_key = api_key
         self._filter_errors = filter_errors
 
     def __str__(self) -> str:
@@ -79,9 +81,9 @@ class EmbedTask(Task):
         """
         info = ""
         info += "Embed Task:\n"
-        info += f"  embedding_nim_endpoint: {self._embedding_nim_endpoint}\n"
-        info += f"  embedding_nim_model_name: {self._embedding_nim_model_name}\n"
-        info += "  nvidia_build_api_key: [redacted]\n"
+        info += f"  endpoint_url: {self._endpoint_url}\n"
+        info += f"  model_name: {self._model_name}\n"
+        info += "  api_key: [redacted]\n"
         info += f"  filter_errors: {self._filter_errors}\n"
         return info
 
@@ -94,11 +96,11 @@ class EmbedTask(Task):
             "filter_errors": self._filter_errors,
         }
 
-        if self._embedding_nim_endpoint is not None:
-            task_properties["embedding_nim_endpoint"] = self._embedding_nim_endpoint
-        if self._embedding_nim_model_name is not None:
-            task_properties["embedding_nim_model_name"] = self._embedding_nim_model_name
-        if self._nvidia_build_api_key is not None:
-            task_properties["nvidia_build_api_key"] = self._nvidia_build_api_key
+        if self._endpoint_url is not None:
+            task_properties["endpoint_url"] = self._endpoint_url
+        if self._model_name is not None:
+            task_properties["model_name"] = self._model_name
+        if self._api_key is not None:
+            task_properties["api_key"] = self._api_key
 
         return {"type": "embed", "task_properties": task_properties}

--- a/client/src/nv_ingest_client/primitives/tasks/embed.py
+++ b/client/src/nv_ingest_client/primitives/tasks/embed.py
@@ -79,12 +79,16 @@ class EmbedTask(Task):
         """
         Returns a string with the object's config and run time state
         """
-        info = ""
-        info += "Embed Task:\n"
-        info += f"  endpoint_url: {self._endpoint_url}\n"
-        info += f"  model_name: {self._model_name}\n"
-        info += "  api_key: [redacted]\n"
+        info = "Embed Task:\n"
+
+        if self._endpoint_url:
+            info += f"  endpoint_url: {self._endpoint_url}\n"
+        if self._model_name:
+            info += f"  model_name: {self._model_name}\n"
+        if self._api_key:
+            info += "  api_key: [redacted]\n"
         info += f"  filter_errors: {self._filter_errors}\n"
+
         return info
 
     def to_dict(self) -> Dict:
@@ -96,11 +100,13 @@ class EmbedTask(Task):
             "filter_errors": self._filter_errors,
         }
 
-        if self._endpoint_url is not None:
+        if self._endpoint_url:
             task_properties["endpoint_url"] = self._endpoint_url
-        if self._model_name is not None:
+
+        if self._model_name:
             task_properties["model_name"] = self._model_name
-        if self._api_key is not None:
+
+        if self._api_key:
             task_properties["api_key"] = self._api_key
 
         return {"type": "embed", "task_properties": task_properties}

--- a/src/nv_ingest/modules/transforms/embed_extractions.py
+++ b/src/nv_ingest/modules/transforms/embed_extractions.py
@@ -354,17 +354,17 @@ def _embed_extractions(builder: mrc.Builder):
             task_props = remove_task_by_type(message, "embed")
             model_dump = task_props.model_dump()
 
-            embedding_nim_endpoint = model_dump.get("embedding_nim_endpoint", validated_config.embedding_nim_endpoint)
-            embedding_model = model_dump.get("embedding_nim_model_name", validated_config.embedding_model)
-            api_key = model_dump.get("nvidia_build_api_key", validated_config.api_key)
+            endpoint_url = task_props.get("endpoint_url") or validated_config.embedding_nim_endpoint
+            model_name = task_props.get("model_name") or validated_config.embedding_model
+            api_key = task_props.get("api_key") or validated_config.api_key
             filter_errors = model_dump.get("filter_errors", False)
 
             return _generate_embeddings(
                 message,
                 validated_config.batch_size,  # This parameter is now ignored in _generate_embeddings.
                 api_key,
-                embedding_nim_endpoint,
-                embedding_model,
+                endpoint_url,
+                model_name,
                 validated_config.encoding_format,
                 validated_config.input_type,
                 validated_config.truncate,

--- a/src/nv_ingest/schemas/ingest_job_schema.py
+++ b/src/nv_ingest/schemas/ingest_job_schema.py
@@ -132,9 +132,9 @@ class IngestTaskDedupSchema(BaseModelNoExt):
 
 
 class IngestTaskEmbedSchema(BaseModelNoExt):
-    embedding_nim_endpoint: str = "http://embedding:8000/v1"
-    embedding_nim_model_name: str = "nvidia/llama-3.2-nv-embedqa-1b-v2"
-    nvidia_build_api_key: Optional[str] = None
+    endpoint_url: Optional[str] = None
+    model_name: Optional[str] = None
+    api_key: Optional[str] = None
     filter_errors: bool = False
 
 

--- a/src/nv_ingest/stages/embeddings/text_embeddings.py
+++ b/src/nv_ingest/stages/embeddings/text_embeddings.py
@@ -295,13 +295,13 @@ def _generate_text_embeddings_df(
         ContentTypeEnum.VIDEO: lambda x: None,  # Not supported yet.
     }
 
-    embedding_nim_endpoint = task_props.get("embedding_nim_endpoint", validated_config.embedding_nim_endpoint)
-    embedding_model = task_props.get("embedding_nim_model_name", validated_config.embedding_model)
-    api_key = task_props.get("nvidia_build_api_key", validated_config.api_key)
+    endpoint_url = task_props.get("endpoint_url") or validated_config.embedding_nim_endpoint
+    model_name = task_props.get("model_name") or validated_config.embedding_model
+    api_key = task_props.get("api_key") or validated_config.api_key
     filter_errors = task_props.get("filter_errors", False)
 
-    logger.info(embedding_nim_endpoint)
-    logger.info(embedding_model)
+    logger.info(endpoint_url)
+    logger.info(model_name)
     logger.info(api_key)
 
     logger.debug("Generating text embeddings for supported content types: TEXT, STRUCTURED, IMAGE, AUDIO.")
@@ -333,8 +333,8 @@ def _generate_text_embeddings_df(
         content_embeddings = _async_runner(
             filtered_content_batches,
             api_key,
-            embedding_nim_endpoint,
-            embedding_model,
+            endpoint_url,
+            model_name,
             validated_config.encoding_format,
             validated_config.input_type,
             validated_config.truncate,

--- a/src/nv_ingest/stages/embeddings/text_embeddings.py
+++ b/src/nv_ingest/stages/embeddings/text_embeddings.py
@@ -300,10 +300,6 @@ def _generate_text_embeddings_df(
     api_key = task_props.get("api_key") or validated_config.api_key
     filter_errors = task_props.get("filter_errors", False)
 
-    logger.info(endpoint_url)
-    logger.info(model_name)
-    logger.info(api_key)
-
     logger.debug("Generating text embeddings for supported content types: TEXT, STRUCTURED, IMAGE, AUDIO.")
 
     # Process each supported content type.

--- a/tests/nv_ingest_client/primitives/tasks/test_embed.py
+++ b/tests/nv_ingest_client/primitives/tasks/test_embed.py
@@ -2,8 +2,6 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-
 import pytest
 from nv_ingest_client.primitives.tasks.embed import EmbedTask
 
@@ -11,66 +9,70 @@ from nv_ingest_client.primitives.tasks.embed import EmbedTask
 
 
 def test_embed_task_initialization():
-    os.environ["EMBEDDING_NIM_ENDPOINT"] = "embedding-ms:8000"
-    os.environ["EMBEDDING_NIM_MODEL_NAME"] = "nvidia/test-model"
-    os.environ["NVIDIA_BUILD_API_KEY"] = "api-key"
 
     task = EmbedTask(
+        endpoint_url="http://embedding-ms:8000/v1",
+        model_name="nvidia/test-model",
+        api_key="api-key",
         filter_errors=True,
     )
 
-    del os.environ["EMBEDDING_NIM_ENDPOINT"]
-    del os.environ["EMBEDDING_NIM_MODEL_NAME"]
-    del os.environ["NVIDIA_BUILD_API_KEY"]
-
-    assert task._embedding_nim_endpoint == "http://embedding-ms:8000/v1"
-    assert task._embedding_nim_model_name == "nvidia/test-model"
-    assert task._nvidia_build_api_key == "api-key"
+    assert task._endpoint_url == "http://embedding-ms:8000/v1"
+    assert task._model_name == "nvidia/test-model"
+    assert task._api_key == "api-key"
     assert task._filter_errors
+
+
+# String Representation Tests
+
+
+def test_embed_task_str_representation():
+    task = EmbedTask(
+        endpoint_url="http://embedding-ms:8000/v1",
+        model_name="nvidia/llama-3.2-nv-embedqa-1b-v2",
+        api_key="api-key",
+        filter_errors=False,
+    )
+    expected_str = (
+        "Embed Task:\n"
+        "  endpoint_url: http://embedding-ms:8000/v1\n"
+        "  model_name: nvidia/llama-3.2-nv-embedqa-1b-v2\n"
+        "  api_key: [redacted]\n"
+        "  filter_errors: False\n"
+    )
+    assert str(task) == expected_str
 
 
 # Dictionary Representation Tests
 
 
 @pytest.mark.parametrize(
-    "embedding_nim_endpoint, embedding_nim_model_name, nvidia_build_api_key, filter_errors",
+    "endpoint_url, model_name, api_key, filter_errors",
     [
-        ("localhost:8000", "nvidia/embedding-model", "", True),
+        ("https://integrate.api.nvidia.com/v1", "nvidia/embedding-model", "", True),
         ("http://embedding-ms:8000/v1", "nvidia/llama-3.2-nv-embedqa-1b-v2", "test-key", False),
         ("", "nvidia/nv-embedqa-e5-v5", "42", True),
+        (None, None, None, False),
     ],
 )
 def test_embed_task_to_dict(
-    embedding_nim_endpoint,
-    embedding_nim_model_name,
-    nvidia_build_api_key,
+    endpoint_url,
+    model_name,
+    api_key,
     filter_errors,
 ):
-    os.environ["EMBEDDING_NIM_ENDPOINT"] = embedding_nim_endpoint
-    os.environ["EMBEDDING_NIM_MODEL_NAME"] = embedding_nim_model_name
-    os.environ["NVIDIA_BUILD_API_KEY"] = nvidia_build_api_key
 
-    task = EmbedTask(filter_errors=filter_errors)
+    task = EmbedTask(endpoint_url=endpoint_url, model_name=model_name, api_key=api_key, filter_errors=filter_errors)
 
-    del os.environ["EMBEDDING_NIM_ENDPOINT"]
-    del os.environ["EMBEDDING_NIM_MODEL_NAME"]
-    del os.environ["NVIDIA_BUILD_API_KEY"]
+    expected_dict = {"type": "embed", "task_properties": {"filter_errors": filter_errors}}
 
-    expected_dict = {
-        "type": "embed",
-        "task_properties": {
-            "embedding_nim_model_name": embedding_nim_model_name,
-            "nvidia_build_api_key": nvidia_build_api_key,
-            "filter_errors": filter_errors,
-        },
-    }
-
-    if embedding_nim_endpoint == "":
-        expected_dict["task_properties"]["embedding_nim_endpoint"] = "https://integrate.api.nvidia.com/v1"
-    elif embedding_nim_endpoint[:7] != "http://" and embedding_nim_endpoint[:8] != "https://":
-        expected_dict["task_properties"]["embedding_nim_endpoint"] = "http://" + embedding_nim_endpoint + "/v1"
-    else:
-        expected_dict["task_properties"]["embedding_nim_endpoint"] = embedding_nim_endpoint
+    # Only add properties to expected_dict if they are not None
+    if endpoint_url:
+        expected_dict["task_properties"]["endpoint_url"] = endpoint_url
+    if model_name:
+        expected_dict["task_properties"]["model_name"] = model_name
+    if api_key:
+        expected_dict["task_properties"]["api_key"] = api_key
 
     print(expected_dict)
     print(task.to_dict())
@@ -84,9 +86,6 @@ def test_embed_task_to_dict(
 def test_embed_task_default_params():
     task = EmbedTask()
     expected_str_contains = [
-        "embedding_nim_endpoint: https://integrate.api.nvidia.com/v1",
-        "embedding_nim_model_name: nvidia/llama-3.2-nv-embedqa-1b-v2",
-        "nvidia_build_api_key: [redacted]",
         "filter_errors: False",
     ]
     for expected_part in expected_str_contains:
@@ -95,9 +94,6 @@ def test_embed_task_default_params():
     expected_dict = {
         "type": "embed",
         "task_properties": {
-            "embedding_nim_endpoint": "https://integrate.api.nvidia.com/v1",
-            "embedding_nim_model_name": "nvidia/llama-3.2-nv-embedqa-1b-v2",
-            "nvidia_build_api_key": "",
             "filter_errors": False,
         },
     }


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Reverts env variable logic changes from #440 and adds endpoint_url, model_name, and api arguments to `.embed()`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
