### PR TITLE
[REVIEW]Add  back embedding replicas

### DIFF
--- a/src/nv_ingest/framework/orchestration/ray/util/pipeline/stage_builders.py
+++ b/src/nv_ingest/framework/orchestration/ray/util/pipeline/stage_builders.py
@@ -522,7 +522,7 @@ def add_text_embedding_stage(pipeline, default_cpu_count, stage_name="text_embed
         stage_actor=TextEmbeddingTransformStage,
         config=config,
         min_replicas=0,
-        max_replicas=2,
+        max_replicas=_get_max_replicas(default_cpu_count, percentage_of_cpu=0.20),
     )
 
     return stage_name


### PR DESCRIPTION
## Description
This PR adds embedding replicas and with `nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2:latest ` , a small follow up to : https://github.com/NVIDIA/nv-ingest/pull/896

 I got:

```bash
(nv-ingest) vjawa@1u1g-gen-0063:/raid/vjawa/rapids-microbenchmarks/nv-ingest/scripts$ python3 bo767_ingest.py
Processing: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 767/767 [29:31<00:00,  2.31s/doc]
[]
07-22-25_12: ingestion_time: 1797.7605156898499
07-22-25_12: ingestion_pages_per_sec: 30.44343199349809
07-22-25_12: failure_count: 0
07-22-25_12: failures: []
07-22-25_12: ingestion_files_per_sec: 0.4266419210490231
07-22-25_12: record_count: 767
07-22-25_12: schema_creation: 3.4433674812316895
```


Other relevant config: 
```
NV_INGEST_MAX_UTIL=32
MAX_INGEST_PROCESS_WORKERS=32

INGEST_DISABLE_DYNAMIC_SCALING=true
PAGE_ELEMENTS_BATCH_SIZE=32
GRAPHIC_ELEMENTS_BATCH_SIZE=32
TABLE_STRUCTURE_BATCH_SIZE=32
```