### PR TITLE
Set NIM_TRITON_MODEL_BATCH_SIZE = 1 for all NIMs by default

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -473,6 +473,7 @@ milvus:
       storageClass: null
   minio:
     mode: standalone
+    bucketName: a-bucket
     persistence:
       size: 10Gi
       storageClass: null

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -7,7 +7,7 @@ affinity: {}
 nodeSelector: {}
 
 ## @param logLevel Log level of NVIngest service. Possible values of the variable are TRACE, DEBUG, INFO, WARNING, ERROR, CRITICAL.
-logLevel: DEBUG
+logLevel: DEFAULT
 
 ## @param extraEnvVarsCM [string] [default: ""] A Config map holding Enviroment variables to include in the NVIngest containerextraEnvVarsCM: ""
 extraEnvVarsCM: ""
@@ -461,6 +461,10 @@ llama-32-nv-rerankqa-1b-v2:
 milvusDeployed: true
 ## @param milvus [default: sane {}] Find values at https://artifacthub.io/packages/helm/milvus-helm/milvus
 milvus:
+  image:
+    all:
+      repository: milvusdb/milvus
+      tag: v2.5.3-gpu
   cluster:
     enabled: false
   etcd:
@@ -475,6 +479,9 @@ milvus:
   pulsar:
     enabled: false
   standalone:
+    resources:
+      limits:
+        nvidia.com/gpu: 1
     persistence:
       persistentVolumeClaim:
         size: 10Gi

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -129,6 +129,8 @@ nemoretriever-page-elements-v2:
   env:
     - name: NIM_HTTP_API_PORT
       value: "8000"
+    - name: NIM_TRITON_MODEL_BATCH_SIZE
+      value: "1"
 
 ## @skip nemoretriever-graphic-elements-v1
 ## @param nemoretriever-graphic-elements-v1.deployed [default: true] true if the nemoretriever-graphic-elements NIM should be deployed and false otherwise
@@ -168,6 +170,8 @@ nemoretriever-graphic-elements-v1:
   env:
     - name: NIM_HTTP_API_PORT
       value: "8000"
+    - name: NIM_TRITON_MODEL_BATCH_SIZE
+      value: "1"
 
 ## @skip nemoretriever-table-structure-v1
 ## @param nemoretriever-table-structure-v1.deployed [default: true] true if the nemoretriever-table-structure NIM should be deployed and false otherwise
@@ -208,6 +212,8 @@ nemoretriever-table-structure-v1:
   env:
     - name: NIM_HTTP_API_PORT
       value: "8000"
+    - name: NIM_TRITON_MODEL_BATCH_SIZE
+      value: "1"
 
 ## @skip nim-vlm-image-captioning
 ## @param nim-vlm-image-captioning.deployed [default: false] true if the vlm-nim should be deployed and false otherwise
@@ -238,6 +244,8 @@ nim-vlm-image-captioning:
   env:
     - name: NIM_HTTP_API_PORT
       value: "8000"
+    - name: NIM_TRITON_MODEL_BATCH_SIZE
+      value: "1"
 
 ## @skip nim-vlm-text-extraction
 ## @param nim-vlm-text-extraction.deployed [default: false] true if the vlm-nim should be deployed and false otherwise
@@ -268,6 +276,8 @@ nim-vlm-text-extraction:
   env:
     - name: NIM_HTTP_API_PORT
       value: "8000"
+    - name: NIM_TRITON_MODEL_BATCH_SIZE
+      value: "1"
 
 ## @skip paddleocr-nim
 ## @param paddleocr-nim.deployed [default: true] true if the paddleocr-nim should be deployed and false otherwise
@@ -308,6 +318,8 @@ paddleocr-nim:
   env:
     - name: NIM_HTTP_API_PORT
       value: "8000"
+    - name: NIM_TRITON_MODEL_BATCH_SIZE
+      value: "1"
 
 
 ## @skip text-embedding-nim
@@ -348,6 +360,9 @@ text-embedding-nim:
     logLevel: "INFO"
   env:
     - name: NIM_HTTP_API_PORT
+      value: "8000"
+    - name: NIM_TRITON_MODEL_BATCH_SIZE
+      value: "1"
 
 
 ## @skip nvidia-nim-llama-32-nv-embedqa-1b-v2
@@ -388,6 +403,9 @@ nvidia-nim-llama-32-nv-embedqa-1b-v2:
     logLevel: "INFO"
   env:
     - name: NIM_HTTP_API_PORT
+      value: "8000"
+    - name: NIM_TRITON_MODEL_BATCH_SIZE
+      value: "1"
 
 
 ## @skip llama-32-nv-rerankqa-1b-v2
@@ -428,6 +446,9 @@ llama-32-nv-rerankqa-1b-v2:
     logLevel: "INFO"
   env:
     - name: NIM_HTTP_API_PORT
+      value: "8000"
+    - name: NIM_TRITON_MODEL_BATCH_SIZE
+      value: "1"
 
 
 ## @section Milvus Deployment parameters


### PR DESCRIPTION
## Description
Set NIM_TRITON_MODEL_BATCH_SIZE = 1 for all NIMs by default. Values can be overridden at deploy time by using `--set {NIM_NAME}.env.NIM_TRITON_MODEL_BATCH_SIZE=X`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
