### PR TITLE
Fix invalid pytest mock names

### DIFF
--- a/api/api_tests/internal/primitives/tracing/test_latency.py
+++ b/api/api_tests/internal/primitives/tracing/test_latency.py
@@ -38,15 +38,15 @@ class MockControlMessage:
 
 
 # Mocked function to be decorated
-def test_function(control_message):
+def mock_test_function(control_message):
     return "Test Function Executed"
 
 
 # Decorating the test function
-decorated_test_function = latency_logger()(test_function)
+decorated_test_function = latency_logger()(mock_test_function)
 
 # Decorating with custom name
-decorated_test_function_custom_name = latency_logger(name="CustomName")(test_function)
+decorated_test_function_custom_name = latency_logger(name="CustomName")(mock_test_function)
 
 
 @pytest.fixture

--- a/api/api_tests/util/exception_handlers/test_converters.py
+++ b/api/api_tests/util/exception_handlers/test_converters.py
@@ -12,12 +12,12 @@ from nv_ingest_api.util.converters.datetools import remove_tz
 
 # Example functions to test the decorator
 @datetools_exception_handler
-def test_func_raises_exception():
+def mock_test_func_raises_exception():
     raise ValueError("Test exception")
 
 
 @datetools_exception_handler
-def test_func_success():
+def mock_test_func_success():
     return "Success"
 
 
@@ -28,7 +28,7 @@ def test_datetools_exception_handler_with_exception():
     """
     start_time = remove_tz(datetime.now(timezone.utc))
 
-    result = test_func_raises_exception()
+    result = mock_test_func_raises_exception()
 
     # Convert result back to datetime object for comparison
     result_datetime = datetime.fromisoformat(result)
@@ -50,5 +50,5 @@ def test_datetools_exception_handler_without_exception():
     """
     Test the decorator with a function that does not raise an exception.
     """
-    result = test_func_success()
+    result = mock_test_func_success()
     assert result == "Success", "Decorator should not interfere with the function's normal execution"


### PR DESCRIPTION

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
