### PR TITLE
add flush streaming inserts

### DIFF
--- a/client/src/nv_ingest_client/util/vdb/milvus.py
+++ b/client/src/nv_ingest_client/util/vdb/milvus.py
@@ -903,6 +903,7 @@ def stream_insert_milvus(records, client: MilvusClient, collection_name: str, ba
     for idx in range(0, len(records), batch_size):
         client.insert(collection_name=collection_name, data=records[idx : idx + batch_size])
         count += len(records[idx : idx + batch_size])
+    client.flush(collection_name)
     logger.info(f"streamed {count} records")
 
 
@@ -923,6 +924,9 @@ def wait_for_index(collection_name: str, num_elements: int, client: MilvusClient
             for i in range(20):
                 new_indexed_rows = client.describe_index(collection_name, index_name)["indexed_rows"]
                 time.sleep(1)
+                logger.info(
+                    f"polling for indexed rows, {collection_name}, {index_name} -  {new_indexed_rows} / {num_elements}"
+                )
                 if new_indexed_rows == num_elements:
                     indexed_rows = new_indexed_rows
                     break


### PR DESCRIPTION
## Description
This PR solves a bug that was introduced in the new milvus streaming insert logic. Where if the user does not insert enough rows to start the flush process, all rows are kept in a growing segment that is never sealed. This causes the index row count to not grow and kept us in a loop when checking for updates index row count.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
