### PR TITLE
Adding the option to set an env var for client batch size

### DIFF
--- a/client/src/nv_ingest_client/client/client.py
+++ b/client/src/nv_ingest_client/client/client.py
@@ -8,6 +8,7 @@ import concurrent
 import json
 import logging
 import math
+import os
 import time
 from collections import defaultdict
 from concurrent.futures import Future
@@ -978,7 +979,8 @@ class NvIngestClient:
         Parameters
         ----------
         batch_size : Optional[int]
-            The batch_size value to validate. None uses default.
+            The batch_size value to validate. None uses value from 
+            NV_INGEST_BATCH_SIZE environment variable or default 32.
         
         Returns
         -------
@@ -987,7 +989,10 @@ class NvIngestClient:
         """
         # Handle None/default case
         if batch_size is None:
-            return 32
+            try:
+                batch_size = int(os.getenv("NV_INGEST_BATCH_SIZE", "32"))
+            except ValueError:
+                batch_size = 32
         
         # Validate type and range
         if not isinstance(batch_size, int):

--- a/client/src/nv_ingest_client/client/client.py
+++ b/client/src/nv_ingest_client/client/client.py
@@ -990,7 +990,7 @@ class NvIngestClient:
         # Handle None/default case
         if batch_size is None:
             try:
-                batch_size = int(os.getenv("NV_INGEST_BATCH_SIZE", "32"))
+                batch_size = int(os.getenv("NV_INGEST_CLIENT_BATCH_SIZE", "32"))
             except ValueError:
                 batch_size = 32
         


### PR DESCRIPTION
## Description
Client batch size

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
