### PR TITLE
Ignore markdown files for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
     -   id: trailing-whitespace
         exclude: '^(docs|data)'
+        exclude: \.(md|markdown)$
     -   id: end-of-file-fixer
     -   id: check-added-large-files
         args: [-- maxkb=1500]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,7 @@ repos:
     rev: v5.0.0
     hooks:
     -   id: trailing-whitespace
-        exclude: '^(docs|data)'
-        exclude: \.(md|markdown)$
+        exclude: '(^(docs|data)/|\.md$)'
     -   id: end-of-file-fixer
     -   id: check-added-large-files
         args: [-- maxkb=1500]


### PR DESCRIPTION
## Description
Ignore markdown files with linter

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
