### PR TITLE
Add SplitTask support for audio file types

### DIFF
--- a/api/api_tests/internal/transform/test_split_text.py
+++ b/api/api_tests/internal/transform/test_split_text.py
@@ -108,7 +108,7 @@ def test_split_into_chunks_empty_text():
 
 
 def test_build_split_documents_skips_empty_chunks():
-    row = SimpleNamespace(metadata={"existing": "value"})
+    row = SimpleNamespace(document_type="text", metadata={"existing": "value"})
     chunks = ["  ", None, "", "Valid chunk"]
 
     documents = module_under_test._build_split_documents(row, chunks)
@@ -121,7 +121,7 @@ def test_build_split_documents_skips_empty_chunks():
 
 def test_build_split_documents_handles_no_metadata():
     # Row without metadata attribute
-    row = SimpleNamespace()
+    row = SimpleNamespace(document_type="text")
     chunks = ["Chunk A", "Chunk B"]
 
     documents = module_under_test._build_split_documents(row, chunks)

--- a/api/src/nv_ingest_api/internal/transform/split_text.py
+++ b/api/src/nv_ingest_api/internal/transform/split_text.py
@@ -31,12 +31,16 @@ def _build_split_documents(row, chunks: List[str]) -> List[dict[str, Any]]:
         metadata = row.metadata if hasattr(row, "metadata") and isinstance(row.metadata, dict) else {}
         metadata = copy.deepcopy(metadata)
 
-        if row["document_type"] == ContentTypeEnum.AUDIO:
+        if row.document_type == ContentTypeEnum.AUDIO:
             metadata["audio_metadata"]["audio_transcript"] = text
+            documents.append(
+                {"document_type": ContentTypeEnum.AUDIO.value, "metadata": metadata, "uuid": str(uuid.uuid4())}
+            )
         else:
             metadata["content"] = text
-
-        documents.append({"document_type": ContentTypeEnum.TEXT.value, "metadata": metadata, "uuid": str(uuid.uuid4())})
+            documents.append(
+                {"document_type": ContentTypeEnum.TEXT.value, "metadata": metadata, "uuid": str(uuid.uuid4())}
+            )
 
     return documents
 

--- a/api/src/nv_ingest_api/internal/transform/split_text.py
+++ b/api/src/nv_ingest_api/internal/transform/split_text.py
@@ -31,7 +31,10 @@ def _build_split_documents(row, chunks: List[str]) -> List[dict[str, Any]]:
         metadata = row.metadata if hasattr(row, "metadata") and isinstance(row.metadata, dict) else {}
         metadata = copy.deepcopy(metadata)
 
-        metadata["content"] = text
+        if row["document_type"] == ContentTypeEnum.AUDIO:
+            metadata["audio_metadata"]["audio_transcript"] = text
+        else:
+            metadata["content"] = text
 
         documents.append({"document_type": ContentTypeEnum.TEXT.value, "metadata": metadata, "uuid": str(uuid.uuid4())})
 
@@ -118,7 +121,7 @@ def transform_text_split_and_tokenize_internal(
     )
 
     # Filter to documents with text content.
-    text_type_condition = df_transform_ledger["document_type"] == ContentTypeEnum.TEXT
+    text_type_condition = df_transform_ledger["document_type"].isin([ContentTypeEnum.TEXT, ContentTypeEnum.AUDIO])
 
     normalized_meta_df = pd.json_normalize(df_transform_ledger["metadata"], errors="ignore")
     if "source_metadata.source_type" in normalized_meta_df.columns:
@@ -147,7 +150,14 @@ def transform_text_split_and_tokenize_internal(
 
     split_docs: List[Dict[str, Any]] = []
     for _, row in df_filtered.iterrows():
-        content: str = row["metadata"]["content"] if row["metadata"]["content"] is not None else ""
+        if row["document_type"] == ContentTypeEnum.AUDIO:
+            content: str = (
+                row["metadata"]["audio_metadata"]["audio_transcript"]
+                if row["metadata"]["audio_metadata"]["audio_transcript"] is not None
+                else ""
+            )
+        else:
+            content: str = row["metadata"]["content"] if row["metadata"]["content"] is not None else ""
         chunks: List[str] = _split_into_chunks(content, tokenizer_model, chunk_size, chunk_overlap)
         split_docs.extend(_build_split_documents(row, chunks))
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This adds support for using the SplitTask with the `"split_source_types":` `"mp3"` or `"wav"`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
