### PR TITLE
In pipeline_runners set is_port_in_use to use SO_REUSEADDR

### DIFF
--- a/src/nv_ingest/util/pipeline/pipeline_runners.py
+++ b/src/nv_ingest/util/pipeline/pipeline_runners.py
@@ -360,7 +360,7 @@ def _terminate_subprocess(process: Optional["subprocess.Popen"] = None) -> None:
 
 def is_port_in_use(port, host="127.0.0.1"):
     """
-    Checks if a given port is in use on the specified host.
+    Checks if a given port is in use on the specified host with socket reuse settings.
 
     Parameters:
         port (int): The port number to check.
@@ -370,6 +370,7 @@ def is_port_in_use(port, host="127.0.0.1"):
         bool: True if the port is in use, False otherwise.
     """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             sock.bind((host, port))
             return False


### PR DESCRIPTION
Checking to see if this reduces the time required between re-running the local pipeline.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
