### PR TITLE
Fix content metadata filtering in client vdb upload

### DIFF
--- a/client/src/nv_ingest_client/util/vdb/milvus.py
+++ b/client/src/nv_ingest_client/util/vdb/milvus.py
@@ -518,7 +518,7 @@ def _record_dict(text, element, sparse_vector: csr_array = None):
         "text": text,
         "vector": cp_element["metadata"].pop("embedding"),
         "source": cp_element["metadata"].pop("source_metadata"),
-        "content_metadata": cp_element["metadata"],
+        "content_metadata": cp_element["metadata"].pop("content_metadata"),
     }
     if sparse_vector is not None:
         record["sparse"] = _format_sparse_embedding(sparse_vector)


### PR DESCRIPTION
## Description

This restores backward compatibility. Without this change, I get errors such as:

```python
Traceback (most recent call last):
  File "/work/git/nv-ingest/bo767_full.py", line 142, in <module>
    hits = get_recall_scores(df_query, "multimodal")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/git/nv-ingest/bo767_full.py", line 112, in get_recall_scores
    retrieved_pages = [str(result['entity']['content_metadata']['page_number']) for result in retrieved_answers]
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'page_number'
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
