### PR TITLE
Update stage builders to convert NV_INGEST_MAX_UTIL to int from str

### DIFF
--- a/src/nv_ingest/framework/orchestration/morpheus/util/pipeline/stage_builders.py
+++ b/src/nv_ingest/framework/orchestration/morpheus/util/pipeline/stage_builders.py
@@ -134,7 +134,7 @@ def get_nim_service(env_var_prefix):
 
 
 def get_default_cpu_count():
-    default_cpu_count = os.environ.get("NV_INGEST_MAX_UTIL", int(max(1, math.floor(len(os.sched_getaffinity(0))))))
+    default_cpu_count = int(os.environ.get("NV_INGEST_MAX_UTIL", int(max(1, math.floor(len(os.sched_getaffinity(0)))))))
 
     return default_cpu_count
 


### PR DESCRIPTION
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
