### PR TITLE
remove document_type suffix from source_name in image data extraction

### DIFF
--- a/src/nv_ingest/extraction_workflows/image/image_handlers.py
+++ b/src/nv_ingest/extraction_workflows/image/image_handlers.py
@@ -18,6 +18,7 @@
 
 import io
 import logging
+import os
 import traceback
 from datetime import datetime
 from typing import Dict
@@ -295,7 +296,7 @@ def image_data_extractor(
     base_unified_metadata = row_data.get(kwargs.get("metadata_column", "metadata"), {})
     current_iso_datetime = datetime.now().isoformat()
     source_metadata = {
-        "source_name": source_id,
+        "source_name": source_id if os.path.splitext(source_id)[1] else f"{source_id}.{document_type}",
         "source_id": source_id,
         "source_location": row_data.get("source_location", ""),
         "source_type": document_type,

--- a/src/nv_ingest/extraction_workflows/image/image_handlers.py
+++ b/src/nv_ingest/extraction_workflows/image/image_handlers.py
@@ -295,7 +295,7 @@ def image_data_extractor(
     base_unified_metadata = row_data.get(kwargs.get("metadata_column", "metadata"), {})
     current_iso_datetime = datetime.now().isoformat()
     source_metadata = {
-        "source_name": f"{source_id}_{document_type}",
+        "source_name": source_id,
         "source_id": source_id,
         "source_location": row_data.get("source_location", ""),
         "source_type": document_type,


### PR DESCRIPTION
## Description
This PR proposes to remove the `document_type` suffix from the `source_name` field in the image extraction workflow, because the suffix caused confusion for some customers. This aligns with other extraction workflows (the only exception is PDF extraction, where including `document_type` in `source_name` is intentional due to the way PDF metadata is processed).

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
