### PR TITLE
Adjust default vlm endpoints

### DIFF
--- a/client/src/nv_ingest_client/nv_ingest_cli.py
+++ b/client/src/nv_ingest_client/nv_ingest_cli.py
@@ -131,7 +131,7 @@ Tasks and Options:
       - api_key (str): API key for captioning service.
       Default: os.environ(NVIDIA_BUILD_API_KEY).'
       - endpoint_url (str): Endpoint URL for captioning service.
-      Default: 'https://build.nvidia.com/meta/llama-3.2-90b-vision-instruct'.
+      Default: 'https://build.nvidia.com/meta/llama-3.2-11b-vision-instruct'.
       - prompt (str): Prompt for captioning service.
       Default: 'Caption the content of this image:'.
 \b

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -299,7 +299,7 @@ redis:
 ## @param envVars.MINIO_INTERNAL_ADDRESS [default: "nv-ingest-minio:9000"] Override this to the cluster local DNS name of minio
 ## @param envVars.MINIO_PUBLIC_ADDRESS [default: "http://localhost:9000"] Override this to publicly routable minio address, default assumes port-forwarding
 ## @param envVars.MINIO_BUCKET [default: "nv-ingest"] Override this for specific minio bucket to upload extracted images to
-## @param envVars.VLM_CAPTION_ENDPOINT [default: "https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-90b-vision-instruct/chat/completions"] Override this for specific VLM caption endpoint
+## @param envVars.VLM_CAPTION_ENDPOINT [default: "https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-11b-vision-instruct/chat/completions"] Override this for specific VLM caption endpoint
 ## @skip envVars.REDIS_MORPHEUS_TASK_QUEUE
 ## @skip envVars.CACHED_GRPC_ENDPOINT
 ## @skip envVars.CACHED_HTTP_ENDPOINT
@@ -339,7 +339,8 @@ envVars:
   EMBEDDING_NIM_ENDPOINT: "http://nv-ingest-embedding:8000/v1"
   MILVUS_ENDPOINT: "http://nv-ingest-milvus:19530"
 
-  VLM_CAPTION_ENDPOINT: "https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-90b-vision-instruct/chat/completions"
+  VLM_CAPTION_ENDPOINT: "https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-11b-vision-instruct/chat/completions"
+  VLM_CAPTION_MODEL_NAME: "meta/llama-3.2-11b-vision-instruct"
 
 ## @section Open Telemetry
 ## @descriptionStart

--- a/src/nv_ingest/schemas/image_caption_extraction_schema.py
+++ b/src/nv_ingest/schemas/image_caption_extraction_schema.py
@@ -8,8 +8,8 @@ from pydantic import ConfigDict, BaseModel
 
 class ImageCaptionExtractionSchema(BaseModel):
     api_key: str = "api_key"
-    endpoint_url: str = "https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-90b-vision-instruct/chat/completions"
+    endpoint_url: str = "https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-11b-vision-instruct/chat/completions"
     prompt: str = "Caption the content of this image:"
-    model_name: str = "meta/llama-3.2-90b-vision-instruct"
+    model_name: str = "meta/llama-3.2-11b-vision-instruct"
     raise_on_failure: bool = False
     model_config = ConfigDict(extra="forbid")

--- a/src/nv_ingest/util/pipeline/pipeline_runners.py
+++ b/src/nv_ingest/util/pipeline/pipeline_runners.py
@@ -84,6 +84,7 @@ class PipelineCreationSchema(BaseModel):
     vlm_caption_endpoint: str = os.getenv(
         "VLM_CAPTION_ENDPOINT", "https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-11b-vision-instruct/chat/completions"
     )
+    vlm_caption_model_name: str = os.getenv("VLM_CAPTION_MODEL_NAME", "meta/llama-3.2-11b-vision-instruct")
 
     # YOLOX model endpoints for various document processing tasks
     yolox_graphic_elements_http_endpoint: str = os.getenv(

--- a/src/nv_ingest/util/pipeline/stage_builders.py
+++ b/src/nv_ingest/util/pipeline/stage_builders.py
@@ -458,7 +458,7 @@ def add_image_caption_stage(pipe, morpheus_pipeline_config, ingest_config, defau
     )
 
     endpoint_url = os.environ.get("VLM_CAPTION_ENDPOINT", "localhost:5000")
-    model_name = os.environ.get("VLM_CAPTION_MODEL_NAME", "meta/nv-llama-3.2-90b-vision-instruct")
+    model_name = os.environ.get("VLM_CAPTION_MODEL_NAME", "meta/llama-3.2-11b-vision-instruct")
 
     image_caption_config = ingest_config.get(
         "image_caption_extraction_module",

--- a/tests/nv_ingest/schemas/test_image_caption_extraction_schema.py
+++ b/tests/nv_ingest/schemas/test_image_caption_extraction_schema.py
@@ -11,9 +11,9 @@ def test_valid_schema():
     }
     schema = ImageCaptionExtractionSchema(**valid_data)
     assert schema.api_key == "your-api-key-here"
-    assert schema.endpoint_url == "https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-90b-vision-instruct/chat/completions"
+    assert schema.endpoint_url == "https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-11b-vision-instruct/chat/completions"
     assert schema.prompt == "Caption the content of this image:"
-    assert schema.model_name == "meta/llama-3.2-90b-vision-instruct"
+    assert schema.model_name == "meta/llama-3.2-11b-vision-instruct"
     assert schema.raise_on_failure is False
 
 


### PR DESCRIPTION
## Description
Change default VLM endpoints from 90b -> 11b

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
