### PR TITLE
Downgrade pypdfium2 from 4.30.1 -> 4.30.0 since 4.30.1 was yanked fro…

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "opentelemetry-sdk>=1.27.0",
     "pydantic>2.0.0",
     "pydantic-settings>2.0.0",
-    "pypdfium2==4.30.1",
+    "pypdfium2==4.30.0",
     "pytest>=8.0.2",
     "pytest-mock>=3.14.0",
     "pytest-cov>=6.0.0",


### PR DESCRIPTION
## Description
Downgrade pypdfium2 from 4.30.1 -> 4.30.0 since 4.30.1 was yanked from pypi

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
