### PR TITLE
guard against error string responses in custom ocr extractor

### DIFF
--- a/api/src/nv_ingest_api/internal/primitives/nim/model_interface/custom_ocr.py
+++ b/api/src/nv_ingest_api/internal/primitives/nim/model_interface/custom_ocr.py
@@ -288,9 +288,20 @@ class CustomOCRModelInterface(ModelInterface):
         ValueError
             If the `table_content_format` is unrecognized.
         """
+        if isinstance(json_response, str):
+            raise RuntimeError(f"CustomOCR error response: {json_response}")
+
+        if not isinstance(json_response, list):
+            raise RuntimeError(
+                f"Unexpected response type {type(json_response).__name__}; expected list of item dictionaries."
+            )
+
         results: List[str] = []
 
         for item_idx, item in enumerate(json_response):
+            if not isinstance(item, dict):
+                raise RuntimeError(f"Unexpected response type {type(item).__name__}; expected dictionary.")
+
             regions = item.get("regions", [])
 
             text_predictions = []


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
