### PR TITLE
Allow specifying extract_method on html types

### DIFF
--- a/api/src/nv_ingest_api/internal/transform/embed_text.py
+++ b/api/src/nv_ingest_api/internal/transform/embed_text.py
@@ -453,13 +453,16 @@ def transform_create_text_embeddings_internal(
 
     logger.debug("Generating text embeddings for supported content types: TEXT, STRUCTURED, IMAGE.")
 
+    def _content_type_getter(row):
+        return row["content_metadata"]["type"]
+
     # Process each supported content type.
     for content_type, content_getter in pandas_content_extractor.items():
         if not content_getter:
             logger.debug(f"Skipping unsupported content type: {content_type}")
             continue
 
-        content_mask = df_transform_ledger["document_type"] == content_type.value
+        content_mask = df_transform_ledger["metadata"].apply(_content_type_getter) == content_type.value
         if not content_mask.any():
             continue
 

--- a/api/src/nv_ingest_api/util/converters/type_mappings.py
+++ b/api/src/nv_ingest_api/util/converters/type_mappings.py
@@ -7,7 +7,7 @@ from nv_ingest_api.internal.enums.common import ContentTypeEnum
 DOC_TO_CONTENT_MAP = {
     DocumentTypeEnum.BMP: ContentTypeEnum.IMAGE,
     DocumentTypeEnum.DOCX: ContentTypeEnum.STRUCTURED,
-    DocumentTypeEnum.HTML: ContentTypeEnum.STRUCTURED,
+    DocumentTypeEnum.HTML: ContentTypeEnum.TEXT,
     DocumentTypeEnum.JPEG: ContentTypeEnum.IMAGE,
     DocumentTypeEnum.MP3: ContentTypeEnum.AUDIO,
     DocumentTypeEnum.PDF: ContentTypeEnum.STRUCTURED,

--- a/client/src/nv_ingest_client/primitives/tasks/extract.py
+++ b/client/src/nv_ingest_client/primitives/tasks/extract.py
@@ -36,7 +36,7 @@ _DEFAULT_EXTRACTOR_MAP = {
     "csv": "pandas",
     "docx": "python_docx",
     "excel": "openpyxl",
-    "html": "beautifulsoup",
+    "html": "txt",
     "jpeg": "image",
     "jpg": "image",
     "parquet": "pandas",
@@ -75,17 +75,18 @@ _Type_Extract_Method_Text = Literal["txt"]
 _Type_Extract_Method_Map = {
     "bmp": get_args(_Type_Extract_Method_Image),
     "docx": get_args(_Type_Extract_Method_DOCX),
+    "html": get_args(_Type_Extract_Method_Text),
     "jpeg": get_args(_Type_Extract_Method_Image),
     "jpg": get_args(_Type_Extract_Method_Image),
     "pdf": get_args(_Type_Extract_Method_PDF),
     "png": get_args(_Type_Extract_Method_Image),
     "pptx": get_args(_Type_Extract_Method_PPTX),
     # "svg": get_args(_Type_Extract_Method_Image),
+    "text": get_args(_Type_Extract_Method_Text),
     "tiff": get_args(_Type_Extract_Method_Image),
+    "txt": get_args(_Type_Extract_Method_Text),
     "mp3": get_args(_Type_Extract_Method_Audio),
     "wav": get_args(_Type_Extract_Method_Audio),
-    "text": get_args(_Type_Extract_Method_Text),
-    "txt": get_args(_Type_Extract_Method_Text),
 }
 
 _Type_Extract_Tables_Method_PDF = Literal["yolox", "pdfium", "nemoretriever_parse"]
@@ -150,8 +151,8 @@ class ExtractTaskSchema(BaseModel):
     def extract_method_must_be_valid(cls, v, values, **kwargs):
         document_type = values.data.get("document_type", "").lower()  # Ensure case-insensitive comparison
 
-        # Skip validation for txt since it does not have an extract stage.
-        if document_type in ["txt", "text"]:
+        # Skip validation for txt and html types since it does not have an extract stage.
+        if document_type in ["txt", "text", "html"]:
             return
 
         valid_methods = set(_Type_Extract_Method_Map[document_type])


### PR DESCRIPTION
## Description
Same workaround for HTML as in https://github.com/NVIDIA/nv-ingest/pull/678 to unblock downstream teams until we have a more robust interface.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
