### PR TITLE
Adjust Github PyPi workflow to publish from main

### DIFF
--- a/.github/workflows/pypi-nightly-publish.yml
+++ b/.github/workflows/pypi-nightly-publish.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Install build dependencies
         run: |


### PR DESCRIPTION
## Description
Adjust Github PyPi workflow to publish from main

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
