### PR TITLE
restore backward compatibility in nim client

### DIFF
--- a/api/src/nv_ingest_api/internal/primitives/nim/nim_client.py
+++ b/api/src/nv_ingest_api/internal/primitives/nim/nim_client.py
@@ -253,7 +253,10 @@ class NimClient:
         logger.debug(f"gRPC inference response: {response}")
 
         # TODO(self.client.has_error(response)) => raise error
-        return [response.as_numpy(output.name()) for output in outputs]
+        if len(outputs) == 1:
+            return response.as_numpy(outputs[0].name())
+        else:
+            return [response.as_numpy(output.name()) for output in outputs]
 
     def _http_infer(self, formatted_input: dict) -> dict:
         """


### PR DESCRIPTION
## Description
This PR fixes the following errors I'm getting from image NIMs:
```
nv-ingest-ms-runtime-1  | 2025-05-12 16:58:01,150 - ERROR - Unhandled error during page element extraction: Error during NimClient inference [yolox-page-elements, grpc]: expec
ted np.ndarray (got list)                                                                                                                                                      
nv-ingest-ms-runtime-1  | Traceback (most recent call last):                                                                                                                   
nv-ingest-ms-runtime-1  |   File "/opt/conda/envs/nv_ingest_runtime/lib/python3.10/site-packages/nv_ingest_api/internal/primitives/nim/nim_client.py", line 206, in infer      
nv-ingest-ms-runtime-1  |     batch_results = self.model_interface.process_inference_results(                                                                                  
nv-ingest-ms-runtime-1  |   File "/opt/conda/envs/nv_ingest_runtime/lib/python3.10/site-packages/nv_ingest_api/internal/primitives/nim/model_interface/yolox.py", line 353, in 
process_inference_results                                                                                                                                                      
nv-ingest-ms-runtime-1  |     pred = postprocess_model_prediction(                                                                                                             
nv-ingest-ms-runtime-1  |   File "/opt/conda/envs/nv_ingest_runtime/lib/python3.10/site-packages/nv_ingest_api/internal/primitives/nim/model_interface/yolox.py", line 610, in 
postprocess_model_prediction                                                                                                                                                   
nv-ingest-ms-runtime-1  |     prediction = torch.from_numpy(prediction.copy())                                                                                                 
nv-ingest-ms-runtime-1  | TypeError: expected np.ndarray (got list)                                                                                                            
nv-ingest-ms-runtime-1  |                                                                                                                                                      
nv-ingest-ms-runtime-1  | During handling of the above exception, another exception occurred:                                                                                  
nv-ingest-ms-runtime-1  |                                                                                                                                                      
nv-ingest-ms-runtime-1  | Traceback (most recent call last):                                                                                                                   
nv-ingest-ms-runtime-1  |   File "/opt/conda/envs/nv_ingest_runtime/lib/python3.10/site-packages/nv_ingest_api/internal/extract/pdf/engines/pdfium.py", line 103, in _extract_p
age_elements_using_image_ensemble                                                                                                                                              
nv-ingest-ms-runtime-1  |     inference_results = yolox_client.infer(                                                                                                          
nv-ingest-ms-runtime-1  |   File "/opt/conda/envs/nv_ingest_runtime/lib/python3.10/site-packages/nv_ingest_api/internal/primitives/tracing/tagging.py", line 187, in wrapper_in
ject_trace_info                                                                                                                                                                
nv-ingest-ms-runtime-1  |     result = func(*args, **kwargs)                                                                                                                   
nv-ingest-ms-runtime-1  |   File "/opt/conda/envs/nv_ingest_runtime/lib/python3.10/site-packages/nv_ingest_api/internal/primitives/nim/nim_client.py", line 220, in infer      
nv-ingest-ms-runtime-1  |     raise RuntimeError(error_str)                                                                                                                    
nv-ingest-ms-runtime-1  | RuntimeError: Error during NimClient inference [yolox-page-elements, grpc]: expected np.ndarray (got list)                                           
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
