### PR TITLE
docs: Updates including return_failures edit, Overview addition, html(markdown), and 400 MB Relnote (25.9.0-RC1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ NeMo Retriever Extraction supports the following file types:
 
 - `bmp`
 - `docx`
-- `html` (treated as text)
+- `html` (converted to markdown format)
 - `jpeg`
 - `json` (treated as text)
 - `md` (treated as text)
@@ -172,9 +172,16 @@ ingestor = (
 
 print("Starting ingestion..")
 t0 = time.time()
-results = ingestor.ingest(show_progress=True)
+
+# Return both successes and failures
+# Use for large batches where you want successful chunks/pages to be committed, while collecting detailed diagnostics for failures.
+results, failures = ingestor.ingest(show_progress=True, return_failures=True)
+
+# Return only successes
+# results = ingestor.ingest(show_progress=True)
+
 t1 = time.time()
-print(f"Time taken: {t1 - t0} seconds")
+print(f"Total time: {t1 - t0} seconds")
 
 # results blob is directly inspectable
 print(ingest_json_results_to_blob(results[0]))
@@ -184,7 +191,7 @@ You can see the extracted text that represents the content of the ingested test 
 
 ```shell
 Starting ingestion..
-Time taken: 9.243880033493042 seconds
+Total time: 9.243880033493042 seconds
 
 TestingDocument
 A sample document with headings and placeholder text

--- a/docs/docs/extraction/audio.md
+++ b/docs/docs/extraction/audio.md
@@ -136,6 +136,6 @@ Instead of running NV-Ingest locally, you can use NVCF to perform inference by u
 
 ## Related Topics
 
-- [Support Matrix](support-matrix.md).
-- [Troubleshoot Nemo Retriever Extraction](troubleshoot.md).
-- [Use the NV-Ingest Python API](nv-ingest-python-api.md).
+- [Support Matrix](support-matrix.md)
+- [Troubleshoot Nemo Retriever Extraction](troubleshoot.md)
+- [Use the NV-Ingest Python API](nv-ingest-python-api.md)

--- a/docs/docs/extraction/data-store.md
+++ b/docs/docs/extraction/data-store.md
@@ -20,7 +20,6 @@ It does not store the embeddings for images.
 
 NeMo Retriever extraction supports uploading data by using the [Ingestor.vdb_upload API](nv-ingest-python-api.md). 
 Currently, data upload is not supported through the [NV Ingest CLI](nv-ingest_cli.md).
- 
 
 
 ## Upload to Milvus
@@ -40,7 +39,11 @@ You can delete all collections by deleting that volume, and then restarting the 
 
     When you use the `vdb_upload` task with Milvus, you must expose the ports for the Milvus and MinIO containers to the nv-ingest client. This ensures that the nv-ingest client can connect to both services and perform the `vdb_upload` action.
 
-To upload to Milvus, use code similar to the following.
+!!! tip
+
+    When you use the `vdb_upload` method, the behavior of the upload depends on the `return_failures` parameter of the `ingest` method. For details, refer to [Capture Job Failures](nv-ingest-python-api.md#capture-job-failures).
+
+To upload to Milvus, use code similar to the following to define your `Ingestor`.
 
 ```python
 Ingestor(client=client)
@@ -72,3 +75,10 @@ NeMo Retriever extraction does not provide connections to other data sources.
     NVIDIA makes no claim about accuracy, performance, or functionality of any vector database except Milvus. If you use a different vector database, it's your responsibility to test and maintain it.
 
 For more information, refer to [Build a Custom Vector Database Operator](https://github.com/NVIDIA/nv-ingest/blob/main/examples/building_vdb_operator.ipynb).
+
+
+
+## Related Topics
+
+- [Use the NeMo Retriever Extraction Python API](nv-ingest-python-api.md)
+- [Troubleshoot Nemo Retriever Extraction](troubleshoot.md)

--- a/docs/docs/extraction/nemoretriever-parse.md
+++ b/docs/docs/extraction/nemoretriever-parse.md
@@ -104,6 +104,6 @@ Instead of running NV-Ingest locally, you can use NVCF to perform inference by u
 
 ## Related Topics
 
-- [Support Matrix](support-matrix.md).
-- [Troubleshoot Nemo Retriever Extraction](troubleshoot.md).
-- [Use the NV-Ingest Python API](nv-ingest-python-api.md).
+- [Support Matrix](support-matrix.md)
+- [Troubleshoot Nemo Retriever Extraction](troubleshoot.md)
+- [Use the NV-Ingest Python API](nv-ingest-python-api.md)

--- a/docs/docs/extraction/nv-ingest-python-api.md
+++ b/docs/docs/extraction/nv-ingest-python-api.md
@@ -53,7 +53,7 @@ Use the following code.
 # Return both successes and failures
 results, failures = ingestor.ingest(show_progress=True, return_failures=True)
 
-print(len(results), "successful documents")
+print(f"{len(results)} successful docs; {len(failures)} failures")
 
 if failures:
     print("Failures:", failures[:1])

--- a/docs/docs/extraction/nv-ingest-python-api.md
+++ b/docs/docs/extraction/nv-ingest-python-api.md
@@ -29,6 +29,65 @@ The following table describes methods of the `Ingestor` class.
 | `vdb_upload` | Pushes extraction results to Milvus vector database. For more information, refer to [Data Upload](data-store.md). |
 
 
+
+## Track Job Progress
+
+For large document batches, you can enable a progress bar by setting `show_progress` to true. 
+Use the following code.
+
+```python
+# Return only successes
+results = ingestor.ingest(show_progress=True)
+
+print(len(results), "successful documents")
+```
+
+
+
+## Capture Job Failures
+
+You can capture job failures by setting `return_failures` to true. 
+Use the following code.
+
+```python
+# Return both successes and failures
+results, failures = ingestor.ingest(show_progress=True, return_failures=True)
+
+print(len(results), "successful documents")
+
+if failures:
+    print("Failures:", failures[:1])
+```
+
+When you use the `vdb_upload` method, uploads are performed after ingestion completes. 
+The behavior of the upload depends on the following values of `return_failures`:
+
+- **return_failures=False** – If any job fails, the `ingest` method raises a runtime error and does not upload any data (all-or-nothing data upload). This is the default setting.
+- **return_failures=True** – If any jobs succeed, the results from those jobs are uploaded, and no errors are raised (partial data upload). The `ingest()` method returns a failures object that contains the details for any jobs that failed. You can inspect the failures object and selectively retry or remediate the failed jobs.
+
+
+The following example uploads data to Milvus and returns any failures.
+
+```python
+ingestor = (
+    Ingestor(client=client)
+    .files(["/path/doc1.pdf", "/path/doc2.pdf"])
+    .extract()
+    .embed()
+    .vdb_upload(collection_name="my_collection", milvus_uri="milvus.db")
+)
+
+# Use for large batches where you want successful chunks/pages to be committed, while collecting detailed diagnostics for failures.
+results, failures = ingestor.ingest(return_failures=True)
+
+print(f"Uploaded {len(results)} successful docs; {len(failures)} failures")
+
+if failures:
+    print("Failures:", failures[:1])
+```
+
+
+
 ## Quick Start: Extracting PDFs
 
 The following example demonstrates how to initialize `Ingestor`, load a PDF file, and extract its contents.
@@ -82,7 +141,7 @@ ingestor = ingestor.extract(
 
 ### Extract Non-standard Document Types
 
-NV-Ingest also supports extracting text from `.md`, `.sh`, and `.html` files
+Use the following code to extract text from `.md`, `.sh`, and `.html` files.
 
 ```python
 ingestor = Ingestor().files(["path/to/doc1.md", "path/to/doc2.html"])
@@ -105,17 +164,6 @@ Use the following code to specify a custom document type for extraction.
 
 ```python
 ingestor = ingestor.extract(document_type="pdf")
-```
-
-
-
-## Track Job Progress
-
-For large document batches, you can enable a progress bar by setting `show_progress` to true. 
-Use the following code.
-
-```python
-result = ingestor.extract().ingest(show_progress=True)
 ```
 
 
@@ -200,7 +248,7 @@ results = ingestor.ingest()
 ## Related Topics
 
 - [Split Documents](chunking.md)
-- [Troubleshoot Nemo Retriever Extraction](troubleshoot.md).
+- [Troubleshoot Nemo Retriever Extraction](troubleshoot.md)
 - [Use Nemo Retriever Extraction with nemoretriever-parse](nemoretriever-parse.md)
 - [Use NeMo Retriever Extraction with Riva for Audio Processing](nemoretriever-parse.md)
 - [Use Multimodal Embedding](vlm-embed.md)

--- a/docs/docs/extraction/nv-ingest-python-api.md
+++ b/docs/docs/extraction/nv-ingest-python-api.md
@@ -62,8 +62,8 @@ if failures:
 When you use the `vdb_upload` method, uploads are performed after ingestion completes. 
 The behavior of the upload depends on the following values of `return_failures`:
 
-- **return_failures=False** – If any job fails, the `ingest` method raises a runtime error and does not upload any data (all-or-nothing data upload). This is the default setting.
-- **return_failures=True** – If any jobs succeed, the results from those jobs are uploaded, and no errors are raised (partial data upload). The `ingest()` method returns a failures object that contains the details for any jobs that failed. You can inspect the failures object and selectively retry or remediate the failed jobs.
+- **False** – If any job fails, the `ingest` method raises a runtime error and does not upload any data (all-or-nothing data upload). This is the default setting.
+- **True** – If any jobs succeed, the results from those jobs are uploaded, and no errors are raised (partial data upload). The `ingest` method returns a failures object that contains the details for any jobs that failed. You can inspect the failures object and selectively retry or remediate the failed jobs.
 
 
 The following example uploads data to Milvus and returns any failures.

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -35,7 +35,7 @@ NeMo Retriever extraction supports the following file types:
 
 - `bmp`
 - `docx`
-- `html` (treated as text)
+- `html` (converted to markdown format)
 - `jpeg`
 - `json` (treated as text)
 - `md` (treated as text)

--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -133,7 +133,7 @@ pip install nv-ingest-client==2025.3.10.dev20250310
 
 You can submit jobs programmatically in Python or using the [NV-Ingest CLI](nv-ingest_cli.md).
 
-In the below examples, we are doing text, chart, table, and image extraction:
+In the following examples, we do text, chart, table, and image extraction.
 
 - **extract_text** — Uses [PDFium](https://github.com/pypdfium2-team/pypdfium2/) to find and extract text from pages.
 - **extract_images** — Uses [PDFium](https://github.com/pypdfium2-team/pypdfium2/) to extract images.
@@ -177,13 +177,25 @@ ingestor = (
         dense_dim=2048
     )
 )
+
 print("Starting ingestion..")
 t0 = time.time()
-results = ingestor.ingest()
+
+# Return both successes and failures
+# Use for large batches where you want successful chunks/pages to be committed, while collecting detailed diagnostics for failures.
+results, failures = ingestor.ingest(show_progress=True, return_failures=True)
+
+# Return only successes
+# results = ingestor.ingest(show_progress=True)
+
 t1 = time.time()
-print(f"Time taken: {t1-t0} seconds")
+print(f"Total time: {t1-t0} seconds")
+
 # results blob is directly inspectable
 print(ingest_json_results_to_blob(results[0]))
+
+if failures:
+    print(f"There were {len(failures)} failures. Sample: {failures[0]}")
 ```
 
 !!! note
@@ -191,11 +203,13 @@ print(ingest_json_results_to_blob(results[0]))
     To use library mode with nemoretriever_parse, uncomment `extract_method="nemoretriever_parse"` in the previous code. For more information, refer to [Use Nemo Retriever Extraction with nemoretriever-parse](nemoretriever-parse.md).
 
 
+The output looks similar to the following.
+
 ```
 Starting ingestion..
 1 records to insert to milvus
 logged 8 records
-Time taken: 5.479151725769043 seconds
+Total time: 5.479151725769043 seconds
 This chart shows some gadgets, and some very fictitious costs. Gadgets and their cost   Chart 1 - Hammer - Powerdrill - Bluetooth speaker - Minifridge - Premium desk fan Dollars $- - $20.00 - $40.00 - $60.00 - $80.00 - $100.00 - $120.00 - $140.00 - $160.00 Cost
 Table 1
 | This table describes some animals, and some activities they might be doing in specific locations. | This table describes some animals, and some activities they might be doing in specific locations. | This table describes some animals, and some activities they might be doing in specific locations. |
@@ -282,7 +296,8 @@ nv-ingest-cli \
   --client_port=7670
 ```
 
-You should notice output indicating document processing status followed by a breakdown of time spent during job execution:
+You should see output that indicates the document processing status followed by a breakdown of time spent during job execution.
+
 ```
 None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
 [nltk_data] Downloading package punkt_tab to

--- a/docs/docs/extraction/quickstart-library-mode.md
+++ b/docs/docs/extraction/quickstart-library-mode.md
@@ -131,12 +131,22 @@ ingestor = (
 
 print("Starting ingestion..")
 t0 = time.time()
-results = ingestor.ingest(show_progress=True)
+
+# Return both successes and failures
+# Use for large batches where you want successful chunks/pages to be committed, while collecting detailed diagnostics for failures.
+results, failures = ingestor.ingest(show_progress=True, return_failures=True)
+
+# Return only successes
+# results = ingestor.ingest(show_progress=True)
+
 t1 = time.time()
-print(f"Time taken: {t1 - t0} seconds")
+print(f"Total time: {t1 - t0} seconds")
 
 # results blob is directly inspectable
 print(ingest_json_results_to_blob(results[0]))
+
+if failures:
+    print(f"There were {len(failures)} failures. Sample: {failures[0]}")
 ```
 
 !!! note
@@ -147,7 +157,7 @@ You can see the extracted text that represents the content of the ingested test 
 
 ```shell
 Starting ingestion..
-Time taken: 9.243880033493042 seconds
+Total time: 9.243880033493042 seconds
 
 TestingDocument
 A sample document with headings and placeholder text

--- a/docs/docs/extraction/releasenotes-nv-ingest.md
+++ b/docs/docs/extraction/releasenotes-nv-ingest.md
@@ -28,7 +28,7 @@ The NeMo Retriever extraction 25.09 release adds new hardware and software suppo
 
 ### Known Issues
 
-The following are the know issues for this release:
+The following are the known issues for this release:
 
 - A10G is not supported. For details, refer to [Support Matrix](support-matrix.md).
 - `nemoretriever-parse` is not supported on RTX Pro 6000 or B200. For details, refer to [Support Matrix](support-matrix.md).
@@ -58,7 +58,7 @@ The previously released 25.6.2 container on NGC remains unchanged.
 
 ### Known Issues
 
-The following are the know issues for this release:
+The following are the known issues for this release:
 
 - The NeMo Retriever extraction pipeline does not support ingestion of batches that include individual files greater than approximately 400MB.
 
@@ -80,7 +80,7 @@ The NeMo Retriever extraction 25.06 release focuses on accuracy improvements and
 
 ### Known Issues
 
-The following are the know issues for this release:
+The following are the known issues for this release:
 
 - The NeMo Retriever extraction pipeline does not support ingestion of batches that include individual files greater than approximately 400MB.
 

--- a/docs/docs/extraction/releasenotes-nv-ingest.md
+++ b/docs/docs/extraction/releasenotes-nv-ingest.md
@@ -30,7 +30,7 @@ The NeMo Retriever extraction 25.09 release adds new hardware and software suppo
 
 The following are the known issues for this release:
 
-- A10G is not supported. For details, refer to [Support Matrix](support-matrix.md).
+- A10G and L40S are not supported. For details, refer to [Support Matrix](support-matrix.md).
 - `nemoretriever-parse` is not supported on RTX Pro 6000 or B200. For details, refer to [Support Matrix](support-matrix.md).
 - The NeMo Retriever extraction pipeline does not support ingestion of batches that include individual files greater than approximately 400MB.
 

--- a/docs/docs/extraction/releasenotes-nv-ingest.md
+++ b/docs/docs/extraction/releasenotes-nv-ingest.md
@@ -8,9 +8,9 @@ This documentation contains the release notes for [NeMo Retriever extraction](ov
 
 
 
-## Release 25.8.0
+## Release 25.09 (25.9.0)
 
-The NeMo Retriever extraction 25.8.0 release adds new hardware and software support, and other improvements, including the following:
+The NeMo Retriever extraction 25.09 release adds new hardware and software support, and other improvements, including the following:
 
 - Add functional support for [RTX Pro 6000](https://www.nvidia.com/en-us/products/workstations/professional-desktop-gpus/rtx-pro-6000/).
 - Add functional support for [DGX B200](https://www.nvidia.com/en-us/data-center/dgx-b200/).
@@ -25,17 +25,20 @@ The NeMo Retriever extraction 25.8.0 release adds new hardware and software supp
 - Add support for Integer, float, boolean, and array in custom metadata during Milvus entity creation.
 - Add support for running more than one VLM at a time by using Helm.  For details, refer to [NV-Ingest Helm Charts](https://github.com/nkmcalli/nv-ingest/tree/main/helm).
 
+
 ### Known Issues
 
 The following are the know issues for this release:
 
 - A10G is not supported. For details, refer to [Support Matrix](support-matrix.md).
 - `nemoretriever-parse` is not supported on RTX Pro 6000 or B200. For details, refer to [Support Matrix](support-matrix.md).
+- The NeMo Retriever extraction pipeline does not support ingestion of batches that include individual files greater than approximately 400MB.
 
 
 ### Breaking Changes
 
 There are no breaking changes in this version.
+
 
 ### Upgrade
 
@@ -53,6 +56,13 @@ Only the release branch and the `nv-ingest-client` package have been updated in 
 The previously released 25.6.2 container on NGC remains unchanged.
 
 
+### Known Issues
+
+The following are the know issues for this release:
+
+- The NeMo Retriever extraction pipeline does not support ingestion of batches that include individual files greater than approximately 400MB.
+
+
 
 ## Release 25.6.2
 
@@ -68,9 +78,17 @@ The NeMo Retriever extraction 25.06 release focuses on accuracy improvements and
 - New notebook for [How to add metadata to your documents and filter searches](https://github.com/NVIDIA/nv-ingest/blob/release/25.6.2/examples/metadata_and_filtered_search.ipynb).
 
 
+### Known Issues
+
+The following are the know issues for this release:
+
+- The NeMo Retriever extraction pipeline does not support ingestion of batches that include individual files greater than approximately 400MB.
+
+
 ### Breaking Changes
 
 There are no breaking changes in this version.
+
 
 ### Upgrade
 

--- a/docs/docs/extraction/support-matrix.md
+++ b/docs/docs/extraction/support-matrix.md
@@ -57,7 +57,7 @@ The following are the hardware requirements to run NeMo Retriever extraction.
 
 !!! note
 
-    Release 25.09 does not support A10G hardware. For details, refer to [Release Notes](releasenotes-nv-ingest.md).
+    Release 25.09 does not support A10G and L40S hardware. For details, refer to [Release Notes](releasenotes-nv-ingest.md).
 
 
 

--- a/docs/docs/extraction/support-matrix.md
+++ b/docs/docs/extraction/support-matrix.md
@@ -57,7 +57,7 @@ The following are the hardware requirements to run NeMo Retriever extraction.
 
 !!! note
 
-    Release 25.08 does not support A10G hardware. For details, refer to [Release Notes](releasenotes-nv-ingest.md).
+    Release 25.09 does not support A10G hardware. For details, refer to [Release Notes](releasenotes-nv-ingest.md).
 
 
 

--- a/docs/docs/extraction/vlm-embed.md
+++ b/docs/docs/extraction/vlm-embed.md
@@ -122,6 +122,6 @@ results = ingestor.ingest()
 
 ## Related Topics
 
-- [Support Matrix](support-matrix.md).
-- [Troubleshoot Nemo Retriever Extraction](troubleshoot.md).
-- [Use the NV-Ingest Python API](nv-ingest-python-api.md).
+- [Support Matrix](support-matrix.md)
+- [Troubleshoot Nemo Retriever Extraction](troubleshoot.md)
+- [Use the NV-Ingest Python API](nv-ingest-python-api.md)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -2,7 +2,10 @@
 
 NVIDIA NeMo Retriever is a collection of microservices 
 for building and scaling multimodal data extraction, embedding, and reranking pipelines 
-with high accuracy and maximum data privacy – built with NVIDIA NIM.
+with high accuracy and maximum data privacy – built with NVIDIA NIM. 
+NeMo Retriever, part of the [NVIDIA NeMo](https://www.nvidia.com/en-us/ai-data-science/products/nemo/) software suite for managing the AI agent lifecycle, 
+ensures data privacy and seamlessly connects to proprietary data wherever it resides, 
+empowering secure, enterprise-grade retrieval.
 
 NeMo Retriever provides the following:
 


### PR DESCRIPTION
docs: Updates including return_failures edit, Overview addition, html(markdown), and 400 MB Relnote 

Same changes as #952 cherry-picked into 25.9.0-RC1