### PR TITLE
Rename  field names for library mode

### DIFF
--- a/src/nv_ingest/util/pipeline/pipeline_runners.py
+++ b/src/nv_ingest/util/pipeline/pipeline_runners.py
@@ -90,7 +90,7 @@ class PipelineCreationSchema(BaseModel):
         "YOLOX_GRAPHIC_ELEMENTS_HTTP_ENDPOINT",
         "https://ai.api.nvidia.com/v1/cv/nvidia/nemoretriever-graphic-elements-v1",
     )
-    yolox_graphic_elements_inf_protocol: str = "http"
+    yolox_graphic_elements_infer_protocol: str = "http"
     yolox_http_endpoint: str = os.getenv(
         "YOLOX_HTTP_ENDPOINT", "https://ai.api.nvidia.com/v1/cv/nvidia/nemoretriever-page-elements-v2"
     )
@@ -98,7 +98,7 @@ class PipelineCreationSchema(BaseModel):
     yolox_table_structure_http_endpoint: str = os.getenv(
         "YOLOX_TABLE_STRUCTURE_HTTP_ENDPOINT", "https://ai.api.nvidia.com/v1/cv/nvidia/nemoretriever-table-structure-v1"
     )
-    yolox_table_structure_inf_protocol: str = "http"
+    yolox_table_structure_infer_protocol: str = "http"
 
     model_config = ConfigDict(extra="forbid")
 


### PR DESCRIPTION
## Description
Since the schema field names are used for overwriting the environment variables:
https://github.com/NVIDIA/nv-ingest/blob/6eed5f77d1400a87080fa0e6f7580be580c2c0e6/src/nv_ingest/util/pipeline/pipeline_runners.py#L389-L390
they should match the environment variable names, e.g.,
https://github.com/NVIDIA/nv-ingest/blob/6eed5f77d1400a87080fa0e6f7580be580c2c0e6/docker-compose.yaml#L287

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
