### PR TITLE
Revert 'caption_model_name' to 'model_name' for backwards compatibility.

### DIFF
--- a/api/api_tests/interface/test_interface.py
+++ b/api/api_tests/interface/test_interface.py
@@ -133,7 +133,7 @@ class TestTransformImageCreateVlmCaption(unittest.TestCase):
         self.assertEqual(config.api_key, "test_api_key")
         self.assertEqual(config.prompt, "Describe this image")
         self.assertEqual(config.endpoint_url, "test_endpoint")
-        self.assertEqual(config.image_caption_model_name, "test_model")
+        self.assertEqual(config.model_name, "test_model")
 
     @patch("nv_ingest_api.interface.transform.build_dataframe_from_files")
     @patch("nv_ingest_api.interface.transform.transform_image_create_vlm_caption_internal")

--- a/api/api_tests/internal/schemas/transform/test_image_caption_schema.py
+++ b/api/api_tests/internal/schemas/transform/test_image_caption_schema.py
@@ -13,7 +13,7 @@ def test_image_caption_extraction_schema_defaults():
     assert schema.api_key == "api_key"
     assert schema.endpoint_url.startswith("https://")
     assert schema.prompt.startswith("Caption")
-    assert schema.image_caption_model_name.startswith("meta/")
+    assert schema.model_name.startswith("meta/")
     assert schema.raise_on_failure is False
 
 
@@ -22,13 +22,13 @@ def test_image_caption_extraction_schema_accepts_custom_values():
         api_key="mykey",
         endpoint_url="https://custom.endpoint",
         prompt="Describe this image in detail.",
-        image_caption_model_name="custom/model",
+        model_name="custom/model",
         raise_on_failure=True,
     )
     assert schema.api_key == "mykey"
     assert schema.endpoint_url == "https://custom.endpoint"
     assert schema.prompt == "Describe this image in detail."
-    assert schema.image_caption_model_name == "custom/model"
+    assert schema.model_name == "custom/model"
     assert schema.raise_on_failure is True
 
 

--- a/api/api_tests/internal/transform/test_caption_image.py
+++ b/api/api_tests/internal/transform/test_caption_image.py
@@ -30,7 +30,7 @@ def dummy_task_config():
         "api_key": "api_key",
         "prompt": "Describe the image",
         "endpoint_url": "https://fake.endpoint",
-        "image_caption_model_name": "fake_model",
+        "model_name": "fake_model",
     }
 
 
@@ -41,7 +41,7 @@ def dummy_transform_config():
         api_key = "default_api_key"
         prompt = "default_prompt"
         endpoint_url = "https://default.endpoint"
-        image_caption_model_name = "default_model"
+        model_name = "default_model"
 
     return Dummy()
 
@@ -68,7 +68,7 @@ def test_transform_image_create_vlm_caption_internal_happy_path(
         dummy_task_config["prompt"],
         dummy_task_config["api_key"],
         dummy_task_config["endpoint_url"],
-        dummy_task_config["image_caption_model_name"],
+        dummy_task_config["model_name"],
     )
 
     # Assert captions updated correctly in the DataFrame
@@ -120,7 +120,7 @@ def test_transform_image_create_vlm_caption_internal_uses_fallback_config(
         dummy_transform_config.prompt,
         dummy_transform_config.api_key,
         dummy_transform_config.endpoint_url,
-        dummy_transform_config.image_caption_model_name,
+        dummy_transform_config.model_name,
     )
 
     # Assert captions updated correctly

--- a/api/src/nv_ingest_api/interface/transform.py
+++ b/api/src/nv_ingest_api/interface/transform.py
@@ -207,7 +207,7 @@ def transform_image_create_vlm_caption(
         "api_key": api_key,
         "prompt": prompt,
         "endpoint_url": endpoint_url,
-        "image_caption_model_name": model_name,
+        "model_name": model_name,
     }
     filtered_task_config: Dict[str, str] = {k: v for k, v in task_config.items() if v is not None}
 

--- a/api/src/nv_ingest_api/internal/schemas/meta/ingest_job_schema.py
+++ b/api/src/nv_ingest_api/internal/schemas/meta/ingest_job_schema.py
@@ -76,7 +76,7 @@ class IngestTaskCaptionSchema(BaseModelNoExt):
     api_key: Optional[str] = None
     endpoint_url: Optional[str] = None
     prompt: Optional[str] = None
-    caption_model_name: Optional[str] = None
+    model_name: Optional[str] = None
 
 
 class IngestTaskFilterParamsSchema(BaseModelNoExt):

--- a/api/src/nv_ingest_api/internal/schemas/transform/transform_image_caption_schema.py
+++ b/api/src/nv_ingest_api/internal/schemas/transform/transform_image_caption_schema.py
@@ -10,6 +10,6 @@ class ImageCaptionExtractionSchema(BaseModel):
     api_key: str = "api_key"
     endpoint_url: str = "https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-11b-vision-instruct/chat/completions"
     prompt: str = "Caption the content of this image:"
-    image_caption_model_name: str = "meta/llama-3.2-11b-vision-instruct"
+    model_name: str = "meta/llama-3.2-11b-vision-instruct"
     raise_on_failure: bool = False
     model_config = ConfigDict(extra="forbid")

--- a/api/src/nv_ingest_api/internal/transform/caption_image.py
+++ b/api/src/nv_ingest_api/internal/transform/caption_image.py
@@ -173,7 +173,7 @@ def transform_image_create_vlm_caption_internal(
     api_key: str = task_config.get("api_key") or transform_config.api_key
     prompt: str = task_config.get("prompt") or transform_config.prompt
     endpoint_url: str = task_config.get("endpoint_url") or transform_config.endpoint_url
-    model_name: str = task_config.get("image_caption_model_name") or transform_config.image_caption_model_name
+    model_name: str = task_config.get("model_name") or transform_config.model_name
 
     # Create a mask for rows where the content type is "image".
     df_mask: pd.Series = df_transform_ledger["metadata"].apply(

--- a/src/nv_ingest/framework/orchestration/ray/examples/pipeline_test_harness.py
+++ b/src/nv_ingest/framework/orchestration/ray/examples/pipeline_test_harness.py
@@ -155,7 +155,7 @@ if __name__ == "__main__":
     logger.info("Environment variables set.")
 
     image_caption_endpoint_url = "https://integrate.api.nvidia.com/v1/chat/completions"
-    image_caption_model_name = "meta/llama-3.2-11b-vision-instruct"
+    model_name = "meta/llama-3.2-11b-vision-instruct"
     yolox_grpc, yolox_http, yolox_auth, yolox_protocol = get_nim_service("yolox")
     (
         yolox_table_structure_grpc,
@@ -228,7 +228,7 @@ if __name__ == "__main__":
     image_caption_config = {
         "api_key": yolox_auth,
         "endpoint_url": image_caption_endpoint_url,
-        "image_caption_model_name": image_caption_model_name,
+        "model_name": model_name,
         "prompt": "Caption the content of this image:",
     }
     logger.info("Service configuration retrieved from get_nim_service and environment variables.")

--- a/src/nv_ingest/framework/orchestration/ray/util/pipeline/stage_builders.py
+++ b/src/nv_ingest/framework/orchestration/ray/util/pipeline/stage_builders.py
@@ -479,7 +479,7 @@ def add_image_caption_stage(pipeline, default_cpu_count, stage_name="image_capti
         **{
             "api_key": auth_token,
             "endpoint_url": endpoint_url,
-            "image_caption_model_name": model_name,
+            "model_name": model_name,
             "prompt": "Caption the content of this image:",
         }
     )

--- a/tests/service_tests/schemas/test_image_caption_extraction_schema.py
+++ b/tests/service_tests/schemas/test_image_caption_extraction_schema.py
@@ -13,7 +13,7 @@ def test_valid_schema():
     assert schema.api_key == "your-api-key-here"
     assert schema.endpoint_url == "https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-11b-vision-instruct/chat/completions"
     assert schema.prompt == "Caption the content of this image:"
-    assert schema.image_caption_model_name == "meta/llama-3.2-11b-vision-instruct"
+    assert schema.model_name == "meta/llama-3.2-11b-vision-instruct"
     assert schema.raise_on_failure is False
 
 
@@ -23,14 +23,14 @@ def test_valid_schema_with_custom_values():
         "api_key": "your-api-key-here",
         "endpoint_url": "https://custom.api.endpoint",
         "prompt": "Describe the image:",
-        "image_caption_model_name": "some-vlm-model",
+        "model_name": "some-vlm-model",
         "raise_on_failure": True,
     }
     schema = ImageCaptionExtractionSchema(**valid_data)
     assert schema.api_key == "your-api-key-here"
     assert schema.endpoint_url == "https://custom.api.endpoint"
     assert schema.prompt == "Describe the image:"
-    assert schema.image_caption_model_name == "some-vlm-model"
+    assert schema.model_name == "some-vlm-model"
     assert schema.raise_on_failure is True
 
 


### PR DESCRIPTION
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
