### PR TITLE
[Draft] [Bug] Resolves a corner case issue with Ray queues where data loss could occur.

### DIFF
--- a/src/nv_ingest/framework/orchestration/ray/primitives/pipeline_topology.py
+++ b/src/nv_ingest/framework/orchestration/ray/primitives/pipeline_topology.py
@@ -422,12 +422,12 @@ class PipelineTopology:
                                         # mysteriously lose control messages.
                                         # This lets the shutdown future complete, but leaves the actor to be killed off
                                         # by ray.actor_exit()
-                                        delay_thread = threading.Thread(
-                                            target=self._delayed_actor_release,
-                                            args=(actor_handle_to_delay, actor_id_str_to_delay, 60),  # 60s delay
-                                            daemon=True,
-                                        )
-                                        delay_thread.start()
+                                        # delay_thread = threading.Thread(
+                                        #    target=self._delayed_actor_release,
+                                        #    args=(actor_handle_to_delay, actor_id_str_to_delay, 60),  # 60s delay
+                                        #    daemon=True,
+                                        # )
+                                        # delay_thread.start()
                                         logger.debug(
                                             f"[TopologyCleanupLoop-{stage_to_update}] Started delayed release thread "
                                             f"for '{actor_id_str_to_delay}'."

--- a/src/nv_ingest/framework/orchestration/ray/primitives/ray_pipeline.py
+++ b/src/nv_ingest/framework/orchestration/ray/primitives/ray_pipeline.py
@@ -345,7 +345,7 @@ class RayPipeline(PipelineInterface):
                     )
                     try:
                         actor = stage.callable.options(
-                            name=actor_name, max_concurrency=10, max_restarts=0, lifetime="detached"
+                            name=actor_name, max_concurrency=10, max_restarts=0  # , lifetime="detached"
                         ).remote(config=stage.config)
                         replicas.append(actor)
                     except Exception as e:
@@ -504,7 +504,7 @@ class RayPipeline(PipelineInterface):
         logger.debug(f"[ScaleUtil] Creating new actor '{actor_name}' for stage '{stage_info.name}'")
         try:
             new_actor = stage_info.callable.options(
-                name=actor_name, max_concurrency=10, max_restarts=0, lifetime="detached"
+                name=actor_name, max_concurrency=10, max_restarts=0  # , lifetime="detached"
             ).remote(config=stage_info.config)
 
             return new_actor


### PR DESCRIPTION
This addresses a situation where a ray actor places a work item into a queue, and is subsequently scaled down. Due to Ray's ownership rules, if an objectRef outlives its owner, it is no longer considered retrievable, see (https://docs.ray.io/en/latest/ray-core/fault-tolerance.html)

This PR addresses the problem by manually constructing the ObjectRef before placing it into the queue, and assigning the queue actor itself as the owner of the object. Now, even if the stage actor is scaled down, the ObjectRef will remain alive.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
