### PR TITLE
Adjust python builds to append .devYYYYMMDD to each nightly dev build

### DIFF
--- a/.github/workflows/pypi-nightly-publish.yml
+++ b/.github/workflows/pypi-nightly-publish.yml
@@ -52,7 +52,7 @@ jobs:
           else
 
             echo "Setting VERSION to $(date +'%y.%m.%d'). DEFAULT"
-            echo "VERSION=$(date +'%y.%m.%d')" >> $GITHUB_ENV
+            echo "VERSION=$(date +'%y.%m.%d').dev$(date + '%y%m%d')" >> $GITHUB_ENV
           fi
 
       - name: Checkout code


### PR DESCRIPTION
## Description
Adjust python builds to append .devYYYYMMDD to each nightly dev build

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
