### PR TITLE
add return failure mode to client

### DIFF
--- a/client/src/nv_ingest_client/client/interface.py
+++ b/client/src/nv_ingest_client/client/interface.py
@@ -206,7 +206,7 @@ class Ingestor:
 
         return self
 
-    def ingest(self, show_progress: bool = False, **kwargs: Any) -> List[Dict[str, Any]]:
+    def ingest(self, show_progress: bool = False, return_failures=False, **kwargs: Any) -> List[Dict[str, Any]]:
         """
         Synchronously submits jobs to the NvIngestClient and fetches the results.
 
@@ -240,7 +240,12 @@ class Ingestor:
 
             fetch_kwargs["completion_callback"] = progress_callback
 
-        result = self._client.fetch_job_result(self._job_ids, **fetch_kwargs)
+        if return_failures:
+            result, failure = self._client.fetch_job_result(
+                self._job_ids, return_failures=return_failures, **fetch_kwargs
+            )
+        else:
+            result = self._client.fetch_job_result(self._job_ids, return_failures=return_failures, **fetch_kwargs)
 
         if show_progress and pbar:
             pbar.close()
@@ -249,6 +254,9 @@ class Ingestor:
             self._vdb_bulk_upload.run(result)
             # only upload as part of jobs user specified this action
             self._vdb_bulk_upload = None
+
+        if return_failures:
+            return result, failure
 
         return result
 

--- a/tests/nv_ingest_client/client/test_interface.py
+++ b/tests/nv_ingest_client/client/test_interface.py
@@ -244,8 +244,23 @@ def test_ingest(ingestor, mock_client):
     mock_client.add_job.assert_called_once_with(ingestor._job_specs)
     mock_client.submit_job.assert_called_once_with(mock_client.add_job.return_value, ingestor._job_queue_id)
 
-    mock_client.fetch_job_result.assert_called_once_with(mock_client.add_job.return_value)
+    mock_client.fetch_job_result.assert_called_once_with(mock_client.add_job.return_value, return_failures=False)
     assert result == [{"result": "success"}]
+
+
+def test_ingest_return_failures(ingestor, mock_client):
+    mock_client.add_job.return_value = ["job_id_1", "job_id_2"]
+    mock_client.submit_job.return_value = ["job_state_1", "job_state_2"]
+    mock_client.fetch_job_result.return_value = [{"result": "success"}], [(0, {"status": "FAILED"})]
+
+    results, failures = ingestor.ingest(timeout=30, return_failures=True)
+
+    mock_client.add_job.assert_called_once_with(ingestor._job_specs)
+    mock_client.submit_job.assert_called_once_with(mock_client.add_job.return_value, ingestor._job_queue_id)
+
+    mock_client.fetch_job_result.assert_called_once_with(mock_client.add_job.return_value, return_failures=True)
+    assert results == [{"result": "success"}]
+    assert failures == [(0, {"status": "FAILED"})]
 
 
 def test_ingest_async(ingestor, mock_client):


### PR DESCRIPTION
## Description
```python
results = ingestor.ingest()  # Existing behavior
results, failures = ingestor.ingest(return_failures=True)  # New behavior
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
