### PR TITLE
Add /v1/char/completions to end of URL for locally deployed VLM NIM

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
               value: "{{ .Values.logLevel }}"
             {{- if index .Values "nim-vlm-image-captioning" "deployed" }}
             - name: VLM_CAPTION_ENDPOINT
-              value: {{ index .Values "nim-vlm-image-captioning" "fullnameOverride" }}:8000
+              value: {{ index .Values "nim-vlm-image-captioning" "fullnameOverride" }}:8000/v1/chat/completions
             {{- else }}
             - name: VLM_CAPTION_ENDPOINT
               value: "https://integrate.api.nvidia.com/v1/chat/completions"


### PR DESCRIPTION
## Description
Add /v1/char/completions to end of URL for locally deployed VLM NIM

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
