### PR TITLE
Fix API docs missing from TOC, add one link, fix page title wrapper

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -31,9 +31,9 @@ The following are some applications that use NVIDIA Nemo Retriever:
 - [Digital Human for Customer Service](https://github.com/NVIDIA-AI-Blueprints/digital-human) (NVIDIA AI Blueprint)
 - [AI Virtual Assistant for Customer Service](https://github.com/NVIDIA-AI-Blueprints/ai-virtual-assistant) (NVIDIA AI Blueprint)
 - [Building Code Documentation Agents with CrewAI](https://github.com/crewAIInc/nvidia-demo) (CrewAI Demo)
+- [Video Search and Summarization](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization) (NVIDIA AI Blueprint)
 
 <!-- [Build an Enterprise RAG Pipeline](https://github.com/NVIDIA-AI-Blueprints/rag/tree/v2.0.0) -->
-<!-- [Visual AI Agent for Video Search and Summarization]() -->
 
 
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -70,7 +70,7 @@ nav:
         - Content Metadata: extraction/content-metadata.md
         - Environment Variables: extraction/environment-config.md
         - CLI Reference: extraction/nv-ingest_cli.md
-        - API Reference: extraction/api-docs/index.html
+        - API Reference: extraction/api-docs
 
 plugins:
   - search

--- a/docs/sphinx_docs/source/openapi.rst
+++ b/docs/sphinx_docs/source/openapi.rst
@@ -1,6 +1,6 @@
-===============
+==================================
 NV-Ingest OpenAPI reference
-===============
+==================================
 
 .. swagger-plugin:: openapi.yaml
     :id: nv-ingest-openapi


### PR DESCRIPTION
Fix API docs missing from TOC, add one link, fix page title wrapper