### PR TITLE
Update client to use PyPdfium2 4.30.0 as it seems the maintainers yan…

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pyarrow>=19.0.0",
     "pydantic>2.0.0",
     "pydantic-settings>2.0.0",
-    "pypdfium2>=4.30.1",
+    "pypdfium2>=4.30.0",
     "python-docx>=1.1.2",
     "python-magic>=0.4.27",
     "python-pptx>=1.0.2",


### PR DESCRIPTION
## Description
Update client to use PyPdfium2 4.30.0 as it seems the maintainers yanked version 4.30.0

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
