### PR TITLE
fix sparse index recording for meta collection log

### DIFF
--- a/client/src/nv_ingest_client/util/milvus.py
+++ b/client/src/nv_ingest_client/util/milvus.py
@@ -338,8 +338,9 @@ def create_nvingest_index_params(
                 metric_type="L2",
                 params={
                     "intermediate_graph_degree": 128,
-                    "graph_degree": 64,
+                    "graph_degree": 96,
                     "build_algo": "NN_DESCENT",
+                    "cache_dataset_on_device": "true",
                     "adapt_for_cpu": "false" if gpu_search else "true",
                 },
             )
@@ -468,7 +469,7 @@ def create_nvingest_collection(
         milvus_uri=milvus_uri,
         dense_index=d_idx._index_type,
         dense_dim=dense_dim,
-        sparse_index=s_idx if sparse else None,
+        sparse_index=s_idx._index_type if sparse else None,
         recreate=recreate_meta,
     )
 
@@ -1122,7 +1123,7 @@ def nvingest_retrieval(
     client = MilvusClient(milvus_uri)
     nv_ranker_top_k = top_k
     if nv_ranker:
-        top_k = top_k * 2
+        top_k = top_k * 20
     if milvus_uri.endswith(".db"):
         local_index = True
     if hybrid:

--- a/tests/nv_ingest_client/util/test_milvus_util.py
+++ b/tests/nv_ingest_client/util/test_milvus_util.py
@@ -74,10 +74,11 @@ def test_op_dict_to_params(collection_name, expected_results):
         coll_name in collection_name.keys()
 
 
-def test_milvus_meta_collection(tmp_path):
+@pytest.mark.parametrize("sparse", [True, False])
+def test_milvus_meta_collection(tmp_path, sparse):
     collection_name = "collection"
     milvus_uri = f"{tmp_path}/test.db"
-    create_nvingest_collection(collection_name, milvus_uri=milvus_uri)
+    create_nvingest_collection(collection_name, milvus_uri=milvus_uri, sparse=sparse)
     results = grab_meta_collection_info(collection_name, milvus_uri=milvus_uri)
     keys = list(results[0].keys())
     assert ["pk", "collection_name", "indexes", "models", "timestamp", "user_fields"] == keys


### PR DESCRIPTION
## Description
Fixes a bug that occurs when you try to log the new collection being created if the collection is using a sparse index. 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
