### PR TITLE
Switch to python 3.12 in conda container

### DIFF
--- a/conda/environments/nv_ingest_environment.yml
+++ b/conda/environments/nv_ingest_environment.yml
@@ -28,7 +28,7 @@ dependencies:
   - pytest>=8.0.2
   - pytest-mock>=3.14.0
   - pytest-cov>=6.0.0
-  - python==3.11
+  - python==3.12
   - python-build>=1.2.2
   - python-docx>=1.1.2
   - python-dotenv>=1.0.1


### PR DESCRIPTION
## Description
Switch to python 3.12 in conda container

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
