### PR TITLE
Fix incorrect path when saving results to disk

### DIFF
--- a/client/src/nv_ingest_client/client/interface.py
+++ b/client/src/nv_ingest_client/client/interface.py
@@ -436,7 +436,7 @@ class Ingestor:
                 clean_source_basename = get_valid_filename(os.path.basename(source_name))
                 file_name, file_ext = os.path.splitext(clean_source_basename)
                 file_suffix = f".{file_ext}.results.jsonl"
-                jsonl_filepath = safe_filename(output_dir, file_name, file_suffix)
+                jsonl_filepath = os.path.join(output_dir, safe_filename(output_dir, file_name, file_suffix))
 
                 num_items_saved = save_document_results_to_jsonl(
                     doc_data,


### PR DESCRIPTION
## Description
This PR fixes a recently introduced bug where `Ingestor.save_to_disk(output_directory=...)` would write result .jsonl files to the current working directory instead of the specified output_directory.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
