### PR TITLE
Fix caption embedding ordering

### DIFF
--- a/api/src/nv_ingest_api/internal/transform/embed_text.py
+++ b/api/src/nv_ingest_api/internal/transform/embed_text.py
@@ -466,7 +466,7 @@ def transform_create_text_embeddings_internal(
 
     for content_type, content_getter in pandas_content_extractor.items():
         if not content_getter:
-            logger.debug(f"Skipping unsupported content type: {content_type}")
+            logger.warning(f"Skipping text_embedding generation for unsupported content type: {content_type}")
             continue
 
         # Get rows matching the content type

--- a/src/nv_ingest/framework/orchestration/ray/stages/transforms/text_embed.py
+++ b/src/nv_ingest/framework/orchestration/ray/stages/transforms/text_embed.py
@@ -32,7 +32,7 @@ class TextEmbeddingTransformStage(RayActorStage):
     """
 
     def __init__(self, config: TextEmbeddingSchema) -> None:
-        super().__init__(config)
+        super().__init__(config, log_to_stdout=False)
         try:
             self.validated_config = config
             logger.info("TextEmbeddingTransformStage configuration validated successfully.")

--- a/src/nv_ingest/framework/orchestration/ray/util/pipeline/pipeline_builders.py
+++ b/src/nv_ingest/framework/orchestration/ray/util/pipeline/pipeline_builders.py
@@ -174,9 +174,9 @@ def setup_ingestion_pipeline(pipeline: RayPipeline, ingest_config: Dict[str, Any
     pipeline.make_edge(image_dedup_stage_id, text_splitter_stage_id, queue_size=ingest_edge_buffer_size)
 
     ###### Primitive Transforms ########
-    pipeline.make_edge(text_splitter_stage_id, embed_extractions_stage_id, queue_size=ingest_edge_buffer_size)
-    pipeline.make_edge(embed_extractions_stage_id, image_caption_stage_id, queue_size=ingest_edge_buffer_size)
-    pipeline.make_edge(image_caption_stage_id, image_storage_stage_id, queue_size=ingest_edge_buffer_size)
+    pipeline.make_edge(text_splitter_stage_id, image_caption_stage_id, queue_size=ingest_edge_buffer_size)
+    pipeline.make_edge(image_caption_stage_id, embed_extractions_stage_id, queue_size=ingest_edge_buffer_size)
+    pipeline.make_edge(embed_extractions_stage_id, image_storage_stage_id, queue_size=ingest_edge_buffer_size)
 
     ###### Primitive Storage ########
     pipeline.make_edge(image_storage_stage_id, embedding_storage_stage_id, queue_size=ingest_edge_buffer_size)


### PR DESCRIPTION
Fixes a regression where the image captioning stage came later in the pipeline than the embedding stage. Resulting in failures to create embeddings for captioned images.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
