### PR TITLE
docs: Remove --build and edit OOM / save to disk content (25.9.0-RC2)

### DIFF
--- a/docs/docs/extraction/audio.md
+++ b/docs/docs/extraction/audio.md
@@ -68,10 +68,9 @@ Again, replace <your-ngc-key> with your actual NGC key.
 3. Start the nv-ingest services with the `audio` profile. This profile includes the necessary components for audio processing. Use the following command.
 
     - The `--profile audio` flag ensures that audio-specific services are launched. For more information, refer to [Profile Information](quickstart-guide.md#profile-information).
-    - The `--build` flag ensures that any changes to the container images are applied before starting.
 
     ```shell
-    docker compose --profile retrieval --profile audio up --build
+    docker compose --profile retrieval --profile audio up
     ```
 
 4. After the services are running, you can interact with nv-ingest by using Python.

--- a/docs/docs/extraction/nemoretriever-parse.md
+++ b/docs/docs/extraction/nemoretriever-parse.md
@@ -31,10 +31,9 @@ Use the following procedure to run the NIM locally.
 1. Start the nv-ingest services with the `nemoretriever-parse` profile. This profile includes the necessary components for extracting text and metadata from images. Use the following command.
 
     - The --profile nemoretriever-parse flag ensures that vision-language retrieval services are launched.  For more information, refer to [Profile Information](quickstart-guide.md#profile-information).
-    - The --build flag ensures that any changes to the container images are applied before starting.
 
     ```shell
-    docker compose --profile nemoretriever-parse up --build
+    docker compose --profile nemoretriever-parse up
     ```
 
 2. After the services are running, you can interact with nv-ingest by using Python.

--- a/docs/docs/extraction/nv-ingest-python-api.md
+++ b/docs/docs/extraction/nv-ingest-python-api.md
@@ -168,6 +168,93 @@ ingestor = ingestor.extract(document_type="pdf")
 
 
 
+## Work with Large Datasets: Save to Disk
+
+By default, NeMo Retriever extraction stores the results from every document in system memory (RAM). 
+When you process a very large dataset with thousands of documents, you might encounter an Out-of-Memory (OOM) error. 
+The `save_to_disk` method configures the extraction pipeline to write the output for each document to a separate JSONL file on disk.
+
+
+### Basic Usage: Save to a Directory
+
+To save results to disk, simply chain the `save_to_disk` method to your ingestion task.
+By using `save_to_disk` the `ingest` method returns a list of `LazyLoadedList` objects, 
+which are memory-efficient proxies that read from the result files on disk.
+
+In the following example, the results are saved to a directory named `my_ingest_results`. 
+You are responsible for managing the created files.
+
+```python
+ingestor = Ingestor().files("large_dataset/*.pdf")
+
+# Use save_to_disk to configure the ingestor to save results to a specific directory.
+# Set cleanup=False to ensure that the directory is not deleted by any automatic process.
+ingestor.save_to_disk(output_directory="./my_ingest_results", cleanup=False)  # Offload results to disk to prevent OOM errors
+
+# 'results' is a list of LazyLoadedList objects that point to the new jsonl files.
+results = ingestor.extract().ingest()
+
+print("Ingestion results saved in ./my_ingest_results")
+# You can now iterate over the results or inspect the files directly.
+```
+
+### Managing Disk Space with Automatic Cleanup
+
+When you use `save_to_disk`, NeMo Retriever extraction creates intermediate files. 
+For workflows where these files are temporary, NeMo Retriever extraction provides two automatic cleanup mechanisms.
+
+- **Directory Cleanup with Context Manager** — While not required for general use, the Ingestor can be used as a context manager (`with` statement). This enables the automatic cleanup of the entire output directory when `save_to_disk(cleanup=True)` is set (which is the default).
+
+- **File Purge After VDB Upload** – The `vdb_upload` method includes a `purge_results_after_upload: bool = True` parameter (the default). After a successful VDB upload, this feature deletes the individual `.jsonl` files that were just uploaded.
+
+You can also configure the output directory by using the `NV_INGEST_CLIENT_SAVE_TO_DISK_OUTPUT_DIRECTORY` environment variable.
+
+
+#### Example (Fully Automatic Cleanup)
+
+Fully Automatic cleanup is the recommended pattern for ingest-and-upload workflows where the intermediate files are no longer needed. 
+The entire process is temporary, and no files are left on disk.
+The following example includes automatic file purge. 
+
+```python
+# After the 'with' block finishes, 
+# the temporary directory and all its contents are automatically deleted.
+
+with (
+    Ingestor()
+    .files("/path/to/large_dataset/*.pdf")
+    .extract()
+    .embed()
+    .save_to_disk()  # cleanup=True is the default, enables directory deletion on exit
+    .vdb_upload()  # purge_results_after_upload=True is the default, deletes files after upload
+) as ingestor:
+    results = ingestor.ingest()
+
+```
+
+
+#### Example (Preserve Results on Disk)
+
+In scenarios where you need to inspect or use the intermediate `jsonl` files, you can disable the cleanup features. 
+The following example disables automatic file purge. 
+
+```python
+# After the 'with' block finishes, 
+# the './permanent_results' directory and all jsonl files are preserved for inspection or other uses.
+
+with (
+    Ingestor()
+    .files("/path/to/large_dataset/*.pdf")
+    .extract()
+    .embed()
+    .save_to_disk(output_directory="./permanent_results", cleanup=False)  # Specify a directory and disable directory-level cleanup
+    .vdb_upload(purge_results_after_upload=False)  # Disable automatic file purge after the VDB upload
+) as ingestor:
+    results = ingestor.ingest()
+```
+
+
+
 ## Extract Captions from Images
 
 The `caption` method generates image captions by using a vision-language model. 

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -45,6 +45,17 @@ ulimit -u 10,000
 
 
 
+## Out-of-Memory (OOM) Error when Processing Large Datasets
+
+When you process a very large dataset with thousands of documents, you might encounter an Out-of-Memory (OOM) error. 
+This happens because, by default, NeMo Retriever extraction stores the results from every document in system memory (RAM). 
+If the total size of the results exceeds the available memory, the process fails.
+
+To resolve this issue, use the `save_to_disk` method. 
+For details, refer to [Working with Large Datasets: Saving to Disk](nv-ingest-python-api.md#work-with-large-datasets-save-to-disk).
+
+
+
 ## Embedding service fails to start with an unsupported batch size error
 
 On certain hardware, for example RTX 6000, 


### PR DESCRIPTION
Remove --build and edit OOM / save to disk content (25.9.0-RC2)

(cherry picked from commit 9702c97ae52f4d5b5b524d78a9c1e9d0d8c90a16)

Includes edit for #975 