### PR TITLE
Relax Python version requirements for client to allow >= python 3.11

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -11,9 +11,9 @@ authors = [
     {name = "Jeremy Dyer", email = "jdyer@nvidia.com"}
 ]
 license = {file = "LICENSE"}
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 classifiers = [
-    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.11",
     "Operating System :: OS Independent",
 ]
 dependencies = [


### PR DESCRIPTION
## Description
Relax Python version requirements for client to allow >= python 3.11

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
