### PR TITLE
raise exception instead of returning none when parakeet fails

### DIFF
--- a/src/nv_ingest/util/nim/parakeet.py
+++ b/src/nv_ingest/util/nim/parakeet.py
@@ -209,7 +209,7 @@ class ParakeetClient:
             return response
         except grpc.RpcError as e:
             logger.error(f"Error transcribing audio file: {e.details()}")
-            return None
+            raise
 
 
 def convert_to_mono_wav(audio_bytes):


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
