### PR TITLE
Make milvus and minio optional for the client and completely remove r…

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -23,25 +23,31 @@ dependencies = [
     "click>=8.1.8",
     "fsspec>=2025.2.0",
     "httpx==0.27.2",
-    "langchain-milvus==0.1.7",
     "langchain-nvidia-ai-endpoints>=0.3.7",
     "llama-index-embeddings-nvidia==0.1.5",
-    "minio>=7.2.15",
     "openai~=1.68.1",
     "pyarrow>=19.0.0",
     "pydantic>2.0.0",
     "pydantic-settings>2.0.0",
-    "pymilvus==2.5.8",
-    "pymilvus[bulk_writer,model]",
     "pypdfium2>=4.30.1",
     "python-docx>=1.1.2",
     "python-magic>=0.4.27",
     "python-pptx==0.6.23",
-    "redis~=5.2.1",
     "requests>=2.28.2",
     "setuptools>=58.2.0",
     "tqdm>=4.67.1",
 ]
+
+[project.optional-dependencies]
+milvus = [
+    "pymilvus==2.5.8",
+    "pymilvus[bulk_writer,model]",
+    "langchain-milvus==0.1.7",
+]
+minio = [
+    "minio>=7.2.15",
+]
+
 
 [project.urls]
 homepage = "https://github.com/NVIDIA/nv-ingest"

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "python-docx>=1.1.2",
     "python-dotenv>=1.0.1",
     "python-pptx>=1.0.2",
-    "torch==2.4.1",  # https://github.com/pytorch/pytorch/issues/111469
+    "torch==2.6.0",
     "ray[all]>=2.37.0",
     "redis>=5.2.1",
     "requests>=2.28.2",


### PR DESCRIPTION
## Description
Make milvus and minio optional for the client and completely remove redis

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
