### PR TITLE
Making Batch Size Configurable on the API Client

### DIFF
--- a/client/src/nv_ingest_client/client/client.py
+++ b/client/src/nv_ingest_client/client/client.py
@@ -971,10 +971,46 @@ class NvIngestClient:
 
         return [self._fetch_job_result(job_id, data_only=data_only) for job_id in job_ids]
 
+    def _validate_batch_size(self, batch_size: Optional[int]) -> int:
+        """
+        Validates and returns a sanitized batch_size value.
+        
+        Parameters
+        ----------
+        batch_size : Optional[int]
+            The batch_size value to validate. None uses default.
+        
+        Returns
+        -------
+        int
+            Validated batch_size value.
+        """
+        # Handle None/default case
+        if batch_size is None:
+            return 64
+        
+        # Validate type and range
+        if not isinstance(batch_size, int):
+            logger.warning(f"batch_size must be an integer, got {type(batch_size).__name__}. Using default 64.")
+            return 64
+        
+        if batch_size < 1:
+            logger.warning(f"batch_size must be >= 1, got {batch_size}. Using default 64.")
+            return 64
+        
+        # Performance guidance warnings
+        if batch_size < 8:
+            logger.warning(f"batch_size {batch_size} is very small and may impact performance.")
+        elif batch_size > 128:
+            logger.warning(f"batch_size {batch_size} is large and may increase memory usage.")
+        
+        return batch_size
+
     def process_jobs_concurrently(
         self,
         job_indices: Union[str, List[str]],
         job_queue_id: Optional[str] = None,
+        batch_size: Optional[int] = None,
         concurrency_limit: int = 64,
         timeout: int = 100,
         max_job_retries: Optional[int] = None,
@@ -995,8 +1031,12 @@ class NvIngestClient:
             Single or multiple job indices to process.
         job_queue_id : str, optional
             Queue identifier for submission.
+        batch_size : int, optional
+            Maximum number of jobs to process in each internal batch.
+            Higher values may improve throughput but increase memory usage.
+            Must be >= 1. Default is 64.
         concurrency_limit : int, optional
-            Max number of simultaneous in-flight jobs. Default is 128.
+            Max number of simultaneous in-flight jobs. Default is 64.
         timeout : int, optional
             Timeout in seconds per fetch attempt. Default is 100.
         max_job_retries : int, optional
@@ -1034,13 +1074,16 @@ class NvIngestClient:
         if not job_indices:
             return ([], []) if return_failures else []
 
+        # Validate and set batch_size
+        validated_batch_size = self._validate_batch_size(batch_size)
+
         # Prepare timeout tuple for fetch calls
         effective_timeout: Tuple[int, None] = (timeout, None)
 
         # Delegate to the concurrent processor
         processor = _ConcurrentProcessor(
             client=self,
-            batch_size=64,
+            batch_size=validated_batch_size,
             job_indices=job_indices,
             job_queue_id=job_queue_id,
             timeout=effective_timeout,


### PR DESCRIPTION
## Description
# Add Configurable batch_size Parameter to process_jobs_concurrently

The `_ConcurrentProcessor` batch size was hardcoded to `16`, preventing users from optimizing performance for different workloads.

Added optional `batch_size` parameter to `process_jobs_concurrently()` that:
- Defaults to `64`
- Validates input with warnings for edge cases
- Works automatically via `filter_function_kwargs()` in `Ingestor.ingest()`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
