### PR TITLE
Adjust nv-ingest wheel name to be PyPi friendly

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -5,15 +5,15 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "nv-ingest-client"
 description = "Python client for the nv-ingest service"
-dynamic = ["version"]  # Declare attrs that will be generated at build time
+dynamic = ["version"]
 readme = "README.md"
 authors = [
     {name = "Jeremy Dyer", email = "jdyer@nvidia.com"}
 ]
 license = {file = "LICENSE"}
+requires-python = ">=3.10"
 classifiers = [
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.10",
     "Operating System :: OS Independent",
 ]
 dependencies = [
@@ -39,7 +39,7 @@ dependencies = [
     "python-pptx==0.6.23",
     "redis==5.0.8",
     "requests>=2.32.3",
-    "setuptools>=75.8.0",
+    "setuptools>=58.2.0",
     "tqdm>=4.67.1",
 ]
 
@@ -51,6 +51,9 @@ documentation = "https://docs.nvidia.com/nv-ingest"
 [project.scripts]
 nv-ingest-cli = "nv_ingest_client.nv_ingest_cli:main"
 process-json-files = "nv_ingest_client.util.process_json_files:main"
+
+[tool.setuptools]
+py-modules = ["nv_ingest_client"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/client/src/version.py
+++ b/client/src/version.py
@@ -16,10 +16,12 @@ def get_version():
     if not version:
         version = f"{datetime.datetime.now().strftime('%Y.%m.%d')}"
 
-    # Ensure the version is PEP 440 compatible
-    pep440_regex = r"^\d{4}\.\d{1,2}\.\d{1,2}$"
-    if not re.match(pep440_regex, version):
-        raise ValueError(f"Version '{version}' is not PEP 440 compatible")
+    # We only check this for dev, we assume for release the user knows what they are doing
+    if release_type != "release":
+        # Ensure the version is PEP 440 compatible
+        pep440_regex = r"^\d{4}\.\d{1,2}\.\d{1,2}$"
+        if not re.match(pep440_regex, version):
+            raise ValueError(f"Version '{version}' is not PEP 440 compatible")
 
     # Construct the final version string
     if release_type == "dev":


### PR DESCRIPTION
## Description
Adjust the `version.py` file to not attempt to use a date for an actual "release"

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
