### PR TITLE
Provide option to pass full url and headers to RestClient

### DIFF
--- a/api/src/nv_ingest_api/util/service_clients/rest/rest_client.py
+++ b/api/src/nv_ingest_api/util/service_clients/rest/rest_client.py
@@ -215,11 +215,11 @@ class RestClient(MessageBrokerClientBase):
 
                 # Fetch using streaming response
                 with requests.get(
-                        url,
-                        timeout=(30, 600),
-                        stream=True,
-                        headers=headers,
-                        auth=self._auth,
+                    url,
+                    timeout=(30, 600),
+                    stream=True,
+                    headers=headers,
+                    auth=self._auth,
                 ) as result:
                     response_code = result.status_code
 

--- a/api/src/nv_ingest_api/util/service_clients/rest/rest_client.py
+++ b/api/src/nv_ingest_api/util/service_clients/rest/rest_client.py
@@ -96,6 +96,7 @@ class RestClient(MessageBrokerClientBase):
         max_backoff: int = 32,
         connection_timeout: int = 300,
         http_allocator: Any = httpx.AsyncClient,
+        **kwargs,
     ):
         self._host = host
         self._port = port
@@ -108,6 +109,14 @@ class RestClient(MessageBrokerClientBase):
 
         self._submit_endpoint = "/v1/submit_job"
         self._fetch_endpoint = "/v1/fetch_job"
+
+        if "base_url" in kwargs:
+            logger.debug("Using custom base_url; ignoring host and port")
+
+        self._base_url = kwargs.get("base_url") or self.generate_url(self._host, self._port)
+        self._headers = kwargs.get("headers", {})
+        self._auth = kwargs.get("auth", None)
+
 
     def _connect(self) -> None:
         """
@@ -194,13 +203,24 @@ class RestClient(MessageBrokerClientBase):
             The fetched message wrapped in a ResponseSchema object.
         """
         retries = 0
+        url = f"{self._base_url}{self._fetch_endpoint}/{job_id}"
+
+        # Ensure headers are included
+        headers = {"Content-Type": "application/json"}
+        headers.update(self._headers)
+
         while True:
             try:
-                url = f"{self.generate_url(self._host, self._port)}{self._fetch_endpoint}/{job_id}"
                 logger.debug(f"Invoking fetch_message http endpoint @ '{url}'")
 
                 # Fetch using streaming response
-                with requests.get(url, timeout=(30, 600), stream=True) as result:
+                with requests.get(
+                        url,
+                        timeout=(30, 600),
+                        stream=True,
+                        headers=headers,
+                        auth=self._auth,
+                ) as result:
                     response_code = result.status_code
 
                     if response_code in _TERMINAL_RESPONSE_STATUSES:
@@ -282,11 +302,22 @@ class RestClient(MessageBrokerClientBase):
             The response from the server wrapped in a ResponseSchema object.
         """
         retries = 0
+        url = f"{self._base_url}{self._submit_endpoint}"
+
+        # Ensure content-type is present
+        headers = {"Content-Type": "application/json"}
+        headers.update(self._headers)
+
         while True:
             try:
                 # Submit via HTTP
-                url = f"{self.generate_url(self._host, self._port)}{self._submit_endpoint}"
-                result = requests.post(url, json={"payload": message}, headers={"Content-Type": "application/json"})
+                result = requests.post(
+                    url,
+                    json={"payload": message},
+                    headers=headers,
+                    auth=self._auth,
+                    timeout=self._connection_timeout,
+                )
 
                 response_code = result.status_code
                 if response_code in _TERMINAL_RESPONSE_STATUSES:

--- a/api/src/nv_ingest_api/util/service_clients/rest/rest_client.py
+++ b/api/src/nv_ingest_api/util/service_clients/rest/rest_client.py
@@ -117,7 +117,6 @@ class RestClient(MessageBrokerClientBase):
         self._headers = kwargs.get("headers", {})
         self._auth = kwargs.get("auth", None)
 
-
     def _connect(self) -> None:
         """
         Attempts to reconnect to the HTTP server if the current connection is not responsive.


### PR DESCRIPTION
## Description
This PR modifies the RestClient to allow the full URL of the nv-ingest endpoint to be passed, as an alternative to the hostname/port parameters. This is intended as a minimally intrusive, backward compatible change that can flexibly handle a variety of URL scheme, hostname, and port options. 

For example, for our application we intend to use a base URLs of the form: https://mysite.com/path. Given this base URL, the client would then be able to call https://mysite.com/path/v1/submit_job and https://mysite.com/path/v1/submit_job.

There is no way to get the current hostname/port parameters to correctly handle this type of URL, as any path after the base URL gets dropped. (It also doesn't seem to handle https:// URLs or non-default port numbers very well.) 

The PR also allows the user to specify HTTP headers such as an authentication token that are applied on calls to the backend nv-ingest service.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
