### PR TITLE
Downgrade pypdfium2 on nv-ingest

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "nv-ingest-api==25.6.2",
     "pydantic>2.0.0",
     "pydantic-settings>2.0.0",
-    "pypdfium2==4.30.1",
+    "pypdfium2==4.30.0",
     "pytest>=8.0.2",
     "pytest-mock>=3.14.0",
     "pytest-cov>=6.0.0",


### PR DESCRIPTION
## Description
https://github.com/NVIDIA/nv-ingest/pull/898 downgraded for client, but the nv-ingest package still requires 4.30.1 which breaks the install.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
