### PR TITLE
Add psutil to pyproject.toml

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "opentelemetry-api>=1.27.0",
     "opentelemetry-exporter-otlp>=1.27.0",
     "opentelemetry-sdk>=1.27.0",
+    "psutil>=7.1.0",
     "pydantic>2.0.0",
     "pydantic-settings>2.0.0",
     "pypdfium2==4.30.0",


### PR DESCRIPTION
## Description
Fixes
```
Traceback (most recent call last):
  File "/Users/edwardk/git/nv-ingest/libmode.py", line 3, in <module>
    from nv_ingest.framework.orchestration.ray.util.pipeline.pipeline_runners import run_pipeline
  File "/Users/edwardk/git/nv-ingest/nvingest/lib/python3.12/site-packages/nv_ingest/framework/orchestration/ray/util/pipeline/pipeline_runners.py", line 9, in <module>
    from nv_ingest.framework.orchestration.ray.primitives.ray_pipeline import (
  File "/Users/edwardk/git/nv-ingest/nvingest/lib/python3.12/site-packages/nv_ingest/framework/orchestration/ray/primitives/ray_pipeline.py", line 11, in <module>
    import psutil
ModuleNotFoundError: No module named 'psutil'
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
