### PR TITLE
Remove graphviz and its dependencies from Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -139,6 +139,11 @@ RUN  --mount=type=cache,target=/root/.cache/pip \
     source activate nv_ingest_runtime \
     && python3 /workspace/docker/post_build_triggers.py
 
+# Remove graphviz and its dependencies to reduce image size
+RUN source activate nv_ingest_runtime && \
+    mamba remove graphviz python-graphviz --force -y && \
+    mamba uninstall gtk3 pango cairo fonts-conda-ecosystem -y
+
 RUN chmod +x /workspace/docker/entrypoint.sh
 
 # Set entrypoint to tini with a custom entrypoint script


### PR DESCRIPTION
## Description

This pull request includes a change to the `Dockerfile` to reduce the image size by removing unnecessary dependencies.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R142-R146): Removed `graphviz`, `python-graphviz`, and other dependencies to reduce the image size.

I'm not 100% sure if the test suite covers this.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] ~If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.~
