### PR TITLE
update prompt for VLM inference requests.

### DIFF
--- a/api/api_tests/internal/primitives/nim/model_interface/test_vlm.py
+++ b/api/api_tests/internal/primitives/nim/model_interface/test_vlm.py
@@ -144,8 +144,10 @@ class TestVLMModelInterface(unittest.TestCase):
             self.assertEqual(message["content"][0]["type"], "text")
             self.assertEqual(message["content"][0]["text"], self.sample_prompt)
             self.assertEqual(message["content"][1]["type"], "image_url")
-            self.assertEqual(message["content"][1]["image_url"]["url"], f"data:image/png;base64,{self.sample_images[i]}")
-            
+            self.assertEqual(
+                message["content"][1]["image_url"]["url"], f"data:image/png;base64,{self.sample_images[i]}"
+            )
+
         # Check batch data
         self.assertEqual(len(batch_data), 1)
         self.assertEqual(batch_data[0]["base64_images"], self.sample_images)

--- a/api/api_tests/internal/primitives/nim/model_interface/test_vlm.py
+++ b/api/api_tests/internal/primitives/nim/model_interface/test_vlm.py
@@ -101,8 +101,12 @@ class TestVLMModelInterface(unittest.TestCase):
         # Check message format
         message = payloads[0]["messages"][0]
         self.assertEqual(message["role"], "user")
-        self.assertTrue(self.sample_prompt in message["content"])
-        self.assertTrue(f'<img src="data:image/png;base64,{self.sample_image}"' in message["content"])
+        self.assertIsInstance(message["content"], list)
+        self.assertEqual(len(message["content"]), 2)
+        self.assertEqual(message["content"][0]["type"], "text")
+        self.assertEqual(message["content"][0]["text"], self.sample_prompt)
+        self.assertEqual(message["content"][1]["type"], "image_url")
+        self.assertEqual(message["content"][1]["image_url"]["url"], f"data:image/png;base64,{self.sample_image}")
 
         # Check default parameters
         self.assertEqual(payloads[0]["max_tokens"], 512)
@@ -135,9 +139,13 @@ class TestVLMModelInterface(unittest.TestCase):
         # Check each message
         for i, message in enumerate(messages):
             self.assertEqual(message["role"], "user")
-            self.assertTrue(self.sample_prompt in message["content"])
-            self.assertTrue(f'<img src="data:image/png;base64,{self.sample_images[i]}"' in message["content"])
-
+            self.assertIsInstance(message["content"], list)
+            self.assertEqual(len(message["content"]), 2)
+            self.assertEqual(message["content"][0]["type"], "text")
+            self.assertEqual(message["content"][0]["text"], self.sample_prompt)
+            self.assertEqual(message["content"][1]["type"], "image_url")
+            self.assertEqual(message["content"][1]["image_url"]["url"], f"data:image/png;base64,{self.sample_images[i]}")
+            
         # Check batch data
         self.assertEqual(len(batch_data), 1)
         self.assertEqual(batch_data[0]["base64_images"], self.sample_images)

--- a/api/src/nv_ingest_api/internal/primitives/nim/model_interface/vlm.py
+++ b/api/src/nv_ingest_api/internal/primitives/nim/model_interface/vlm.py
@@ -93,7 +93,14 @@ class VLMModelInterface(ModelInterface):
         for batch in batches:
             # Create one message per image in the batch.
             messages = [
-                {"role": "user","content": [{"type": "text","text": f"{prompt}"},{"type": "image_url","image_url": {"url": f"data:image/png;base64,{img}"}}]} for img in batch
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": f"{prompt}"},
+                        {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{img}"}},
+                    ],
+                }
+                for img in batch
             ]
             payload = {
                 "model": kwargs.get("model_name"),

--- a/api/src/nv_ingest_api/internal/primitives/nim/model_interface/vlm.py
+++ b/api/src/nv_ingest_api/internal/primitives/nim/model_interface/vlm.py
@@ -93,7 +93,7 @@ class VLMModelInterface(ModelInterface):
         for batch in batches:
             # Create one message per image in the batch.
             messages = [
-                {"role": "user", "content": f'{prompt} <img src="data:image/png;base64,{img}" />'} for img in batch
+                {"role": "user","content": [{"type": "text","text": f"{prompt}"},{"type": "image_url","image_url": {"url": f"data:image/png;base64,{img}"}}]} for img in batch
             ]
             payload = {
                 "model": kwargs.get("model_name"),


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Change prompt in vlm.py to send Image as a image_url type, not include as a string with prompt.

Feature request: https://github.com/NVIDIA/nv-ingest/issues/1030
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
