### PR TITLE
Add option to set env var for client spill-to-disk

### DIFF
--- a/client/src/nv_ingest_client/client/interface.py
+++ b/client/src/nv_ingest_client/client/interface.py
@@ -874,6 +874,37 @@ class Ingestor:
         output_directory: Optional[str] = None,
         cleanup: bool = True,
     ) -> "Ingestor":
+        """Configures the Ingestor to save results to disk instead of memory.
+
+        This method enables disk-based storage for ingestion results. When called,
+        the `ingest()` method will write the output for each processed document to a
+        separate JSONL file. The return value of `ingest()` will be a list of
+        `LazyLoadedList` objects, which are memory-efficient proxies to these files.
+
+        The output directory can be specified directly, via an environment variable,
+        or a temporary directory will be created automatically.
+
+        Parameters
+        ----------
+        output_directory : str, optional
+            The path to the directory where result files (.jsonl) will be saved.
+            If not provided, it defaults to the value of the environment variable
+            `NV_INGEST_CLIENT_SAVE_TO_DISK_OUTPUT_DIRECTORY`. If the environment
+            variable is also not set, a temporary directory will be created.
+            Defaults to None.
+        cleanup : bool, optional)
+            If True, the entire `output_directory` will be recursively deleted
+            when the Ingestor's context is exited (i.e., when used in a `with`
+            statement).
+            Defaults to True.
+
+        Returns
+        -------
+        Ingestor
+            Returns self for chaining.
+        """
+        output_directory = output_directory or os.getenv("NV_INGEST_CLIENT_SAVE_TO_DISK_OUTPUT_DIRECTORY")
+
         if not output_directory:
             self._created_temp_output_dir = tempfile.mkdtemp(prefix="ingestor_results_")
             output_directory = self._created_temp_output_dir


### PR DESCRIPTION
## Description
Adds an env var named `NV_INGEST_CLIENT_SAVE_TO_DISK_OUTPUT_DIRECTORY` for setting the output directory of `save_to_disk()` Ingestor task.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
