### PR TITLE
Add milvus filter and metadata add  on support

### DIFF
--- a/client/client_tests/util/test_milvus_util.py
+++ b/client/client_tests/util/test_milvus_util.py
@@ -9,8 +9,10 @@ from nv_ingest_client.util.milvus import (
     create_nvingest_collection,
     grab_meta_collection_info,
     reconstruct_pages,
+    add_metadata,
 )
 from nv_ingest_client.util.util import ClientConfigSchema
+import pandas as pd
 
 
 @pytest.fixture
@@ -106,8 +108,9 @@ def test_milvus_meta_multiple_coll(tmp_path):
     assert entity["collection_name"] == f"{collection_name}2"
 
 
-def test_page_reconstruction():
-    records = [
+@pytest.fixture
+def records():
+    return [
         [
             {
                 "document_type": "text",
@@ -178,6 +181,21 @@ def test_page_reconstruction():
             },
         ],
     ]
+
+
+@pytest.fixture
+def metadata():
+    return pd.DataFrame(
+        {
+            "source_name": ["file_1.pdf", "file_2.pdf"],
+            "meta_a": ["meta_a_1", "meta_a_2"],
+            "meta_b": ["meta_b_1", "meta_b_2"],
+        }
+    )
+
+
+def test_page_reconstruction(records):
+
     candidates = [
         {
             "id": 456331433807935937,
@@ -213,3 +231,15 @@ def test_page_reconstruction():
     pages.append(reconstruct_pages(candidates[1], records, page_signum=1))
     assert pages[0] == "roses are red.\nviolets are blue.\nsunflowers are yellow.\n"
     assert pages[1] == "two time two is four.\nfour times four is sixteen.\n"
+
+
+def test_metadata_add(records, metadata):
+    for record in records:
+        for element in record:
+            add_metadata(element, metadata, "source_name", ["meta_a", "meta_b"])
+
+            assert "meta_a" in [*element["metadata"]["content_metadata"]]
+            assert "meta_b" in [*element["metadata"]["content_metadata"]]
+            idx = element["metadata"]["source_metadata"]["source_name"].split("_")[1].split(".")[0]
+            assert element["metadata"]["content_metadata"]["meta_a"] == f"meta_a_{idx}"
+            assert element["metadata"]["content_metadata"]["meta_b"] == f"meta_b_{idx}"

--- a/client/src/nv_ingest_client/util/milvus.py
+++ b/client/src/nv_ingest_client/util/milvus.py
@@ -200,6 +200,9 @@ class MilvusOperator:
         access_key: str = "minioadmin",
         secret_key: str = "minioadmin",
         bucket_name: str = "a-bucket",
+        meta_dataframe=None,
+        meta_source_field=None,
+        meta_fields=None,
         **kwargs,
     ):
         self.milvus_kwargs = locals()
@@ -596,6 +599,18 @@ def _insert_location_into_content_metadata(
     element["metadata"]["content_metadata"]["max_dimensions"] = max_dimensions
 
 
+def add_metadata(element, meta_dataframe, meta_source_field, meta_data_fields):
+    element_name = element["metadata"]["source_metadata"]["source_name"]
+    df = meta_dataframe[meta_dataframe[meta_source_field] == element_name]
+    if df is None:
+        logger.info(f"NO METADATA ENTRY found for {element_name}")
+    if df.shape[0] > 1:
+        logger.info(f"FOUND MORE THAN ONE metadata entry for {element_name}, will use first entry")
+    meta_fields = df[meta_data_fields]
+    for col in meta_data_fields:
+        element["metadata"]["content_metadata"][col] = meta_fields.iloc[0][col]
+
+
 def write_records_minio(
     records,
     writer: RemoteBulkWriter,
@@ -607,6 +622,9 @@ def write_records_minio(
     enable_infographics: bool = True,
     enable_audio: bool = True,
     record_func=_record_dict,
+    meta_dataframe=None,
+    meta_source_field=None,
+    meta_fields=None,
 ) -> RemoteBulkWriter:
     """
     Writes the supplied records to milvus using the supplied writer.
@@ -654,6 +672,8 @@ def write_records_minio(
             _insert_location_into_content_metadata(
                 element, enable_charts, enable_tables, enable_images, enable_infographics
             )
+            if meta_dataframe is not None and meta_source_field and meta_fields:
+                add_metadata(element, meta_dataframe, meta_source_field, meta_fields)
             if text:
                 if sparse_model is not None:
                     writer.append_row(record_func(text, element, sparse_model.encode_documents([text])))
@@ -766,6 +786,9 @@ def stream_insert_milvus(
     enable_infographics: bool = True,
     enable_audio: bool = True,
     record_func=_record_dict,
+    meta_dataframe=None,
+    meta_source_field=None,
+    meta_fields=None,
 ):
     """
     This function takes the input records and creates a corpus,
@@ -808,6 +831,8 @@ def stream_insert_milvus(
             _insert_location_into_content_metadata(
                 element, enable_charts, enable_tables, enable_images, enable_infographics
             )
+            if meta_dataframe is not None and meta_source_field and meta_fields:
+                add_metadata(element, meta_dataframe, meta_source_field, meta_fields)
             if text:
                 if sparse_model is not None:
                     data.append(record_func(text, element, sparse_model.encode_documents([text])))
@@ -834,6 +859,9 @@ def write_to_nvingest_collection(
     secret_key: str = "minioadmin",
     bucket_name: str = "a-bucket",
     threshold: int = 10,
+    meta_dataframe=None,
+    meta_source_field=None,
+    meta_fields=None,
 ):
     """
     This function takes the input records and creates a corpus,
@@ -913,6 +941,9 @@ def write_to_nvingest_collection(
             enable_tables=enable_tables,
             enable_images=enable_images,
             enable_infographics=enable_infographics,
+            meta_dataframe=meta_dataframe,
+            meta_source_field=meta_source_field,
+            meta_fields=meta_fields,
         )
     else:
         # Connections parameters to access the remote bucket
@@ -935,6 +966,9 @@ def write_to_nvingest_collection(
             enable_tables=enable_tables,
             enable_images=enable_images,
             enable_infographics=enable_infographics,
+            meta_dataframe=meta_dataframe,
+            meta_source_field=meta_source_field,
+            meta_fields=meta_fields,
         )
         bulk_insert_milvus(collection_name, writer, milvus_uri)
         # this sleep is required, to ensure atleast this amount of time
@@ -950,6 +984,7 @@ def dense_retrieval(
     top_k: int,
     dense_field: str = "vector",
     output_fields: List[str] = ["text"],
+    _filter: str = "",
 ):
     """
     This function takes the input queries and conducts a dense
@@ -987,6 +1022,7 @@ def dense_retrieval(
         anns_field=dense_field,
         limit=top_k,
         output_fields=output_fields,
+        filter=_filter,
     )
     return results
 
@@ -1003,6 +1039,7 @@ def hybrid_retrieval(
     output_fields: List[str] = ["text"],
     gpu_search: bool = True,
     local_index: bool = False,
+    _filter: str = "",
 ):
     """
     This function takes the input queries and conducts a hybrid
@@ -1057,6 +1094,7 @@ def hybrid_retrieval(
         "anns_field": dense_field,
         "param": s_param_1,
         "limit": top_k,
+        "expr": _filter,
     }
 
     dense_req = AnnSearchRequest(**search_param_1)
@@ -1069,6 +1107,7 @@ def hybrid_retrieval(
         "anns_field": sparse_field,
         "param": s_param_2,
         "limit": top_k,
+        "expr": _filter,
     }
     sparse_req = AnnSearchRequest(**search_param_2)
 
@@ -1098,6 +1137,7 @@ def nvingest_retrieval(
     nv_ranker_truncate: str = "END",
     nv_ranker_top_k: int = 50,
     nv_ranker_max_batch_size: int = 64,
+    _filter: str = "",
 ):
     """
     This function takes the input queries and conducts a hybrid/dense
@@ -1178,9 +1218,12 @@ def nvingest_retrieval(
             output_fields=output_fields,
             gpu_search=gpu_search,
             local_index=local_index,
+            _filter=_filter,
         )
     else:
-        results = dense_retrieval(queries, collection_name, client, embed_model, top_k, output_fields=output_fields)
+        results = dense_retrieval(
+            queries, collection_name, client, embed_model, top_k, output_fields=output_fields, _filter=_filter
+        )
     if nv_ranker:
         rerank_results = []
         for query, candidates in zip(queries, results):


### PR DESCRIPTION
## Description
This PR creates support for adding new metadata via a dataframe (pandas currently) and supplying a source field name and metadata field names. Before writing the elements to milvus all relevant user defined metadata is added to the content_metadata field as it is supplied via the dataframe. Then during search we supply the _filter kwarg which can be used to employ filtering techniques for json as defined by milvus here https://milvus.io/docs/use-json-fields.md.   

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
