### PR TITLE
update python client usage notebook

### DIFF
--- a/client/client_examples/examples/python_client_usage.ipynb
+++ b/client/client_examples/examples/python_client_usage.ipynb
@@ -44,7 +44,7 @@
     "DEFAULT_JOB_TIMEOUT = 90\n",
     "\n",
     "# sample input file and output directory\n",
-    "SAMPLE_PDF = \"/workspace/nv-ingest/data/multimodal_test.pdf\""
+    "SAMPLE_PDF = \"/workspace/data/multimodal_test.pdf\""
    ]
   },
   {
@@ -94,8 +94,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "SAMPLE_PDF = \"../../../data/multimodal_test.pdf\"\n",
-    "\n",
     "ingestor = (\n",
     "    Ingestor(message_client_hostname=HTTP_HOST)\n",
     "    .files(SAMPLE_PDF)\n",
@@ -104,7 +102,7 @@
     "        extract_tables=True,\n",
     "        extract_charts=True,\n",
     "        extract_images=True,\n",
-    "        text_depth=\"document\",\n",
+    "        text_depth=\"page\",\n",
     "    ).dedup(\n",
     "        content_type=\"image\",\n",
     "        filter=True,\n",
@@ -246,7 +244,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "table_metadata = generated_metadata[4][\"metadata\"]\n",
+    "table_metadata = next(d[\"metadata\"] for d in generated_metadata if d[\"metadata\"][\"content_metadata\"][\"subtype\"] == \"table\")\n",
     "redact_metadata_helper(table_metadata)"
    ]
   },
@@ -316,7 +314,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "chart_metadata = generated_metadata[7][\"metadata\"]\n",
+    "chart_metadata = next(d[\"metadata\"] for d in generated_metadata if d[\"metadata\"][\"content_metadata\"][\"subtype\"] == \"chart\")\n",
     "chart_metadata_redact = chart_metadata.copy()\n",
     "chart_metadata_redact[\"content\"] = \"<---Redacted for readability--->\"\n",
     "chart_metadata_redact"
@@ -386,7 +384,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img_metadata = generated_metadata[1][\"metadata\"]\n",
+    "img_metadata = next(d[\"metadata\"] for d in generated_metadata if d[\"metadata\"][\"content_metadata\"][\"type\"] == \"image\")\n",
     "redact_metadata_helper(img_metadata)"
    ]
   },
@@ -452,7 +450,7 @@
     "        extract_tables=True,\n",
     "        extract_charts=True,\n",
     "        extract_images=True,\n",
-    "        text_depth=\"document\",\n",
+    "        text_depth=\"page\",\n",
     "    ).dedup(\n",
     "        content_type=\"image\",\n",
     "        filter=True,\n",
@@ -462,12 +460,11 @@
     "        max_aspect_ratio=5.0,\n",
     "        min_aspect_ratio=0.2,\n",
     "        filter=True,\n",
-    "    ).split(\n",
-    "        chunk_size=300,\n",
-    "        chunk_overlap=10,\n",
-    "        params={\n",
-    "            \"split_source_types\": [\"PDF\"],\n",
-    "        },\n",
+    "    )\n",
+    "    .split(\n",
+    "        tokenizer=\"meta-llama/Llama-3.2-1B\",\n",
+    "        chunk_size=1024,\n",
+    "        chunk_overlap=150,\n",
     "    )\n",
     "    .embed()\n",
     "    .vdb_upload(dense_dim=2048)\n",
@@ -511,15 +508,17 @@
     "\n",
     "query = \"What is the dog doing and where?\"\n",
     "\n",
-    "nvingest_retrieval(\n",
-    "        [query],\n",
-    "        \"nv_ingest_collection\",\n",
-    "        hybrid=False,\n",
-    "        embedding_endpoint=\"http://localhost:8012/v1\",\n",
-    "        model_name=\"nvidia/llama-3.2-nv-embedqa-1b-v2\",\n",
-    "        top_k=1,\n",
-    "        gpu_search=True,\n",
-    ")"
+    "query_results = nvingest_retrieval(\n",
+    "    [query],\n",
+    "    \"nv_ingest_collection\",\n",
+    "    hybrid=False,\n",
+    "    embedding_endpoint=\"http://localhost:8012/v1\",\n",
+    "    model_name=\"nvidia/llama-3.2-nv-embedqa-1b-v2\",\n",
+    "    top_k=1,\n",
+    "    gpu_search=True,\n",
+    ")\n",
+    "\n",
+    "print(query_results[0])"
    ]
   },
   {
@@ -547,7 +546,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description
The notebook was using the old splitter. This PR updates it to the new, tokenizer-based splitter.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- ~~[ ] New or existing tests cover these changes.~~
- [x] The documentation is up to date with these changes.
- ~~[ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.~~
