### PR TITLE
add external parkeet endpoint for library mode

### DIFF
--- a/src/nv_ingest/util/pipeline/pipeline_runners.py
+++ b/src/nv_ingest/util/pipeline/pipeline_runners.py
@@ -43,7 +43,7 @@ class PipelineCreationSchema(BaseModel):
 
     # Audio processing settings
     audio_grpc_endpoint: str = os.getenv("AUDIO_GRPC_ENDPOINT", "grpc.nvcf.nvidia.com:443")
-    audio_function_id: str = os.getenv("AUDIO_FUNCTION_ID", "")
+    audio_function_id: str = os.getenv("AUDIO_FUNCTION_ID", "1598d209-5e27-4d3c-8079-4751568b1081")
     audio_infer_protocol: str = "grpc"
 
     # Embedding model settings


### PR DESCRIPTION
## Description
You can double-check the function ID on build: https://build.nvidia.com/nvidia/parakeet-ctc-1_1b-asr/api

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
