### PR TITLE
Adjust pypi version to use YYYY instead of YY in nightly package names

### DIFF
--- a/.github/workflows/pypi-nightly-publish.yml
+++ b/.github/workflows/pypi-nightly-publish.yml
@@ -51,8 +51,8 @@ jobs:
             echo "VERSION=${{ github.event.inputs.VERSION }}" >> $GITHUB_ENV
           else
 
-            echo "Setting VERSION to $(date +'%y.%m.%d'). DEFAULT"
-            echo "VERSION=$(date +'%y.%m.%d')" >> $GITHUB_ENV
+            echo "Setting VERSION to $(date +'%Y.%m.%d'). DEFAULT"
+            echo "VERSION=$(date +'%Y.%m.%d')" >> $GITHUB_ENV
           fi
 
       - name: Checkout code


### PR DESCRIPTION
## Description
Adjust pypi version to use YYYY instead of YY in nightly package names

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
