### PR TITLE
Pin riva client version to 2.19.1

### DIFF
--- a/.github/workflows/test-library-mode.yml
+++ b/.github/workflows/test-library-mode.yml
@@ -91,7 +91,7 @@ jobs:
           # Install other dependencies
           conda install -y -c conda-forge librosa
           # Install pip dependencies
-          $CONDA/envs/nvingest/bin/python -m pip install opencv-python llama-index-embeddings-nvidia pymilvus 'pymilvus[bulk_writer, model]' milvus-lite nvidia-riva-client unstructured-client tritonclient markitdown
+          $CONDA/envs/nvingest/bin/python -m pip install opencv-python llama-index-embeddings-nvidia pymilvus 'pymilvus[bulk_writer, model]' milvus-lite nvidia-riva-client==2.19.1 unstructured-client tritonclient markitdown
 
       - name: Run integration test
         env:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Create a fresh Conda environment to install nv-ingest and dependencies.
 conda create -y --name nvingest python=3.12 && \
     conda activate nvingest && \
     conda install -y -c rapidsai -c conda-forge -c nvidia nv_ingest=25.4.2 nv_ingest_client=25.4.2 nv_ingest_api=25.4.2 && \
-    pip install opencv-python llama-index-embeddings-nvidia pymilvus 'pymilvus[bulk_writer, model]' milvus-lite nvidia-riva-client unstructured-client tritonclient markitdown
+    pip install opencv-python llama-index-embeddings-nvidia pymilvus 'pymilvus[bulk_writer, model]' milvus-lite nvidia-riva-client==2.19.1 unstructured-client tritonclient markitdown
 ```
 
 Set your NVIDIA_BUILD_API_KEY and NVIDIA_API_KEY. If you don't have a key, you can get one on [build.nvidia.com](https://org.ngc.nvidia.com/setup/api-keys). For instructions, refer to [Generate Your NGC Keys](/docs/docs/extraction/ngc-api-key.md).

--- a/conda/environments/nv_ingest_environment.yml
+++ b/conda/environments/nv_ingest_environment.yml
@@ -54,6 +54,6 @@ dependencies:
       - pymilvus>=2.5.0
       - pymilvus[bulk_writer, model]
       - tritonclient
-      - nvidia-riva-client>=2.18.0
+      - nvidia-riva-client==2.19.1
       - unstructured-client
       - markitdown

--- a/conda/packages/nv_ingest/meta.yaml
+++ b/conda/packages/nv_ingest/meta.yaml
@@ -63,7 +63,7 @@ requirements:
     # - unstructured-client>=0.25.9
     - uvicorn
   pip:
-    - nvidia-riva-client>=2.18.0
+    - nvidia-riva-client==2.19.1
     - markitdown
 
   test:

--- a/docs/docs/extraction/quickstart-library-mode.md
+++ b/docs/docs/extraction/quickstart-library-mode.md
@@ -21,7 +21,7 @@ Use the following procedure to prepare your environment.
     conda create -y --name nvingest python=3.12 && \
     conda activate nvingest && \
     conda install -y -c rapidsai -c conda-forge -c nvidia nv_ingest=25.4.2 nv_ingest_client=25.4.2 nv_ingest_api=25.4.2 && \
-    pip install opencv-python llama-index-embeddings-nvidia pymilvus 'pymilvus[bulk_writer, model]' milvus-lite nvidia-riva-client unstructured-client tritonclient
+    pip install opencv-python llama-index-embeddings-nvidia pymilvus 'pymilvus[bulk_writer, model]' milvus-lite ==2.19.1 unstructured-client tritonclient
     ```
 
     !!! tip

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
     "pymilvus>=2.5.10",
     "pymilvus[bulk_writer, model]",
     "tritonclient",
-    "nvidia-riva-client>=2.18.0",
+    "nvidia-riva-client==2.19.1",
     "unstructured-client",
     "markitdown",
 ]


### PR DESCRIPTION
## Description
Pin riva client version to 2.19.1 to prevent protobuf version errors

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
