### PR TITLE
Add vdb notice

### DIFF
--- a/examples/building_vdb_operator.ipynb
+++ b/examples/building_vdb_operator.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "This tutorial demonstrates how to build a custom Vector Database (VDB) operator for NV-Ingest using the abstract `VDB` class. We implement a complete OpenSearch operator as an example.\n",
     "\n",
-    "**Note that NVIDIA makes no claim about accuracy, performance, or functionality of any vector database except Milvus. If you use an alternative vector database, it's your responsibility to test and maintain.**\n",
+    "**Important:** NVIDIA makes no claim about accuracy, performance, or functionality of any vector database except Milvus. If you use a different vector database, it's your responsibility to test and maintain it.\n",
     "\n",
     "## Overview\n",
     "\n",


### PR DESCRIPTION
## Description
This PR adds an advisory notice to the custom vdb operator example notebook. The notice explains that milvus is the only supported vector database and all others are available only as references, but no other vdb operator is fully supported.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
