### PR TITLE
Add HTML extractor stage

### DIFF
--- a/.github/workflows/test-library-mode.yml
+++ b/.github/workflows/test-library-mode.yml
@@ -91,7 +91,7 @@ jobs:
           # Install other dependencies
           conda install -y -c conda-forge librosa
           # Install pip dependencies
-          $CONDA/envs/nvingest/bin/python -m pip install opencv-python llama-index-embeddings-nvidia pymilvus 'pymilvus[bulk_writer, model]' milvus-lite nvidia-riva-client unstructured-client tritonclient
+          $CONDA/envs/nvingest/bin/python -m pip install opencv-python llama-index-embeddings-nvidia pymilvus 'pymilvus[bulk_writer, model]' milvus-lite nvidia-riva-client unstructured-client tritonclient markitdown
 
       - name: Run integration test
         env:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Create a fresh Conda environment to install nv-ingest and dependencies.
 conda create -y --name nvingest python=3.12 && \
     conda activate nvingest && \
     conda install -y -c rapidsai -c conda-forge -c nvidia nv_ingest=25.4.2 nv_ingest_client=25.4.2 nv_ingest_api=25.4.2 && \
-    pip install opencv-python llama-index-embeddings-nvidia pymilvus 'pymilvus[bulk_writer, model]' milvus-lite nvidia-riva-client unstructured-client tritonclient
+    pip install opencv-python llama-index-embeddings-nvidia pymilvus 'pymilvus[bulk_writer, model]' milvus-lite nvidia-riva-client unstructured-client tritonclient markitdown
 ```
 
 Set your NVIDIA_BUILD_API_KEY and NVIDIA_API_KEY. If you don't have a key, you can get one on [build.nvidia.com](https://org.ngc.nvidia.com/setup/api-keys). For instructions, refer to [Generate Your NGC Keys](/docs/docs/extraction/ngc-api-key.md).

--- a/api/api_tests/internal/extract/html/__init__.py
+++ b/api/api_tests/internal/extract/html/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/api/api_tests/internal/extract/html/test_html_extractor.py
+++ b/api/api_tests/internal/extract/html/test_html_extractor.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from unittest.mock import Mock, patch
+import pandas as pd
+
+# Import the module under test
+import nv_ingest_api.internal.extract.html.html_extractor as module_under_test
+from nv_ingest_api.internal.extract.html.html_extractor import _convert_html
+from nv_ingest_api.internal.enums.common import ContentTypeEnum
+
+# Define module path constant for patching
+MODULE_UNDER_TEST = f"{module_under_test.__name__}"
+
+
+class TestHtmlExtraction(unittest.TestCase):
+    """Tests for HTML extraction functionality."""
+
+    def setUp(self):
+        """Set up common test fixtures."""
+        # Sample HTML content
+        self.sample_content = "<!DOCTYPE html><html><body><h1>The Heading</h1><p>The body.</p></body></html>"
+
+        # Sample valid audio metadata
+        self.valid_html_metadata = {
+            "content": self.sample_content,
+        }
+
+        # Sample row data
+        self.sample_row = pd.Series(
+            {
+                "content": self.sample_content,
+                "source_id": "test-html",
+                "filename": "test.html",
+                "file_size": 12345,
+            }
+        )
+
+        # Sample task config
+        self.sample_task_config = {
+            "method": "markitdown",
+            "params": {
+                "extract_text": True,
+                "extract_images": False,
+                "extract_tables": False,
+                "extract_charts": False,
+                "extract_infographics": False,
+            },
+        }
+
+        # Sample trace info
+        self.trace_info = {"request_id": "test-request-123", "timestamp": "2025-03-10T12:00:00Z"}
+
+    @patch(f"{MODULE_UNDER_TEST}.validate_schema")
+    def test_convert_html_valid(self, mock_validate_schema):
+        """Test _convert_html with valid html content"""
+        # Configure mocks
+        mock_validate_schema.side_effect = lambda data, schema: Mock(model_dump=lambda: data)
+
+        # Create a sample row with valid audio metadata
+        row = pd.Series({"content": self.sample_content, "metadata": self.valid_html_metadata.copy()})
+
+        result = _convert_html(row, self.trace_info)
+
+        self.assertEqual(result[0][1]["content"], "# The Heading\n\nThe body.")
+        self.assertEqual(result[0][0], ContentTypeEnum.TEXT)
+
+        # Verify validate_schema was called once
+        self.assertEqual(mock_validate_schema.call_count, 1)
+
+    def test_convert_html_empty(self):
+        """Test _convert_html with empty html content"""
+
+        # Create a sample row with valid audio metadata
+        empty_meta = self.valid_html_metadata.copy()
+        empty_meta["content"] = ""
+        row = pd.Series({"content": "", "metadata": empty_meta})
+
+        result = _convert_html(row, self.trace_info)
+
+        self.assertEqual(result[0][1]["content"], "")
+        self.assertEqual(result[0][0], ContentTypeEnum.TEXT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/api/src/nv_ingest_api/internal/extract/html/__init__.py
+++ b/api/src/nv_ingest_api/internal/extract/html/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/api/src/nv_ingest_api/internal/extract/html/html_extractor.py
+++ b/api/src/nv_ingest_api/internal/extract/html/html_extractor.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import logging
+import uuid
+from typing import Optional, Dict, Any, Union, Tuple, List
+
+import pandas as pd
+
+from nv_ingest_api.internal.enums.common import ContentTypeEnum
+from nv_ingest_api.internal.schemas.meta.metadata_schema import MetadataSchema
+from nv_ingest_api.internal.schemas.extract.extract_html_schema import HtmlExtractorSchema
+from nv_ingest_api.util.schema.schema_validator import validate_schema
+from nv_ingest_api.util.exception_handlers.decorators import unified_exception_handler
+
+from markitdown.converters import HtmlConverter
+
+logger = logging.getLogger(__name__)
+
+
+@unified_exception_handler
+def _convert_html(row: pd.Series, execution_trace_log: Optional[List[Any]] = None):
+    metadata = row.get("metadata")
+    html_content = row.get("content")
+
+    html_converter = HtmlConverter()
+    md_content = html_converter.convert_string(html_content=html_content).text_content
+
+    metadata["content"] = md_content
+    return [[ContentTypeEnum.TEXT, validate_schema(metadata, MetadataSchema).model_dump(), str(uuid.uuid4())]]
+
+
+def extract_markdown_from_html_internal(
+    df_extraction_ledger: pd.DataFrame,
+    task_config: Dict[str, Any],
+    extraction_config: HtmlExtractorSchema,
+    execution_trace_log: Optional[Dict[str, Any]] = None,
+) -> Tuple[pd.DataFrame, Union[Dict, None]]:
+    """
+    Processes a pandas DataFrame containing HTML file content, extracting html as text from
+    each document and converting it to markdown.
+
+    Parameters
+    ----------
+    df_extraction_ledger : pd.DataFrame
+        The input DataFrame containing html files as raw text. Expected columns include
+        'source_id' and 'content'.
+    task_config : Union[Dict[str, Any], BaseModel]
+        Configuration instructions for the document processing task. This can be provided as a
+        dictionary or a Pydantic model.
+    extraction_config : Any
+        A configuration object for document extraction that guides the extraction process.
+    execution_trace_log : Optional[Dict[str, Any]], default=None
+        An optional dictionary containing trace information for debugging or logging.
+
+    Returns
+    -------
+    pd.DataFrame
+        A DataFrame with the original html content converted to markdown. The resulting
+        DataFrame contains the columns "document_type", "metadata", and "uuid".
+
+    Raises
+    ------
+    Exception
+        If an error occurs during the document extraction process, the exception is logged and
+        re-raised.
+    """
+
+    # Apply the decode_and_extract function to each row in the DataFrame.
+    sr_extraction = df_extraction_ledger.apply(lambda row: _convert_html(row, execution_trace_log), axis=1)
+
+    # Explode any list results and drop missing values.
+    sr_extraction = sr_extraction.explode().dropna()
+
+    # Convert the extraction results to a DataFrame if available.
+    if not sr_extraction.empty:
+        extracted_df = pd.DataFrame(sr_extraction.to_list(), columns=["document_type", "metadata", "uuid"])
+    else:
+        extracted_df = pd.DataFrame({"document_type": [], "metadata": [], "uuid": []})
+
+    return extracted_df, {}

--- a/api/src/nv_ingest_api/internal/extract/html/html_extractor.py
+++ b/api/src/nv_ingest_api/internal/extract/html/html_extractor.py
@@ -25,10 +25,11 @@ def _convert_html(row: pd.Series, execution_trace_log: Optional[List[Any]] = Non
     metadata = row.get("metadata")
     html_content = row.get("content")
 
-    html_converter = HtmlConverter()
-    md_content = html_converter.convert_string(html_content=html_content).text_content
+    if html_content:
+        html_converter = HtmlConverter()
+        md_content = html_converter.convert_string(html_content=html_content).text_content
+        metadata["content"] = md_content
 
-    metadata["content"] = md_content
     return [[ContentTypeEnum.TEXT, validate_schema(metadata, MetadataSchema).model_dump(), str(uuid.uuid4())]]
 
 

--- a/api/src/nv_ingest_api/internal/schemas/extract/extract_html_schema.py
+++ b/api/src/nv_ingest_api/internal/schemas/extract/extract_html_schema.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import logging
+
+from pydantic import ConfigDict, BaseModel
+
+logger = logging.getLogger(__name__)
+
+
+class HtmlExtractorSchema(BaseModel):
+    """
+    Configuration schema for the Html extractor settings.
+
+    Parameters
+    ----------
+    max_queue_size : int, default=1
+        The maximum number of items allowed in the processing queue.
+
+    n_workers : int, default=16
+        The number of worker threads to use for processing.
+
+    raise_on_failure : bool, default=False
+        A flag indicating whether to raise an exception on processing failure.
+
+    """
+
+    max_queue_size: int = 1
+    n_workers: int = 16
+    raise_on_failure: bool = False
+
+    model_config = ConfigDict(extra="forbid")

--- a/client/src/nv_ingest_client/primitives/tasks/extract.py
+++ b/client/src/nv_ingest_client/primitives/tasks/extract.py
@@ -36,7 +36,7 @@ _DEFAULT_EXTRACTOR_MAP = {
     "csv": "pandas",
     "docx": "python_docx",
     "excel": "openpyxl",
-    "html": "txt",
+    "html": "markitdown",
     "jpeg": "image",
     "jpg": "image",
     "parquet": "pandas",
@@ -74,10 +74,12 @@ _Type_Extract_Method_Audio = Literal["audio"]
 
 _Type_Extract_Method_Text = Literal["txt"]
 
+_Type_Extract_Method_Html = Literal["markitdown"]
+
 _Type_Extract_Method_Map = {
     "bmp": get_args(_Type_Extract_Method_Image),
     "docx": get_args(_Type_Extract_Method_DOCX),
-    "html": get_args(_Type_Extract_Method_Text),
+    "html": get_args(_Type_Extract_Method_Html),
     "jpeg": get_args(_Type_Extract_Method_Image),
     "jpg": get_args(_Type_Extract_Method_Image),
     "pdf": get_args(_Type_Extract_Method_PDF),
@@ -153,7 +155,7 @@ class ExtractTaskSchema(BaseModel):
         document_type = values.data.get("document_type", "").lower()  # Ensure case-insensitive comparison
 
         # Skip validation for text-like types, since they do not have 'extract' stages.
-        if document_type in ["txt", "text", "html", "json", "md", "sh"]:
+        if document_type in ["txt", "text", "json", "md", "sh"]:
             return
 
         valid_methods = set(_Type_Extract_Method_Map[document_type])

--- a/conda/environments/nv_ingest_environment.yml
+++ b/conda/environments/nv_ingest_environment.yml
@@ -55,3 +55,4 @@ dependencies:
       - tritonclient
       - nvidia-riva-client>=2.18.0
       - unstructured-client
+      - markitdown

--- a/conda/packages/nv_ingest/meta.yaml
+++ b/conda/packages/nv_ingest/meta.yaml
@@ -64,6 +64,7 @@ requirements:
     - uvicorn
   pip:
     - nvidia-riva-client>=2.18.0
+    - markitdown
 
   test:
     commands:

--- a/src/nv_ingest/framework/orchestration/ray/stages/extractors/html_extractor.py
+++ b/src/nv_ingest/framework/orchestration/ray/stages/extractors/html_extractor.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import logging
+
+import ray
+
+from nv_ingest.framework.orchestration.ray.stages.meta.ray_actor_stage_base import RayActorStage
+from nv_ingest.framework.util.flow_control import filter_by_task
+from nv_ingest_api.internal.extract.html.html_extractor import extract_markdown_from_html_internal
+from nv_ingest_api.internal.primitives.ingest_control_message import remove_task_by_type, IngestControlMessage
+from nv_ingest_api.internal.primitives.tracing.tagging import traceable
+from nv_ingest_api.internal.schemas.extract.extract_html_schema import HtmlExtractorSchema
+from nv_ingest_api.util.exception_handlers.decorators import (
+    nv_ingest_node_failure_try_except,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@ray.remote
+class HtmlExtractorStage(RayActorStage):
+    """
+    A Ray actor stage that extracts text in markdown format from html content.
+
+    It expects an IngestControlMessage containing a DataFrame with html content. It then:
+      1. Removes the "html_content_extract" task from the message.
+      2. Calls the html extraction logic (via extract_markdown_from_html_internal) using a validated configuration.
+      3. Updates the message payload with the extracted text DataFrame.
+    """
+
+    def __init__(self, config: HtmlExtractorSchema) -> None:
+        super().__init__(config, log_to_stdout=False)
+        try:
+            self.validated_config = config
+            self._logger.info("HtmlExtractorStage configuration validated successfully.")
+        except Exception as e:
+            self._logger.exception(f"Error validating Html Extractor config: {e}")
+            raise
+
+    @traceable("html_extractor")
+    @filter_by_task(required_tasks=[("extract", {"document_type": "html"})])
+    @nv_ingest_node_failure_try_except(annotation_id="html_extractor", raise_on_failure=False)
+    def on_data(self, control_message: IngestControlMessage) -> IngestControlMessage:
+        """
+        Process the control message by extracting content from html.
+
+        Parameters
+        ----------
+        control_message : IngestControlMessage
+            The message containing a DataFrame payload with html content.
+
+        Returns
+        -------
+        IngestControlMessage
+            The updated message with extracted content.
+        """
+        self._logger.debug("HtmlExtractorStage.on_data: Starting html extraction process.")
+
+        # Extract the DataFrame payload.
+        df_ledger = control_message.payload()
+        self._logger.debug("Extracted payload with %d rows.", len(df_ledger))
+
+        # Remove the "html_content_extract" task from the message to obtain task-specific configuration.
+        task_config = remove_task_by_type(control_message, "extract")
+        self._logger.debug("Extracted task config: %s", task_config)
+
+        # Perform html content extraction.
+        new_df, extraction_info = extract_markdown_from_html_internal(
+            df_extraction_ledger=df_ledger,
+            task_config=task_config,
+            extraction_config=self.validated_config,
+            execution_trace_log=None,
+        )
+
+        # Update the message payload with the extracted text DataFrame.
+        control_message.payload(new_df)
+        control_message.set_metadata("html_extraction_info", extraction_info)
+
+        return control_message

--- a/src/nv_ingest/framework/orchestration/ray/util/pipeline/pipeline_builders.py
+++ b/src/nv_ingest/framework/orchestration/ray/util/pipeline/pipeline_builders.py
@@ -19,6 +19,7 @@ from nv_ingest.framework.orchestration.ray.util.pipeline.stage_builders import (
     add_image_extractor_stage,
     add_docx_extractor_stage,
     add_audio_extractor_stage,
+    add_html_extractor_stage,
     add_image_dedup_stage,
     add_image_filter_stage,
     add_table_extractor_stage,
@@ -103,6 +104,7 @@ def setup_ingestion_pipeline(pipeline: RayPipeline, ingest_config: Dict[str, Any
     docx_extractor_stage_id = add_docx_extractor_stage(pipeline, default_cpu_count)
     pptx_extractor_stage_id = add_pptx_extractor_stage(pipeline, default_cpu_count)
     audio_extractor_stage_id = add_audio_extractor_stage(pipeline, default_cpu_count)
+    html_extractor_stage_id = add_html_extractor_stage(pipeline, default_cpu_count)
     ########################################################################################################
 
     ########################################################################################################
@@ -159,7 +161,8 @@ def setup_ingestion_pipeline(pipeline: RayPipeline, ingest_config: Dict[str, Any
     pipeline.make_edge(audio_extractor_stage_id, docx_extractor_stage_id, queue_size=ingest_edge_buffer_size)
     pipeline.make_edge(docx_extractor_stage_id, pptx_extractor_stage_id, queue_size=ingest_edge_buffer_size)
     pipeline.make_edge(pptx_extractor_stage_id, image_extractor_stage_id, queue_size=ingest_edge_buffer_size)
-    pipeline.make_edge(image_extractor_stage_id, infographic_extraction_stage_id, queue_size=ingest_edge_buffer_size)
+    pipeline.make_edge(image_extractor_stage_id, html_extractor_stage_id, queue_size=ingest_edge_buffer_size)
+    pipeline.make_edge(html_extractor_stage_id, infographic_extraction_stage_id, queue_size=ingest_edge_buffer_size)
 
     ###### Primitive Extractors ########
     pipeline.make_edge(infographic_extraction_stage_id, table_extraction_stage_id, queue_size=ingest_edge_buffer_size)

--- a/src/nv_ingest/framework/orchestration/ray/util/pipeline/stage_builders.py
+++ b/src/nv_ingest/framework/orchestration/ray/util/pipeline/stage_builders.py
@@ -23,6 +23,7 @@ from nv_ingest.framework.orchestration.ray.stages.extractors.infographic_extract
 from nv_ingest.framework.orchestration.ray.stages.extractors.pdf_extractor import PDFExtractorStage
 from nv_ingest.framework.orchestration.ray.stages.extractors.pptx_extractor import PPTXExtractorStage
 from nv_ingest.framework.orchestration.ray.stages.extractors.table_extractor import TableExtractorStage
+from nv_ingest.framework.orchestration.ray.stages.extractors.html_extractor import HtmlExtractorStage
 
 from nv_ingest.framework.orchestration.ray.stages.injectors.metadata_injector import MetadataInjectionStage
 from nv_ingest.framework.orchestration.ray.stages.mutate.image_dedup import ImageDedupStage
@@ -49,6 +50,7 @@ from nv_ingest_api.internal.schemas.extract.extract_image_schema import ImageCon
 from nv_ingest_api.internal.schemas.extract.extract_pdf_schema import PDFExtractorSchema
 from nv_ingest_api.internal.schemas.extract.extract_pptx_schema import PPTXExtractorSchema
 from nv_ingest_api.internal.schemas.extract.extract_table_schema import TableExtractorSchema
+from nv_ingest_api.internal.schemas.extract.extract_html_schema import HtmlExtractorSchema
 from nv_ingest_api.internal.schemas.mutate.mutate_image_dedup_schema import ImageDedupSchema
 from nv_ingest_api.internal.schemas.store.store_embedding_schema import EmbeddingStorageSchema
 from nv_ingest_api.internal.schemas.store.store_image_schema import ImageStorageModuleSchema
@@ -378,6 +380,19 @@ def add_audio_extractor_stage(pipeline, default_cpu_count, stage_name="audio_ext
         config=audio_extractor_config,
         min_replicas=0,
         max_replicas=1,  # Audio extraction is a heavy IO bound operation with minimal CPU usage
+    )
+
+    return stage_name
+
+
+def add_html_extractor_stage(pipeline, default_cpu_count, stage_name="html_extractor"):
+
+    pipeline.add_stage(
+        name=stage_name,
+        stage_actor=HtmlExtractorStage,
+        config=HtmlExtractorSchema(),
+        min_replicas=0,
+        max_replicas=int(max(1, (default_cpu_count // 14))),  # 7% of available CPU cores
     )
 
     return stage_name

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -65,6 +65,7 @@ dependencies = [
     "tritonclient",
     "nvidia-riva-client>=2.18.0",
     "unstructured-client",
+    "markitdown",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This adds an HTML extractor stage that uses [markitdown](https://github.com/microsoft/markitdown) to convert the raw html to markdown 

## TODO:
- [x] Add tests
- [ ] Update docs

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
