### PR TITLE
NV_INGEST_MAX_UTIL must be cast from string to int

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v5.0.0
     hooks:
     -   id: trailing-whitespace
-        exclude: '^(docs|data)'
+        exclude: '(^(docs|data)/|\.md$)'
     -   id: end-of-file-fixer
     -   id: check-added-large-files
         args: [-- maxkb=1500]

--- a/README.md
+++ b/README.md
@@ -6,19 +6,14 @@ SPDX-License-Identifier: Apache-2.0
 
 ## NVIDIA-Ingest: Multi-modal data extraction
 
-NVIDIA-Ingest is a scalable, performance-oriented document content and metadata extraction microservice. Including support for parsing PDFs, Word and PowerPoint documents, it uses specialized NVIDIA NIM microservices to find, contextualize, and extract text, tables, charts and images for use in downstream generative applications.
+NVIDIA-Ingest is a scalable, performance-oriented content and metadata extraction SDK for a variety of input formats. NV-Ingest includes support for parsing PDFs, text files, Microsoft Word and PowerPoint documents, plain images, and audio files. NV-Ingest uses specialized NVIDIA NIMs (self-hosted microservices, or hosted on build.nvidia.com) to find, contextualize, and extract text, tables, charts, and unstructured images that you can use in downstream generative applications.
 
 > [!Note]
-> NVIDIA Ingest is also known as NV-Ingest and NeMo Retriever Extraction.
+> NVIDIA Ingest is also known as NV-Ingest and [NeMo Retriever Extraction](https://docs.nvidia.com/nemo/retriever/extraction/overview/).
 
-NVIDIA Ingest enables parallelization of splitting documents into pages where artifacts are classified (such as text, tables, charts, and images), extracted, and further contextualized through optical character recognition (OCR) into a well defined JSON schema. From there, NVIDIA Ingest can optionally manage computation of embeddings for the extracted content, and also optionally manage storing into a vector database [Milvus](https://milvus.io/).
+NVIDIA Ingest enables parallelization of the process of splitting documents into pages where contents are classified (as tables, charts, images, text), extracted into discrete content, and further contextualized via optical character recognition (OCR) into a well defined JSON schema. From there, NVIDIA Ingest can optionally manage computation of embeddings for the extracted content, and also optionally manage storing into a vector database [Milvus](https://milvus.io/).
 
-> [!Note]
-> Cached and Deplot are deprecated.
-> Instead, docker-compose now uses a beta version of the yolox-graphic-elements container.
-> With this change, you should now be able to run nv-ingest on a single 80GB A100 or H100 GPU.
-> If you want to use the old pipeline, with Cached and Deplot, use the [nv-ingest 24.12.1 release](https://github.com/NVIDIA/nv-ingest/tree/24.12.1).
-
+![Pipeline Overview](https://docs.nvidia.com/nemo/retriever/extraction/images/overview-extraction.png)
 
 ### Table of Contents
 1. [Introduction](#introduction)
@@ -31,12 +26,13 @@ NVIDIA Ingest enables parallelization of splitting documents into pages where ar
 
 ## What NVIDIA-Ingest Is ✔️
 
-NV-Ingest is a microservice service that does the following:
+NV-Ingest is a library and microservice service that does the following:
 
-- Accept a JSON job description, containing a document payload, and a set of ingestion tasks to perform on that payload.
-- Allow the results of a job to be retrieved. The result is a JSON dictionary that contains a list of metadata describing objects extracted from the base document, and processing annotations and timing/trace data.
-- Support multiple methods of extraction for each document type to balance trade-offs between throughput and accuracy. For example, for .pdf documents, we support extraction through pdfium, Unstructured.io, and Adobe Content Extraction Services.
-- Support various types of pre- and post- processing operations, including text splitting and chunking, transform and filtering, embedding generation, and image offloading to storage.
+- Accept a job specification that contains a document payload and a set of ingestion tasks to perform on that payload.
+- Store the result of each job to retrieve later. The result is a dictionary that contains a list of metadata that describes the objects extracted from the base document, and processing annotations and timing/trace data.
+- Support multiple methods of extraction for each document type to balance trade-offs between throughput and accuracy. For example, for .pdf documents nv-ingest supports extraction through pdfium, [nemoretriever-parse](https://build.nvidia.com/nvidia/nemoretriever-parse), Unstructured.io, and Adobe Content Extraction Services.
+- Support various types of before and after processing operations, including text splitting and chunking, transform and filtering, embedding generation, and image offloading to storage.
+
 
 NV-Ingest supports the following file types:
 
@@ -49,353 +45,215 @@ NV-Ingest supports the following file types:
 - `tiff`
 - `txt`
 
-
-## What NVIDIA-Ingest Isn't ✖️
-
-NV-Ingest does not do the following:
-
-- Run a static pipeline or fixed set of operations on every submitted document.
-- Act as a wrapper for any specific document parsing library.
-
-
 ## Prerequisites
 
-### Hardware
+For production-level performance and scalability, we recommend that you deploy the pipeline and supporting NIMs by using Docker Compose or Kubernetes ([helm charts](helm)). For more information, refer to [prerequisites](https://docs.nvidia.com/nv-ingest/user-guide/getting-started/prerequisites).
 
-| GPU | Family | Memory | # of GPUs (min.) |
-| ------ | ------ | ------ | ------ |
-| H100 | SXM or PCIe | 80GB | 1 |
-| A100 | SXM or PCIe | 80GB | 1 |
+## Library Mode Quickstart
 
-### Software
+For small-scale workloads, such as workloads of fewer than 100 PDFs, you can use library mode setup. Library mode set up depends on NIMs that are already self-hosted, or, by default, NIMs that are hosted on build.nvidia.com.
+
+Library mode deployment of nv-ingest requires:
 
 - Linux operating systems (Ubuntu 22.04 or later recommended)
-- [Docker](https://docs.docker.com/engine/install/)
-- [Docker Compose](https://docs.docker.com/compose/install/)
-- [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads) (NVIDIA Driver >= `535`, CUDA >= `12.2`)
-- [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+- [Conda Python environment and package manager](https://github.com/conda-forge/miniforge)
+- Python 3.10
 
-> [!Note]
-> You install Python in a later step. NVIDIA-Ingest only supports [Python version 3.10](https://www.python.org/downloads/release/python-3100/).
+### Step 1: Prepare Your Environment
 
-## Quickstart
+Create a fresh conda environment in which to install nv-ingest and dependencies.
 
-To get started using NVIDIA Ingest, you need to do a few things:
-1. [Start supporting NIM microservices](#step-1-starting-containers) 🏗️
-2. [Install the NVIDIA Ingest client dependencies in a Python environment](#step-2-installing-python-dependencies) 🐍
-3. [Submit ingestion job(s)](#step-3-ingesting-documents) 📓
-4. [Inspect and consume results](#step-4-inspecting-and-consuming-results) 🔍
-
-Optional:
-1. [Direct Library Deployment](docs/docs/extraction/quickstart-library-mode.md) 📦
-
-### Step 1: Starting containers
-
-This example demonstrates how to use the provided [docker-compose.yaml](docker-compose.yaml) to start all needed services with a few commands.
-
-> [!IMPORTANT]
-> NIM containers on their first startup can take 10-15 minutes to pull and fully load models.
-
-If you prefer, you can run on Kubernetes by using [our Helm chart](helm/README.md). Also, there are [additional environment variables](docs/docs/extraction/environment-config.md) you may wish to configure.
-
-1. Git clone the repo:
-`git clone https://github.com/nvidia/nv-ingest`
-2. Change directory to the cloned repo
-`cd nv-ingest`.
-
-3. [Generate API keys](docs/docs/extraction/ngc-api-key.md) and authenticate with NGC with the `docker login` command:
 ```shell
-# This is required to access pre-built containers and NIM microservices
-$ docker login nvcr.io
-Username: $oauthtoken
-Password: <Your Key>
+conda create -y --name nvingest python=3.10 && \
+    conda activate nvingest && \
+    conda install -y -c rapidsai -c conda-forge -c nvidia nv_ingest=25.3.0 nv_ingest_client=25.3.0 nv_ingest_api=25.3.0 && \
+    pip install opencv-python llama-index-embeddings-nvidia pymilvus 'pymilvus[bulk_writer, model]' milvus-lite nvidia-riva-client unstructured-client
 ```
 
-> [!NOTE]
-> During the early access (EA) phase, you must apply for early access here: https://developer.nvidia.com/nemo-microservices-early-access/join.
-> When your early access is approved, follow the instructions in the email to create an organization and team, link your profile, and generate your NGC API key.
-
-4. Create a .env file that contains your NVIDIA Build API key and other environment variables.
-
-> [!NOTE]
-> If you use an NGC personal key, then you should provide the same value for all keys, but you must specify each environment variable individually.
-> In the past, you could create an API key. If you have an API key, you can still use that.
-> For more information, refer to [Generate Your NGC Keys](docs/docs/extraction/ngc-api-key.md) and [Environment Configuration Variables](docs/docs/extraction/environment-config.md).
-
+Make sure to set your NVIDIA_BUILD_API_KEY and NVIDIA_API_KEY. If you don't have one, you can get one on [build.nvidia.com](https://build.nvidia.com/nvidia/llama-3_2-nv-embedqa-1b-v2?snippet_tab=Python&signin=true&api_key=true).
 ```
-# Container images must access resources from NGC.
-
-NVIDIA_BUILD_API_KEY=<key to use NIMs that are hosted on build.nvidia.com>
-NVIDIA_API_KEY=<copy of NVIDIA_BUILD_API_KEY, llama-index connectors use this key>
+#Note: these should be the same value
+export NVIDIA_BUILD_API_KEY=nvapi-...
+export NVIDIA_API_KEY=nvapi-...
 ```
 
-> [!NOTE]
-> As configured by default in [docker-compose.yaml](docker-compose.yaml#L52), the DePlot NIM is on a dedicated GPU. All other NIMs and the nv-ingest container itself share a second. This is to avoid DePlot and other NIMs competing for VRAM on the same device.
->
-> Change the `CUDA_VISIBLE_DEVICES` pinnings as desired for your system within docker-compose.yaml.
+### Step 2: Ingest Documents
 
-> [!IMPORTANT]
-> Make sure NVIDIA is set as your default container runtime before running the docker compose command with the command:
-> `sudo nvidia-ctk runtime configure --runtime=docker --set-as-default`
+You can submit jobs programmatically in Python.
 
-> [!NOTE]
-> The most accurate tokenizer based splitting depends on the [llama-3.2 tokenizer](https://huggingface.co/meta-llama/Llama-3.2-1B). To download this model at container build time, you must set `DOWNLOAD_LLAMA_TOKENIZER=True` _and_ supply an authorized HuggingFace access token via `HF_ACCESS_TOKEN=<your access token>`. If not, the ungated [e5-large-unsupervised](https://huggingface.co/intfloat/e5-large-unsupervised) tokenizer model will be downloaded instead. By default, the split task will use whichever model has been predownloaded. Refer to [Environment Configuration Variables](docs/docs/extraction/environment-config.md) for more info.
-
-5. Start all services:
-`docker compose --profile retrieval up`
-
-> [!TIP]
-> By default we have [configured log levels to be verbose](docker-compose.yaml).
->
-> It's possible to observe service startup proceeding: you will notice many log messages. Disable verbose logging by configuring `NIM_TRITON_LOG_VERBOSE=0` for each NIM in [docker-compose.yaml](docker-compose.yaml).
->
-> If you want to build from source, use `docker compose up --build` instead. This will build from your repo's code rather than from an already published container.
-
-6. When all services have fully started, `nvidia-smi` should show processes like the following:
+Note: Make sure your conda environment is activated. `which python` should indicate that you're using the conda provided python installation (not an OS provided python).
 ```
-# If it's taking > 1m for `nvidia-smi` to return, it's likely the bus is still busy setting up the models.
-+---------------------------------------------------------------------------------------+
-| Processes:                                                                            |
-|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
-|        ID   ID                                                             Usage      |
-|=======================================================================================|
-|    0   N/A  N/A   1352957      C   tritonserver                                762MiB |
-|    1   N/A  N/A   1322081      C   /opt/nim/llm/.venv/bin/python3            63916MiB |
-|    2   N/A  N/A   1355175      C   tritonserver                                478MiB |
-|    2   N/A  N/A   1367569      C   ...s/python/triton_python_backend_stub       12MiB |
-|    3   N/A  N/A   1321841      C   python                                      414MiB |
-|    3   N/A  N/A   1352331      C   tritonserver                                478MiB |
-|    3   N/A  N/A   1355929      C   ...s/python/triton_python_backend_stub      424MiB |
-|    3   N/A  N/A   1373202      C   tritonserver                                414MiB |
-+---------------------------------------------------------------------------------------+
+which python
+/home/dev/miniforge3/envs/nvingest/bin/python
 ```
 
-
-Observe the started containers with `docker ps`:
+If you have a very high number of CPUs and see the process hang without progress, we recommend using taskset to limit the number of CPUs visible to the process:
 ```
-CONTAINER ID   IMAGE                                                                      COMMAND                  CREATED          STATUS                    PORTS                                                                                                                                                                                                                                                                                NAMES
-0f2f86615ea5   nvcr.io/nvidia/nemo-microservices/nv-ingest:24.12                       "/opt/conda/bin/tini…"   35 seconds ago   Up 33 seconds             0.0.0.0:7670->7670/tcp, :::7670->7670/tcp                                                                                                                                                                                                                                            nv-ingest-nv-ingest-ms-runtime-1
-de44122c6ddc   otel/opentelemetry-collector-contrib:0.91.0                                "/otelcol-contrib --…"   14 hours ago     Up 24 seconds             0.0.0.0:4317-4318->4317-4318/tcp, :::4317-4318->4317-4318/tcp, 0.0.0.0:8888-8889->8888-8889/tcp, :::8888-8889->8888-8889/tcp, 0.0.0.0:13133->13133/tcp, :::13133->13133/tcp, 55678/tcp, 0.0.0.0:32849->9411/tcp, :::32848->9411/tcp, 0.0.0.0:55680->55679/tcp, :::55680->55679/tcp   nv-ingest-otel-collector-1
-02c9ab8c6901   nvcr.io/nvidia/nemo-microservices/cached:0.2.0                          "/opt/nvidia/nvidia_…"   14 hours ago     Up 24 seconds             0.0.0.0:8006->8000/tcp, :::8006->8000/tcp, 0.0.0.0:8007->8001/tcp, :::8007->8001/tcp, 0.0.0.0:8008->8002/tcp, :::8008->8002/tcp                                                                                                                                                      nv-ingest-cached-1
-d49369334398   nvcr.io/nim/nvidia/nv-embedqa-e5-v5:1.1.0                                  "/opt/nvidia/nvidia_…"   14 hours ago     Up 33 seconds             0.0.0.0:8012->8000/tcp, :::8012->8000/tcp, 0.0.0.0:8013->8001/tcp, :::8013->8001/tcp, 0.0.0.0:8014->8002/tcp, :::8014->8002/tcp                                                                                                                                                      nv-ingest-embedding-1
-508715a24998   nvcr.io/nvidia/nemo-microservices/nv-yolox-structured-images-v1:0.2.0   "/opt/nvidia/nvidia_…"   14 hours ago     Up 33 seconds             0.0.0.0:8000-8002->8000-8002/tcp, :::8000-8002->8000-8002/tcp                                                                                                                                                                                                                        nv-ingest-yolox-1
-5b7a174a0a85   nvcr.io/nvidia/nemo-microservices/deplot:1.0.0                          "/opt/nvidia/nvidia_…"   14 hours ago     Up 33 seconds             0.0.0.0:8003->8000/tcp, :::8003->8000/tcp, 0.0.0.0:8004->8001/tcp, :::8004->8001/tcp, 0.0.0.0:8005->8002/tcp, :::8005->8002/tcp                                                                                                                                                      nv-ingest-deplot-1
-430045f98c02   nvcr.io/nvidia/nemo-microservices/paddleocr:0.2.0                       "/opt/nvidia/nvidia_…"   14 hours ago     Up 24 seconds             0.0.0.0:8009->8000/tcp, :::8009->8000/tcp, 0.0.0.0:8010->8001/tcp, :::8010->8001/tcp, 0.0.0.0:8011->8002/tcp, :::8011->8002/tcp                                                                                                                                                      nv-ingest-paddle-1
-8e587b45821b   grafana/grafana                                                            "/run.sh"                14 hours ago     Up 33 seconds             0.0.0.0:3000->3000/tcp, :::3000->3000/tcp                                                                                                                                                                                                                                            grafana-service
-aa2c0ec387e2   redis/redis-stack                                                          "/entrypoint.sh"         14 hours ago     Up 33 seconds             0.0.0.0:6379->6379/tcp, :::6379->6379/tcp, 8001/tcp                                                                                                                                                                                                                                  nv-ingest-redis-1
-bda9a2a9c8b5   openzipkin/zipkin                                                          "start-zipkin"           14 hours ago     Up 33 seconds (healthy)   9410/tcp, 0.0.0.0:9411->9411/tcp, :::9411->9411/tcp                                                                                                                                                                                                                                  nv-ingest-zipkin-1
-ac27e5297d57   prom/prometheus:latest                                                     "/bin/prometheus --w…"   14 hours ago     Up 33 seconds             0.0.0.0:9090->9090/tcp, :::9090->9090/tcp                                                                                                                                                                                                                                            nv-ingest-prometheus-1
+taskset -c 0-3 python your_ingestion_script.py
 ```
 
-> [!TIP]
-> nv-ingest is in Early Access mode, meaning the codebase gets frequent updates. To build an updated nv-ingest service container with the latest changes you can:
-> ```
-> docker compose build
-> ```
->
-> After the image builds, run `docker compose --profile retrieval up` or `docker compose up --build` as explained in the previous step.
+On a 4 CPU core low end laptop, the following should take about 10 seconds:
+```python
+import logging, os, time, sys
+               
+from nv_ingest.util.pipeline.pipeline_runners import start_pipeline_subprocess
+from nv_ingest_client.client import Ingestor, NvIngestClient
+from nv_ingest_client.message_clients.simple.simple_client import SimpleClient
+from nv_ingest.util.pipeline.pipeline_runners import PipelineCreationSchema
+from nv_ingest_client.util.process_json_files import ingest_json_results_to_blob
 
-### Step 2: Install Python dependencies
+# Start the pipeline subprocess for library mode
+config = PipelineCreationSchema()
 
-To interact with the nv-ingest service, you can do so from the host, or by `docker exec`-ing into the nv-ingest container.
+pipeline_process = start_pipeline_subprocess(config)
+# you can configure the subprocesses to log stderr to stdout for debugging purposes
+#pipeline_process = start_pipeline_subprocess(config, stderr=sys.stderr, stdout=sys.stdout)
 
-To interact from the host, you'll need a Python environment and install the client dependencies:
+client = NvIngestClient(
+    message_client_allocator=SimpleClient,
+    message_client_port=7671,
+    message_client_hostname="localhost"
+)
+                                            
+# Note: gpu_cagra accelerated indexing is not yet available in milvus-lite
+# Provide a filename for milvus_uri to use milvus-lite
+milvus_uri = "milvus.db"
+collection_name = "test"
+sparse=False
 
-```bash
-# conda not required, but makes it easy to create a fresh python environment
-conda env create --name nv-ingest-dev --file ./conda/environments/nv_ingest_environment.yml
-conda activate nv-ingest-dev
+# do content extraction from files
+ingestor = (
+    Ingestor(client=client)
+    .files("data/multimodal_test.pdf")
+    .extract(
+        extract_text=True,
+        extract_tables=True,
+        extract_charts=True,
+        extract_images=True,
+        paddle_output_format="markdown",
+        extract_infographics=True,
+        # Slower, but maximally accurate, especially for PDFs with pages that are scanned images
+        #extract_method="nemoretriever_parse",
+        text_depth="page"
+    ).embed()
+    .vdb_upload(
+        collection_name=collection_name,
+        milvus_uri=milvus_uri,
+        sparse=sparse,
+        # for llama-3.2 embedder, use 1024 for e5-v5
+        dense_dim=2048
+    )
+)
 
-cd client
-pip install .
+print("Starting ingestion..")
+t0 = time.time()
+results = ingestor.ingest(show_progress=True)
+t1 = time.time()
+print(f"Time taken: {t1-t0} seconds")
 
-# When not using Conda, pip dependencies for the client can be installed directly via pip. Pip based installation of
-# the ingest service is not supported.
-cd client
-pip install .
+# results blob is directly inspectable
+print(ingest_json_results_to_blob(results[0]))
 ```
 
-> [!NOTE]
-> Interacting from the host depends on the appropriate port being exposed from the nv-ingest container to the host as defined in [docker-compose.yaml](docker-compose.yaml).
->
-> If you prefer, you can disable exposing that port, and interact with the nv-ingest service directly from within its container.
->
-> To interact within the container:
-> ```
-> docker exec -it nv-ingest-nv-ingest-ms-runtime-1 bash
-> ```
-> You'll be in the `/workspace` directory, which has `DATASET_ROOT` from the .env file mounted at `./data`. The pre-activated `morpheus` conda environment has all the python client libraries pre-installed:
-> ```
-> (morpheus) root@aba77e2a4bde:/workspace#
-> ```
->
-> From the bash prompt above, you can run nv-ingest-cli and Python examples described below.
+You can see the extracted text that represents the content of the ingested test document.
+```shell
+Starting ingestion..
+Time taken: 9.243880033493042 seconds
 
-### Step 3: Ingesting Documents
+TestingDocument
+A sample document with headings and placeholder text
+Introduction
+This is a placeholder document that can be used for any purpose. It contains some 
+headings and some placeholder text to fill the space. The text is not important and contains 
+no real value, but it is useful for testing. Below, we will have some simple tables and charts 
+that we can use to confirm Ingest is working as expected.
+Table 1
+This table describes some animals, and some activities they might be doing in specific 
+locations.
+Animal Activity Place
+Gira@e Driving a car At the beach
+Lion Putting on sunscreen At the park
+Cat Jumping onto a laptop In a home o@ice
+Dog Chasing a squirrel In the front yard
+Chart 1
+This chart shows some gadgets, and some very fictitious costs.
+... document extract continues ...
+```
 
-You can submit jobs programmatically in Python or via the [NV-Ingest CLI](nv-ingest_cli.md).
+### Step 3: Query Ingested Content
 
-In the below examples, we are doing text, chart, table, and image extraction:
-
-- **extract_text** — Uses [PDFium](https://github.com/pypdfium2-team/pypdfium2/) to find and extract text from pages.
-- **extract_images** — Uses [PDFium](https://github.com/pypdfium2-team/pypdfium2/) to extract images.
-- **extract_tables** — Uses [YOLOX](https://github.com/Megvii-BaseDetection/YOLOX) to find tables and charts. Uses [PaddleOCR](https://github.com/PaddlePaddle/PaddleOCR) for table extraction, and [Deplot](https://huggingface.co/google/deplot) and CACHED for chart extraction.
-- **extract_charts** — (Optional) Enables or disables Deplot and CACHED for chart extraction.
-
-> [!IMPORTANT]
-> `extract_tables` controls extraction for both tables and charts. You can optionally disable chart extraction by setting `extract_charts` to false.
-
-#### In Python
-
-> [!NOTE]
-> You can find more examples in [the client examples folder](client/client_examples/examples/).
-
+Below is an example snippet demonstrating how to query for relevant snippets of the ingested content and insert them into a basic prompt for use with an LLM to generate answers.
 
 ```python
-import logging, time
+from openai import OpenAI
+from nv_ingest_client.util.milvus import nvingest_retrieval
+import os
 
-from nv_ingest_client.client import NvIngestClient
-from nv_ingest_client.primitives import JobSpec
-from nv_ingest_client.primitives.tasks import ExtractTask
-from nv_ingest_client.util.file_processing.extract import extract_file_content
+milvus_uri = "milvus.db"
+collection_name = "test"
+sparse=False
 
-logger = logging.getLogger("nv_ingest_client")
+queries = ["Which animal is responsible for the typos?"]
 
-file_name = "data/multimodal_test.pdf"
-file_content, file_type = extract_file_content(file_name)
-
-# A JobSpec is an object that defines a document and how it should
-# be processed by the nv-ingest service.
-job_spec = JobSpec(
-  document_type=file_type,
-  payload=file_content,
-  source_id=file_name,
-  source_name=file_name,
-  extended_options=
-    {
-      "tracing_options":
-      {
-        "trace": True,
-        "ts_send": time.time_ns()
-      }
-    }
+retrieved_docs = nvingest_retrieval(
+    queries,
+    collection_name,
+    milvus_uri=milvus_uri,
+    hybrid=sparse,
+    top_k=1,
 )
 
-# configure desired extraction modes here. Multiple extraction
-# methods can be defined for a single JobSpec
-extract_task = ExtractTask(
-  document_type=file_type,
-  extract_text=True,
-  extract_images=True,
-  extract_tables=True
+# simple generation example
+extract = retrieved_docs[0][0]["entity"]["text"]
+client = OpenAI(
+  base_url = "https://integrate.api.nvidia.com/v1",
+  api_key = os.environ["NVIDIA_BUILD_API_KEY"]
 )
 
-job_spec.add_task(extract_task)
-
-# Create the client and inform it about the JobSpec we want to process.
-client = NvIngestClient(
-  message_client_hostname="localhost", # Host where nv-ingest-ms-runtime is running
-  message_client_port=7670 # REST port, defaults to 7670
+prompt = f"Using the following content: {extract}\n\n Answer the user query: {queries[0]}"
+print(f"Prompt: {prompt}")
+completion = client.chat.completions.create(
+  model="nvidia/llama-3.1-nemotron-70b-instruct",
+  messages=[{"role":"user","content": prompt}],
 )
-job_id = client.add_job(job_spec)
-client.submit_job(job_id, "morpheus_task_queue")
-result = client.fetch_job_result(job_id, timeout=60)
-print(f"Got {len(result)} results")
+response = completion.choices[0].message.content
+
+print(f"Answer: {response}")
 ```
-
-#### Using the `nv-ingest-cli`
-
-> [!NOTE]
-> You can find more examples in [the client examples folder](client/client_examples/examples/).
 
 ```shell
-nv-ingest-cli \
-  --doc ./data/multimodal_test.pdf \
-  --output_directory ./processed_docs \
-  --task='extract:{"document_type": "pdf", "extract_method": "pdfium", "extract_tables": "true", "extract_images": "true"}' \
-  --client_host=localhost \
-  --client_port=7670
+Prompt: Using the following content: TestingDocument
+A sample document with headings and placeholder text
+Introduction
+This is a placeholder document that can be used for any purpose. It contains some 
+headings and some placeholder text to fill the space. The text is not important and contains 
+no real value, but it is useful for testing. Below, we will have some simple tables and charts 
+that we can use to confirm Ingest is working as expected.
+Table 1
+This table describes some animals, and some activities they might be doing in specific 
+locations.
+Animal Activity Place
+Gira@e Driving a car At the beach
+Lion Putting on sunscreen At the park
+Cat Jumping onto a laptop In a home o@ice
+Dog Chasing a squirrel In the front yard
+Chart 1
+This chart shows some gadgets, and some very fictitious costs.
+
+ Answer the user query: Which animal is responsible for the typos?
+Answer: A clever query!
+
+After carefully examining the provided content, I'd like to point out the potential "typos" (assuming you're referring to the unusual or intentionally incorrect text) and attempt to playfully "assign blame" to an animal based on the context:
+
+1. **Gira@e** (instead of Giraffe) - **Animal blamed: Giraffe** (Table 1, first row)
+	* The "@" symbol in "Gira@e" suggests a possible typo or placeholder character, which we'll humorously attribute to the Giraffe's alleged carelessness.
+2. **o@ice** (instead of Office) - **Animal blamed: Cat**
+	* The same "@" symbol appears in "o@ice", which is related to the Cat's activity in the same table. Perhaps the Cat was in a hurry while typing and introduced the error?
+
+So, according to this whimsical analysis, both the **Giraffe** and the **Cat** are "responsible" for the typos, with the Giraffe possibly being the more egregious offender given the more blatant character substitution in its name.
 ```
 
-You should notice output indicating document processing status, followed by a breakdown of time spent during job execution:
-```
-INFO:nv_ingest_client.nv_ingest_cli:Processing 1 documents.
-INFO:nv_ingest_client.nv_ingest_cli:Output will be written to: ./processed_docs
-Processing files: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:10<00:00, 10.47s/file, pages_per_sec=0.29]
-INFO:nv_ingest_client.cli.util.processing:dedup_images: Avg: 1.02 ms, Median: 1.02 ms, Total Time: 1.02 ms, Total % of Trace Computation: 0.01%
-INFO:nv_ingest_client.cli.util.processing:dedup_images_channel_in: Avg: 1.44 ms, Median: 1.44 ms, Total Time: 1.44 ms, Total % of Trace Computation: 0.01%
-INFO:nv_ingest_client.cli.util.processing:docx_content_extractor: Avg: 0.66 ms, Median: 0.66 ms, Total Time: 0.66 ms, Total % of Trace Computation: 0.01%
-INFO:nv_ingest_client.cli.util.processing:docx_content_extractor_channel_in: Avg: 1.09 ms, Median: 1.09 ms, Total Time: 1.09 ms, Total % of Trace Computation: 0.01%
-INFO:nv_ingest_client.cli.util.processing:filter_images: Avg: 0.84 ms, Median: 0.84 ms, Total Time: 0.84 ms, Total % of Trace Computation: 0.01%
-INFO:nv_ingest_client.cli.util.processing:filter_images_channel_in: Avg: 7.75 ms, Median: 7.75 ms, Total Time: 7.75 ms, Total % of Trace Computation: 0.07%
-INFO:nv_ingest_client.cli.util.processing:job_counter: Avg: 2.13 ms, Median: 2.13 ms, Total Time: 2.13 ms, Total % of Trace Computation: 0.02%
-INFO:nv_ingest_client.cli.util.processing:job_counter_channel_in: Avg: 2.05 ms, Median: 2.05 ms, Total Time: 2.05 ms, Total % of Trace Computation: 0.02%
-INFO:nv_ingest_client.cli.util.processing:metadata_injection: Avg: 14.48 ms, Median: 14.48 ms, Total Time: 14.48 ms, Total % of Trace Computation: 0.14%
-INFO:nv_ingest_client.cli.util.processing:metadata_injection_channel_in: Avg: 0.22 ms, Median: 0.22 ms, Total Time: 0.22 ms, Total % of Trace Computation: 0.00%
-INFO:nv_ingest_client.cli.util.processing:pdf_content_extractor: Avg: 10332.97 ms, Median: 10332.97 ms, Total Time: 10332.97 ms, Total % of Trace Computation: 99.45%
-INFO:nv_ingest_client.cli.util.processing:pdf_content_extractor_channel_in: Avg: 0.44 ms, Median: 0.44 ms, Total Time: 0.44 ms, Total % of Trace Computation: 0.00%
-INFO:nv_ingest_client.cli.util.processing:pptx_content_extractor: Avg: 1.19 ms, Median: 1.19 ms, Total Time: 1.19 ms, Total % of Trace Computation: 0.01%
-INFO:nv_ingest_client.cli.util.processing:pptx_content_extractor_channel_in: Avg: 0.98 ms, Median: 0.98 ms, Total Time: 0.98 ms, Total % of Trace Computation: 0.01%
-INFO:nv_ingest_client.cli.util.processing:redis_source_network_in: Avg: 12.27 ms, Median: 12.27 ms, Total Time: 12.27 ms, Total % of Trace Computation: 0.12%
-INFO:nv_ingest_client.cli.util.processing:redis_task_sink_channel_in: Avg: 2.16 ms, Median: 2.16 ms, Total Time: 2.16 ms, Total % of Trace Computation: 0.02%
-INFO:nv_ingest_client.cli.util.processing:redis_task_source: Avg: 8.00 ms, Median: 8.00 ms, Total Time: 8.00 ms, Total % of Trace Computation: 0.08%
-INFO:nv_ingest_client.cli.util.processing:Unresolved time: 82.82 ms, Percent of Total Elapsed: 0.79%
-INFO:nv_ingest_client.cli.util.processing:Processed 1 files in 10.47 seconds.
-INFO:nv_ingest_client.cli.util.processing:Total pages processed: 3
-INFO:nv_ingest_client.cli.util.processing:Throughput (Pages/sec): 0.29
-INFO:nv_ingest_client.cli.util.processing:Throughput (Files/sec): 0.10
-```
-
-### Step 4: Inspecting and Consuming Results
-
-After the ingestion steps above have completed, you should be able to find `text` and `image` subfolders inside your processed docs folder. Each will contain JSON formatted extracted content and metadata.
-
-#### When processing has completed, you'll have separate result files for text and image data:
-```shell
-ls -R processed_docs/
-```
-```shell
-processed_docs/:
-image  structured  text
-
-processed_docs/image:
-multimodal_test.pdf.metadata.json
-
-processed_docs/structured:
-multimodal_test.pdf.metadata.json
-
-processed_docs/text:
-multimodal_test.pdf.metadata.json
-```
-For the full metadata definitions, refer to [Content Metadata](/docs/docs/extraction/content-metadata.md).
-
-#### We also provide a script for inspecting [extracted images](src/util/image_viewer.py)
-
-First, install `tkinter` by running the following code. Choose the code for your OS.
-
-- For Ubuntu/Debian Linux:
-
-  ```shell
-  sudo apt-get update
-  sudo apt-get install python3-tk
-  ```
-
-- For Fedora/RHEL Linux:
-
-  ```shell
-  sudo dnf install python3-tkinter
-  ```
-
-- For macOS using Homebrew:
-
-  ```shell
-  brew install python-tk
-  ```
-
-Then run the following command to execute the script for inspecting the extracted image:
-```shell
-python src/util/image_viewer.py --file_path ./processed_docs/image/multimodal_test.pdf.metadata.json
-```
+For more information, please check out the [official documentation](https://docs.nvidia.com/nemo/retriever/extraction/overview/).
 
 > [!TIP]
 > Beyond inspecting the results, you can read them into things like [llama-index](examples/llama_index_multimodal_rag.ipynb) or [langchain](examples/langchain_multimodal_rag.ipynb) retrieval pipelines.
@@ -404,20 +262,25 @@ python src/util/image_viewer.py --file_path ./processed_docs/image/multimodal_te
 
 ## Repo Structure
 
-Beyond the relevant documentation, examples, and other links above, below is a description of contents in this repo's folders:
+Beyond the relevant documentation, examples, and other links above, below is a description of the contents in this repo's folders:
 
-1. [.github](.github): GitHub repo configuration files
-2. [ci](ci): scripts used to build the nv-ingest container and other packages
-3. [client](client): docs and source code for the nv-ingest-cli utility
-4. [config](config): various yaml files defining configuration for OTEL, Prometheus
-5. [data](data): Sample PDFs provided for testing convenience
-6. [docker](docker): houses scripts used by the nv-ingest docker container
-7. [docs](docs): Various READMEs describing deployment, metadata schemas, auth and telemetry setup
-8. [examples](examples): Example notebooks, scripts, and longer form tutorial content
-9. [helm](helm): Documentation for deploying nv-ingest to a Kubernetes cluster via Helm chart
-10. [skaffold](skaffold): Skaffold configuration
-11. [src](src): source code for the nv-ingest pipelines and service
-12. [tests](tests): unit tests for nv-ingest
+- [.github](https://github.com/NVIDIA/nv-ingest/tree/main/.github): GitHub repo configuration files
+- [api](https://github.com/NVIDIA/nv-ingest/tree/main/api): Core API python logic shared across python modules
+- [ci](https://github.com/NVIDIA/nv-ingest/tree/main/ci): Scripts used to build the NV-Ingest container and other packages
+- [client](https://github.com/NVIDIA/nv-ingest/tree/main/client): Docs and source code for the nv-ingest-cli utility
+- [conda](https://github.com/NVIDIA/nv-ingest/tree/main/conda): Conda environment and packaging definitions
+- [config](https://github.com/NVIDIA/nv-ingest/tree/main/config): Various .yaml files defining configuration for OTEL, Prometheus
+- [data](https://github.com/NVIDIA/nv-ingest/tree/main/data): Sample PDFs provided for testing convenience
+- [deploy](https://github.com/NVIDIA/nv-ingest/tree/main/deploy): Brev.dev hosted launchable
+- [docker](https://github.com/NVIDIA/nv-ingest/tree/main/docker): Houses scripts used by the nv-ingest docker container
+- [docs](https://github.com/NVIDIA/nv-ingest/tree/main/docs/docs): Various READMEs describing deployment, metadata schemas, auth and telemetry setup
+- [evaluation](https://github.com/NVIDIA/nv-ingest/tree/main/evaluation): Contains notebooks demonstrating how to test recall accuracy
+- [examples](https://github.com/NVIDIA/nv-ingest/tree/main/examples): Example notebooks, scripts, and longer-form tutorial content
+- [helm](https://github.com/NVIDIA/nv-ingest/tree/main/helm): Documentation for deploying NV-Ingest to a Kubernetes cluster via Helm chart
+- [skaffold](https://github.com/NVIDIA/nv-ingest/tree/main/skaffold): Skaffold configuration
+- [src](https://github.com/NVIDIA/nv-ingest/tree/main/src): Source code for the NV-Ingest pipelines and service
+- [.devcontainer](https://github.com/NVIDIA/nv-ingest/tree/main/.devcontainer): VSCode containers for local development
+- [tests](https://github.com/NVIDIA/nv-ingest/tree/main/tests): Unit tests for NV-Ingest
 
 ## Notices
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Create a fresh conda environment in which to install nv-ingest and dependencies.
 conda create -y --name nvingest python=3.10 && \
     conda activate nvingest && \
     conda install -y -c rapidsai -c conda-forge -c nvidia nv_ingest=25.3.0 nv_ingest_client=25.3.0 nv_ingest_api=25.3.0 && \
-    pip install opencv-python llama-index-embeddings-nvidia pymilvus 'pymilvus[bulk_writer, model]' milvus-lite nvidia-riva-client unstructured-client
+    pip install opencv-python llama-index-embeddings-nvidia 'pymilvus==2.5.4' 'pymilvus[bulk_writer, model]' milvus-lite nvidia-riva-client unstructured-client
 ```
 
 Make sure to set your NVIDIA_BUILD_API_KEY and NVIDIA_API_KEY. If you don't have one, you can get one on [build.nvidia.com](https://build.nvidia.com/nvidia/llama-3_2-nv-embedqa-1b-v2?snippet_tab=Python&signin=true&api_key=true).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -153,7 +153,7 @@ services:
       - reranker
 
   nemoretriever-parse:
-    image: ${NEMORETRIEVER_PARSE_IMAGE:-nvcr.io/nvidia/nemo-microservices/nemoretriever-parse}:${NEMORETRIEVER_PARSE_TAG:-latest}
+    image: ${NEMORETRIEVER_PARSE_IMAGE:-nvcr.io/nim/nvidia/nemoretriever-parse}:${NEMORETRIEVER_PARSE_TAG:-1.2.0}
     ports:
       - "8015:8000"
       - "8016:8001"
@@ -201,7 +201,7 @@ services:
       - vlm
 
   audio:
-    image: ${AUDIO_IMAGE:-nvcr.io/nim/nvidia/riva-asr}:${AUDIO_TAG:-latest}
+    image: ${AUDIO_IMAGE:-nvcr.io/nim/nvidia/riva-asr}:${AUDIO_TAG:-1.3.0}
     shm_size: 2gb
     ports:
       - "8021:50051"  # grpc

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - "6379:6379"
 
   page-elements:
-    image: ${YOLOX_IMAGE:-nvcr.io/nvidia/nemo-microservices/nv-yolox-page-elements-v1}:${YOLOX_TAG:-1.0.0}
+    image: ${YOLOX_IMAGE:-nvcr.io/nim/nvidia/nemoretriever-page-elements-v2}:${YOLOX_TAG:-1.2.0}
     ports:
       - "8000:8000"
       - "8001:8001"
@@ -40,7 +40,7 @@ services:
     runtime: nvidia
 
   graphic-elements:
-    image: ${YOLOX_GRAPHIC_ELEMENTS_IMAGE:-nvcr.io/nvidia/nemo-microservices/nemoretriever-graphic-elements-v1}:${YOLOX_GRAPHIC_ELEMENTS_TAG:-1.1}
+    image: ${YOLOX_GRAPHIC_ELEMENTS_IMAGE:-nvcr.io/nim/nvidia/nemoretriever-graphic-elements-v1}:${YOLOX_GRAPHIC_ELEMENTS_TAG:-1.2.0}
     ports:
       - "8003:8000"
       - "8004:8001"
@@ -62,7 +62,7 @@ services:
     runtime: nvidia
 
   table-structure:
-    image: ${YOLOX_TABLE_STRUCTURE_IMAGE:-set-image-name-in-dot-env}:${YOLOX_TABLE_STRUCTURE_TAG:-set-image-tag-in-dot-env}
+    image: ${YOLOX_TABLE_STRUCTURE_IMAGE:-nvcr.io/nim/nvidia/nemoretriever-table-structure-v1}:${YOLOX_TABLE_STRUCTURE_TAG:-1.2.0}
     ports:
       - "8006:8000"
       - "8007:8001"
@@ -71,7 +71,7 @@ services:
     environment:
       - NIM_HTTP_API_PORT=8000
       - NIM_TRITON_LOG_VERBOSE=1
-      - NGC_API_KEY=${STAGING_NIM_NGC_API_KEY}
+      - NGC_API_KEY=${NIM_NGC_API_KEY:-${NGC_API_KEY:-ngcapikey}}
       - CUDA_VISIBLE_DEVICES=0
       - NIM_TRITON_MODEL_BATCH_SIZE=${TABLE_STRUCTURE_BATCH_SIZE:-1}
     deploy:
@@ -86,7 +86,7 @@ services:
       - table-structure
 
   paddle:
-    image: ${PADDLE_IMAGE:-nvcr.io/nvidia/nemo-microservices/paddleocr}:${PADDLE_TAG:-1.0.0}
+    image: ${PADDLE_IMAGE:-nvcr.io/nim/baidu/paddleocr}:${PADDLE_TAG:-1.2.0}
     shm_size: 2gb
     ports:
       - "8009:8000"
@@ -109,7 +109,7 @@ services:
 
   embedding:
     # NIM ON
-    image: ${EMBEDDING_IMAGE:-nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2}:${EMBEDDING_TAG:-1.3.0}
+    image: ${EMBEDDING_IMAGE:-nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2}:${EMBEDDING_TAG:-1.5.0}
     shm_size: 16gb
     ports:
       - "8012:8000"
@@ -153,7 +153,7 @@ services:
       - reranker
 
   nemoretriever-parse:
-    image: ${NEMORETRIEVER_PARSE_IMAGE:-nvcr.io/nvidia/nemo-microservices/nemoretriever-parse}:${NEMORETRIEVER_PARSE_TAG:-1.2.0ea}
+    image: ${NEMORETRIEVER_PARSE_IMAGE:-nvcr.io/nvidia/nemo-microservices/nemoretriever-parse}:${NEMORETRIEVER_PARSE_TAG:-latest}
     ports:
       - "8015:8000"
       - "8016:8001"
@@ -201,7 +201,7 @@ services:
       - vlm
 
   audio:
-    image: nvcr.io/nim/nvidia/riva-asr:1.3.0
+    image: ${AUDIO_IMAGE:-nvcr.io/nim/nvidia/riva-asr}:${AUDIO_TAG:-latest}
     shm_size: 2gb
     ports:
       - "8021:50051"  # grpc
@@ -224,7 +224,7 @@ services:
       - audio
 
   nv-ingest-ms-runtime:
-    image: nvcr.io/nvidia/nemo-microservices/nv-ingest:24.12
+    image: nvcr.io/nvidia/nemo-microservices/nv-ingest:25.3.0
     build:
       context: ${NV_INGEST_ROOT:-.}
       dockerfile: "./Dockerfile"

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -1,20 +1,20 @@
 # What is NeMo Retriever Extraction?
 
-NeMo Retriever extraction is a scalable, performance-oriented document content and metadata extraction microservice. 
-NeMo Retriever extraction uses specialized NVIDIA NIM microservices 
+NeMo Retriever Extraction is a scalable, performance-oriented document content and metadata extraction microservice. 
+NeMo Retriever Extraction uses specialized NVIDIA NIM microservices 
 to find, contextualize, and extract text, tables, charts and images that you can use in downstream generative applications.
 
 !!! note
 
-    NeMo Retriever extraction is also known as NVIDIA Ingest and nv-ingest.
+    NeMo Retriever Extraction is also known as NVIDIA Ingest and nv-ingest.
 
-NeMo Retriever extraction enables parallelization of splitting documents into pages where artifacts are classified (such as text, tables, charts, and images), extracted, and further contextualized through optical character recognition (OCR) into a well defined JSON schema. 
+NeMo Retriever Extraction enables parallelization of splitting documents into pages where artifacts are classified (such as text, tables, charts, and images), extracted, and further contextualized through optical character recognition (OCR) into a well defined JSON schema. 
 From there, NeMo Retriever extraction can optionally manage computation of embeddings for the extracted content, 
 and optionally manage storing into a vector database [Milvus](https://milvus.io/).
 
 !!! note
 
-    Cached and Deplot are deprecated. Instead, docker-compose now uses a beta version of the yolox-graphic-elements container. With this change, you should now be able to run nv-ingest on a single 80GB A100 or H100 GPU. If you want to use the old pipeline, with Cached and Deplot, use the [nv-ingest 24.12.1 release](https://github.com/NVIDIA/nv-ingest/tree/24.12.1).
+    Cached and Deplot are deprecated. Instead, NeMo Retriever Extraction now uses the yolox-graphic-elements NIM. With this change, you should now be able to run nv-ingest on a single 24GB A10G or better GPU. If you want to use the old pipeline, with Cached and Deplot, use the [nv-ingest 24.12.1 release](https://github.com/NVIDIA/nv-ingest/tree/24.12.1).
 
 
 

--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -97,7 +97,7 @@ If you prefer, you can run on Kubernetes by using [our Helm chart](https://githu
 
 ## Step 2: Install Python Dependencies
 
-You can interact with the NV-Ingest service from the host or by `docker exec`-ing into the NV-Ingest container.
+You can interact with the NV-Ingest service from the host, or by using `docker exec` to run commands in the NV-Ingest container.
 
 To interact from the host, you'll need a Python environment and install the client dependencies:
 
@@ -400,6 +400,18 @@ You can specify multiple `--profile` options.
 | `audio`               | Advanced | Use [Riva](https://docs.nvidia.com/deeplearning/riva/user-guide/docs/index.html) for processing audio files. For more information, refer to [Audio Processing](nemoretriever-parse.md). | [1 additional dedicated GPU](support-matrix.md) | ~37GB additional space |
 | `nemoretriever-parse` | Advanced | Use [nemoretriever-parse](https://build.nvidia.com/nvidia/nemoretriever-parse). For more information, refer to [Use Nemo Retriever Extraction with nemoretriever-parse](nemoretriever-parse.md). | [1 additional dedicated GPU](support-matrix.md) | ~16 GB additional space |
 | `vlm`                 | Advanced | Uses llama 3.2 11B VLM for experimental image captioning of unstructured images. | [1 additional dedicated GPU](support-matrix.md) | ~16GB additional space |
+
+
+
+## Troubleshooting
+
+In rare cases, when you run a job you might an see an error similar to `max open file descriptor`. 
+This error is related to number of active jobs and cores available on your computer. 
+To resolve this issue, raise the maximum number of open file descriptors by using the following [ulimit](https://ss64.com/bash/ulimit.html) command.
+
+```bash
+ulimit -n 10,000
+```
 
 
 

--- a/docs/docs/extraction/quickstart-library-mode.md
+++ b/docs/docs/extraction/quickstart-library-mode.md
@@ -15,48 +15,25 @@ To get started using [NeMo Retriever extraction](overview.md) in library mode, y
 
 Use the following procedure to prepare your environment.
 
-1. Run the following code to create your NVIDIA Ingest Conda environment.
+1. Run the following code to create your nvingest conda environment.
 
     ```
-    conda create -y --name nvingest python=3.10
-    conda activate nvingest
-    conda install -y -c rapidsai -c rapidsai-nightly -c conda-forge -c nvidia nvidia/label/dev::nv_ingest nvidia/label/dev::nv_ingest_client nvidia/label/dev::nv_ingest_api
-    pip install opencv-python llama-index-embeddings-nvidia pymilvus 'pymilvus[bulk_writer, model]' milvus-lite dotenv ffmpeg nvidia-riva-client
+conda create -y --name nvingest python=3.10 && \
+    conda activate nvingest && \
+    conda install -y -c rapidsai -c conda-forge -c nvidia nv_ingest=25.3.0 nv_ingest_client=25.3.0 nv_ingest_api=25.3.0 && \
+    pip install opencv-python llama-index-embeddings-nvidia pymilvus 'pymilvus[bulk_writer, model]' milvus-lite nvidia-riva-client unstructured-client
     ```
 
     !!! tip
 
-        To confirm that you have activated your Conda environment, run `which pip` and `which python`, and confirm that you see `nvingest` in the result. You can do this before any pip or python command that you run.
+        Make sure your conda environment is activated. `which python` should indicate that you're using the conda provided python installation (not an OS provided python).
 
-
-2. Create a .env file that contains your NVIDIA Build API key and other environment variables.
-
-    !!! note
-
-        If you use an NGC personal key, then you should provide the same value for all keys, but you must specify each environment variable individually. In the past, you could create an API key. If you have an API key, you can still use that. For more information, refer to [Generate Your NGC Keys](ngc-api-key.md) and [Environment Configuration Variables](environment-config.md).
-
-    ```
-    NVIDIA_BUILD_API_KEY=nvapi-<your key>
-    NVIDIA_API_KEY=nvapi-<your key>
-
-    PADDLE_HTTP_ENDPOINT=<endpoint>
-    PADDLE_INFER_PROTOCOL=http
-    YOLOX_HTTP_ENDPOINT=<endpoint>
-    YOLOX_INFER_PROTOCOL=http
-    YOLOX_GRAPHIC_ELEMENTS_HTTP_ENDPOINT=<endpoint>
-    YOLOX_GRAPHIC_ELEMENTS_INFER_PROTOCOL=http
-    YOLOX_TABLE_STRUCTURE_HTTP_ENDPOINT=<endpoint>
-    YOLOX_TABLE_STRUCTURE_INFER_PROTOCOL=http
-    EMBEDDING_NIM_ENDPOINT=<endpoint>
-    EMBEDDING_NIM_MODEL_NAME=<model>
-    VLM_CAPTION_ENDPOINT=<endpoint>
-    VLM_CAPTION_MODEL_NAME=<model>
-    # NemoRetriever Parse:
-    NEMORETRIEVER_PARSE_HTTP_ENDPOINT=<enpoint>
-    NEMORETRIEVER_PARSE_INFER_PROTOCOL=http
-    ```
-
-
+Make sure to set your NVIDIA_BUILD_API_KEY and NVIDIA_API_KEY. If you don't have one, you can get one on [build.nvidia.com](https://build.nvidia.com/nvidia/llama-3_2-nv-embedqa-1b-v2?snippet_tab=Python&signin=true&api_key=true).
+```
+#Note: these should be the same value
+export NVIDIA_BUILD_API_KEY=nvapi-...
+export NVIDIA_API_KEY=nvapi-...
+```
 
 ## Step 2: Ingest Documents
 
@@ -78,13 +55,8 @@ taskset -c 0-3 python your_ingestion_script.py
 On a 4 CPU core low end laptop, the following code should take about 10 seconds.
 
 ```python
-# must be first: pipeline subprocesses pickup config from env variables
-from dotenv import load_dotenv
-load_dotenv(".env")
-
-import logging, os, time
-from nv_ingest.util.logging.configuration import configure_logging as configure_local_logging
-
+import logging, os, time, sys
+               
 from nv_ingest.util.pipeline.pipeline_runners import start_pipeline_subprocess
 from nv_ingest_client.client import Ingestor, NvIngestClient
 from nv_ingest_client.message_clients.simple.simple_client import SimpleClient
@@ -93,20 +65,21 @@ from nv_ingest_client.util.process_json_files import ingest_json_results_to_blob
 
 # Start the pipeline subprocess for library mode                       
 config = PipelineCreationSchema()                                                  
-print(config)
 
-pipeline_process = start_pipeline_subprocess(config,stderr=sys.stderr,stdout=sys.stdout)
-
-client = NvIngestClient(                                                                          
-    message_client_allocator=SimpleClient,                                           
-    message_client_port=7671,                                                                
-    message_client_hostname="localhost"         
-)                                                                  
-
+pipeline_process = start_pipeline_subprocess(config)
+# you can configure the subprocesses to log stderr to stdout for debugging purposes
+#pipeline_process = start_pipeline_subprocess(config, stderr=sys.stderr, stdout=sys.stdout)
+                                                                          
+client = NvIngestClient(
+    message_client_allocator=SimpleClient,
+    message_client_port=7671,
+    message_client_hostname="localhost"
+)
+                                            
 # Note: gpu_cagra accelerated indexing is not yet available in milvus-lite
 # Provide a filename for milvus_uri to use milvus-lite
-milvus_uri = "milvus.db"                
-collection_name = "test"      
+milvus_uri = "milvus.db"
+collection_name = "test"
 sparse=False
 
 # do content extraction from files                                
@@ -120,10 +93,10 @@ ingestor = (
         extract_images=True,
         paddle_output_format="markdown",
         extract_infographics=True,
-        # extract_method="nemoretriever_parse", # Slower, but maximally accurate, especially for PDFs with pages that are scanned images
+        # Slower, but maximally accurate, especially for PDFs with pages that are scanned images
+        #extract_method="nemoretriever_parse",
         text_depth="page"
     ).embed()
-    .caption()
     .vdb_upload(
         collection_name=collection_name,
         milvus_uri=milvus_uri,
@@ -135,7 +108,7 @@ ingestor = (
 
 print("Starting ingestion..")
 t0 = time.time()
-results = ingestor.ingest()
+results = ingestor.ingest(show_progress=True)
 t1 = time.time()
 print(f"Time taken: {t1-t0} seconds")
 
@@ -150,16 +123,10 @@ print(ingest_json_results_to_blob(results[0]))
 You can see the extracted text that represents the content of the ingested test document.
 
 ```shell
-...
-Chart 2
-This chart shows some average frequency ranges for speaker drivers.
-Conclusion
-This is the conclusion of the document. It has some more placeholder text, but the most 
-important thing is that this is the conclusion. As we end this document, we should have 
-been able to extract 2 tables, 2 charts, and some text including 3 bullet points.
-image_caption:[]
+Starting ingestion..
+Time taken: 9.243880033493042 seconds
 
-Prompt: Using the following content: TestingDocument
+TestingDocument
 A sample document with headings and placeholder text
 Introduction
 This is a placeholder document that can be used for any purpose. It contains some 
@@ -176,19 +143,21 @@ Cat Jumping onto a laptop In a home o@ice
 Dog Chasing a squirrel In the front yard
 Chart 1
 This chart shows some gadgets, and some very fictitious costs.
+
+... document extract continues ...
 ```
 
-
-
 ## Step 3: Query Ingested Content
-
-To query for relevant snippets of the ingested content, and use it with LLMs to generate answers, use the following code.
 
 ```python
 from openai import OpenAI
 from nv_ingest_client.util.milvus import nvingest_retrieval
+import os
 
-#queries = ["Where and what is the dog doing?"]
+milvus_uri = "milvus.db"
+collection_name = "test"
+sparse=False
+
 queries = ["Which animal is responsible for the typos?"]
 
 retrieved_docs = nvingest_retrieval(
@@ -218,22 +187,35 @@ print(f"Answer: {response}")
 ```
 
 ```shell
+Prompt: Using the following content: TestingDocument
+A sample document with headings and placeholder text
+Introduction
+This is a placeholder document that can be used for any purpose. It contains some 
+headings and some placeholder text to fill the space. The text is not important and contains 
+no real value, but it is useful for testing. Below, we will have some simple tables and charts 
+that we can use to confirm Ingest is working as expected.
+Table 1
+This table describes some animals, and some activities they might be doing in specific 
+locations.
+Animal Activity Place
+Gira@e Driving a car At the beach
+Lion Putting on sunscreen At the park
+Cat Jumping onto a laptop In a home o@ice
+Dog Chasing a squirrel In the front yard
+Chart 1
+This chart shows some gadgets, and some very fictitious costs.
+
  Answer the user query: Which animal is responsible for the typos?
 Answer: A clever query!
 
-After carefully examining the provided content, I'll do my best to deduce the answer:
-**Inferences and Observations:**
-1. **Typos identification**: I've spotted potential typos in two places:
-        * "Gira@e" (likely meant to be "Giraffe")
-        * "o@ice" (likely meant to be "office")
-2. **Association with typos**: Both typos are related to specific animal entries in "Table 1".
+After carefully examining the provided content, I'd like to point out the potential "typos" (assuming you're referring to the unusual or intentionally incorrect text) and attempt to playfully "assign blame" to an animal based on the context:
 
-**Answer:**
-Based on the observations, I'll playfully attribute the "responsibility" for the typos to:
-* **Giraffe** (for "Gira@e") and
-* **Cat** (for "o@ice", as it's associated with "In a home o@ice")
+1. **Gira@e** (instead of Giraffe) - **Animal blamed: Giraffe** (Table 1, first row)
+	* The "@" symbol in "Gira@e" suggests a possible typo or placeholder character, which we'll humorously attribute to the Giraffe's alleged carelessness.
+2. **o@ice** (instead of Office) - **Animal blamed: Cat**
+	* The same "@" symbol appears in "o@ice", which is related to the Cat's activity in the same table. Perhaps the Cat was in a hurry while typing and introduced the error?
 
-Please keep in mind that this response is light-hearted and intended for entertainment, as typos are simply errors in the provided text, not genuinely caused by animals.
+So, according to this whimsical analysis, both the **Giraffe** and the **Cat** are "responsible" for the typos, with the Giraffe possibly being the more egregious offender given the more blatant character substitution in its name.
 ```
 
 

--- a/docs/docs/extraction/quickstart-library-mode.md
+++ b/docs/docs/extraction/quickstart-library-mode.md
@@ -21,7 +21,7 @@ Use the following procedure to prepare your environment.
 conda create -y --name nvingest python=3.10 && \
     conda activate nvingest && \
     conda install -y -c rapidsai -c conda-forge -c nvidia nv_ingest=25.3.0 nv_ingest_client=25.3.0 nv_ingest_api=25.3.0 && \
-    pip install opencv-python llama-index-embeddings-nvidia pymilvus 'pymilvus[bulk_writer, model]' milvus-lite nvidia-riva-client unstructured-client
+    pip install opencv-python llama-index-embeddings-nvidia 'pymilvus==2.5.4' 'pymilvus[bulk_writer, model]' milvus-lite nvidia-riva-client unstructured-client
     ```
 
     !!! tip

--- a/src/nv_ingest/util/pipeline/stage_builders.py
+++ b/src/nv_ingest/util/pipeline/stage_builders.py
@@ -99,7 +99,7 @@ def get_nim_service(env_var_prefix):
 
 
 def get_default_cpu_count():
-    default_cpu_count = os.environ.get("NV_INGEST_MAX_UTIL", int(max(1, math.floor(len(os.sched_getaffinity(0))))))
+    default_cpu_count = int(os.environ.get("NV_INGEST_MAX_UTIL", int(max(1, math.floor(len(os.sched_getaffinity(0)))))))
 
     return default_cpu_count
 


### PR DESCRIPTION
When passing this override in via env in k8s it can only be provided as a string. Cast to int if it's provided.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
