### PR TITLE
use current timestamp in telemetry when job fails

### DIFF
--- a/src/nv_ingest/modules/telemetry/otel_meter.py
+++ b/src/nv_ingest/modules/telemetry/otel_meter.py
@@ -102,12 +102,15 @@ def _metrics_aggregation(builder: mrc.Builder) -> None:
         gauges["failed_jobs_total"].set(failed_jobs)
 
     def update_job_latency(message):
-        for key, val in message.filter_timestamp("trace::exit::").items():
-            exit_key = key
-            entry_key = exit_key.replace("trace::exit::", "trace::entry::")
-            ts_exit = val
-            ts_entry = message.get_timestamp(entry_key)
-            job_name = key.replace("trace::exit::", "")
+        for key, val in message.filter_timestamp("trace::entry::").items():
+            entry_key = key
+            exit_key = entry_key.replace("trace::entry::", "trace::exit::")
+            ts_entry = val
+            ts_exit = (
+                message.get_timestamp(exit_key) or datetime.now()
+            )  # When a job fails, it may not have exit time. Default to current time.
+
+            job_name = key.replace("trace::entry::", "")
 
             # Sanitize job name
             sanitized_job_name = sanitize_name(job_name)

--- a/src/nv_ingest/modules/telemetry/otel_tracer.py
+++ b/src/nv_ingest/modules/telemetry/otel_tracer.py
@@ -4,6 +4,7 @@
 
 import logging
 import traceback
+from datetime import datetime
 
 import mrc
 from morpheus.utils.module_utils import ModuleLoaderFactory
@@ -141,7 +142,12 @@ def extract_timestamps_from_message(message):
             dedup_counter[task_name] = 0
 
         ts_entry = message.get_timestamp(entry_key)
-        ts_exit = message.get_timestamp(exit_key)
+        if ts_entry is None:
+            continue
+
+        ts_exit = (
+            message.get_timestamp(exit_key) or datetime.now()
+        )  # When a job fails, it may not have exit time. Default to current time.
         ts_entry_ns = int(ts_entry.timestamp() * 1e9)
         ts_exit_ns = int(ts_exit.timestamp() * 1e9)
 


### PR DESCRIPTION
## Description
Sometimes when a job fails, the exit timestamp is not available, and this may result in error logs being polluted irrelevant errors in opentelemetry stages. This PR proposes to use the current time as default when exit timestamps are not avilable.
```
nv-ingest-ms-runtime-1  |     latency_ms = (ts_exit - ts_entry).total_seconds() * 1e3
nv-ingest-ms-runtime-1  | TypeError: unsupported operand type(s) for -: 'datetime.datetime' and 'NoneType'
nv-ingest-ms-runtime-1  | Traceback (most recent call last):
nv-ingest-ms-runtime-1  |   File "/opt/conda/envs/nv_ingest_runtime/lib/python3.10/site-packages/nv_ingest/modules/telemetry/otel_tracer.py", line 115, in on_next
nv-ingest-ms-runtime-1  |     collect_timestamps(message)
nv-ingest-ms-runtime-1  |   File "/opt/conda/envs/nv_ingest_runtime/lib/python3.10/site-packages/nv_ingest/modules/telemetry/otel_tracer.py", line 74, in collect_timestamps
nv-ingest-ms-runtime-1  |     timestamps = extract_timestamps_from_message(message)
nv-ingest-ms-runtime-1  |   File "/opt/conda/envs/nv_ingest_runtime/lib/python3.10/site-packages/nv_ingest/modules/telemetry/otel_tracer.py", line 145, in extract_timestamps_from_message
nv-ingest-ms-runtime-1  |     ts_entry_ns = int(ts_entry.timestamp() * 1e9)
nv-ingest-ms-runtime-1  | AttributeError: 'NoneType' object has no attribute 'timestamp'
```


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
