### PR TITLE
trace_ids are returned to the client as UUID values. Those values nee…

### DIFF
--- a/client/src/nv_ingest_client/util/zipkin.py
+++ b/client/src/nv_ingest_client/util/zipkin.py
@@ -80,7 +80,7 @@ def collect_traces_from_zipkin(
     # Take the Dictionary of filenames -> trace_ids and build just a list of trace_ids to send to Zipkin
     trace_ids = []
     for filename in trace_id_map.keys():
-        trace_ids.append(trace_id_map[filename])
+        trace_ids.append(trace_id_map[filename].replace("-", ""))
 
     traces = asyncio.run(zipkin_client.get_metrics(trace_ids=trace_ids))
 


### PR DESCRIPTION
…d their hypen removed to query and get results from zipkin

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
