### PR TITLE
Mil search speed

### DIFF
--- a/client/src/nv_ingest_client/util/vdb/milvus.py
+++ b/client/src/nv_ingest_client/util/vdb/milvus.py
@@ -34,7 +34,7 @@ from pymilvus.bulk_writer import RemoteBulkWriter
 from pymilvus.milvus_client.index import IndexParams
 from pymilvus.model.sparse import BM25EmbeddingFunction
 from pymilvus.model.sparse.bm25.tokenizers import build_default_analyzer
-from pymilvus.orm.types import CONSISTENCY_STRONG
+from pymilvus.orm.types import CONSISTENCY_BOUNDED
 from scipy.sparse import csr_array
 from nv_ingest_client.util.transport import infer_microservice
 from nv_ingest_client.util.vdb.adt_vdb import VDB
@@ -42,7 +42,7 @@ from nv_ingest_client.util.vdb.adt_vdb import VDB
 
 logger = logging.getLogger(__name__)
 
-CONSISTENCY = CONSISTENCY_STRONG
+CONSISTENCY = CONSISTENCY_BOUNDED
 
 pandas_reader_map = {
     ".json": pd.read_json,


### PR DESCRIPTION
## Description
Fix the search speed of milvus while still guaranteeing ingest to milvus is complete.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
