### PR TITLE
docs: Update release notes to include link to Helm Chart

### DIFF
--- a/docs/docs/extraction/releasenotes-nv-ingest.md
+++ b/docs/docs/extraction/releasenotes-nv-ingest.md
@@ -22,7 +22,7 @@ There are no breaking changes in this version.
 
 ### Upgrade
 
-To upgrade to the Helm Charts for this version, refer to [NV-Ingest Helm Charts](https://github.com/NVIDIA/nv-ingest/tree/main/helm).
+To upgrade the Helm Charts for this version, refer to [NV-Ingest Helm Charts](https://github.com/NVIDIA/nv-ingest/tree/main/helm).
 
 
 


### PR DESCRIPTION
 Update release notes to include:

- "Upgrade" subsection with link to Helm Chart
- "Breaking changes" subsection

I updated the previous release notes as a template.  Include this in the v.Next release notes by copy-paste.