### PR TITLE
remove llama index package

### DIFF
--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "click>=8.1.8",
     "fsspec>=2025.2.0",
     "httpx>=0.28.1",
-    "llama-index-embeddings-nvidia==0.1.5",
     "pydantic>2.0.0",
     "pydantic-settings>2.0.0",
     "requests>=2.28.2",


### PR DESCRIPTION
## Description
Now that we are no longer using the llama-index-nvidia-embeddings we can remove the package.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
