### PR TITLE
Fix issue with embed calls from client

### DIFF
--- a/client/src/nv_ingest_client/util/transport.py
+++ b/client/src/nv_ingest_client/util/transport.py
@@ -26,7 +26,7 @@ def infer_microservice(
         client = NimClient(
             model_interface=EmbeddingModelInterface(),
             protocol="grpc",
-            endpoints=(embedding_endpoint, embedding_endpoint),
+            endpoints=(embedding_endpoint, None),
             auth_token=nvidia_api_key,
         )
         return client.infer(
@@ -43,7 +43,7 @@ def infer_microservice(
         client = NimClient(
             model_interface=EmbeddingModelInterface(),
             protocol="http",
-            endpoints=(embedding_endpoint, embedding_endpoint),
+            endpoints=(None, embedding_endpoint),
             auth_token=nvidia_api_key,
         )
         return client.infer(data, model_name, input_type=input_type, truncate=truncate, batch_size=batch_size)


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This fixes an issue where using the `infer_microservice` function in transport.py with an http embedding endpoint still results in an attempted grpc call to the endpoint

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
