### PR TITLE
Pin morpheus version to 25.02

### DIFF
--- a/.github/workflows/conda-publish.yml
+++ b/.github/workflows/conda-publish.yml
@@ -53,4 +53,4 @@ jobs:
 
       # Publish nv-ingest conda packages
       - name: Publish conda package
-        run: anaconda -t "${{ secrets.NVIDIA_CONDA_TOKEN }}" upload --label $CONDA_CHANNEL ./conda/output_conda_channel/linux-64/*.conda
+        run: anaconda -t "${{ secrets.NVIDIA_CONDA_TOKEN }}" upload --force --force-metadata-update --label $CONDA_CHANNEL ./conda/output_conda_channel/linux-64/*.conda

--- a/.github/workflows/conda-publish.yml
+++ b/.github/workflows/conda-publish.yml
@@ -53,4 +53,4 @@ jobs:
 
       # Publish nv-ingest conda packages
       - name: Publish conda package
-        run: anaconda -t "${{ secrets.NVIDIA_CONDA_TOKEN }}" upload --force --force-metadata-update --label $CONDA_CHANNEL ./conda/output_conda_channel/linux-64/*.conda
+        run: anaconda -t "${{ secrets.NVIDIA_CONDA_TOKEN }}" upload --force --label $CONDA_CHANNEL ./conda/output_conda_channel/linux-64/*.conda

--- a/conda/environments/nv_ingest_environment.yml
+++ b/conda/environments/nv_ingest_environment.yml
@@ -15,8 +15,8 @@ dependencies:
   - isodate>=0.7.2
   - langdetect>=1.0.9
   - minio>=7.2.12
-  - morpheus-core=25.02.00a
-  - morpheus-llm=25.02.00a
+  - morpheus-core=25.02
+  - morpheus-llm=25.02
   - openai>=1.57.1
   - opentelemetry-api>=1.27.0
   - opentelemetry-exporter-otlp>=1.27.0

--- a/conda/packages/nv_ingest/meta.yaml
+++ b/conda/packages/nv_ingest/meta.yaml
@@ -44,8 +44,8 @@ requirements:
     - isodate>=0.7.2
     - langdetect>=1.0.9
     - minio>=7.2.12
-    - morpheus-core=25.02.00a
-    - morpheus-llm=25.02.00a
+    - morpheus-core=25.02
+    - morpheus-llm=25.02
     - openai>=1.57.1
     - opentelemetry-api>=1.27.0
     - opentelemetry-exporter-otlp>=1.27.0


### PR DESCRIPTION
## Description
Pins the Morpheus version to 25.02

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
