### PR TITLE
Fix vlm build endpoint url

### DIFF
--- a/api/src/nv_ingest_api/internal/schemas/transform/transform_image_caption_schema.py
+++ b/api/src/nv_ingest_api/internal/schemas/transform/transform_image_caption_schema.py
@@ -8,7 +8,7 @@ from pydantic import ConfigDict, BaseModel
 
 class ImageCaptionExtractionSchema(BaseModel):
     api_key: str = "api_key"
-    endpoint_url: str = "https://ai.api.nvidia.com/v1/gr/nvidia/llama-3.1-nemotron-nano-vl-8b-v1/chat/completions"
+    endpoint_url: str = "https://integrate.api.nvidia.com/v1/chat/completions"
     prompt: str = "Caption the content of this image:"
     model_name: str = "nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
     raise_on_failure: bool = False

--- a/client/src/nv_ingest_client/nv_ingest_cli.py
+++ b/client/src/nv_ingest_client/nv_ingest_cli.py
@@ -126,7 +126,7 @@ Tasks and Options:
       - api_key (str): API key for captioning service.
       Default: os.environ(NVIDIA_API_KEY).'
       - endpoint_url (str): Endpoint URL for captioning service.
-      Default: 'https://build.nvidia.com/nvidia/llama-3.1-nemotron-nano-vl-8b-v1'.
+      Default: 'https://integrate.api.nvidia.com/v1/chat/completions'.
       - prompt (str): Prompt for captioning service.
       Default: 'Caption the content of this image:'.
 \b

--- a/docs/docs/extraction/nv-ingest-python-api.md
+++ b/docs/docs/extraction/nv-ingest-python-api.md
@@ -132,7 +132,7 @@ To specify a different API endpoint, pass additional parameters to `caption`.
 
 ```python
 ingestor = ingestor.caption(
-    endpoint_url="https://ai.api.nvidia.com/v1/gr/nvidia/llama-3.1-nemotron-nano-vl-8b-v1/chat/completions",
+    endpoint_url="https://integrate.api.nvidia.com/v1/chat/completions",
     model_name="nvidia/llama-3.1-nemotron-nano-vl-8b-v1",
     api_key="nvapi-"
 )

--- a/helm/README.md
+++ b/helm/README.md
@@ -329,7 +329,7 @@ You can also use NV-Ingest's Python client API to interact with the service runn
 | envVars.PADDLE_HTTP_ENDPOINT | string | `"http://nv-ingest-paddle:8000/v1/infer"` |  |
 | envVars.PADDLE_INFER_PROTOCOL | string | `"grpc"` |  |
 | envVars.REDIS_INGEST_TASK_QUEUE | string | `"ingest_task_queue"` |  |
-| envVars.VLM_CAPTION_ENDPOINT | string | `"https://ai.api.nvidia.com/v1/gr/nvidia/llama-3.1-nemotron-nano-vl-8b-v1/chat/completions"` |  |
+| envVars.VLM_CAPTION_ENDPOINT | string | `"https://integrate.api.nvidia.com/v1/chat/completions"` |  |
 | envVars.VLM_CAPTION_MODEL_NAME | string | `"nvidia/llama-3.1-nemotron-nano-vl-8b-v1"` |  |
 | envVars.YOLOX_GRAPHIC_ELEMENTS_GRPC_ENDPOINT | string | `"nemoretriever-graphic-elements-v1:8001"` |  |
 | envVars.YOLOX_GRAPHIC_ELEMENTS_HTTP_ENDPOINT | string | `"http://nemoretriever-graphic-elements-v1:8000/v1/infer"` |  |

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -858,7 +858,7 @@ prometheus:
 ## @param envVars.EMBEDDING_NIM_ENDPOINT [default: "http://nv-ingest-embedqa:8000/v1"] Endpoint for embedding service
 ## @param envVars.EMBEDDING_NIM_MODEL_NAME [default: "nvidia/llama-3.2-nv-embedqa-1b-v2"] Model name for embedding service
 ## @param envVars.MILVUS_ENDPOINT [default: "http://nv-ingest-milvus:19530"] Endpoint for Milvus vector database
-## @param envVars.VLM_CAPTION_ENDPOINT [default: "https://ai.api.nvidia.com/v1/gr/nvidia/llama-3.1-nemotron-nano-vl-8b-v1/chat/completions"] Endpoint for VLM caption service
+## @param envVars.VLM_CAPTION_ENDPOINT [default: "https://integrate.api.nvidia.com/v1/chat/completions"] Endpoint for VLM caption service
 ## @param envVars.VLM_CAPTION_MODEL_NAME [default: "nvidia/llama-3.1-nemotron-nano-vl-8b-v1"] Model name for VLM caption service
 ## @param envVars.AUDIO_GRPC_ENDPOINT [default: "nv-ingest-riva-nim:50051"] gRPC endpoint for audio service
 ## @param envVars.AUDIO_INFER_PROTOCOL [default: "grpc"] Protocol for audio service
@@ -902,7 +902,7 @@ envVars:
   EMBEDDING_NIM_MODEL_NAME: "nvidia/llama-3.2-nv-embedqa-1b-v2"
   MILVUS_ENDPOINT: "http://nv-ingest-milvus:19530"
 
-  VLM_CAPTION_ENDPOINT: "https://ai.api.nvidia.com/v1/gr/nvidia/llama-3.1-nemotron-nano-vl-8b-v1/chat/completions"
+  VLM_CAPTION_ENDPOINT: "https://integrate.api.nvidia.com/v1/chat/completions"
   VLM_CAPTION_MODEL_NAME: "nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
 
   AUDIO_GRPC_ENDPOINT: "nv-ingest-riva-nim:50051"

--- a/src/nv_ingest/framework/orchestration/ray/util/pipeline/pipeline_runners.py
+++ b/src/nv_ingest/framework/orchestration/ray/util/pipeline/pipeline_runners.py
@@ -91,7 +91,7 @@ class PipelineCreationSchema(BaseModel):
     # Vision language model settings
     vlm_caption_endpoint: str = os.getenv(
         "VLM_CAPTION_ENDPOINT",
-        "https://ai.api.nvidia.com/v1/gr/nvidia/llama-3.1-nemotron-nano-vl-8b-v1/chat/completions",
+        "https://integrate.api.nvidia.com/v1/chat/completions",
     )
     vlm_caption_model_name: str = os.getenv("VLM_CAPTION_MODEL_NAME", "nvidia/llama-3.1-nemotron-nano-vl-8b-v1")
 

--- a/tests/service_tests/schemas/test_image_caption_extraction_schema.py
+++ b/tests/service_tests/schemas/test_image_caption_extraction_schema.py
@@ -13,10 +13,7 @@ def test_valid_schema():
     }
     schema = ImageCaptionExtractionSchema(**valid_data)
     assert schema.api_key == "your-api-key-here"
-    assert (
-        schema.endpoint_url
-        == "https://integrate.api.nvidia.com/v1/chat/completions"
-    )
+    assert schema.endpoint_url == "https://integrate.api.nvidia.com/v1/chat/completions"
     assert schema.prompt == "Caption the content of this image:"
     assert schema.model_name == "nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
     assert schema.raise_on_failure is False

--- a/tests/service_tests/schemas/test_image_caption_extraction_schema.py
+++ b/tests/service_tests/schemas/test_image_caption_extraction_schema.py
@@ -15,7 +15,7 @@ def test_valid_schema():
     assert schema.api_key == "your-api-key-here"
     assert (
         schema.endpoint_url
-        == "https://ai.api.nvidia.com/v1/gr/nvidia/llama-3.1-nemotron-nano-vl-8b-v1/chat/completions"
+        == "https://integrate.api.nvidia.com/v1/chat/completions"
     )
     assert schema.prompt == "Caption the content of this image:"
     assert schema.model_name == "nvidia/llama-3.1-nemotron-nano-vl-8b-v1"


### PR DESCRIPTION
## Description

Update VLM caption endpoint url with the correct url.

https://build.nvidia.com/nvidia/llama-3.1-nemotron-nano-vl-8b-v1?snippet_tab=Python

<img width="529" height="497" alt="image" src="https://github.com/user-attachments/assets/85478733-d1f7-41d2-947b-be440abbdd02" />


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
