### PR TITLE
[ci] push docker image directly from buildx step

### DIFF
--- a/.github/workflows/docker-nightly-publish.yml
+++ b/.github/workflows/docker-nightly-publish.yml
@@ -40,8 +40,4 @@ jobs:
       - name: Build Docker image
         run: |
           docker buildx create --use
-          docker buildx build --platform linux/amd64,linux/arm64 --load --target runtime --build-arg GIT_COMMIT=${GITHUB_SHA} -t ${{ secrets.DOCKER_REGISTRY }}/nv-ingest:${{ env.CURRENT_DATE }} .
-
-      # Push the container to NGC
-      - name: Upload nv-ingest container
-        run: docker push ${{ secrets.DOCKER_REGISTRY }}/nv-ingest:${{ env.CURRENT_DATE }}
+          docker buildx build --platform linux/amd64,linux/arm64 --push --target runtime --build-arg GIT_COMMIT=${GITHUB_SHA} -t ${{ secrets.DOCKER_REGISTRY }}/nv-ingest:${{ env.CURRENT_DATE }} .

--- a/.github/workflows/docker-release-publish.yml
+++ b/.github/workflows/docker-release-publish.yml
@@ -36,8 +36,4 @@ jobs:
       - name: Build Docker image
         run: |
           docker buildx create --use
-          docker buildx build --platform linux/amd64,linux/arm64 --load --target runtime --build-arg GIT_COMMIT=${GITHUB_SHA} -t ${{ secrets.DOCKER_REGISTRY }}/nv-ingest:${{ env.SHORT_BRANCH_NAME }} .
-
-      # Push the container to NGC
-      - name: Upload nv-ingest container
-        run: docker push ${{ secrets.DOCKER_REGISTRY }}/nv-ingest:${{ env.SHORT_BRANCH_NAME }}
+          docker buildx build --platform linux/amd64,linux/arm64 --push --target runtime --build-arg GIT_COMMIT=${GITHUB_SHA} -t ${{ secrets.DOCKER_REGISTRY }}/nv-ingest:${{ env.SHORT_BRANCH_NAME }} .


### PR DESCRIPTION
## Description
Using `--load` in https://github.com/NVIDIA/nv-ingest/pull/1081 results in an error:
```
ERROR: failed to build: docker exporter does not currently support exporting manifest lists
```
`--load` is for single platforms. `--push` should be used on multi-platform.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
