### PR TITLE
Bump python minimum version to 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ NV-Ingest does not do the following:
 - [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
 
 > [!Note]
-> You install Python in a later step. NVIDIA-Ingest only supports [Python version 3.10](https://www.python.org/downloads/release/python-3100/).
+> You install Python in a later step. NVIDIA-Ingest only supports [Python version 3.12](https://www.python.org/downloads/release/python-3120/).
 
 ## Quickstart
 

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -11,9 +11,9 @@ authors = [
     {name = "Jeremy Dyer", email = "jdyer@nvidia.com"}
 ]
 license = {file = "LICENSE"}
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 classifiers = [
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
 ]
 dependencies = [
@@ -39,7 +39,7 @@ dependencies = [
     "python-pptx==0.6.23",
     "redis==5.0.8",
     "requests>=2.28.2",
-    "setuptools>=58.2.0",
+    "setuptools>=75.8.2",
     "tqdm>=4.67.1",
 ]
 

--- a/conda/environments/nv_ingest_api_environment.yml
+++ b/conda/environments/nv_ingest_api_environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - pytest>=8.0.2
   - pytest-mock>=3.14.0
   - pytest-cov>=6.0.0
-  - python>=3.10
+  - python>=3.12
   - python-build>=1.2.2
-  - setuptools>=58.2.0
+  - setuptools>=75.8.2
   - pip

--- a/conda/environments/nv_ingest_client_environment.yml
+++ b/conda/environments/nv_ingest_client_environment.yml
@@ -1,6 +1,5 @@
 name: nv_ingest_client
 channels:
-  - nvidia/label/dev
   - rapidsai
   - nvidia
   - conda-forge
@@ -13,11 +12,11 @@ dependencies:
   - pytest>=8.0.2
   - pytest-mock>=3.14.0
   - pytest-cov>=6.0.0
-  - python>=3.10
+  - python>=3.12
   - python-build>=1.2.2
   - python-docx>=1.1.2
   - python-pptx>=1.0.2
   - requests>=2.28.2
-  - setuptools>=58.2.0
+  - setuptools>=75.8.2
   - tqdm>=4.67.1
   - pip

--- a/conda/environments/nv_ingest_environment.yml
+++ b/conda/environments/nv_ingest_environment.yml
@@ -6,43 +6,43 @@ channels:
   - conda-forge
   - pytorch
 dependencies:
-  - azure-core>=1.32.0
-  - click>=8.1.7
-  - fastapi>=0.115.6
-  - fastparquet>=2024.11.0
-  - fsspec>=2024.10.0
+  - azure-core
+  - click
+  - fastapi
+  - fastparquet
+  - fsspec
   - gunicorn
-  - httpx>=0.28.1
-  - isodate>=0.7.2
-  - langdetect>=1.0.9
-  - minio>=7.2.12
-  - morpheus-core=25.02
-  - morpheus-llm=25.02
-  - openai>=1.57.1
+  - httpx
+  - isodate
+  - langdetect
+  - minio
+  - morpheus-core=25.06.00a
+  - morpheus-llm=25.06.00a
+  - openai
   - opentelemetry-api>=1.27.0
   - opentelemetry-exporter-otlp>=1.27.0
   - opentelemetry-sdk>=1.27.0
   - pydantic>2.0.0
   - pydantic-settings>2.0.0
-  - pypdfium2>=4.30.0
-  - pytest>=8.0.2
-  - pytest-mock>=3.14.0
-  - pytest-cov>=6.0.0
-  - python>=3.10
-  - python-build>=1.2.2
-  - python-docx>=1.1.2
-  - python-dotenv>=1.0.1
-  - python-pptx>=1.0.2
+  - pypdfium2
+  - pytest
+  - pytest-mock
+  - pytest-cov
+  - python>=3.12
+  - python-build
+  - python-docx
+  - python-dotenv
+  - python-pptx
   - pytorch
-  - redis-py>=5.2.1
-  - requests>=2.28.2
-  - scipy>=1.15.1
-  - setuptools>=58.2.0
-  - tabulate>=0.9.0
+  - redis-py
+  - requests
+  - scipy
+  - setuptools
+  - tabulate
   - torchvision
   - torchaudio
-  - transformers>=4.47.0
-  - tqdm>=4.67.1
+  - transformers
+  - tqdm
   - uvicorn
   - pip
   - pip:

--- a/conda/packages/nv_ingest/meta.yaml
+++ b/conda/packages/nv_ingest/meta.yaml
@@ -32,8 +32,8 @@ build:
 requirements:
   build:
     - pip
-    - python=3.10
-    - setuptools>=58.2.0
+    - python=3.12
+    - setuptools>=75.8.2
   run:
     - azure-core>=1.32.0
     - click>=8.1.7
@@ -54,7 +54,7 @@ requirements:
     - pypdfium2>=4.30.0
     - pytest>=8.0.2
     - pytest-mock>=3.14.0
-    - python>=3.10
+    - python>=3.12
     - python-docx>=1.1.2
     - python-dotenv>=1.0.1
     - python-magic>=0.4.27
@@ -63,7 +63,7 @@ requirements:
     - redis-py>=5.2.1
     - requests>=2.28.2
     - scipy>=1.15.1
-    - setuptools>=58.2.0
+    - setuptools>=75.8.2
     - tabulate>=0.9.0
     - torchaudio
     - torchvision

--- a/conda/packages/nv_ingest_api/meta.yaml
+++ b/conda/packages/nv_ingest_api/meta.yaml
@@ -24,8 +24,8 @@ build:
 requirements:
   build:
     - pip
-    - python=3.10
-    - setuptools>=58.2.0
+    - python=3.12
+    - setuptools>=75.8.2
   run:
     - azure-core>=1.32.0
     - fastparquet>=2024.11.0
@@ -38,14 +38,14 @@ requirements:
     - pypdfium2>=4.30.0
     - pytest>=8.0.2
     - pytest-mock>=3.14.0
-    - python>=3.10
+    - python>=3.12
     - python-docx>=1.1.2
     - python-dotenv>=1.0.1
     - python-magic>=0.4.27
     - python-pptx>=1.0.2
     - pytorch
     - requests>=2.28.2
-    - setuptools>=58.2.0
+    - setuptools>=75.8.2
     - tabulate>=0.9.0
     - torchaudio
     - torchvision

--- a/conda/packages/nv_ingest_client/meta.yaml
+++ b/conda/packages/nv_ingest_client/meta.yaml
@@ -24,19 +24,19 @@ build:
 requirements:
   build:
     - pip
-    - python=3.10
-    - setuptools>=58.2.0
+    - python=3.12
+    - setuptools>=75.8.2
   run:
     - click>=8.1.7
     - fsspec>=2024.10.0
     - httpx>=0.28.1
     - pydantic>=2.0.0
     - pypdfium2>=4.30.0
-    - python>=3.10
+    - python>=3.12
     - python-docx>=1.1.2
     - python-pptx>=1.0.2
     - requests>=2.28.2
-    - setuptools>=58.2.0
+    - setuptools>=75.8.2
     - tqdm>=4.67.1
 
   test:

--- a/deploy/pdf-blueprint.ipynb
+++ b/deploy/pdf-blueprint.ipynb
@@ -1079,7 +1079,7 @@
       "Python-dotenv could not parse statement starting at line 57\n",
       "None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.\n",
       "[nltk_data] Downloading package punkt_tab to\n",
-      "[nltk_data]     /home/ubuntu/.pyenv/versions/3.10.15/lib/python3.10/si\n",
+      "[nltk_data]     /home/ubuntu/.pyenv/versions/3.12.15/lib/python3.10/si\n",
       "[nltk_data]     te-packages/llama_index/core/_static/nltk_cache...\n",
       "[nltk_data]   Unzipping tokenizers/punkt_tab.zip.\n"
      ]
@@ -1222,7 +1222,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.12.16"
   }
  },
  "nbformat": 4,

--- a/docs/docs/extraction/prerequisites.md
+++ b/docs/docs/extraction/prerequisites.md
@@ -15,7 +15,7 @@ Before you begin using [NeMo Retriever extraction](overview.md), ensure the foll
 
 !!! note
 
-    You install Python later. NV-Ingest only supports [Python version 3.10](https://www.python.org/downloads/release/python-3100/).
+    You install Python later. NV-Ingest only supports [Python version 3.12](https://www.python.org/downloads/release/python-3120/).
 
 
 ## Related Topics

--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -103,7 +103,7 @@ To interact from the host, you'll need a Python environment and install the clie
 
 ```
 # conda not required but makes it easy to create a fresh Python environment
-conda create --name nv-ingest-dev python=3.10
+conda create --name nv-ingest-dev python=3.12
 conda activate nv-ingest-dev
 pip install nv-ingest-client==2025.3.10.dev20250310
 ```

--- a/docs/docs/extraction/quickstart-library-mode.md
+++ b/docs/docs/extraction/quickstart-library-mode.md
@@ -7,7 +7,7 @@ To get started using [NeMo Retriever extraction](overview.md) in library mode, y
 
 - Linux operating systems (Ubuntu 22.04 or later recommended)
 - [Conda Python environment and package manager](https://github.com/conda-forge/miniforge)
-- [Python version 3.10](https://www.python.org/downloads/release/python-3100/)
+- [Python version 3.12](https://www.python.org/downloads/release/python-3120/)
 
 
 
@@ -18,7 +18,7 @@ Use the following procedure to prepare your environment.
 1. Run the following code to create your NVIDIA Ingest Conda environment.
 
     ```
-    conda create -y --name nvingest python=3.10
+    conda create -y --name nvingest python=3.12
     conda activate nvingest
     conda install -y -c rapidsai -c rapidsai-nightly -c conda-forge -c nvidia nvidia/label/dev::nv_ingest nvidia/label/dev::nv_ingest_client nvidia/label/dev::nv_ingest_api
     pip install opencv-python llama-index-embeddings-nvidia pymilvus 'pymilvus[bulk_writer, model]' milvus-lite dotenv ffmpeg nvidia-riva-client

--- a/examples/llama_index_multimodal_rag.ipynb
+++ b/examples/llama_index_multimodal_rag.ipynb
@@ -186,7 +186,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.12.16"
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,6 @@ setup(
     name="nv_ingest",
     package_dir={"": "src"},
     packages=find_packages(where="src"),
-    python_requires=">=3.10",
+    python_requires=">=3.12",
     version=get_version(),
 )


### PR DESCRIPTION
## Description
This PR bumps the minimum required Python version for nv-ingest from 3.10 -> 3.12. This also supports the latest version of Morpheus.

Developers will need to update their local environments to account for these changes.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
