### PR TITLE
fix error in dtype for metadata

### DIFF
--- a/client/src/nv_ingest_client/util/vdb/milvus.py
+++ b/client/src/nv_ingest_client/util/vdb/milvus.py
@@ -620,7 +620,7 @@ def add_metadata(element, meta_dataframe, meta_source_field, meta_data_fields):
         logger.info(f"FOUND MORE THAN ONE metadata entry for {element_name}, will use first entry")
     meta_fields = df[meta_data_fields]
     for col in meta_data_fields:
-        element["metadata"]["content_metadata"][col] = meta_fields.iloc[0][col]
+        element["metadata"]["content_metadata"][col] = str(meta_fields.iloc[0][col])
 
 
 def write_records_minio(records, writer: RemoteBulkWriter) -> RemoteBulkWriter:


### PR DESCRIPTION
## Description
This PR ensures a cast to a string for metadata fields. Prevents auto casting to primitive dtype which changes the dtype of field and causes issues in milvus field. 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
