### PR TITLE
Add handling for scene_text_wrapper gRPC OCR model

### DIFF
--- a/api/src/nv_ingest_api/internal/extract/image/chart_extractor.py
+++ b/api/src/nv_ingest_api/internal/extract/image/chart_extractor.py
@@ -103,7 +103,7 @@ def _run_chart_inference(
             dtypes=["FP32", "BYTES"],
             merge_level="paragraph",
         )
-    elif ocr_model_name == "scene_text_ensemble":
+    elif ocr_model_name in {"scene_text_ensemble", "scene_text_wrapper"}:
         future_ocr_kwargs.update(
             model_name=ocr_model_name,
             input_names=["INPUT_IMAGE_URLS", "MERGE_LEVELS"],

--- a/api/src/nv_ingest_api/internal/extract/image/infographic_extractor.py
+++ b/api/src/nv_ingest_api/internal/extract/image/infographic_extractor.py
@@ -115,7 +115,7 @@ def _update_infographic_metadata(
             dtypes=["FP32", "BYTES"],
             merge_level="paragraph",
         )
-    elif ocr_model_name == "scene_text_ensemble":
+    elif ocr_model_name in {"scene_text_ensemble", "scene_text_wrapper"}:
         infer_kwargs.update(
             model_name=ocr_model_name,
             input_names=["INPUT_IMAGE_URLS", "MERGE_LEVELS"],

--- a/api/src/nv_ingest_api/internal/extract/image/table_extractor.py
+++ b/api/src/nv_ingest_api/internal/extract/image/table_extractor.py
@@ -103,7 +103,7 @@ def _run_inference(
             dtypes=["FP32", "BYTES"],
             merge_level="word",
         )
-    elif ocr_model_name == "scene_text_ensemble":
+    elif ocr_model_name in {"scene_text_ensemble", "scene_text_wrapper"}:
         future_ocr_kwargs.update(
             model_name=ocr_model_name,
             input_names=["INPUT_IMAGE_URLS", "MERGE_LEVELS"],


### PR DESCRIPTION
## Description
Adds handling for experimental gRPC `scene_text_wrapper` OCR model, which is equivalent to that of `scene_text_ensemble`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
