### PR TITLE
Add integration test for audio extraction

### DIFF
--- a/api/api_tests/primitives/nim/model_interface/test_parakeet.py
+++ b/api/api_tests/primitives/nim/model_interface/test_parakeet.py
@@ -89,7 +89,7 @@ class TestParakeetClient(unittest.TestCase):
     def test_initialization_auto_ssl(self):
         """Test automatic SSL detection based on function_id."""
         # With function_id but no explicit use_ssl
-        client = ParakeetClient(endpoint="test.endpoint:50051", function_id="test_function_id")
+        client = ParakeetClient(endpoint="grpc.nvcf.nvidia.com:443", function_id="test_function_id")
         self.assertTrue(client.use_ssl)
 
         # Without function_id and no explicit use_ssl

--- a/api/src/nv_ingest_api/internal/primitives/nim/model_interface/parakeet.py
+++ b/api/src/nv_ingest_api/internal/primitives/nim/model_interface/parakeet.py
@@ -60,7 +60,7 @@ class ParakeetClient:
         self.auth_token = auth_token
         self.function_id = function_id
         if use_ssl is None:
-            self.use_ssl = True if self.function_id else False
+            self.use_ssl = True if ("grpc.nvcf.nvidia.com" in self.endpoint) and self.function_id else False
         else:
             self.use_ssl = use_ssl
         self.ssl_cert = ssl_cert

--- a/src/nv_ingest/framework/orchestration/morpheus/util/pipeline/stage_builders.py
+++ b/src/nv_ingest/framework/orchestration/morpheus/util/pipeline/stage_builders.py
@@ -408,29 +408,38 @@ def get_audio_retrieval_service(env_var_prefix):
         "",
     )
     auth_token = os.environ.get(
-        "RIVA_NGC_API_KEY",
+        "NVIDIA_BUILD_API_KEY",
+        "",
+    ) or os.environ.get(
+        "NGC_API_KEY",
         "",
     )
     infer_protocol = os.environ.get(
         "AUDIO_INFER_PROTOCOL",
         "http" if http_endpoint else "grpc" if grpc_endpoint else "",
     )
+    function_id = os.environ.get(
+        "AUDIO_FUNCTION_ID",
+        "",
+    )
 
-    logger.info(f"{prefix}_GRPC_TRITON: {grpc_endpoint}")
-    logger.info(f"{prefix}_HTTP_TRITON: {http_endpoint}")
+    logger.info(f"{prefix}_GRPC_ENDPOINT: {grpc_endpoint}")
+    logger.info(f"{prefix}_HTTP_ENDPOINT: {http_endpoint}")
     logger.info(f"{prefix}_INFER_PROTOCOL: {infer_protocol}")
+    logger.info(f"{prefix}_FUNCTION_ID: {function_id}")
 
-    return grpc_endpoint, http_endpoint, auth_token, infer_protocol
+    return grpc_endpoint, http_endpoint, auth_token, infer_protocol, function_id
 
 
 def add_audio_extractor_stage(pipe, morpheus_pipeline_config, ingest_config, default_cpu_count):
-    audio_grpc, audio_http, audio_auth, audio_infer_protocol = get_audio_retrieval_service("audio")
+    audio_grpc, audio_http, audio_auth, audio_infer_protocol, audio_function_id = get_audio_retrieval_service("audio")
     audio_extractor_config = ingest_config.get(
         "audio_extraction_module",
         {
             "audio_extraction_config": {
                 "audio_endpoints": (audio_grpc, audio_http),
                 "audio_infer_protocol": audio_infer_protocol,
+                "function_id": audio_function_id,
                 "auth_token": audio_auth,
                 # All auth tokens are the same for the moment
             }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,27 @@
+import sys
+import time
+
+import pytest
+
+from nv_ingest.framework.orchestration.morpheus.util.pipeline.pipeline_runners import PipelineCreationSchema
+from nv_ingest.framework.orchestration.morpheus.util.pipeline.pipeline_runners import start_pipeline_subprocess
+
+
+@pytest.fixture
+def pipeline_process():
+    config = PipelineCreationSchema()
+    process = start_pipeline_subprocess(
+        config,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+    )
+
+    time.sleep(5)
+
+    if process.poll() is not None:
+        raise RuntimeError("Error running pipeline subprocess.")
+
+    yield process
+
+    process.kill()
+    process.wait()

--- a/tests/integration/test_extract_audio.py
+++ b/tests/integration/test_extract_audio.py
@@ -8,7 +8,8 @@ from nv_ingest_client.client import Ingestor
 from nv_ingest_client.client import NvIngestClient
 
 
-def test_images_extract_only(
+@pytest.mark.integration
+def test_audio_extract_only(
     pipeline_process,
 ):
     client = NvIngestClient(

--- a/tests/integration/test_extract_audio.py
+++ b/tests/integration/test_extract_audio.py
@@ -1,0 +1,38 @@
+import subprocess
+import sys
+import time
+
+import pytest
+from nv_ingest_api.util.message_brokers.simple_message_broker import SimpleClient
+from nv_ingest_client.client import Ingestor
+from nv_ingest_client.client import NvIngestClient
+
+
+def test_images_extract_only(
+    pipeline_process,
+):
+    client = NvIngestClient(
+        message_client_allocator=SimpleClient,
+        message_client_port=7671,
+        message_client_hostname="localhost",
+    )
+
+    ingestor = (
+        Ingestor(client=client)
+        .files("./data/multimodal_test.wav")
+        .extract(
+            extract_method="audio",
+        )
+    )
+
+    results = ingestor.ingest()
+    assert len(results) == 1
+
+    transcript = results[0][0]["metadata"]["audio_metadata"]["audio_transcript"]
+    expected = (
+        "Section one, this is the first section of the document. "
+        "It has some more placeholder text to show how the document looks like. "
+        "The text is not meant to be meaningful or informative, "
+        "but rather to demonstrate the layout and formatting of the document."
+    )
+    assert transcript == expected


### PR DESCRIPTION
## Description
This PR introduces an integration test for audio extraction that validates transcription output from a `.wav` file using the "audio" extract method. The test ensures that audio input is correctly processed and returns the expected transcript.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
