### PR TITLE
Bump client httpx version to align with nv-ingest service

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "charset-normalizer>=3.4.1",
     "click>=8.1.8",
     "fsspec>=2025.2.0",
-    "httpx==0.27.2",
+    "httpx>=0.28.1",
     "langchain-nvidia-ai-endpoints>=0.3.7",
     "llama-index-embeddings-nvidia==0.1.5",
     "openai~=1.82.0",


### PR DESCRIPTION
## Description
Bump `nv-ingest-client` httpx version to align with the version specified in `nv-ingest` service

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
