### PR TITLE
Fix basename extraction from fsspec file URLs

### DIFF
--- a/client/src/nv_ingest_client/client/interface.py
+++ b/client/src/nv_ingest_client/client/interface.py
@@ -16,6 +16,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Union
+from urllib.parse import urlparse
 
 import fsspec
 from nv_ingest_client.client.client import NvIngestClient
@@ -194,7 +195,8 @@ class Ingestor:
                     local_files.append(local_path)
             else:
                 with fsspec.open(pattern_or_path, **kwargs) as f:
-                    original_name = os.path.basename(f.path)
+                    parsed_url = urlparse(f.path)
+                    original_name = os.path.basename(parsed_url.path)
                     local_path = os.path.join(temp_dir, original_name)
                     with open(local_path, "wb") as local_file:
                         shutil.copyfileobj(f, local_file)


### PR DESCRIPTION
## Description
Previously, `os.path.basename(f.path)` could return incorrect results for remote paths handled by `fsspec`, particularly those including query terms in AWS pre-signed URLs https://aws-s3-presigned-url/remote.txt?a-long-query-term-with-1708-charactrers. This change uses `urllib.parse.urlparse` to extract the path component before passing it to `os.path.basename`, ensuring correct filename resolution.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
