### PR TITLE
Decompose nv-ingest-ms-runtime into nv-ingest-rest-api & nv-ingest-worker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
     //   "grafana",
     //   "milvus",
     //   "minio",
-    //   "nv-ingest-ms-runtime",
+    //   "nv-ingest-rest-api",
     //   "otel-collector",
     //   "prometheus",
     //   "redis",

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,8 @@ ENTRYPOINT ["tini", "--", "/workspace/docker/entrypoint-rest-api.sh"]
 
 FROM nv_ingest_install AS worker
 
+COPY src/microservice_entrypoint.py ./
+
 # Copy entrypoint script(s)
 COPY ./docker/scripts/entrypoint-worker.sh /workspace/docker/entrypoint-worker.sh
 COPY ./docker/scripts/entrypoint_source_ext.sh /workspace/docker/entrypoint_source_ext.sh

--- a/client/README.md
+++ b/client/README.md
@@ -196,7 +196,7 @@ efficiently. Below are the public methods available:
 - **Example**:
   ```python
   client = NvIngestClient(
-    message_client_hostname="localhost", # Host where nv-ingest-ms-runtime is running
+    message_client_hostname="localhost", # Host where nv-ingest-rest-api is running
     message_client_port=7670 # REST port, defaults to 7670
   )
   ```

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -241,24 +241,19 @@ services:
     profiles:
       - audio
 
-  nv-ingest-ms-runtime:
-    image: nvcr.io/nvidia/nemo-microservices/nv-ingest:25.6.2
-    shm_size: 40gb # Should be at minimum 30% of assigned memory per Ray documentation
+  nv-ingest-rest-api:
+    image: nvcr.io/nvidia/nemo-microservices/nv-ingest-rest-api:latest
     build:
       context: ${NV_INGEST_ROOT:-.}
       dockerfile: "./Dockerfile"
-      target: runtime
+      target: rest-api
       args:
         DOWNLOAD_LLAMA_TOKENIZER: ${DOWNLOAD_LLAMA_TOKENIZER:-False}
         HF_ACCESS_TOKEN: ${HF_ACCESS_TOKEN:-hfaccesstoken}
         MODEL_PREDOWNLOAD_PATH: ${MODEL_PREDOWNLOAD_PATH:-/workspace/models/}
-    volumes:
-      - ${DATASET_ROOT:-./data}:/workspace/data
     ports:
       # HTTP API
       - "7670:7670"
-      # Simple Broker -- Uncomment if running SimpleBroker in the container
-      #- "7671:7671"
       # Ray Dashboards
       - "8265:8265"
     cap_add:
@@ -339,7 +334,7 @@ services:
       #    comma separated list of HTTP environment variables for specific services to check for ready
       - COMPONENTS_TO_READY_CHECK=ALL
     healthcheck:
-      test: curl --fail http://nv-ingest-ms-runtime:7670/v1/health/ready || exit 1
+      test: curl --fail http://nv-ingest-rest-api:7670/v1/health/ready || exit 1
       interval: 10s
       timeout: 5s
       retries: 20
@@ -350,6 +345,91 @@ services:
             - driver: nvidia
               device_ids: ["0"]
               capabilities: [gpu]
+
+
+  nv-ingest-worker:
+    image: nvcr.io/nvidia/nemo-microservices/nv-ingest-worker:latest
+    shm_size: 40gb # Should be at minimum 30% of assigned memory per Ray documentation
+    build:
+      context: ${NV_INGEST_ROOT:-.}
+      dockerfile: "./Dockerfile"
+      target: worker
+      args:
+        DOWNLOAD_LLAMA_TOKENIZER: ${DOWNLOAD_LLAMA_TOKENIZER:-False}
+        HF_ACCESS_TOKEN: ${HF_ACCESS_TOKEN:-hfaccesstoken}
+        MODEL_PREDOWNLOAD_PATH: ${MODEL_PREDOWNLOAD_PATH:-/workspace/models/}
+    volumes:
+      - ${DATASET_ROOT:-./data}:/workspace/data
+    cap_add:
+      - sys_nice
+    environment:
+      - ARROW_DEFAULT_MEMORY_POOL=system
+      - OMP_NUM_THREADS=1
+      - AUDIO_GRPC_ENDPOINT=audio:50051
+      - AUDIO_INFER_PROTOCOL=grpc
+      - CUDA_VISIBLE_DEVICES=-1
+      - MAX_INGEST_PROCESS_WORKERS=${MAX_INGEST_PROCESS_WORKERS:-16}
+      - EMBEDDING_NIM_ENDPOINT=${EMBEDDING_NIM_ENDPOINT:-http://embedding:8000/v1}
+      - EMBEDDING_NIM_MODEL_NAME=${EMBEDDING_NIM_MODEL_NAME:-nvidia/llama-3.2-nv-embedqa-1b-v2}
+      - INGEST_LOG_LEVEL=DEFAULT
+      - INGEST_EDGE_BUFFER_SIZE=64
+      - INGEST_DYNAMIC_MEMORY_THRESHOLD=0.80
+      - INGEST_DISABLE_DYNAMIC_SCALING=${INGEST_DISABLE_DYNAMIC_SCALING:-false}
+      - RAY_num_grpc_threads=1
+      # Dynamic Memory Scaling Configuration
+      # - INGEST_DISABLE_DYNAMIC_SCALING=true # Disable dynamic scaling and use static worker count
+      # - INGEST_DYNAMIC_MEMORY_KP=0.2
+      # - INGEST_DYNAMIC_MEMORY_KI=0.01
+      # - INGEST_DYNAMIC_MEMORY_EMA_ALPHA=0.1
+      # - INGEST_DYNAMIC_MEMORY_TARGET_QUEUE_DEPTH=0
+      # - INGEST_DYNAMIC_MEMORY_PENALTY_FACTOR=0.1
+      # - INGEST_DYNAMIC_MEMORY_ERROR_BOOST_FACTOR=1.5
+      # - INGEST_DYNAMIC_MEMORY_RCM_MEMORY_SAFETY_BUFFER_FRACTION=0.15
+      # - INSTALL_AUDIO_EXTRACTION_DEPS=true
+      # Message client for development
+      #- MESSAGE_CLIENT_HOST=0.0.0.0
+      #- MESSAGE_CLIENT_PORT=7671
+      #- MESSAGE_CLIENT_TYPE=simple # Configure the ingest service to use the simple broker
+      # Message client for production
+      - MESSAGE_CLIENT_HOST=redis
+      - MESSAGE_CLIENT_PORT=6379
+      - MESSAGE_CLIENT_TYPE=redis
+      - MINIO_BUCKET=${MINIO_BUCKET:-nv-ingest}
+      # build.nvidia.com hosted nemoretriever-parse
+      # - NEMORETRIEVER_PARSE_HTTP_ENDPOINT=https://integrate.api.nvidia.com/v1/chat/completions
+      - NEMORETRIEVER_PARSE_HTTP_ENDPOINT=http://nemoretriever-parse:8000/v1/chat/completions
+      - NEMORETRIEVER_PARSE_INFER_PROTOCOL=http
+      #- NEMORETRIEVER_PARSE_MODEL_NAME=nvidia/nemoretriever-parse
+      - NGC_API_KEY=${NGC_API_KEY:-ngcapikey}
+      - NVIDIA_API_KEY=${NVIDIA_API_KEY:-${NGC_API_KEY:-ngcapikey}}
+      - NV_INGEST_MAX_UTIL=${NV_INGEST_MAX_UTIL:-48}
+      - OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317
+      # Self-hosted ocr endpoints.
+      - OCR_GRPC_ENDPOINT=ocr:8001
+      - OCR_HTTP_ENDPOINT=http://ocr:8000/v1/infer
+      - OCR_INFER_PROTOCOL=grpc
+      - OCR_MODEL_NAME=${OCR_MODEL_NAME:-paddle}
+      # build.nvidia.com hosted ocr endpoints.
+      #- OCR_HTTP_ENDPOINT=https://ai.api.nvidia.com/v1/cv/baidu/paddleocr
+      #- OCR_INFER_PROTOCOL=http
+      - REDIS_INGEST_TASK_QUEUE=ingest_task_queue
+      # Self-hosted redis endpoints.
+      - YOLOX_PAGE_IMAGE_FORMAT=JPEG # JPG is faster than PNG
+      - YOLOX_GRPC_ENDPOINT=page-elements:8001
+      - YOLOX_HTTP_ENDPOINT=http://page-elements:8000/v1/infer
+      - YOLOX_INFER_PROTOCOL=grpc
+      # build.nvidia.com hosted endpoints.
+      #- YOLOX_HTTP_ENDPOINT=https://ai.api.nvidia.com/v1/cv/nvidia/nv-yolox-page-elements-v1
+      #- YOLOX_INFER_PROTOCOL=http
+      - YOLOX_GRAPHIC_ELEMENTS_GRPC_ENDPOINT=graphic-elements:8001
+      - YOLOX_GRAPHIC_ELEMENTS_HTTP_ENDPOINT=http://graphic-elements:8000/v1/infer
+      - YOLOX_GRAPHIC_ELEMENTS_INFER_PROTOCOL=grpc
+      - YOLOX_TABLE_STRUCTURE_GRPC_ENDPOINT=table-structure:8001
+      - YOLOX_TABLE_STRUCTURE_HTTP_ENDPOINT=http://table-structure:8000/v1/infer
+      - YOLOX_TABLE_STRUCTURE_INFER_PROTOCOL=grpc
+      - VLM_CAPTION_ENDPOINT=http://vlm:8000/v1/chat/completions
+      - VLM_CAPTION_MODEL_NAME=nvidia/llama-3.1-nemotron-nano-vl-8b-v1
+      - MODEL_PREDOWNLOAD_PATH=${MODEL_PREDOWNLOAD_PATH:-/workspace/models/}
 
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.91.0

--- a/docker/scripts/entrypoint-rest-api.sh
+++ b/docker/scripts/entrypoint-rest-api.sh
@@ -20,8 +20,6 @@
 # Activate the `nv_ingest_runtime` conda environment
 
 set -e
-. /opt/conda/etc/profile.d/conda.sh
-conda activate nv_ingest_runtime
 
 # Source "source" file if it exists
 SRC_FILE="/opt/docker/bin/entrypoint_source"
@@ -82,19 +80,15 @@ else
         _gunicorn_access_logformat=''
     fi
 
-    # --- Launch Services ---
-
-    if [ "${MESSAGE_CLIENT_TYPE}" != "simple" ]; then
-        # Start gunicorn if MESSAGE_CLIENT_TYPE is not 'simple'.
-        gunicorn nv_ingest.api.main:app \
-            -w 32 \
-            -k uvicorn.workers.UvicornWorker \
-            --bind 0.0.0.0:7670 \
-            --timeout 300 \
-            --log-level "${_log_level}" \
-            --access-logfile "${_gunicorn_access_logfile}" \
-            --access-logformat "${_gunicorn_access_logformat}" \
-            --error-logfile - &
-    fi
+    # --- Launch nv-ingest-rest-api ---
+    gunicorn nv_ingest.api.main:app \
+        -w 32 \
+        -k uvicorn.workers.UvicornWorker \
+        --bind 0.0.0.0:7670 \
+        --timeout 300 \
+        --log-level "${_log_level}" \
+        --access-logfile "${_gunicorn_access_logfile}" \
+        --access-logformat "${_gunicorn_access_logformat}" \
+        --error-logfile -
 
 fi

--- a/docker/scripts/entrypoint-rest-api.sh
+++ b/docker/scripts/entrypoint-rest-api.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#!/bin/bash
+
+# Activate the `nv_ingest_runtime` conda environment
+
+set -e
+. /opt/conda/etc/profile.d/conda.sh
+conda activate nv_ingest_runtime
+
+# Source "source" file if it exists
+SRC_FILE="/opt/docker/bin/entrypoint_source"
+[ -f "${SRC_FILE}" ] && . "${SRC_FILE}"
+
+SRC_EXT="/workspace/docker/entrypoint_source_ext.sh"
+[ -f "${SRC_EXT}" ] && . "${SRC_EXT}"
+
+# Determine edge buffer size (default: 32)
+EDGE_BUFFER_SIZE="${INGEST_EDGE_BUFFER_SIZE:-32}"
+
+# Determine ingest config path, if exists and is a valid file.
+if [ -n "${INGEST_CONFIG_PATH}" ] && [ -f "${INGEST_CONFIG_PATH}" ]; then
+    CONFIG_ARG="--ingest_config_path=${INGEST_CONFIG_PATH}"
+else
+    CONFIG_ARG=""
+fi
+
+# Check if INGEST_MEM_TRACE is set to 1, true, on, or yes (case-insensitive)
+MEM_TRACE=false
+if [ -n "${INGEST_MEM_TRACE}" ]; then
+    case "$(echo "${INGEST_MEM_TRACE}" | tr '[:upper:]' '[:lower:]')" in
+        1|true|on|yes)
+            MEM_TRACE=true
+            ;;
+    esac
+fi
+
+# Check if user supplied a command
+if [ "$#" -gt 0 ]; then
+    # If a command is provided, run it.
+    exec "$@"
+else
+    # Normalize log level: default to 'info' if INGEST_LOG_LEVEL is 'DEFAULT'
+    _log_level=$(echo "${INGEST_LOG_LEVEL:-info}" | tr '[:upper:]' '[:lower:]')
+    if [ "$_log_level" = "default" ]; then
+        _log_level="warning"
+    fi
+
+    # --- Determine if access logs should be enabled ---
+    _access_logs_enabled="false"
+
+    # Normalize INGEST_ENABLE_SERVICE_ACCESS_LOGS to lower case
+    _explicit_access_logs=$(echo "${INGEST_ENABLE_SERVICE_ACCESS_LOGS:-false}" | tr '[:upper:]' '[:lower:]')
+
+    if [ "$_log_level" = "debug" ]; then
+        _access_logs_enabled="true"
+    elif [ "$_explicit_access_logs" = "true" ] || [ "$_explicit_access_logs" = "1" ] || [ "$_explicit_access_logs" = "yes" ]; then
+        _access_logs_enabled="true"
+    fi
+
+    # Set gunicorn access log settings
+    if [ "$_access_logs_enabled" = "true" ]; then
+        _gunicorn_access_logfile="-"
+        _gunicorn_access_logformat='default'
+    else
+        _gunicorn_access_logfile="/dev/null"
+        _gunicorn_access_logformat=''
+    fi
+
+    # --- Launch Services ---
+
+    if [ "${MESSAGE_CLIENT_TYPE}" != "simple" ]; then
+        # Start gunicorn if MESSAGE_CLIENT_TYPE is not 'simple'.
+        gunicorn nv_ingest.api.main:app \
+            -w 32 \
+            -k uvicorn.workers.UvicornWorker \
+            --bind 0.0.0.0:7670 \
+            --timeout 300 \
+            --log-level "${_log_level}" \
+            --access-logfile "${_gunicorn_access_logfile}" \
+            --access-logformat "${_gunicorn_access_logformat}" \
+            --error-logfile - &
+    fi
+
+fi

--- a/docker/scripts/entrypoint-worker.sh
+++ b/docker/scripts/entrypoint-worker.sh
@@ -82,20 +82,7 @@ else
         _gunicorn_access_logformat=''
     fi
 
-    # --- Launch Services ---
-
-    if [ "${MESSAGE_CLIENT_TYPE}" != "simple" ]; then
-        # Start gunicorn if MESSAGE_CLIENT_TYPE is not 'simple'.
-        gunicorn nv_ingest.api.main:app \
-            -w 32 \
-            -k uvicorn.workers.UvicornWorker \
-            --bind 0.0.0.0:7670 \
-            --timeout 300 \
-            --log-level "${_log_level}" \
-            --access-logfile "${_gunicorn_access_logfile}" \
-            --access-logformat "${_gunicorn_access_logformat}" \
-            --error-logfile - &
-    fi
+    # --- Launch nv-ingest-worker ---
 
     if [ "${MEM_TRACE}" = true ]; then
         # Run the entrypoint wrapped in memray

--- a/docker/scripts/entrypoint-worker.sh
+++ b/docker/scripts/entrypoint-worker.sh
@@ -20,8 +20,6 @@
 # Activate the `nv_ingest_runtime` conda environment
 
 set -e
-. /opt/conda/etc/profile.d/conda.sh
-conda activate nv_ingest_runtime
 
 # Source "source" file if it exists
 SRC_FILE="/opt/docker/bin/entrypoint_source"

--- a/docs/docs/extraction/nv-ingest_cli.md
+++ b/docs/docs/extraction/nv-ingest_cli.md
@@ -22,9 +22,9 @@ nv-ingest-cli --help
 
 ## Examples
 
-Use the following code examples to submit a document to the `nv-ingest-ms-runtime` service.
+Use the following code examples to submit a document to the `nv-ingest-rest-api` service.
 
-Each of the following commands can be run from the host machine, or from within the `nv-ingest-ms-runtime` container.
+Each of the following commands can be run from the host machine, or from within the `nv-ingest-rest-api` container.
 
 - Host: `nv-ingest-cli ...`
 - Container: `nv-ingest-cli ...`

--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -89,7 +89,7 @@ If you prefer, you can run on Kubernetes by using [our Helm chart](https://githu
 
     ```
     CONTAINER ID  IMAGE                                            COMMAND                 CREATED         STATUS                  PORTS            NAMES
-    1b885f37c991  nvcr.io/nvidia/nemo-microservices/nv-ingest:...  "/opt/conda/envs/nv_…"  3 minutes ago   Up 3 minutes (healthy)  0.0.0.0:7670...  nv-ingest-nv-ingest-ms-runtime-1
+    1b885f37c991  nvcr.io/nvidia/nemo-microservices/nv-ingest:...  "/opt/conda/envs/nv_…"  3 minutes ago   Up 3 minutes (healthy)  0.0.0.0:7670...  nv-ingest-nv-ingest-rest-api-1
     62c6b999c413  zilliz/attu:...                                  "docker-entrypoint.s…"  13 minutes ago  Up 3 minutes            0.0.0.0:3001...  milvus-attu
     14ef31ed7f49  milvusdb/milvus:...                              "/tini -- milvus run…"  13 minutes ago  Up 3 minutes (healthy)  0.0.0.0:9091...  milvus-standalone
     dceaf36cc5df  otel/opentelemetry-collector-contrib:...         "/otelcol-contrib --…"  13 minutes ago  Up 3 minutes            0.0.0.0:4317...  nv-ingest-otel-collector-1
@@ -126,7 +126,7 @@ pip install nv-ingest-client==2025.3.10.dev20250310
 
 !!! note
 
-    Interacting from the host depends on the appropriate port being exposed from the nv-ingest container to the host as defined in [docker-compose.yaml](https://github.com/NVIDIA/nv-ingest/blob/main/docker-compose.yaml#L141). If you prefer, you can disable exposing that port and interact with the NV-Ingest service directly from within its container. To interact within the container run `docker exec -it nv-ingest-nv-ingest-ms-runtime-1 bash`. You'll be in the `/workspace` directory with `DATASET_ROOT` from the .env file mounted at `./data`. The pre-activated `nv_ingest_runtime` conda environment has all the Python client libraries pre-installed and you should see `(nv_ingest_runtime) root@aba77e2a4bde:/workspace#`. From the bash prompt above, you can run the nv-ingest-cli and Python examples described following.
+    Interacting from the host depends on the appropriate port being exposed from the nv-ingest container to the host as defined in [docker-compose.yaml](https://github.com/NVIDIA/nv-ingest/blob/main/docker-compose.yaml#L141). If you prefer, you can disable exposing that port and interact with the NV-Ingest service directly from within its container. To interact within the container run `docker exec -it nv-ingest-nv-ingest-rest-api-1 bash`. You'll be in the `/workspace` directory with `DATASET_ROOT` from the .env file mounted at `./data`. The pre-activated `nv_ingest_runtime` conda environment has all the Python client libraries pre-installed and you should see `(nv_ingest_runtime) root@aba77e2a4bde:/workspace#`. From the bash prompt above, you can run the nv-ingest-cli and Python examples described following.
 
 
 ## Step 3: Ingesting Documents

--- a/skaffold/nv-ingest.skaffold.yaml
+++ b/skaffold/nv-ingest.skaffold.yaml
@@ -14,7 +14,7 @@ build:
     inputDigest: {}
   artifacts:
     # any reference to this image name in our manifests will be replaced by our newly build artifact
-    - image: nv-ingest-ms-runtime
+    - image: nv-ingest-rest-api
       # docker build context
       context: ./
       # docker builder details
@@ -81,7 +81,7 @@ portForward:
     address: 0.0.0.0
     localPort: 8000
   - resourceType: Service
-    resourceName: nv-ingest-ms-runtime
+    resourceName: nv-ingest-rest-api
     port: 7670
     address: 0.0.0.0
     localPort: 7670


### PR DESCRIPTION
## Description
This PR splits the monolithic nv-ingest-ms-runtime service into 2 separate, and new, services.

- nv-ingest-rest-api
- nv-ingest-worker

The driver for this change is several things.

- Scalability. The REST API and worker services can be independently scaled to allow for more fine grained control of traffic
- Canary releases where worker components can be individually upgraded in production while leaving REST API services live
- Ease reverse proxy setups in Helm

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
