### PR TITLE
Add warning for missing API keys, make vdb_upload method always retur…

### DIFF
--- a/client/src/nv_ingest_client/client/interface.py
+++ b/client/src/nv_ingest_client/client/interface.py
@@ -300,7 +300,7 @@ class Ingestor:
             timeout=timeout,
             max_job_retries=max_job_retries,
             completion_callback=callback,
-            return_failures=return_failures,
+            return_failures=True,
             verbose=verbose,
             **proc_kwargs,
         )

--- a/src/nv_ingest/framework/orchestration/ray/util/pipeline/pipeline_runners.py
+++ b/src/nv_ingest/framework/orchestration/ray/util/pipeline/pipeline_runners.py
@@ -331,6 +331,10 @@ def run_pipeline(
     """
     if run_in_subprocess:
         logger.info("Launching pipeline in Python subprocess using multiprocessing.")
+        if (ingest_config.ngc_api_key is None or ingest_config.ngc_api_key == "") and (
+            ingest_config.nvidia_build_api_key is None or ingest_config.nvidia_build_api_key == ""
+        ):
+            logger.warning("NGC_API_KEY or NVIDIA_BUILD_API_KEY are not set. NIM Related functions will not work.")
 
         ctx = multiprocessing.get_context("fork")
         process = ctx.Process(


### PR DESCRIPTION
Add warnings when NGC keys are not set.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
