### PR TITLE
Add test for NIM client single vs multiple response grpc

### DIFF
--- a/api/api_tests/primitives/nim/test_nim_client.py
+++ b/api/api_tests/primitives/nim/test_nim_client.py
@@ -1,0 +1,56 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import numpy as np
+
+from nv_ingest_api.internal.primitives.nim.nim_client import NimClient
+
+
+class MockModelInterface:
+    def name(self):
+        return "mock_model"
+
+
+class TestNimClientGrpc(unittest.TestCase):
+    def setUp(self):
+        self.model_interface = MockModelInterface()
+        self.endpoints = ("localhost:8001", "http://localhost:8000")
+
+    @patch("tritonclient.grpc.InferenceServerClient")
+    def test_grpc_infer_output_format(self, mock_grpc_client):
+        # Setup
+        client = NimClient(self.model_interface, "grpc", self.endpoints)
+        mock_response = MagicMock()
+        mock_response.as_numpy = MagicMock(return_value=np.array([1, 2, 3]).astype(np.float32))
+
+        # Mock the client's infer method
+        client.client.infer = MagicMock(return_value=mock_response)
+
+        # Test data
+        test_input = np.array([1, 2, 3]).astype(np.float32)
+
+        # Test single output
+        result = client._grpc_infer(test_input, "test_model", outputs=["output1"])
+        self.assertIsInstance(result, np.ndarray)
+        np.testing.assert_array_equal(result, test_input)
+
+        # Verify that InferRequestedOutput was called correctly for single output
+        last_call_args = client.client.infer.call_args
+        self.assertEqual(len(last_call_args[1]["outputs"]), 1)
+        self.assertEqual(last_call_args[1]["outputs"][0].name(), "output1")
+
+        # Test multiple outputs
+        result = client._grpc_infer(test_input, "test_model", outputs=["output1", "output2"])
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        np.testing.assert_array_equal(result[0], test_input)
+        np.testing.assert_array_equal(result[1], test_input)
+
+        # Verify that InferRequestedOutput was called correctly for multiple outputs
+        last_call_args = client.client.infer.call_args
+        self.assertEqual(len(last_call_args[1]["outputs"]), 2)
+        self.assertEqual(last_call_args[1]["outputs"][0].name(), "output1")
+        self.assertEqual(last_call_args[1]["outputs"][1].name(), "output2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/src/nv_ingest_api/internal/primitives/nim/nim_client.py
+++ b/api/src/nv_ingest_api/internal/primitives/nim/nim_client.py
@@ -253,7 +253,10 @@ class NimClient:
         logger.debug(f"gRPC inference response: {response}")
 
         # TODO(self.client.has_error(response)) => raise error
-        return [response.as_numpy(output.name()) for output in outputs]
+        if len(outputs) == 1:
+            return response.as_numpy(outputs[0].name())
+        else:
+            return [response.as_numpy(output.name()) for output in outputs]
 
     def _http_infer(self, formatted_input: dict) -> dict:
         """

--- a/api/src/nv_ingest_api/internal/primitives/nim/nim_client.py
+++ b/api/src/nv_ingest_api/internal/primitives/nim/nim_client.py
@@ -251,7 +251,6 @@ class NimClient:
             model_name=model_name, parameters=parameters, inputs=[input_tensors], outputs=outputs
         )
         logger.debug(f"gRPC inference response: {response}")
-
         # TODO(self.client.has_error(response)) => raise error
         if len(outputs) == 1:
             return response.as_numpy(outputs[0].name())


### PR DESCRIPTION
## Description
This PR provides a unit test for grpc, where if you have only one output, it is expected that the output is not in a list otherwise it should be a list.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
