### PR TITLE
Add multiple more text-like filetypes

### DIFF
--- a/client/client_tests/client/test_interface.py
+++ b/client/client_tests/client/test_interface.py
@@ -47,7 +47,23 @@ def documents():
 
 @pytest.fixture
 def text_documents():
-    return ["data/test.txt", "data/test.html", "data/test.json", "data/test.md", "data/test.sh"]
+    return [
+        "data/test.txt",
+        "data/test.html",
+        "data/test.json",
+        "data/test.md",
+        "data/test.sh",
+        "data/test.log",
+        "data/test.xml",
+        "data/test.yaml",
+        "data/test.yml",
+        "data/test.ini",
+        "data/test.conf",
+        "data/test.cfg",
+        "data/test.tex",
+        "data/test.rst",
+        "data/test.adoc",
+    ]
 
 
 @pytest.fixture

--- a/client/src/nv_ingest_client/primitives/tasks/extract.py
+++ b/client/src/nv_ingest_client/primitives/tasks/extract.py
@@ -32,26 +32,41 @@ ADOBE_CLIENT_ID = os.environ.get("ADOBE_CLIENT_ID", None)
 ADOBE_CLIENT_SECRET = os.environ.get("ADOBE_CLIENT_SECRET", None)
 
 _DEFAULT_EXTRACTOR_MAP = {
+    # Image files
     "bmp": "image",
-    "csv": "pandas",
-    "docx": "python_docx",
-    "excel": "openpyxl",
-    "html": "txt",
     "jpeg": "image",
     "jpg": "image",
-    "parquet": "pandas",
-    "pdf": "pdfium",
     "png": "image",
-    "pptx": "python_pptx",
-    "text": "txt",
     "tiff": "image",
-    "txt": "txt",
-    "xml": "lxml",
-    "mp3": "audio",
-    "wav": "audio",
+    # Text files
+    "html": "txt",
     "json": "txt",
     "md": "txt",
     "sh": "txt",
+    "text": "txt",
+    "txt": "txt",
+    "log": "txt",
+    "yaml": "txt",
+    "yml": "txt",
+    "ini": "txt",
+    "conf": "txt",
+    "cfg": "txt",
+    "tex": "txt",
+    "rst": "txt",
+    "adoc": "txt",
+    # Data files
+    "csv": "pandas",
+    "parquet": "pandas",
+    "excel": "openpyxl",
+    # Document files
+    "docx": "python_docx",
+    "pdf": "pdfium",
+    "pptx": "python_pptx",
+    # Audio files
+    "mp3": "audio",
+    "wav": "audio",
+    # XML files
+    "xml": "lxml",
 }
 
 _Type_Extract_Method_PDF = Literal[
@@ -153,7 +168,24 @@ class ExtractTaskSchema(BaseModel):
         document_type = values.data.get("document_type", "").lower()  # Ensure case-insensitive comparison
 
         # Skip validation for text-like types, since they do not have 'extract' stages.
-        if document_type in ["txt", "text", "html", "json", "md", "sh"]:
+        if document_type in [
+            "txt",
+            "text",
+            "html",
+            "json",
+            "md",
+            "sh",
+            "log",
+            "xml",
+            "yaml",
+            "yml",
+            "ini",
+            "conf",
+            "cfg",
+            "tex",
+            "rst",
+            "adoc",
+        ]:
             return
 
         valid_methods = set(_Type_Extract_Method_Map[document_type])

--- a/data/test.adoc
+++ b/data/test.adoc
@@ -1,5 +1,4 @@
 = Test AsciiDoc Document
-Test User <test@example.com>
 v1.0, 2024-07-15
 :toc:
 :icons: font

--- a/data/test.adoc
+++ b/data/test.adoc
@@ -1,0 +1,14 @@
+= Test AsciiDoc Document
+Test User <test@example.com>
+v1.0, 2024-07-15
+:toc:
+:icons: font
+:source-highlighter: highlight.js
+
+== Abstract
+
+This is a test AsciiDoc document for document processing. The quick brown fox jumped over the lazy dog.
+
+== Conclusion
+
+This concludes our test AsciiDoc document. 

--- a/data/test.cfg
+++ b/data/test.cfg
@@ -1,0 +1,14 @@
+# Test CFG Configuration File
+
+[DEFAULT]
+# Default settings for all sections
+debug = false
+log_level = INFO
+base_dir = /opt/test-app
+
+[APP]
+name = Test Application
+description = The quick brown fox jumped over the lazy dog.
+version = 1.0.0
+max_connections = 100
+timeout = 30

--- a/data/test.conf
+++ b/data/test.conf
@@ -3,7 +3,6 @@
 
 server {
     listen 80;
-    server_name example.com;
     root /var/www/html;
     
     location / {
@@ -11,7 +10,6 @@ server {
     }
     
     location /api {
-        proxy_pass http://localhost:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }

--- a/data/test.conf
+++ b/data/test.conf
@@ -1,0 +1,21 @@
+# Test Configuration File
+# The quick brown fox jumped over the lazy dog.
+
+server {
+    listen 80;
+    server_name example.com;
+    root /var/www/html;
+    
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+    
+    location /api {
+        proxy_pass http://localhost:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+    
+    error_page 404 /404.html;
+    error_page 500 502 503 504 /50x.html;
+}

--- a/data/test.ini
+++ b/data/test.ini
@@ -1,0 +1,5 @@
+[General]
+ApplicationName=Test Application
+Version=1.0
+Description=The quick brown fox jumped over the lazy dog.
+Debug=true

--- a/data/test.log
+++ b/data/test.log
@@ -1,0 +1,6 @@
+[2024-07-15 10:23:45] [INFO] The application started successfully
+[2024-07-15 10:23:46] [DEBUG] Initializing connection to database
+[2024-07-15 10:23:47] [INFO] User 'test_user' logged in
+[2024-07-15 10:23:50] [WARNING] Low memory detected (15% available)
+[2024-07-15 10:23:55] [ERROR] Failed to connect to external API: Connection timed out
+[2024-07-15 10:24:00] [INFO] Test operation completed

--- a/data/test.rst
+++ b/data/test.rst
@@ -1,0 +1,23 @@
+===================
+Test RST Document
+===================
+
+:Author: Test User
+:Date: 2024-07-15
+:Version: 1.0
+
+Abstract
+--------
+
+This is a test reStructuredText document for document processing. The quick brown fox jumped over the lazy dog.
+
+Introduction
+-----------
+
+This document includes reStructuredText formatting.
+
+
+Conclusion
+----------
+
+This concludes our test RST document. 

--- a/data/test.tex
+++ b/data/test.tex
@@ -1,0 +1,10 @@
+\documentclass{article}
+\usepackage{graphicx}
+\usepackage{amsmath}
+\usepackage{hyperref}
+
+\title{Test LaTeX Document}
+\author{Test User}
+\date{\today}
+
+\end{document}

--- a/data/test.xml
+++ b/data/test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <header>
+    <title>Test XML Document</title>
+    <description>This is a test XML file for document processing</description>
+    <date>2024-07-15</date>
+  </header>
+  <content>
+    <paragraph id="p1">The quick brown fox jumped over the lazy dog.</paragraph>
+    <paragraph id="p2">This is a sample XML document to test the extraction functionality.</paragraph>
+    <items>
+      <item id="1">First test item</item>
+      <item id="2">Second test item</item>
+      <item id="3">Third test item</item>
+    </items>
+  </content>
+  <metadata>
+    <author>Test User</author>
+    <version>1.0</version>
+  </metadata>
+</root>

--- a/data/test.yaml
+++ b/data/test.yaml
@@ -1,0 +1,5 @@
+---
+# Test YAML Document
+messages:
+  greeting: "The quick brown fox jumped over the lazy dog."
+  error: "Something went wrong. Please try again." 

--- a/data/test.yml
+++ b/data/test.yml
@@ -1,0 +1,8 @@
+---
+# Test YML Document (alternative YAML extension)
+project: test-project
+version: 1.0
+
+notifications:
+  message: "The quick brown fox jumped over the lazy dog."
+... 


### PR DESCRIPTION
## Description
Small PR to add other text-likes, similar to:
- #696  

### Enhancements to document type support:
* Expanded the `text_documents` fixture in `client/client_tests/client/test_interface.py` to include new file types: `.log`, `.xml`, `.yaml`, `.yml`, `.ini`, `.conf`, `.cfg`, `.tex`, `.rst`, and `.adoc`.
* Updated `_DEFAULT_EXTRACTOR_MAP` in `client/src/nv_ingest_client/primitives/tasks/extract.py` to map the new file types to appropriate extractors. For example, `.xml` is mapped to `lxml`, and `.yaml`/`.yml` are mapped to `txt`.
* Modified the `extract_method_must_be_valid` method in `client/src/nv_ingest_client/primitives/tasks/extract.py` to skip validation for the newly added text-like file types.

### New test files for added document types:
* Added test files for `.adoc`, `.cfg`, `.conf`, `.ini`, `.rst`, `.tex`, `.xml`, `.yaml`, and `.yml` in the `data/` directory to validate processing of these formats. Each file contains representative content for its respective format. [[1]](diffhunk://#diff-ec3413761473712fe4b6f41c1bfe016b05ef4bc35475d3113ffdf53a4c4719a2R1-R14) [[2]](diffhunk://#diff-dd59e6a73e265a5b80332ddd56c298d7cc1332d8f14657d581439e2add505074R1-R14) [[3]](diffhunk://#diff-6739a5e1d0f02f7b75c794dc2295ad23ef8a693c3723d07ad67caf1be8c9f986R1-R21) [[4]](diffhunk://#diff-5c1efe7de2984a0f6b1754b91193d8007a79d2be5a7573f10c3e00f4fa726546R1-R5) [[5]](diffhunk://#diff-e89f834b4744ac184ed19f7f4f031c8702ff0fc243a5c3d70351fd2d428a2575R1-R23) [[6]](diffhunk://#diff-69fd842f416e4936904cd29f38aca338c9acb5dbb18ed935bc4cf52f2aba6297R1-R10) [[7]](diffhunk://#diff-fbffdf5701b9269ce114bf08d905cd90f5ee6ab57137dfba38ad7b167d541d44R1-R21) [[8]](diffhunk://#diff-6463e9ee63e3417f6cfc475404191965edee7dd0085997e5f36bed1dcc8aeab5R1-R5) [[9]](diffhunk://#diff-6cb558fa2a419c86e53ea7e35cb9dd2f178a697556b70ec6bb56a9a6c5b4902bR1-R8)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [x] ~If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.~
