### PR TITLE
add library mode support to audio extraction

### DIFF
--- a/client/src/nv_ingest_client/primitives/jobs/job_spec.py
+++ b/client/src/nv_ingest_client/primitives/jobs/job_spec.py
@@ -174,7 +174,8 @@ class JobSpec:
         if isinstance(task, ExtractTask) and (task._extract_infographics is True):
             self._tasks.append(InfographicExtractionTask())
         if isinstance(task, ExtractTask) and (task._extract_method == "audio"):
-            self._tasks.append(AudioExtractionTask())
+            extract_audio_params = task._extract_audio_params or {}
+            self._tasks.append(AudioExtractionTask(**extract_audio_params))
 
 
 class BatchJobSpec:

--- a/client/src/nv_ingest_client/primitives/tasks/audio_extraction.py
+++ b/client/src/nv_ingest_client/primitives/tasks/audio_extraction.py
@@ -10,7 +10,8 @@ import logging
 from typing import Dict
 from typing import Optional
 
-from pydantic import ConfigDict, BaseModel
+from pydantic import BaseModel
+from pydantic import ConfigDict
 
 from .task_base import Task
 
@@ -22,6 +23,7 @@ class AudioExtractionSchema(BaseModel):
     grpc_endpoint: Optional[str] = None
     http_endpoint: Optional[str] = None
     infer_protocol: Optional[str] = None
+    function_id: Optional[str] = None
     use_ssl: Optional[bool] = None
     ssl_cert: Optional[str] = None
 
@@ -35,6 +37,7 @@ class AudioExtractionTask(Task):
         auth_token: str = None,
         grpc_endpoint: str = None,
         infer_protocol: str = None,
+        function_id: Optional[str] = None,
         use_ssl: bool = None,
         ssl_cert: str = None,
     ) -> None:
@@ -43,6 +46,7 @@ class AudioExtractionTask(Task):
         self._auth_token = auth_token
         self._grpc_endpoint = grpc_endpoint
         self._infer_protocol = infer_protocol
+        self._function_id = function_id
         self._use_ssl = use_ssl
         self._ssl_cert = ssl_cert
 
@@ -59,6 +63,8 @@ class AudioExtractionTask(Task):
             info += f"  grpc_endpoint: {self._grpc_endpoint}\n"
         if self._infer_protocol:
             info += f"  infer_protocol: {self._infer_protocol}\n"
+        if self._function_id:
+            info += "  function_id: [redacted]\n"
         if self._use_ssl:
             info += f"  use_ssl: {self._use_ssl}\n"
         if self._ssl_cert:
@@ -80,6 +86,9 @@ class AudioExtractionTask(Task):
 
         if self._infer_protocol:
             task_properties["infer_protocol"] = self._infer_protocol
+
+        if self._function_id:
+            task_properties["function_id"] = self._function_id
 
         if self._use_ssl:
             task_properties["use_ssl"] = self._use_ssl

--- a/client/src/nv_ingest_client/util/process_json_files.py
+++ b/client/src/nv_ingest_client/util/process_json_files.py
@@ -16,7 +16,7 @@ def ingest_json_results_to_blob(result_content):
 
         # Smarter sorting: by page, then structured objects by x0, y0
         def sorting_key(entry):
-            page = entry["metadata"]["content_metadata"]["page_number"]
+            page = entry["metadata"]["content_metadata"].get("page_number", -1)
             if entry["document_type"] == "structured":
                 # Use table location's x0 and y0 as secondary keys
                 x0 = entry["metadata"]["table_metadata"]["table_location"][0]
@@ -49,6 +49,10 @@ def ingest_json_results_to_blob(result_content):
                 # Add image caption to the blob
                 caption = entry["metadata"]["image_metadata"].get("caption", "")
                 blob.append(f"image_caption:[{caption}]")
+                blob.append("\n")
+
+            elif document_type == "audio":
+                blob.append(entry["metadata"]["audio_metadata"]["audio_transcript"])
                 blob.append("\n")
 
         # Join all parts of the blob into a single string

--- a/src/nv_ingest/schemas/audio_extractor_schema.py
+++ b/src/nv_ingest/schemas/audio_extractor_schema.py
@@ -4,7 +4,6 @@
 
 
 import logging
-from typing import List
 from typing import Optional
 from typing import Tuple
 
@@ -46,7 +45,7 @@ class AudioConfigSchema(BaseModel):
     auth_token: Optional[str] = None
     audio_endpoints: Tuple[Optional[str], Optional[str]] = (None, None)
     audio_infer_protocol: Optional[str] = None
-    auth_metadata: Optional[List[Tuple[str, str]]] = None
+    function_id: Optional[str] = None
     use_ssl: Optional[bool] = None
     ssl_cert: Optional[str] = None
 

--- a/src/nv_ingest/schemas/ingest_job_schema.py
+++ b/src/nv_ingest/schemas/ingest_job_schema.py
@@ -11,11 +11,13 @@ from typing import List
 from typing import Optional
 from typing import Union
 
-from pydantic import field_validator, model_validator, Field
+from pydantic import Field
+from pydantic import field_validator
+from pydantic import model_validator
+from typing_extensions import Annotated
 
 from nv_ingest.schemas.base_model_noext import BaseModelNoExt
 from nv_ingest.schemas.metadata_schema import ContentTypeEnum
-from typing_extensions import Annotated
 
 logger = logging.getLogger(__name__)
 
@@ -150,6 +152,7 @@ class IngestTaskAudioExtraction(BaseModelNoExt):
     grpc_endpoint: Optional[str] = None
     http_endpoint: Optional[str] = None
     infer_protocol: Optional[str] = None
+    function_id: Optional[str] = None
     use_ssl: Optional[bool] = None
     ssl_cert: Optional[str] = None
 

--- a/src/nv_ingest/stages/nim/audio_extraction.py
+++ b/src/nv_ingest/stages/nim/audio_extraction.py
@@ -73,7 +73,7 @@ def _update_metadata(row: pd.Series, audio_client: Any, trace_info: Dict) -> Dic
         )
 
         row["document_type"] = ContentTypeEnum.AUDIO
-        audio_metadata = {"audio_transcript": audio_result}
+        audio_metadata = {"audio_transcript": audio_result or ""}
         metadata["audio_metadata"] = validate_schema(audio_metadata, AudioMetadataSchema).model_dump()
         row["metadata"] = validate_schema(metadata, MetadataSchema).model_dump()
     except Exception as e:

--- a/src/nv_ingest/stages/nim/audio_extraction.py
+++ b/src/nv_ingest/stages/nim/audio_extraction.py
@@ -116,22 +116,21 @@ def _transcribe_audio(
     """
     logger.debug(f"Entering audio extraction stage with {len(df)} rows.")
 
-    extract_params = task_props.get("params", {}).get("extract_audio_params", {})
     stage_config = validated_config.audio_extraction_config
 
-    grpc_endpoint = extract_params.get("grpc_endpoint") or stage_config.audio_endpoints[0]
-    http_endpoint = extract_params.get("http_endpoint") or stage_config.audio_endpoints[1]
-    infer_protocol = extract_params.get("infer_protocol") or stage_config.audio_infer_protocol
-    auth_token = extract_params.get("auth_token") or stage_config.auth_token
-    auth_metadata = extract_params.get("auth_metadata") or stage_config.auth_metadata
-    use_ssl = extract_params.get("use_ssl") or stage_config.use_ssl
-    ssl_cert = extract_params.get("ssl_cert") or stage_config.ssl_cert
+    grpc_endpoint = task_props.get("grpc_endpoint") or stage_config.audio_endpoints[0]
+    http_endpoint = task_props.get("http_endpoint") or stage_config.audio_endpoints[1]
+    infer_protocol = task_props.get("infer_protocol") or stage_config.audio_infer_protocol
+    auth_token = task_props.get("auth_token") or stage_config.auth_token
+    function_id = task_props.get("function_id") or stage_config.function_id
+    use_ssl = task_props.get("use_ssl") or stage_config.use_ssl
+    ssl_cert = task_props.get("ssl_cert") or stage_config.ssl_cert
 
     parakeet_client = create_audio_inference_client(
         (grpc_endpoint, http_endpoint),
         infer_protocol=infer_protocol,
         auth_token=auth_token,
-        auth_metadata=auth_metadata,
+        function_id=function_id,
         use_ssl=use_ssl,
         ssl_cert=ssl_cert,
     )

--- a/src/nv_ingest/util/nim/parakeet.py
+++ b/src/nv_ingest/util/nim/parakeet.py
@@ -24,7 +24,7 @@ class ParakeetClient:
         endpoint: str,
         auth_token: Optional[str] = None,
         function_id: Optional[str] = None,
-        use_ssl: bool = False,
+        use_ssl: Optional[bool] = None,
         ssl_cert: Optional[str] = None,
     ):
         """
@@ -48,7 +48,10 @@ class ParakeetClient:
         self.endpoint = endpoint
         self.auth_token = auth_token
         self.function_id = function_id
-        self.use_ssl = use_ssl
+        if use_ssl is None:
+            self.use_ssl = True if self.function_id else False
+        else:
+            self.use_ssl = use_ssl
         self.ssl_cert = ssl_cert
 
         self.auth_metadata = []

--- a/src/nv_ingest/util/nim/parakeet.py
+++ b/src/nv_ingest/util/nim/parakeet.py
@@ -23,7 +23,7 @@ class ParakeetClient:
         self,
         endpoint: str,
         auth_token: Optional[str] = None,
-        auth_metadata: Optional[List[Tuple[str, str]]] = None,
+        function_id: Optional[str] = None,
         use_ssl: bool = False,
         ssl_cert: Optional[str] = None,
     ):
@@ -36,6 +36,8 @@ class ParakeetClient:
             The URL of the Parakeet service endpoint.
         auth_token : Optional[str], default=None
             The authentication token for accessing the service.
+        function_id: Optional[str]
+            The NVCF function ID for invoking the service.
         use_ssl : bool, default=False
             Whether to use SSL for the connection.
         ssl_cert : Optional[str], default=None
@@ -45,11 +47,15 @@ class ParakeetClient:
         """
         self.endpoint = endpoint
         self.auth_token = auth_token
-        self.auth_metadata = auth_metadata or []
-        if self.auth_token:
-            self.auth_metadata.append(("authorization", f"Bearer {self.auth_token}"))
+        self.function_id = function_id
         self.use_ssl = use_ssl
         self.ssl_cert = ssl_cert
+
+        self.auth_metadata = []
+        if self.auth_token:
+            self.auth_metadata.append(("authorization", f"Bearer {self.auth_token}"))
+        if self.function_id:
+            self.auth_metadata.append(("function-id", self.function_id))
 
         # Create authentication and ASR service objects.
         self._auth = riva.client.Auth(self.ssl_cert, self.use_ssl, self.endpoint, self.auth_metadata)
@@ -275,7 +281,7 @@ def create_audio_inference_client(
     endpoints: Tuple[str, str],
     infer_protocol: Optional[str] = None,
     auth_token: Optional[str] = None,
-    auth_metadata: Optional[Tuple[str, str]] = None,
+    function_id: Optional[str] = None,
     use_ssl: bool = False,
     ssl_cert: Optional[str] = None,
 ):
@@ -292,8 +298,8 @@ def create_audio_inference_client(
         HTTP endpoints are not supported for audio inference.
     auth_token : str, optional
         Authorization token for authentication (default: None).
-    auth_metadata : list of tuples, optional
-        Additional metadata for authentication in the form of a key-value tuple (default: None).
+    function_id : str, optional
+        NVCF function ID of the invocation (default: None)
     use_ssl : bool, optional
         Whether to use SSL for secure communication (default: False).
     ssl_cert : str, optional
@@ -318,5 +324,5 @@ def create_audio_inference_client(
         raise ValueError("`http` endpoints are not supported for audio. Use `grpc`.")
 
     return ParakeetClient(
-        grpc_endpoint, auth_token=auth_token, auth_metadata=auth_metadata, use_ssl=use_ssl, ssl_cert=ssl_cert
+        grpc_endpoint, auth_token=auth_token, function_id=function_id, use_ssl=use_ssl, ssl_cert=ssl_cert
     )

--- a/src/nv_ingest/util/pipeline/pipeline_runners.py
+++ b/src/nv_ingest/util/pipeline/pipeline_runners.py
@@ -41,8 +41,9 @@ class PipelineCreationSchema(BaseModel):
     """
 
     # Audio processing settings
-    audio_http_endpoint: str = "unavailable"
-    audio_infer_protocol: str = "http"
+    audio_grpc_endpoint: str = os.getenv("AUDIO_GRPC_ENDPOINT", "grpc.nvcf.nvidia.com:443")
+    audio_function_id: str = os.getenv("AUDIO_FUNCTION_ID", "")
+    audio_infer_protocol: str = "grpc"
 
     # Embedding model settings
     embedding_nim_endpoint: str = os.getenv("EMBEDDING_NIM_ENDPOINT", "https://integrate.api.nvidia.com/v1")

--- a/src/nv_ingest/util/pipeline/stage_builders.py
+++ b/src/nv_ingest/util/pipeline/stage_builders.py
@@ -380,6 +380,7 @@ def get_audio_retrieval_service(env_var_prefix):
 
 def add_audio_extractor_stage(pipe, morpheus_pipeline_config, ingest_config, default_cpu_count):
     audio_grpc, audio_http, audio_auth, audio_infer_protocol = get_audio_retrieval_service("audio")
+    audio_function_id = os.getenv("AUDIO_FUNCTION_ID", "")
     audio_extractor_config = ingest_config.get(
         "audio_extraction_module",
         {
@@ -387,6 +388,7 @@ def add_audio_extractor_stage(pipe, morpheus_pipeline_config, ingest_config, def
                 "audio_endpoints": (audio_grpc, audio_http),
                 "audio_infer_protocol": audio_infer_protocol,
                 "auth_token": audio_auth,
+                "function_id": audio_function_id,
                 # All auth tokens are the same for the moment
             }
         },

--- a/src/nv_ingest/util/pipeline/stage_builders.py
+++ b/src/nv_ingest/util/pipeline/stage_builders.py
@@ -363,7 +363,10 @@ def get_audio_retrieval_service(env_var_prefix):
         "",
     )
     auth_token = os.environ.get(
-        "RIVA_NGC_API_KEY",
+        "NVIDIA_BUILD_API_KEY",
+        "",
+    ) or os.environ.get(
+        "NGC_API_KEY",
         "",
     )
     infer_protocol = os.environ.get(


### PR DESCRIPTION
## Description
This PR enables library mode with audio extraction.

```python
from nv_ingest.util.pipeline.pipeline_runners import PipelineCreationSchema

config = PipelineCreationSchema(
    audio_grpc_endpoint="grpc.nvcf.nvidia.com:443",
    audio_function_id="<redacted>",
)

pipeline_process = start_pipeline_subprocess(config)

client = NvIngestClient(
    message_client_allocator=SimpleClient,
    message_client_port=7671,
    message_client_hostname="localhost"
)

ingestor = (
    Ingestor(client=client)
    .files("/work/data/audio/*.wav")
    .extract(
        extract_method="audio",
    )
)
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
