### PR TITLE
Modify ingestor's vdb_upload to allow partial upload with returned failures when return_failures is specified.

### DIFF
--- a/client/client_tests/client/test_interface.py
+++ b/client/client_tests/client/test_interface.py
@@ -9,7 +9,6 @@ import json
 import logging
 import os
 import tempfile
-import shutil
 from concurrent.futures import Future
 from unittest.mock import ANY
 from unittest.mock import MagicMock
@@ -17,6 +16,13 @@ from unittest.mock import patch
 
 import nv_ingest_client.client.interface as module_under_test
 import pytest
+
+from client.client_tests.utilities_for_test import (
+    cleanup_test_workspace,
+    create_test_workspace,
+    get_git_root,
+    find_root_by_pattern,
+)
 from nv_ingest_client.client import Ingestor
 from nv_ingest_client.client import LazyLoadedList
 from nv_ingest_client.client import NvIngestClient
@@ -35,6 +41,7 @@ from nv_ingest_client.primitives.tasks import TableExtractionTask
 from nv_ingest_client.util.vdb.milvus import Milvus
 from nv_ingest_client.util.vdb import VDB
 
+
 MODULE_UNDER_TEST = f"{module_under_test.__name__}"
 
 
@@ -45,12 +52,74 @@ def mock_client():
 
 
 @pytest.fixture
+def workspace():
+    test_workspace = create_test_workspace("ingestor_pytest_")
+    doc1_path = os.path.join(test_workspace, "doc1.txt")
+    with open(doc1_path, "w") as f:
+        f.write("This is a test document.")
+
+    yield test_workspace, doc1_path
+
+    cleanup_test_workspace(test_workspace)
+
+
+@pytest.fixture
 def documents():
+    # Use utilities to find the actual data directory
+    git_root = get_git_root(__file__)
+    if git_root:
+        data_dir = os.path.join(git_root, "data")
+        if os.path.exists(data_dir):
+            pdf_path = os.path.join(data_dir, "multimodal_test.pdf")
+            if os.path.exists(pdf_path):
+                return [pdf_path]
+
+    # Fallback: search for data directory pattern
+    root_dir = find_root_by_pattern("data/multimodal_test.pdf", start_dir=os.path.dirname(__file__))
+    pdf_path = os.path.join(root_dir, "data", "multimodal_test.pdf")
+    if os.path.exists(pdf_path):
+        return [pdf_path]
+
+    # If no actual test file found, fall back to the original path
     return ["data/multimodal_test.pdf"]
 
 
 @pytest.fixture
 def text_documents():
+    # Use utilities to find the actual data directory
+    git_root = get_git_root(__file__)
+    if git_root:
+        data_dir = os.path.join(git_root, "data")
+        if os.path.exists(data_dir):
+            files = [
+                os.path.join(data_dir, "test.txt"),
+                os.path.join(data_dir, "test.html"),
+                os.path.join(data_dir, "test.json"),
+                os.path.join(data_dir, "test.md"),
+                os.path.join(data_dir, "test.sh"),
+            ]
+            # Return only files that actually exist
+            existing_files = [f for f in files if os.path.exists(f)]
+            if existing_files:
+                return existing_files
+
+    # Fallback: search for data directory pattern
+    root_dir = find_root_by_pattern("data", start_dir=os.path.dirname(__file__))
+    data_dir = os.path.join(root_dir, "data")
+    if os.path.exists(data_dir):
+        files = [
+            os.path.join(data_dir, "test.txt"),
+            os.path.join(data_dir, "test.html"),
+            os.path.join(data_dir, "test.json"),
+            os.path.join(data_dir, "test.md"),
+            os.path.join(data_dir, "test.sh"),
+        ]
+        # Return only files that actually exist
+        existing_files = [f for f in files if os.path.exists(f)]
+        if existing_files:
+            return existing_files
+
+    # If no actual test files found, fall back to original paths
     return [
         "data/test.txt",
         "data/test.html",
@@ -68,18 +137,6 @@ def ingestor(mock_client, documents):
 @pytest.fixture
 def ingestor_without_doc(mock_client):
     return Ingestor(client=mock_client)
-
-
-@pytest.fixture
-def workspace():
-    test_workspace = tempfile.mkdtemp(prefix="ingestor_pytest_")
-    doc1_path = os.path.join(test_workspace, "doc1.txt")
-    with open(doc1_path, "w") as f:
-        f.write("This is a test document.")
-
-    yield test_workspace, doc1_path
-
-    shutil.rmtree(test_workspace)
 
 
 def test_dedup_task_no_args(ingestor):
@@ -760,3 +817,247 @@ def test_vdb_upload_without_purge_preserves_result_files(workspace, monkeypatch)
         mock_vdb_op.run.assert_called_once()
 
     assert os.path.exists(dummy_result_filepath), "Result file should be preserved"
+
+
+def test_vdb_upload_with_failures_return_failures_true(workspace, monkeypatch, caplog):
+    """Test VDB upload with failures when return_failures=True.
+
+    Should upload successful results, emit warning message, and return failures.
+    """
+    mock_client = MagicMock(spec=NvIngestClient)
+    mock_vdb_op = MagicMock(spec=VDB)
+    monkeypatch.setattr(
+        "nv_ingest_client.client.interface.NvIngestClient",
+        lambda *args, **kwargs: mock_client,
+    )
+
+    test_workspace, doc1_path = workspace
+    results_dir = os.path.join(test_workspace, "vdb_failure_test")
+    os.makedirs(results_dir)
+
+    # Mock successful results for 2 jobs and failures for 1 job
+    successful_results = [[{"data": "embedding1", "source": "doc1"}], [{"data": "embedding2", "source": "doc2"}]]
+    failures = [("job_3", "Processing failed")]
+
+    def fake_processor(completion_callback=None, **kwargs):
+        if completion_callback:
+            with open(os.path.join(results_dir, "doc1.txt.results.jsonl"), "w") as f:
+                f.write('{"data": "embedding1"}\n')
+                f.write('{"data": "embedding2"}\n')
+            completion_callback(results_data=successful_results[0], job_id="0")
+            completion_callback(results_data=successful_results[1], job_id="1")
+        return (successful_results, failures)
+
+    mock_client.process_jobs_concurrently.side_effect = fake_processor
+    mock_client._job_index_to_job_spec = {"0": MagicMock(source_name=doc1_path), "1": MagicMock(source_name="doc2.txt")}
+
+    with Ingestor(documents=[doc1_path]) as ingestor:
+        ingestor.save_to_disk(output_directory=results_dir, cleanup=False)
+        ingestor.vdb_upload(vdb_op=mock_vdb_op, purge_results_after_upload=True)
+
+        # Should return results and failures when return_failures=True
+        results, returned_failures = ingestor.ingest(show_progress=False, return_failures=True)
+
+        # Verify VDB upload was called with successful results only
+        mock_vdb_op.run.assert_called_once()
+        called_args = mock_vdb_op.run.call_args[0][0]
+        assert len(called_args) == 2, "Should have 2 LazyLoadedList objects"
+        assert all(isinstance(item, LazyLoadedList) for item in called_args), "Results should be LazyLoadedList objects"
+
+        # Verify warning message was logged
+        assert "Job was not completely successful" in caplog.text
+        assert "2 out of 3 records completed successfully" in caplog.text
+        assert "Uploading successful results to vector database" in caplog.text
+
+        # Verify return values
+        assert len(results) == 2
+        assert all(isinstance(item, LazyLoadedList) for item in results)
+        assert returned_failures == failures
+
+        # Verify purge happened after successful upload
+        assert not os.path.exists(os.path.join(results_dir, "doc1.txt.results.jsonl"))
+
+
+def test_vdb_upload_with_failures_return_failures_false(workspace, monkeypatch):
+    """Test VDB upload with failures when return_failures=False.
+
+    Should raise RuntimeError without uploading anything.
+    """
+    mock_client = MagicMock(spec=NvIngestClient)
+    mock_vdb_op = MagicMock(spec=VDB)
+    monkeypatch.setattr(
+        "nv_ingest_client.client.interface.NvIngestClient",
+        lambda *args, **kwargs: mock_client,
+    )
+
+    test_workspace, doc1_path = workspace
+    results_dir = os.path.join(test_workspace, "vdb_failure_strict_test")
+    os.makedirs(results_dir)
+
+    # Mock some successful results and some failures
+    successful_results = [[{"data": "embedding1"}]]
+    failures = [("job_2", "Processing failed")]
+
+    def fake_processor(completion_callback=None, **kwargs):
+        return (successful_results, failures)
+
+    mock_client.process_jobs_concurrently.side_effect = fake_processor
+
+    with Ingestor(documents=[doc1_path]) as ingestor:
+        ingestor.save_to_disk(output_directory=results_dir, cleanup=False)
+        ingestor.vdb_upload(vdb_op=mock_vdb_op, purge_results_after_upload=True)
+
+        # Should raise RuntimeError when return_failures=False and failures exist
+        with pytest.raises(RuntimeError) as exc_info:
+            ingestor.ingest(show_progress=False, return_failures=False)
+
+        # Verify error message content
+        error_msg = str(exc_info.value)
+        assert "Failed to ingest documents, unable to complete vdb bulk upload" in error_msg
+        assert "no successful results" in error_msg
+        assert "1 out of" in error_msg and "records failed" in error_msg
+
+        # Verify VDB upload was NOT called
+        mock_vdb_op.run.assert_not_called()
+
+
+def test_vdb_upload_with_no_failures(workspace, monkeypatch):
+    """Test VDB upload with no failures.
+
+    Should work normally regardless of return_failures setting.
+    """
+    mock_client = MagicMock(spec=NvIngestClient)
+    mock_vdb_op = MagicMock(spec=VDB)
+    monkeypatch.setattr(
+        "nv_ingest_client.client.interface.NvIngestClient",
+        lambda *args, **kwargs: mock_client,
+    )
+
+    test_workspace, doc1_path = workspace
+    results_dir = os.path.join(test_workspace, "vdb_success_test")
+    os.makedirs(results_dir)
+    dummy_result_filepath = os.path.join(results_dir, "doc1.txt.results.jsonl")
+
+    # Mock only successful results, no failures
+    successful_results = [[{"data": "embedding1"}], [{"data": "embedding2"}]]
+    failures = []
+
+    def fake_processor(completion_callback=None, **kwargs):
+        if completion_callback:
+            with open(dummy_result_filepath, "w") as f:
+                f.write('{"data": "embedding1"}\n')
+                f.write('{"data": "embedding2"}\n')
+            completion_callback(results_data=successful_results[0], job_id="0")
+            completion_callback(results_data=successful_results[1], job_id="1")
+        return (successful_results, failures)
+
+    mock_client.process_jobs_concurrently.side_effect = fake_processor
+    mock_client._job_index_to_job_spec = {"0": MagicMock(source_name=doc1_path), "1": MagicMock(source_name="doc2.txt")}
+
+    with Ingestor(documents=[doc1_path]) as ingestor:
+        ingestor.save_to_disk(output_directory=results_dir, cleanup=False)
+        ingestor.vdb_upload(vdb_op=mock_vdb_op, purge_results_after_upload=True)
+
+        # Test with return_failures=False (should return only results)
+        results = ingestor.ingest(show_progress=False, return_failures=False)
+
+        # Verify VDB upload was called with all results
+        mock_vdb_op.run.assert_called_once()
+        called_args = mock_vdb_op.run.call_args[0][0]
+        assert len(called_args) == 2, "Should have 2 LazyLoadedList objects"
+        assert all(isinstance(item, LazyLoadedList) for item in called_args), "Results should be LazyLoadedList objects"
+
+        # Verify return value (only results, no failures tuple)
+        assert len(results) == 2
+        assert all(isinstance(item, LazyLoadedList) for item in results)
+
+        # Verify purge happened
+        assert not os.path.exists(dummy_result_filepath)
+
+
+def test_vdb_upload_with_all_failures_return_failures_true(workspace, monkeypatch, caplog):
+    """Test VDB upload when all jobs fail and return_failures=True.
+
+    Should not upload anything but should emit warning and return failures.
+    """
+    mock_client = MagicMock(spec=NvIngestClient)
+    mock_vdb_op = MagicMock(spec=VDB)
+    monkeypatch.setattr(
+        "nv_ingest_client.client.interface.NvIngestClient",
+        lambda *args, **kwargs: mock_client,
+    )
+
+    test_workspace, doc1_path = workspace
+    results_dir = os.path.join(test_workspace, "vdb_all_failures_test")
+    os.makedirs(results_dir)
+
+    # Mock no successful results, only failures
+    successful_results = []
+    failures = [("job_1", "Processing failed"), ("job_2", "Processing failed"), ("job_3", "Processing failed")]
+
+    def fake_processor(completion_callback=None, **kwargs):
+        return (successful_results, failures)
+
+    mock_client.process_jobs_concurrently.side_effect = fake_processor
+
+    with Ingestor(documents=[doc1_path]) as ingestor:
+        ingestor.save_to_disk(output_directory=results_dir, cleanup=False)
+        ingestor.vdb_upload(vdb_op=mock_vdb_op, purge_results_after_upload=True)
+
+        # Should return empty results and all failures when return_failures=True
+        results, returned_failures = ingestor.ingest(show_progress=False, return_failures=True)
+
+        # Verify VDB upload was NOT called (no successful results to upload)
+        mock_vdb_op.run.assert_not_called()
+
+        # Verify warning message was logged
+        assert "Job was not completely successful" in caplog.text
+        assert "0 out of 3 records completed successfully" in caplog.text
+
+        # Verify return values
+        assert len(results) == 0
+        assert results == []  # Should be empty list when no successful results
+        assert returned_failures == failures
+
+
+def test_vdb_upload_return_failures_true_with_tuple_return(workspace, monkeypatch):
+    """Test that VDB upload with return_failures=True returns tuple format.
+
+    Verifies the return format is (results, failures) when return_failures=True.
+    """
+    mock_client = MagicMock(spec=NvIngestClient)
+    mock_vdb_op = MagicMock(spec=VDB)
+    monkeypatch.setattr(
+        "nv_ingest_client.client.interface.NvIngestClient",
+        lambda *args, **kwargs: mock_client,
+    )
+
+    test_workspace, doc1_path = workspace
+
+    # Mock successful results with no failures
+    successful_results = [[{"data": "embedding1"}]]
+    failures = []
+
+    def fake_processor(completion_callback=None, **kwargs):
+        return (successful_results, failures)
+
+    mock_client.process_jobs_concurrently.side_effect = fake_processor
+
+    with Ingestor(documents=[doc1_path]) as ingestor:
+        ingestor.vdb_upload(vdb_op=mock_vdb_op)
+
+        # Should return tuple when return_failures=True
+        result = ingestor.ingest(show_progress=False, return_failures=True)
+
+        # Verify it's a tuple with results and failures
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        results, returned_failures = result
+        assert len(results) == 1
+        assert results == successful_results  # Should be raw data when save_to_disk() is not used
+        assert returned_failures == failures
+
+        # Verify VDB upload was called
+        mock_vdb_op.run.assert_called_once()
+        called_args = mock_vdb_op.run.call_args[0][0]
+        assert called_args == successful_results  # Should be raw data when save_to_disk() is not used

--- a/client/client_tests/utilities_for_test.py
+++ b/client/client_tests/utilities_for_test.py
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import subprocess
+import tempfile
+import shutil
+from typing import List, Tuple, Optional
+
+
+def get_git_root(file_path):
+    """
+    Attempts to get the root of the git repository for the given file.
+
+    Parameters:
+        file_path (str): The path of the file to determine the git root for.
+
+    Returns:
+        str: The absolute path to the git repository root if found,
+             otherwise None.
+    """
+    try:
+        # Get the absolute directory of the file.
+        directory = os.path.dirname(os.path.abspath(file_path))
+        # Run the git command to get the repository's top-level directory.
+        git_root = (
+            subprocess.check_output(["git", "-C", directory, "rev-parse", "--show-toplevel"], stderr=subprocess.STDOUT)
+            .strip()
+            .decode("utf-8")
+        )
+        return git_root
+    except subprocess.CalledProcessError:
+        # In case the file is not inside a git repository.
+        return None
+    except Exception:
+        return None
+
+
+def find_root_by_pattern(pattern, start_dir=None):
+    """
+    Backtracks up the directory tree looking for the first directory
+    where the specified pattern exists.
+
+    Parameters:
+        pattern (str): The relative path to check for (e.g., "data/test.pdf").
+        start_dir (str, optional): The starting directory. Defaults to the current working directory.
+
+    Returns:
+        str: The absolute path of the first directory where pattern exists,
+             or "./" if not found.
+    """
+    if start_dir is None:
+        start_dir = os.getcwd()
+    current_dir = os.path.abspath(start_dir)
+
+    while True:
+        candidate = os.path.join(current_dir, pattern)
+        if os.path.exists(candidate):
+            return current_dir
+
+        # Determine the parent directory.
+        parent_dir = os.path.dirname(current_dir)
+        # If we're at the filesystem root, break.
+        if parent_dir == current_dir:
+            break
+        current_dir = parent_dir
+
+    return "./"
+
+
+def create_test_workspace(prefix: str = "client_test_") -> str:
+    """
+    Create a temporary directory for test workspace.
+
+    Parameters:
+        prefix (str): Prefix for the temporary directory name.
+
+    Returns:
+        str: Path to the created temporary directory.
+    """
+    return tempfile.mkdtemp(prefix=prefix)
+
+
+def cleanup_test_workspace(workspace_path: str) -> None:
+    """
+    Clean up a test workspace directory.
+
+    Parameters:
+        workspace_path (str): Path to the workspace directory to clean up.
+    """
+    if os.path.exists(workspace_path):
+        shutil.rmtree(workspace_path)
+
+
+def create_test_file(directory: str, filename: str, content: str = None) -> str:
+    """
+    Create a test file with optional content.
+
+    Parameters:
+        directory (str): Directory where the file should be created.
+        filename (str): Name of the file to create.
+        content (str, optional): Content to write to the file. Defaults to a simple test message.
+
+    Returns:
+        str: Full path to the created file.
+    """
+    if content is None:
+        content = f"This is a test file: {filename}"
+
+    file_path = os.path.join(directory, filename)
+    os.makedirs(directory, exist_ok=True)
+
+    with open(file_path, "w") as f:
+        f.write(content)
+
+    return file_path
+
+
+def create_test_documents(workspace: str, file_specs: List[Tuple[str, Optional[str]]] = None) -> List[str]:
+    """
+    Create multiple test documents in a workspace.
+
+    Parameters:
+        workspace (str): Path to the workspace directory.
+        file_specs (List[Tuple[str, Optional[str]]], optional): List of (filename, content) tuples.
+            If None, creates default test documents.
+
+    Returns:
+        List[str]: List of paths to created files.
+    """
+    if file_specs is None:
+        file_specs = [
+            ("test.pdf", "This is a test PDF document."),
+            ("test.txt", "This is a test text document."),
+            ("test.html", "<html><body>This is a test HTML document.</body></html>"),
+            ("test.json", '{"message": "This is a test JSON document."}'),
+            ("test.md", "# This is a test Markdown document"),
+            ("test.sh", "#!/bin/bash\necho 'This is a test shell script'"),
+        ]
+
+    created_files = []
+    for filename, content in file_specs:
+        file_path = create_test_file(workspace, filename, content)
+        created_files.append(file_path)
+
+    return created_files
+
+
+def create_jsonl_test_file(directory: str, filename: str, data_entries: List[dict]) -> str:
+    """
+    Create a JSONL test file with the given data entries.
+
+    Parameters:
+        directory (str): Directory where the file should be created.
+        filename (str): Name of the JSONL file to create.
+        data_entries (List[dict]): List of dictionaries to write as JSON lines.
+
+    Returns:
+        str: Full path to the created JSONL file.
+    """
+    import json
+
+    file_path = os.path.join(directory, filename)
+    os.makedirs(directory, exist_ok=True)
+
+    with open(file_path, "w") as f:
+        for entry in data_entries:
+            f.write(json.dumps(entry) + "\n")
+
+    return file_path
+
+
+class TestWorkspace:
+    """
+    Context manager for creating and cleaning up test workspaces.
+
+    Usage:
+        with TestWorkspace() as workspace:
+            # Use workspace.path for test operations
+            test_file = workspace.create_file("test.txt", "content")
+    """
+
+    def __init__(self, prefix: str = "client_test_"):
+        self.prefix = prefix
+        self.path = None
+
+    def __enter__(self):
+        self.path = create_test_workspace(self.prefix)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.path:
+            cleanup_test_workspace(self.path)
+
+    def create_file(self, filename: str, content: str = None) -> str:
+        """Create a test file in this workspace."""
+        if self.path is None:
+            raise RuntimeError("Workspace not initialized. Use within 'with' statement.")
+        return create_test_file(self.path, filename, content)
+
+    def create_documents(self, file_specs: List[Tuple[str, Optional[str]]] = None) -> List[str]:
+        """Create multiple test documents in this workspace."""
+        if self.path is None:
+            raise RuntimeError("Workspace not initialized. Use within 'with' statement.")
+        return create_test_documents(self.path, file_specs)
+
+    def create_jsonl_file(self, filename: str, data_entries: List[dict]) -> str:
+        """Create a JSONL test file in this workspace."""
+        if self.path is None:
+            raise RuntimeError("Workspace not initialized. Use within 'with' statement.")
+        return create_jsonl_test_file(self.path, filename, data_entries)

--- a/client/src/nv_ingest_client/client/interface.py
+++ b/client/src/nv_ingest_client/client/interface.py
@@ -535,10 +535,6 @@ class Ingestor:
 
         proc_kwargs = filter_function_kwargs(self._client.process_jobs_concurrently, **kwargs)
 
-        _return_failures = return_failures
-        if self._vdb_bulk_upload:
-            return_failures = True
-
         results, failures = self._client.process_jobs_concurrently(
             job_indices=self._job_ids,
             job_queue_id=self._job_queue_id,
@@ -567,15 +563,39 @@ class Ingestor:
 
         if self._vdb_bulk_upload:
             if len(failures) > 0:
-                raise RuntimeError(f"Failed to ingest documents, unable to complete vdb bulk upload: {failures}")
+                # Calculate success metrics
+                total_jobs = len(results) + len(failures)
+                successful_jobs = len(results)
 
-            self._vdb_bulk_upload.run(results)
+                if return_failures:
+                    # Emit message about partial success
+                    logger.warning(
+                        f"Job was not completely successful. "
+                        f"{successful_jobs} out of {total_jobs} records completed successfully. "
+                        f"Uploading successful results to vector database."
+                    )
 
-            if self._purge_results_after_vdb_upload:
-                logger.info("Purging saved results from disk after successful VDB upload.")
-                self._purge_saved_results(results)
+                    # Upload only the successful results
+                    if successful_jobs > 0:
+                        self._vdb_bulk_upload.run(results)
 
-        return_failures = _return_failures
+                        if self._purge_results_after_vdb_upload:
+                            logger.info("Purging saved results from disk after successful VDB upload.")
+                            self._purge_saved_results(results)
+
+                else:
+                    # Original behavior: raise RuntimeError
+                    raise RuntimeError(
+                        "Failed to ingest documents, unable to complete vdb bulk upload due to "
+                        f"no successful results. {len(failures)} out of {total_jobs} records failed "
+                    )
+            else:
+                # No failures - proceed with normal upload
+                self._vdb_bulk_upload.run(results)
+
+                if self._purge_results_after_vdb_upload:
+                    logger.info("Purging saved results from disk after successful VDB upload.")
+                    self._purge_saved_results(results)
 
         return (results, failures) if return_failures else results
 


### PR DESCRIPTION
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
