### PR TITLE
Add librosa to test-library-mode workflow dependencies

### DIFF
--- a/.github/workflows/test-library-mode.yml
+++ b/.github/workflows/test-library-mode.yml
@@ -81,6 +81,7 @@ jobs:
           conda create -y --name nvingest python=3.10
           conda activate nvingest
           conda install -y -c ./test_artifacts/conda/output_conda_channel -c rapidsai -c conda-forge -c nvidia nv_ingest nv_ingest_api nv_ingest_client
+          conda install -y -c conda-forge librosa
           $CONDA/envs/nvingest/bin/python -m pip install opencv-python llama-index-embeddings-nvidia pymilvus 'pymilvus[bulk_writer, model]' milvus-lite nvidia-riva-client unstructured-client
       - name: Run integration test
         env:


### PR DESCRIPTION
## Description
This PR updates the `test-library-mode.yml` GitHub Actions workflow to explicitly install `librosa` via conda. This ensures that audio-related dependencies are available during integration tests.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
