### PR TITLE
Add Nvidia riva-asr helm chart as optional deployment

### DIFF
--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -20,6 +20,9 @@ dependencies:
 - name: nvidia-nim-llama-32-nv-embedqa-1b-v2
   repository: https://helm.ngc.nvidia.com/nim/nvidia
   version: 1.5.0
+- name: riva-nim
+  repository: https://helm.ngc.nvidia.com/nim/nvidia
+  version: 1.0.0
 - name: milvus
   repository: https://zilliztech.github.io/milvus-helm
   version: 4.1.11
@@ -32,5 +35,5 @@ dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.78.1
-digest: sha256:5c8cae3721298e564b85ba8c06cf320b5abf9db9bf0a0f57886c99f4dec6a661
-generated: "2025-03-15T05:48:53.923722082-04:00"
+digest: sha256:7675e65058740aa9ab90e4f3b458f226bd2dd9a992a3ea7353dd2de6f732a26f
+generated: "2025-05-01T10:32:44.178383534-04:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -26,7 +26,7 @@ dependencies:
     repository: "alias:nvidia-nim"
     version: 1.2.0
     alias: nemoretriever-table-structure-v1
-    condition: nvidia-nim-nemoretriever-table-structure-v1.deployed
+    condition: nemoretriever-table-structure-v1.deployed
 
   # # VLM for image captioning.
   # # This same chart can power several different underlying VLM models. Configure in values.yaml

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -70,6 +70,11 @@ dependencies:
   #   alias: llama-32-nv-rerankqa-1b-v2
   #   condition: llama-32-nv-rerankqa-1b-v2.deployed
 
+  - name: riva-nim
+    repository: "alias:nvidia-nim"
+    version: 1.0.0
+    condition: riva-nim.deployed
+
   - name: milvus
     repository: https://zilliztech.github.io/milvus-helm
     version: 4.1.11

--- a/helm/README.md
+++ b/helm/README.md
@@ -222,6 +222,7 @@ You can also use NV-Ingest's Python client API to interact with the service runn
 | alias:nvidia-nim | nemoretriever-page-elements-v2(nvidia-nim-nemoretriever-page-elements-v2) | 1.2.0 |
 | alias:nvidia-nim | nemoretriever-table-structure-v1(nvidia-nim-nemoretriever-table-structure-v1) | 1.2.0 |
 | alias:nvidia-nim | text-embedding-nim(nvidia-nim-nv-embedqa-e5-v5) | 1.5.0 |
+| alias:nvidia-nim | riva-nim | 1.0.0 |
 | https://open-telemetry.github.io/opentelemetry-helm-charts | opentelemetry-collector | 0.78.1 |
 | https://zilliztech.github.io/milvus-helm | milvus | 4.1.11 |
 | https://zipkin.io/zipkin-helm | zipkin | 0.1.2 |
@@ -240,6 +241,7 @@ You can also use NV-Ingest's Python client API to interact with the service runn
 | containerSecurityContext | object | `{}` |  |
 | envVars.AUDIO_GRPC_ENDPOINT | string | `"audio:50051"` |  |
 | envVars.AUDIO_INFER_PROTOCOL | string | `"grpc"` |  |
+| envVars.COMPONENTS_TO_READY_CHECK | string | `"ALL"` |  |
 | envVars.EMBEDDING_NIM_ENDPOINT | string | `"http://nv-ingest-embedqa:8000/v1"` |  |
 | envVars.EMBEDDING_NIM_MODEL_NAME | string | `"nvidia/llama-3.2-nv-embedqa-1b-v2"` |  |
 | envVars.INGEST_EDGE_BUFFER_SIZE | int | `64` |  |
@@ -259,7 +261,6 @@ You can also use NV-Ingest's Python client API to interact with the service runn
 | envVars.PADDLE_GRPC_ENDPOINT | string | `"nv-ingest-paddle:8001"` |  |
 | envVars.PADDLE_HTTP_ENDPOINT | string | `"http://nv-ingest-paddle:8000/v1/infer"` |  |
 | envVars.PADDLE_INFER_PROTOCOL | string | `"grpc"` |  |
-| envVars.READY_CHECK_ALL_COMPONENTS | string | `"true"` |  |
 | envVars.REDIS_MORPHEUS_TASK_QUEUE | string | `"morpheus_task_queue"` |  |
 | envVars.VLM_CAPTION_ENDPOINT | string | `"https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-11b-vision-instruct/chat/completions"` |  |
 | envVars.VLM_CAPTION_MODEL_NAME | string | `"meta/llama-3.2-11b-vision-instruct"` |  |
@@ -483,7 +484,7 @@ You can also use NV-Ingest's Python client API to interact with the service runn
 | nvidia-nim-llama-32-nv-embedqa-1b-v2.deployed | bool | `true` |  |
 | nvidia-nim-llama-32-nv-embedqa-1b-v2.env[0].name | string | `"NIM_HTTP_API_PORT"` |  |
 | nvidia-nim-llama-32-nv-embedqa-1b-v2.env[0].value | string | `"8000"` |  |
-| nvidia-nim-llama-32-nv-embedqa-1b-v2.env[1].name | string | `"NIM_TRITON_MODEL_BATCH_SIZE"` |  |
+| nvidia-nim-llama-32-nv-embedqa-1b-v2.env[1].name | string | `"NIM_TRITON_MAX_BATCH_SIZE"` |  |
 | nvidia-nim-llama-32-nv-embedqa-1b-v2.env[1].value | string | `"1"` |  |
 | nvidia-nim-llama-32-nv-embedqa-1b-v2.fullnameOverride | string | `"nv-ingest-embedqa"` |  |
 | nvidia-nim-llama-32-nv-embedqa-1b-v2.image.repository | string | `"nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2"` |  |
@@ -597,6 +598,32 @@ You can also use NV-Ingest's Python client API to interact with the service runn
 | resources.limits.memory | string | `"200Gi"` |  |
 | resources.requests.cpu | string | `"24000m"` |  |
 | resources.requests.memory | string | `"24Gi"` |  |
+| riva-nim.autoscaling.enabled | bool | `false` |  |
+| riva-nim.autoscaling.maxReplicas | int | `10` |  |
+| riva-nim.autoscaling.metrics | list | `[]` |  |
+| riva-nim.autoscaling.minReplicas | int | `1` |  |
+| riva-nim.customArgs | list | `[]` |  |
+| riva-nim.customCommand | list | `[]` |  |
+| riva-nim.deployed | bool | `false` |  |
+| riva-nim.env[0].name | string | `"NIM_HTTP_API_PORT"` |  |
+| riva-nim.env[0].value | string | `"8000"` |  |
+| riva-nim.fullnameOverride | string | `"riva-nim"` |  |
+| riva-nim.image.repository | string | `"nvcr.io/nim/nvidia/riva-asr"` |  |
+| riva-nim.image.tag | string | `"1.3.0"` |  |
+| riva-nim.nim.grpcPort | int | `8001` |  |
+| riva-nim.nim.logLevel | string | `"INFO"` |  |
+| riva-nim.podSecurityContext.fsGroup | int | `1000` |  |
+| riva-nim.podSecurityContext.runAsGroup | int | `1000` |  |
+| riva-nim.podSecurityContext.runAsUser | int | `1000` |  |
+| riva-nim.replicaCount | int | `1` |  |
+| riva-nim.service.grpcPort | int | `8001` |  |
+| riva-nim.service.httpPort | int | `8000` |  |
+| riva-nim.service.metricsPort | int | `0` |  |
+| riva-nim.service.name | string | `"riva-nim"` |  |
+| riva-nim.service.type | string | `"ClusterIP"` |  |
+| riva-nim.serviceAccount.create | bool | `false` |  |
+| riva-nim.serviceAccount.name | string | `""` |  |
+| riva-nim.statefuleSet.enabled | bool | `false` |  |
 | service.annotations | object | `{}` |  |
 | service.labels | object | `{}` |  |
 | service.name | string | `""` |  |

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -619,6 +619,67 @@ llama-32-nv-rerankqa-1b-v2:
       value: "1"
 
 
+## @skip riva-nim
+## @param riva-nim.deployed [default: true] true if riva-nim should be deployed and false otherwise
+## @param riva-nim.fullnameOverride [default: "riva-nim"] Override for the full name of the deployment
+## @param riva-nim.customCommand [default: []] Custom command to run in the container
+## @param riva-nim.customArgs [default: []] Custom arguments to pass to the container
+## @param riva-nim.image.repository The repository to override the location of the riva-asr NIM
+## @param riva-nim.image.tag The tag override for riva-asr NIM
+## @param riva-nim.podSecurityContext [default: {}] Security context for the pod
+## @param riva-nim.replicaCount [default: 1] Number of replicas to deploy
+## @param riva-nim.serviceAccount.create [default: false] Whether to create a service account
+## @param riva-nim.serviceAccount.name [default: ""] Name of the service account
+## @param riva-nim.statefuleSet.enabled [default: false] Whether to deploy as a statefulset
+## @param riva-nim.autoscaling.enabled [default: false] Whether to enable autoscaling
+## @param riva-nim.autoscaling.minReplicas [default: 1] Minimum number of replicas
+## @param riva-nim.autoscaling.maxReplicas [default: 10] Maximum number of replicas
+## @param riva-nim.autoscaling.metrics [default: []] Metrics for autoscaling
+## @param riva-nim.service.type [default: "ClusterIP"] The type of Kubernetes service to create
+## @param riva-nim.service.name [default: "riva-nim"] The name of the service
+## @param riva-nim.service.httpPort [default: 8000] The HTTP port for the service
+## @param riva-nim.service.grpcPort [default: 8001] The gRPC port for the service
+## @param riva-nim.service.metricsPort [default: 0] The metrics port for the service
+## @param riva-nim.nim.grpcPort [default: 8001] The gRPC port for NIM communication
+## @param riva-nim.nim.logLevel [default: "INFO"] The log level for NIM
+## @param riva-nim.env [default: []] Environment variables for the container
+riva-nim:
+  deployed: false
+  fullnameOverride: riva-nim
+  customCommand: []
+  customArgs: []
+  image:
+    repository: nvcr.io/nim/nvidia/riva-asr
+    tag: "1.3.0"
+  podSecurityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+  replicaCount: 1
+  serviceAccount:
+    create: false
+    name: ""
+  statefuleSet:
+    enabled: false
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    metrics: []
+  service:
+    type: "ClusterIP"
+    name: riva-nim
+    httpPort: 8000
+    grpcPort: 8001
+    metricsPort: 0  # Generally unused and defaults to 0
+  nim:
+    grpcPort: 8001
+    logLevel: "INFO"
+  env:
+    - name: NIM_HTTP_API_PORT
+      value: "8000"
+
+
 ## @section Milvus Deployment parameters
 ## @descriptionStart
 ## NVIngest uses Milvus and Minio to store extracted images from a document


### PR DESCRIPTION
## Description
Add Nvidia riva-asr helm chart as optional deployment

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
