### PR TITLE
Fix image preprocessing to return uint8 array instead of float32

### DIFF
--- a/api/src/nv_ingest_api/internal/extract/image/image_helpers/common.py
+++ b/api/src/nv_ingest_api/internal/extract/image/image_helpers/common.py
@@ -71,8 +71,8 @@ def load_and_preprocess_image(image_stream: io.BytesIO) -> np.ndarray:
     # Load image from the byte stream
     processed_image = Image.open(image_stream).convert("RGB")
 
-    # Convert image to numpy array and normalize pixel values
-    image_array = np.asarray(processed_image, dtype=np.float32)
+    # Convert image to numpy uint8 array
+    image_array = np.asarray(processed_image)
 
     return image_array
 


### PR DESCRIPTION
## Description
Updated to return a uint8 NumPy array by removing the explicit dtype cast to float32. Applying `np.asarray` directly to a PIL image automatically produces a uint8 array, which is the expected format for downstream processing. This change avoids unnecessary type conversion and preserves the original pixel values as intended.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
