### PR TITLE
Change Dockerfile base image to nvcr.io ubuntu jammy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # syntax=docker/dockerfile:1.3
 
-ARG BASE_IMG=ubuntu
-ARG BASE_IMG_TAG=22.04
+ARG BASE_IMG=nvcr.io/nvidia/base/ubuntu
+ARG BASE_IMG_TAG=jammy-20250415.1
 
 FROM $BASE_IMG:$BASE_IMG_TAG AS base
 


### PR DESCRIPTION
## Description
Change Dockerfile base image to nvcr.io ubuntu jammy

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
