### PR TITLE
switching out VLM to Nemotron 8b Vision

### DIFF
--- a/api/src/nv_ingest_api/internal/schemas/transform/transform_image_caption_schema.py
+++ b/api/src/nv_ingest_api/internal/schemas/transform/transform_image_caption_schema.py
@@ -8,8 +8,8 @@ from pydantic import ConfigDict, BaseModel
 
 class ImageCaptionExtractionSchema(BaseModel):
     api_key: str = "api_key"
-    endpoint_url: str = "https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-11b-vision-instruct/chat/completions"
+    endpoint_url: str = "https://ai.api.nvidia.com/v1/gr/nvidia/llama-3.1-nemotron-nano-vl-8b-v1/chat/completions"
     prompt: str = "Caption the content of this image:"
-    model_name: str = "meta/llama-3.2-11b-vision-instruct"
+    model_name: str = "nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
     raise_on_failure: bool = False
     model_config = ConfigDict(extra="forbid")

--- a/client/src/nv_ingest_client/nv_ingest_cli.py
+++ b/client/src/nv_ingest_client/nv_ingest_cli.py
@@ -126,7 +126,7 @@ Tasks and Options:
       - api_key (str): API key for captioning service.
       Default: os.environ(NVIDIA_BUILD_API_KEY).'
       - endpoint_url (str): Endpoint URL for captioning service.
-      Default: 'https://build.nvidia.com/meta/llama-3.2-11b-vision-instruct'.
+      Default: 'https://build.nvidia.com/nvidia/llama-3.1-nemotron-nano-vl-8b-v1'.
       - prompt (str): Prompt for captioning service.
       Default: 'Caption the content of this image:'.
 \b

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -177,7 +177,7 @@ services:
       - nemoretriever-parse
 
   vlm:
-    image: ${VLM_IMAGE:-nvcr.io/nim/meta/llama-3.2-11b-vision-instruct}:${VLM_TAG:-latest}
+    image: ${VLM_IMAGE:-nvcr.io/nim/nvidia/llama-3.1-nemotron-nano-vl-8b-v1}:${VLM_TAG:-1.1.1}
     ports:
       - "8018:8000"
     user: root
@@ -299,7 +299,7 @@ services:
       - YOLOX_TABLE_STRUCTURE_HTTP_ENDPOINT=http://table-structure:8000/v1/infer
       - YOLOX_TABLE_STRUCTURE_INFER_PROTOCOL=grpc
       - VLM_CAPTION_ENDPOINT=http://vlm:8000/v1/chat/completions
-      - VLM_CAPTION_MODEL_NAME=meta/llama-3.2-11b-vision-instruct
+      - VLM_CAPTION_MODEL_NAME=nvidia/llama-3.1-nemotron-nano-vl-8b-v1
       - MODEL_PREDOWNLOAD_PATH=${MODEL_PREDOWNLOAD_PATH:-/workspace/models/}
       # "ready" check configuration.
       # 1. COMPONENTS_TO_READY_CHECK= to disable and readiness checking

--- a/docs/docs/extraction/nv-ingest-python-api.md
+++ b/docs/docs/extraction/nv-ingest-python-api.md
@@ -122,7 +122,7 @@ This can be used to describe images extracted from documents.
 
 !!! note
 
-    The default model used by `caption` is `meta/llama-3.2-11b-vision-instruct`.
+    The default model used by `caption` is `nvidia/llama-3.1-nemotron-nano-vl-8b-v1`.
 
 ```python
 ingestor = ingestor.caption()
@@ -132,8 +132,8 @@ To specify a different API endpoint, pass additional parameters to `caption`.
 
 ```python
 ingestor = ingestor.caption(
-    endpoint_url="https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-11b-vision-instruct/chat/completions",
-    model_name="meta/llama-3.2-11b-vision-instruct",
+    endpoint_url="https://ai.api.nvidia.com/v1/gr/nvidia/llama-3.1-nemotron-nano-vl-8b-v1/chat/completions",
+    model_name="nvidia/llama-3.1-nemotron-nano-vl-8b-v1",
     api_key="nvapi-"
 )
 ```

--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -392,7 +392,7 @@ You can specify multiple `--profile` options.
 | `table-structure`     | Core     | Enables the yolox table structure NIM which enhances markdown formatting of extracted table content. This benefits answer generation by downstream LLMs. | 
 | `audio`               | Advanced | Use [Riva](https://docs.nvidia.com/deeplearning/riva/user-guide/docs/index.html) for processing audio files. For more information, refer to [Audio Processing](nemoretriever-parse.md). | 
 | `nemoretriever-parse` | Advanced | Use [nemoretriever-parse](https://build.nvidia.com/nvidia/nemoretriever-parse), which adds state-of-the-art text and table extraction. For more information, refer to [Use Nemo Retriever Extraction with nemoretriever-parse](nemoretriever-parse.md). | 
-| `vlm`                 | Advanced | Use [llama 3.2 11B Vision](https://build.nvidia.com/meta/llama-3.2-11b-vision-instruct/modelcard) for experimental image captioning of unstructured images. | 
+| `vlm`                 | Advanced | Use [Nemotron 8b Vision](https://build.nvidia.com/nvidia/llama-3.1-nemotron-nano-vl-8b-v1/modelcard) for experimental image captioning of unstructured images. | 
 
 
 !!! important

--- a/docs/docs/extraction/support-matrix.md
+++ b/docs/docs/extraction/support-matrix.md
@@ -20,7 +20,7 @@ This includes the following:
 
 - Audio extraction — Use [Riva](https://docs.nvidia.com/deeplearning/riva/user-guide/docs/index.html) for processing audio files. For more information, refer to [Audio Processing](nemoretriever-parse.md).
 - `nemoretriever-parse` — Use [nemoretriever-parse](https://build.nvidia.com/nvidia/nemoretriever-parse), which adds state-of-the-art text and table extraction. For more information, refer to [Use Nemo Retriever Extraction with nemoretriever-parse](nemoretriever-parse.md).
-- VLM image captioning — Use [llama 3.2 11B Vision](https://build.nvidia.com/meta/llama-3.2-11b-vision-instruct/modelcard) for experimental image captioning of unstructured images.
+- VLM image captioning — Use [llama 3.2 11B Vision](https://build.nvidia.com/nvidia/llama-3.1-nemotron-nano-vl-8b-v1/modelcard) for experimental image captioning of unstructured images.
 
 
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -329,8 +329,8 @@ You can also use NV-Ingest's Python client API to interact with the service runn
 | envVars.PADDLE_HTTP_ENDPOINT | string | `"http://nv-ingest-paddle:8000/v1/infer"` |  |
 | envVars.PADDLE_INFER_PROTOCOL | string | `"grpc"` |  |
 | envVars.REDIS_INGEST_TASK_QUEUE | string | `"ingest_task_queue"` |  |
-| envVars.VLM_CAPTION_ENDPOINT | string | `"https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-11b-vision-instruct/chat/completions"` |  |
-| envVars.VLM_CAPTION_MODEL_NAME | string | `"meta/llama-3.2-11b-vision-instruct"` |  |
+| envVars.VLM_CAPTION_ENDPOINT | string | `"https://ai.api.nvidia.com/v1/gr/nvidia/llama-3.1-nemotron-nano-vl-8b-v1/chat/completions"` |  |
+| envVars.VLM_CAPTION_MODEL_NAME | string | `"nvidia/llama-3.1-nemotron-nano-vl-8b-v1"` |  |
 | envVars.YOLOX_GRAPHIC_ELEMENTS_GRPC_ENDPOINT | string | `"nemoretriever-graphic-elements-v1:8001"` |  |
 | envVars.YOLOX_GRAPHIC_ELEMENTS_HTTP_ENDPOINT | string | `"http://nemoretriever-graphic-elements-v1:8000/v1/infer"` |  |
 | envVars.YOLOX_GRAPHIC_ELEMENTS_INFER_PROTOCOL | string | `"grpc"` |  |
@@ -507,7 +507,7 @@ You can also use NV-Ingest's Python client API to interact with the service runn
 | nim-vlm-image-captioning.env[1].name | string | `"NIM_TRITON_MODEL_BATCH_SIZE"` |  |
 | nim-vlm-image-captioning.env[1].value | string | `"1"` |  |
 | nim-vlm-image-captioning.fullnameOverride | string | `"nim-vlm-image-captioning"` |  |
-| nim-vlm-image-captioning.image.repository | string | `"nvcr.io/nim/meta/llama-3.2-11b-vision-instruct"` |  |
+| nim-vlm-image-captioning.image.repository | string | `"nvcr.io/nim/nvidia/llama-3.1-nemotron-nano-vl-8b-v1"` |  |
 | nim-vlm-image-captioning.image.tag | string | `"1.1.1"` |  |
 | nim-vlm-image-captioning.nim.grpcPort | int | `8001` |  |
 | nim-vlm-image-captioning.nim.logLevel | string | `"INFO"` |  |

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -276,7 +276,7 @@ nemoretriever-table-structure-v1:
 ## @param nim-vlm-image-captioning.fullnameOverride [default: "nim-vlm-image-captioning"] Override the full name of the deployment
 ## @param nim-vlm-image-captioning.customCommand [default: []] Custom command to run in the container
 ## @param nim-vlm-image-captioning.customArgs [default: []] Custom arguments to pass to the container command
-## @param nim-vlm-image-captioning.image.repository [default: "nvcr.io/nim/meta/llama-3.2-11b-vision-instruct"] The container image repository
+## @param nim-vlm-image-captioning.image.repository [default: "nvcr.io/nim/nvidia/llama-3.1-nemotron-nano-vl-8b-v1"] The container image repository
 ## @param nim-vlm-image-captioning.image.tag [default: "latest"] The container image tag
 ## @param nim-vlm-image-captioning.podSecurityContext [default: {}] Pod security context configuration
 ## @param nim-vlm-image-captioning.replicaCount [default: 1] Number of replicas to deploy
@@ -294,7 +294,7 @@ nim-vlm-image-captioning:
   customCommand: []
   customArgs: []
   image:
-    repository: nvcr.io/nim/meta/llama-3.2-11b-vision-instruct
+    repository: nvcr.io/nim/nvidia/llama-3.1-nemotron-nano-vl-8b-v1
     tag: "1.1.1"
   podSecurityContext:
     runAsUser: 1000
@@ -856,8 +856,8 @@ prometheus:
 ## @param envVars.EMBEDDING_NIM_ENDPOINT [default: "http://nv-ingest-embedqa:8000/v1"] Endpoint for embedding service
 ## @param envVars.EMBEDDING_NIM_MODEL_NAME [default: "nvidia/llama-3.2-nv-embedqa-1b-v2"] Model name for embedding service
 ## @param envVars.MILVUS_ENDPOINT [default: "http://nv-ingest-milvus:19530"] Endpoint for Milvus vector database
-## @param envVars.VLM_CAPTION_ENDPOINT [default: "https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-11b-vision-instruct/chat/completions"] Endpoint for VLM caption service
-## @param envVars.VLM_CAPTION_MODEL_NAME [default: "meta/llama-3.2-11b-vision-instruct"] Model name for VLM caption service
+## @param envVars.VLM_CAPTION_ENDPOINT [default: "https://ai.api.nvidia.com/v1/gr/nvidia/llama-3.1-nemotron-nano-vl-8b-v1/chat/completions"] Endpoint for VLM caption service
+## @param envVars.VLM_CAPTION_MODEL_NAME [default: "nvidia/llama-3.1-nemotron-nano-vl-8b-v1"] Model name for VLM caption service
 ## @param envVars.AUDIO_GRPC_ENDPOINT [default: "nv-ingest-riva-nim:50051"] gRPC endpoint for audio service
 ## @param envVars.AUDIO_INFER_PROTOCOL [default: "grpc"] Protocol for audio service
 ## @param envVars.COMPONENTS_TO_READY_CHECK [default: "ALL"] Components to check during readiness probe
@@ -900,8 +900,8 @@ envVars:
   EMBEDDING_NIM_MODEL_NAME: "nvidia/llama-3.2-nv-embedqa-1b-v2"
   MILVUS_ENDPOINT: "http://nv-ingest-milvus:19530"
 
-  VLM_CAPTION_ENDPOINT: "https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-11b-vision-instruct/chat/completions"
-  VLM_CAPTION_MODEL_NAME: "meta/llama-3.2-11b-vision-instruct"
+  VLM_CAPTION_ENDPOINT: "https://ai.api.nvidia.com/v1/gr/nvidia/llama-3.1-nemotron-nano-vl-8b-v1/chat/completions"
+  VLM_CAPTION_MODEL_NAME: "nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
 
   AUDIO_GRPC_ENDPOINT: "nv-ingest-riva-nim:50051"
   AUDIO_INFER_PROTOCOL: "grpc"

--- a/src/nv_ingest/framework/orchestration/ray/examples/pipeline_test_harness.py
+++ b/src/nv_ingest/framework/orchestration/ray/examples/pipeline_test_harness.py
@@ -151,11 +151,11 @@ if __name__ == "__main__":
     os.environ["PADDLE_INFER_PROTOCOL"] = "grpc"
     os.environ["NEMORETRIEVER_PARSE_HTTP_ENDPOINT"] = "https://integrate.api.nvidia.com/v1/chat/completions"
     os.environ["VLM_CAPTION_ENDPOINT"] = "https://integrate.api.nvidia.com/v1/chat/completions"
-    os.environ["VLM_CAPTION_MODEL_NAME"] = "meta/llama-3.2-11b-vision-instruct"
+    os.environ["VLM_CAPTION_MODEL_NAME"] = "nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
     logger.info("Environment variables set.")
 
     image_caption_endpoint_url = "https://integrate.api.nvidia.com/v1/chat/completions"
-    model_name = "meta/llama-3.2-11b-vision-instruct"
+    model_name = "nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
     yolox_grpc, yolox_http, yolox_auth, yolox_protocol = get_nim_service("yolox")
     (
         yolox_table_structure_grpc,

--- a/src/nv_ingest/framework/orchestration/ray/util/pipeline/pipeline_runners.py
+++ b/src/nv_ingest/framework/orchestration/ray/util/pipeline/pipeline_runners.py
@@ -86,9 +86,9 @@ class PipelineCreationSchema(BaseModel):
 
     # Vision language model settings
     vlm_caption_endpoint: str = os.getenv(
-        "VLM_CAPTION_ENDPOINT", "https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-11b-vision-instruct/chat/completions"
+        "VLM_CAPTION_ENDPOINT", "https://ai.api.nvidia.com/v1/gr/nvidia/llama-3.1-nemotron-nano-vl-8b-v1/chat/completions"
     )
-    vlm_caption_model_name: str = os.getenv("VLM_CAPTION_MODEL_NAME", "meta/llama-3.2-11b-vision-instruct")
+    vlm_caption_model_name: str = os.getenv("VLM_CAPTION_MODEL_NAME", "nvidia/llama-3.1-nemotron-nano-vl-8b-v1")
 
     # YOLOX image processing settings
     yolox_graphic_elements_http_endpoint: str = os.getenv(

--- a/src/nv_ingest/framework/orchestration/ray/util/pipeline/stage_builders.py
+++ b/src/nv_ingest/framework/orchestration/ray/util/pipeline/stage_builders.py
@@ -471,7 +471,7 @@ def add_image_caption_stage(pipeline, default_cpu_count, stage_name="image_capti
     )
 
     endpoint_url = os.environ.get("VLM_CAPTION_ENDPOINT", "localhost:5000")
-    model_name = os.environ.get("VLM_CAPTION_MODEL_NAME", "meta/llama-3.2-11b-vision-instruct")
+    model_name = os.environ.get("VLM_CAPTION_MODEL_NAME", "nvidia/llama-3.1-nemotron-nano-vl-8b-v1")
 
     config = ImageCaptionExtractionSchema(
         **{

--- a/tests/service_tests/schemas/test_image_caption_extraction_schema.py
+++ b/tests/service_tests/schemas/test_image_caption_extraction_schema.py
@@ -11,9 +11,9 @@ def test_valid_schema():
     }
     schema = ImageCaptionExtractionSchema(**valid_data)
     assert schema.api_key == "your-api-key-here"
-    assert schema.endpoint_url == "https://ai.api.nvidia.com/v1/gr/meta/llama-3.2-11b-vision-instruct/chat/completions"
+    assert schema.endpoint_url == "https://ai.api.nvidia.com/v1/gr/nvidia/llama-3.1-nemotron-nano-vl-8b-v1/chat/completions"
     assert schema.prompt == "Caption the content of this image:"
-    assert schema.model_name == "meta/llama-3.2-11b-vision-instruct"
+    assert schema.model_name == "nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
     assert schema.raise_on_failure is False
 
 


### PR DESCRIPTION
## Description
Switched out all instances of meta/llama-3.2-11b-vision-instruct to our new nvidia/llama-3.1-nemotron-nano-vl-8b-v1

Will begin benchmarking on this new VLM in this PR.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
