### PR TITLE
Update Ubuntu Base Container Versioin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # syntax=docker/dockerfile:1.3
 
 ARG BASE_IMG=nvcr.io/nvidia/base/ubuntu
-ARG BASE_IMG_TAG=jammy-20250415.1
+ARG BASE_IMG_TAG=jammy-20250619
 
 FROM $BASE_IMG:$BASE_IMG_TAG AS base
 


### PR DESCRIPTION
## Description
This pull request includes a minor update to the `Dockerfile`. The change updates the base image tag to a newer version for the Ubuntu Jammy distribution.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L7-R7): Updated the `BASE_IMG_TAG` argument from `jammy-20250415.1` to `jammy-20250619` to use a more recent base image.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
