### PR TITLE
Fix threshold parameter in vdb_upload

### DIFF
--- a/client/src/nv_ingest_client/util/vdb/milvus.py
+++ b/client/src/nv_ingest_client/util/vdb/milvus.py
@@ -1865,6 +1865,7 @@ class Milvus(VDB):
         meta_source_field: str = None,
         meta_fields: list[str] = None,
         stream: bool = False,
+        threshold: int = 1000,
         **kwargs,
     ):
         """


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Previously the vdb_upload task would ignore the threshold parameter. This fixes that issue

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
