### PR TITLE
Enable dynamic selection of local NIM deployment vs NGC deployment

### DIFF
--- a/client/src/nv_ingest_client/util/vdb/milvus.py
+++ b/client/src/nv_ingest_client/util/vdb/milvus.py
@@ -878,7 +878,7 @@ def write_to_nvingest_collection(
     compute_bm25_stats: bool = True,
     access_key: str = "minioadmin",
     secret_key: str = "minioadmin",
-    bucket_name: str = "a-bucket",
+    bucket_name: str = "nv-ingest",
     threshold: int = 1000,
     meta_dataframe=None,
     meta_source_field=None,
@@ -1525,7 +1525,7 @@ def embed_index_collection(
     compute_bm25_stats: bool = True,
     access_key: str = "minioadmin",
     secret_key: str = "minioadmin",
-    bucket_name: str = "a-bucket",
+    bucket_name: str = "nv-ingest",
     meta_dataframe: Union[str, pd.DataFrame] = None,
     meta_source_field: str = None,
     meta_fields: list[str] = None,
@@ -1562,7 +1562,7 @@ def embed_index_collection(
         compute_bm25_stats (bool, optional): Whether to compute BM25 statistics. Defaults to True.
         access_key (str, optional): The access key for MinIO authentication. Defaults to "minioadmin".
         secret_key (str, optional): The secret key for MinIO authentication. Defaults to "minioadmin".
-        bucket_name (str, optional): The name of the MinIO bucket. Defaults to "a-bucket".
+        bucket_name (str, optional): The name of the MinIO bucket. Defaults to "nv-ingest".
         meta_dataframe (Union[str, pd.DataFrame], optional): A metadata DataFrame or the path to a CSV file
             containing metadata. Defaults to None.
         meta_source_field (str, optional): The field in the metadata that serves as the source identifier.
@@ -1670,7 +1670,7 @@ def reindex_collection(
     compute_bm25_stats: bool = True,
     access_key: str = "minioadmin",
     secret_key: str = "minioadmin",
-    bucket_name: str = "a-bucket",
+    bucket_name: str = "nv-ingest",
     meta_dataframe: Union[str, pd.DataFrame] = None,
     meta_source_field: str = None,
     meta_fields: list[str] = None,
@@ -1711,7 +1711,7 @@ def reindex_collection(
         compute_bm25_stats (bool, optional): Whether to compute BM25 statistics. Defaults to True.
         access_key (str, optional): The access key for MinIO authentication. Defaults to "minioadmin".
         secret_key (str, optional): The secret key for MinIO authentication. Defaults to "minioadmin".
-        bucket_name (str, optional): The name of the MinIO bucket. Defaults to "a-bucket".
+        bucket_name (str, optional): The name of the MinIO bucket. Defaults to "nv-ingest".
         meta_dataframe (Union[str, pd.DataFrame], optional): A metadata DataFrame or the path to a CSV file
             containing metadata. Defaults to None.
         meta_source_field (str, optional): The field in the metadata that serves as the source identifier.
@@ -1819,7 +1819,7 @@ class Milvus(VDB):
         compute_bm25_stats: bool = True,
         access_key: str = "minioadmin",
         secret_key: str = "minioadmin",
-        bucket_name: str = "a-bucket",
+        bucket_name: str = "nv-ingest",
         meta_dataframe: Union[str, pd.DataFrame] = None,
         meta_source_field: str = None,
         meta_fields: list[str] = None,
@@ -1847,7 +1847,7 @@ class Milvus(VDB):
             compute_bm25_stats (bool, optional): Whether to compute BM25 statistics. Defaults to True.
             access_key (str, optional): The access key for MinIO authentication. Defaults to "minioadmin".
             secret_key (str, optional): The secret key for MinIO authentication. Defaults to "minioadmin".
-            bucket_name (str, optional): The name of the MinIO bucket. Defaults to "a-bucket".
+            bucket_name (str, optional): The name of the MinIO bucket. Defaults to "nv-ingest".
             meta_dataframe (Union[str, pd.DataFrame], optional): A metadata DataFrame or the path to a CSV file
                 containing metadata. Defaults to None.
             meta_source_field (str, optional): The field in the metadata that serves as the source identifier.

--- a/helm/README.md
+++ b/helm/README.md
@@ -413,7 +413,7 @@ You can also use NV-Ingest's Python client API to interact with the service runn
 | milvus.etcd.replicaCount | int | `1` |  |
 | milvus.image.all.repository | string | `"milvusdb/milvus"` |  |
 | milvus.image.all.tag | string | `"v2.5.3-gpu"` |  |
-| milvus.minio.bucketName | string | `"a-bucket"` |  |
+| milvus.minio.bucketName | string | `"nv-ingest"` |  |
 | milvus.minio.mode | string | `"standalone"` |  |
 | milvus.minio.persistence.size | string | `"50Gi"` |  |
 | milvus.minio.persistence.storageClass | string | `nil` |  |

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -92,6 +92,13 @@ spec:
               value: "{{ .Values.logLevel }}"
             - name: LOG_LEVEL
               value: "{{ .Values.logLevel }}"
+            {{- if index .Values "nim-vlm-image-captioning" "deployed" }}
+            - name: VLM_CAPTION_ENDPOINT
+              value: "nim-vlm-image-captioning:8000"
+            {{- else }}
+            - name: VLM_CAPTION_ENDPOINT
+              value: "https://integrate.api.nvidia.com/v1/chat/completions"
+            {{- end }}
 
             {{- if .Values.envVars }}
             {{- range $k, $v := .Values.envVars }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -845,7 +845,7 @@ milvusDeployed: true
 ## @param milvus.standalone.persistence.persistentVolumeClaim.size [default: 50Gi] Size of the PVC for Milvus data
 ## @param milvus.standalone.persistence.persistentVolumeClaim.storageClass Storage class to use for the PVC
 ## @param milvus.minio.mode [default: standalone] MinIO deployment mode
-## @param milvus.minio.bucketName [default: a-bucket] Name of the MinIO bucket to create
+## @param milvus.minio.bucketName [default: nv-ingest] Name of the MinIO bucket to create
 ## @param milvus.minio.persistence.size [default: 50Gi] Size of the PVC for MinIO data
 ## @param milvus.minio.persistence.storageClass Storage class to use for MinIO PVC
 milvus:
@@ -861,7 +861,7 @@ milvus:
       storageClass: null
   minio:
     mode: standalone
-    bucketName: a-bucket
+    bucketName: nv-ingest
     persistence:
       size: 50Gi
       storageClass: null
@@ -1049,7 +1049,10 @@ envVars:
   EMBEDDING_NIM_MODEL_NAME: "nvidia/llama-3.2-nv-embedqa-1b-v2"
   MILVUS_ENDPOINT: "http://nv-ingest-milvus:19530"
 
-  VLM_CAPTION_ENDPOINT: "https://integrate.api.nvidia.com/v1/chat/completions"
+  # This environment variable is controled in the helm/deployment.yaml. There is a ternary operator that
+  # sets this value to "nim-vlm-image-captioning:8001" to use the locally deployed NIM if the nim-vlm-image-captioning.deployed
+  # condition is true, otherwise it is set to "https://integrate.api.nvidia.com/v1/chat/completions" to use the NGC hosted NIM
+  # VLM_CAPTION_ENDPOINT: "DO_NOT_USE_HERE_FOR_REFERENCE_ONLY"
   VLM_CAPTION_MODEL_NAME: "nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
 
   AUDIO_GRPC_ENDPOINT: "nv-ingest-riva-nim:50051"


### PR DESCRIPTION
## Description
Enable dynamic selection of local NIM deployment vs NGC deployment for VLM_CAPTION_ENDPOINT

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
