### PR TITLE
langchain-milvus relax version

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 milvus = [
     "pymilvus==2.5.10",
     "pymilvus[bulk_writer,model]",
-    "langchain-milvus==0.1.7",
+    "langchain-milvus>=0.1.10",
 ]
 minio = [
     "minio>=7.2.15",


### PR DESCRIPTION
## Description
Relax to tight version constraint for `langchain-milvus` to accept versions >= 0.1.10

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
