### PR TITLE
Move to using stringData in secrets instead of data

### DIFF
--- a/helm/templates/secrets.yaml
+++ b/helm/templates/secrets.yaml
@@ -21,7 +21,7 @@ kind: Secret
 metadata:
   name: ngc-api  # Name expected by NIMs
 type: Opaque
-data:
+stringData:
   NGC_CLI_API_KEY: {{ template "nv-ingest.ngcApiSecret" . }}
   NGC_API_KEY: {{ template "nv-ingest.ngcApiSecret" . }}
 {{- end }}


### PR DESCRIPTION
## Description
Move to using `stringData` instead of `data` entries for k8s secrets.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
