### PR TITLE
update prompt for VLM inference requests.

### DIFF
--- a/api/src/nv_ingest_api/internal/primitives/nim/model_interface/vlm.py
+++ b/api/src/nv_ingest_api/internal/primitives/nim/model_interface/vlm.py
@@ -93,7 +93,7 @@ class VLMModelInterface(ModelInterface):
         for batch in batches:
             # Create one message per image in the batch.
             messages = [
-                {"role": "user", "content": f'{prompt} <img src="data:image/png;base64,{img}" />'} for img in batch
+                {"role": "user","content": [{"type": "text","text": f"{prompt}"},{"type": "image_url","image_url": {"url": f"data:image/png;base64,{img}"}}]} for img in batch
             ]
             payload = {
                 "model": kwargs.get("model_name"),


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
Change prompt in vlm.py to send Image as a image_url type, not include as a string with prompt.
<!-- Reference any issues closed by this PR with "closes #1234". -->
Feature request: [#1030](https://github.com/NVIDIA/nv-ingest/issues/1030)
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
