### PR TITLE
Lazy import llama_index in milvus utility to avoid unwanted side effects

### DIFF
--- a/client/src/nv_ingest_client/util/milvus.py
+++ b/client/src/nv_ingest_client/util/milvus.py
@@ -8,7 +8,6 @@ from typing import Union
 from urllib.parse import urlparse
 
 import requests
-from llama_index.embeddings.nvidia import NVIDIAEmbedding
 from nv_ingest_client.util.process_json_files import ingest_json_results_to_blob
 from nv_ingest_client.util.util import ClientConfigSchema
 from pymilvus import AnnSearchRequest
@@ -1150,6 +1149,8 @@ def nvingest_retrieval(
     List
         Nested list of top_k results per query.
     """
+    from llama_index.embeddings.nvidia import NVIDIAEmbedding
+
     client_config = ClientConfigSchema()
     nvidia_api_key = client_config.nvidia_build_api_key
     # required for NVIDIAEmbedding call if the endpoint is Nvidia build api.


### PR DESCRIPTION
## Description

This PR moves `from llama_index.embeddings.nvidia import NVIDIAEmbedding` inside the `nvingest_retrieval()` function in order to prevent top-level import from triggering logging:
```
[nltk_data] Downloading package punkt_tab to
[nltk_data]     /opt/conda/envs/nv_ingest_runtime/lib/python3.10/site-
[nltk_data]     packages/llama_index/core/_static/nltk_cache...
[nltk_data]   Unzipping tokenizers/punkt_tab.zip.
```
and downloading when the module is not used.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
