### PR TITLE
Fix LLM UDF Bug

### DIFF
--- a/api/src/udfs/llm_summarizer_udf.py
+++ b/api/src/udfs/llm_summarizer_udf.py
@@ -57,7 +57,7 @@ def content_summarizer(control_message: "IngestControlMessage") -> "IngestContro
     logger.info("UDF: Starting LLM content summarization")
 
     api_key = os.getenv("NVIDIA_API_KEY")
-    model_name = "moonshotai/kimi-k2-instruct-0905"
+    model_name = os.getenv("LLM_SUMMARIZATION_MODEL", "nvidia/llama-3.1-nemotron-70b-instruct")
     base_url = os.getenv("LLM_SUMMARIZATION_BASE_URL", "https://integrate.api.nvidia.com/v1")
     min_content_length = int(os.getenv("LLM_MIN_CONTENT_LENGTH", 50))
     max_content_length = int(os.getenv("LLM_MAX_CONTENT_LENGTH", 12000))


### PR DESCRIPTION
## Description
Fixes a bug accidentally introduced to https://github.com/NVIDIA/nv-ingest/pull/1067

The DF that is stored back onto the payload is not the original DF, rather, the truncated DF with the chunks selected just for summarization. This is incorrect and should be the original DF but with the summary for that document stored on the first row. 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
