### PR TITLE
Update libmode example to reflect pipeline config changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,16 +124,13 @@ On a 4 CPU core low end laptop, the following code should take about 10 seconds.
 import logging, os, time
 
 from nv_ingest.framework.orchestration.ray.util.pipeline.pipeline_runners import run_pipeline
-from nv_ingest.framework.orchestration.ray.util.pipeline.pipeline_runners import PipelineCreationSchema
 from nv_ingest_api.util.logging.configuration import configure_logging as configure_local_logging
 from nv_ingest_client.client import Ingestor, NvIngestClient
 from nv_ingest_api.util.message_brokers.simple_message_broker import SimpleClient
 from nv_ingest_client.util.process_json_files import ingest_json_results_to_blob
 
 # Start the pipeline subprocess for library mode
-config = PipelineCreationSchema()
-
-run_pipeline(config, block=False, disable_dynamic_scaling=True, run_in_subprocess=True)
+run_pipeline(block=False, disable_dynamic_scaling=True, run_in_subprocess=True)
 
 client = NvIngestClient(
     message_client_allocator=SimpleClient,


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
By default the run_pipeline function now automatically pulls the default libmode env variables and overrides them with any env variables the user has set, so there's no longer a need to manually create a config object.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
