### PR TITLE
pdfium: use the variables rather than literal constants (signed-off variant)

### DIFF
--- a/src/nv_ingest/util/pdf/pdfium.py
+++ b/src/nv_ingest/util/pdf/pdfium.py
@@ -27,13 +27,12 @@ from nv_ingest.util.image_processing.clustering import remove_superset_bboxes
 
 logger = logging.getLogger(__name__)
 
-# Mapping based on the FPDF_PAGEOBJ_* constants
 PDFIUM_PAGEOBJ_MAPPING = {
-    1: "TEXT",  # FPDF_PAGEOBJ_TEXT
-    2: "PATH",  # FPDF_PAGEOBJ_PATH
-    3: "IMAGE",  # FPDF_PAGEOBJ_IMAGE
-    4: "SHADING",  # FPDF_PAGEOBJ_SHADING
-    5: "FORM",  # FPDF_PAGEOBJ_FORM
+    pdfium_c.FPDF_PAGEOBJ_TEXT:    "TEXT",
+    pdfium_c.FPDF_PAGEOBJ_PATH:    "PATH",
+    pdfium_c.FPDF_PAGEOBJ_IMAGE:   "IMAGE",
+    pdfium_c.FPDF_PAGEOBJ_SHADING: "SHADING",
+    pdfium_c.FPDF_PAGEOBJ_FORM:    "FORM",
 }
 
 
@@ -52,9 +51,7 @@ def convert_bitmap_to_corrected_numpy(bitmap: pdfium.PdfBitmap) -> np.ndarray:
     np.ndarray
         A NumPy array representing the correctly formatted image data.
     """
-    # Get the bitmap format information
-    bitmap_info = bitmap.get_info()
-    mode = bitmap_info.mode  # Use the mode to identify the correct format
+    mode = bitmap.mode  # Use the mode to identify the correct format
 
     # Convert to a NumPy array using the built-in method
     img_arr = bitmap.to_numpy().copy()

--- a/src/nv_ingest/util/pdf/pdfium.py
+++ b/src/nv_ingest/util/pdf/pdfium.py
@@ -28,11 +28,11 @@ from nv_ingest.util.image_processing.clustering import remove_superset_bboxes
 logger = logging.getLogger(__name__)
 
 PDFIUM_PAGEOBJ_MAPPING = {
-    pdfium_c.FPDF_PAGEOBJ_TEXT:    "TEXT",
-    pdfium_c.FPDF_PAGEOBJ_PATH:    "PATH",
-    pdfium_c.FPDF_PAGEOBJ_IMAGE:   "IMAGE",
+    pdfium_c.FPDF_PAGEOBJ_TEXT: "TEXT",
+    pdfium_c.FPDF_PAGEOBJ_PATH: "PATH",
+    pdfium_c.FPDF_PAGEOBJ_IMAGE: "IMAGE",
     pdfium_c.FPDF_PAGEOBJ_SHADING: "SHADING",
-    pdfium_c.FPDF_PAGEOBJ_FORM:    "FORM",
+    pdfium_c.FPDF_PAGEOBJ_FORM: "FORM",
 }
 
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Avoid literal constants, and use the variables from the bindings instead.
Also, avoid a needless call of bitmap.get_info() (will disappear in v5). Instead, take the .mode from the bitmap object directly.
Disclaimer: untested.

This is a re-submission of https://github.com/NVIDIA/nv-ingest/pull/412 with signed-off commit.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- New or existing tests cover these changes.
- The documentation is up to date with these changes.
- If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
