### PR TITLE
Add subtype to pptx table extraction

### DIFF
--- a/api/src/nv_ingest_api/internal/extract/pptx/engines/pptx_helper.py
+++ b/api/src/nv_ingest_api/internal/extract/pptx/engines/pptx_helper.py
@@ -627,6 +627,7 @@ def _construct_table_metadata(
             "line": -1,
             "span": -1,
         },
+        "subtype": ContentTypeEnum.TABLE,
     }
     table_metadata = {
         "caption": "",


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This fixes an issue where the subtype field is blank for tables extracted from pptx documents

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
