### PR TITLE
Adjust conda build for CI conda release support

### DIFF
--- a/.github/workflows/conda-publish.yml
+++ b/.github/workflows/conda-publish.yml
@@ -17,6 +17,9 @@ on:
         options:
           - dev
           - main
+      VERSION:
+        description: 'Version string for the release (e.g., 1.0.0)'
+        required: true
 
 jobs:
   build:
@@ -38,7 +41,11 @@ jobs:
       # Build the Conda packages
       - name: Build Conda Packages
         run: |
-          ./conda/build_conda_packages.sh
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            RELEASE_VERSION=${{ github.event.inputs.VERSION }} ./conda/build_conda_packages.sh
+          else
+            ./conda/build_conda_packages.sh
+          fi
 
       # Publish nv-ingest conda packages
       - name: Publish conda package

--- a/conda/build_conda_packages.sh
+++ b/conda/build_conda_packages.sh
@@ -28,6 +28,7 @@ CONDA_CHANNEL=${2:-""}
 BUILD_NV_INGEST=${BUILD_NV_INGEST:-1} # 1 = build by default, 0 = skip
 BUILD_NV_INGEST_API=${BUILD_NV_INGEST_API:-1} # 1 = build by default, 0 = skip
 BUILD_NV_INGEST_CLIENT=${BUILD_NV_INGEST_CLIENT:-1} # 1 = build by default, 0 = skip
+RELEASE_VERSION="${RELEASE_VERSION:-}" # Version to override output name for release
 
 ##############################
 # Package Directories
@@ -51,7 +52,14 @@ if [[ "${BUILD_NV_INGEST_API}" -eq 1 ]]; then
     echo "Building nv_ingest_api..."
     SCRIPT_PATH="$GIT_ROOT/api/src/version.py"
     echo "SCRIPT_PATH: $SCRIPT_PATH"
-    NV_INGEST_API_VERSION=$(python3 -c "import sys, importlib.util; spec = importlib.util.spec_from_file_location('version', '$SCRIPT_PATH'); version = importlib.util.module_from_spec(spec); spec.loader.exec_module(version); print(version.get_version())")
+
+    # Generate the version if not specified
+    if [ -z "$RELEASE_VERSION" ]; then
+        NV_INGEST_API_VERSION=$(python3 -c "import sys, importlib.util; spec = importlib.util.spec_from_file_location('version', '$SCRIPT_PATH'); version = importlib.util.module_from_spec(spec); spec.loader.exec_module(version); print(version.get_version())")
+    else
+        NV_INGEST_API_VERSION=$RELEASE_VERSION
+    fi
+
     echo "NV_INGEST_API_VERSION: $NV_INGEST_API_VERSION"
     NV_INGEST_API_VERSION="${NV_INGEST_API_VERSION}" GIT_ROOT="${GIT_ROOT}/api" GIT_SHA="${GIT_SHA}" conda build "${NV_INGEST_API_DIR}" \
         -c nvidia/label/dev -c rapidsai -c nvidia -c conda-forge -c pytorch \
@@ -62,7 +70,17 @@ fi
 
 if [[ "${BUILD_NV_INGEST}" -eq 1 ]]; then
     echo "Building nv_ingest..."
-    GIT_ROOT="${GIT_ROOT}" GIT_SHA="${GIT_SHA}" conda build "${NV_INGEST_DIR}" \
+
+    # Generate the version if not specified
+    if [ -z "$RELEASE_VERSION" ]; then
+        # Setting to Unknown will cause the version to be pulled from the nv-ingest setup.py file at conda build time
+        NV_INGEST_RELEASE_VERSION="Unknown"
+    else
+        NV_INGEST_RELEASE_VERSION=$RELEASE_VERSION
+    fi
+
+    echo "NV_INGEST_VERSION: $NV_INGEST_RELEASE_VERSION"
+    NV_INGEST_RELEASE_VERSION="${NV_INGEST_RELEASE_VERSION}" GIT_ROOT="${GIT_ROOT}" GIT_SHA="${GIT_SHA}" conda build "${NV_INGEST_DIR}" \
         -c nvidia/label/dev -c rapidsai -c nvidia -c conda-forge -c pytorch \
         --output-folder "${OUTPUT_DIR}" --no-anaconda-upload
 else
@@ -73,7 +91,14 @@ if [[ "${BUILD_NV_INGEST_CLIENT}" -eq 1 ]]; then
     echo "Building nv_ingest_client..."
     SCRIPT_PATH="$GIT_ROOT/client/src/version.py"
     echo "SCRIPT_PATH: $SCRIPT_PATH"
-    NV_INGEST_CLIENT_VERSION=$(python3 -c "import sys, importlib.util; spec = importlib.util.spec_from_file_location('version', '$SCRIPT_PATH'); version = importlib.util.module_from_spec(spec); spec.loader.exec_module(version); print(version.get_version())")
+
+    # Generate the version if not specified
+    if [ -z "$RELEASE_VERSION" ]; then
+        NV_INGEST_CLIENT_VERSION=$(python3 -c "import sys, importlib.util; spec = importlib.util.spec_from_file_location('version', '$SCRIPT_PATH'); version = importlib.util.module_from_spec(spec); spec.loader.exec_module(version); print(version.get_version())")
+    else
+        NV_INGEST_CLIENT_VERSION=$RELEASE_VERSION
+    fi
+
     echo "NV_INGEST_CLIENT_VERSION: $NV_INGEST_CLIENT_VERSION"
     NV_INGEST_CLIENT_VERSION="${NV_INGEST_CLIENT_VERSION}" GIT_ROOT="${GIT_ROOT}/client" GIT_SHA="${GIT_SHA}" conda build "${NV_INGEST_CLIENT_DIR}" \
         -c nvidia/label/dev -c rapidsai -c nvidia -c conda-forge -c pytorch \

--- a/conda/packages/nv_ingest/meta.yaml
+++ b/conda/packages/nv_ingest/meta.yaml
@@ -4,9 +4,14 @@
 
 {% set data = load_setup_py_data() %}
 {% set name = data.get('name', 'nv_ingest') | lower %}
-{% set version = data.get('version') %}
 {% set py_version = environ['CONDA_PY'] %}
 {% set GIT_SHA = environ['GIT_SHA'] %}
+
+{% set version = environ.get('NV_INGEST_RELEASE_VERSION', 'Unknown') %}
+{% if version == 'Unknown' %}
+# Get version from setup.py
+{% set version = data.get('version') %}
+{% endif %}
 
 # Determine Git root, falling back to default path ../../.. if Git is not available or the directory is not a Git repo
 {% set git_root = environ.get('GIT_ROOT', '../../..') %}
@@ -27,7 +32,7 @@ build:
 requirements:
   build:
     - pip
-    - python==3.10
+    - python=3.10
     - setuptools>=58.2.0
   run:
     - azure-core>=1.32.0

--- a/conda/packages/nv_ingest_api/meta.yaml
+++ b/conda/packages/nv_ingest_api/meta.yaml
@@ -24,7 +24,7 @@ build:
 requirements:
   build:
     - pip
-    - python==3.10
+    - python=3.10
     - setuptools>=58.2.0
   run:
     - azure-core>=1.32.0

--- a/conda/packages/nv_ingest_client/meta.yaml
+++ b/conda/packages/nv_ingest_client/meta.yaml
@@ -24,7 +24,7 @@ build:
 requirements:
   build:
     - pip
-    - python==3.10
+    - python=3.10
     - setuptools>=58.2.0
   run:
     - click>=8.1.7


### PR DESCRIPTION
## Description
Adjust conda build process to accept a specific version rather than loading dev versions from scripts. This enabled making conda releases from Github

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
