### PR TITLE
feat: Add Parent-Level Trace Aggregation for Split PDFs

### DIFF
--- a/src/nv_ingest/api/v2/README.md
+++ b/src/nv_ingest/api/v2/README.md
@@ -112,11 +112,15 @@ The fetch endpoint returns a JSON body shaped like the following:
 
 **Parent-Level Trace Aggregation:**
 
-For split PDFs, parent-level metrics are automatically computed for each stage:
+For split PDFs, parent-level metrics are automatically computed for each stage (including nested stages):
 
 - `trace::entry::<stage>` - Earliest entry time across all chunks (when first chunk entered stage)
 - `trace::exit::<stage>` - Latest exit time across all chunks (when last chunk exited stage)
 - `trace::resident_time::<stage>` - Sum of all chunk durations (total compute time in stage)
+
+**Supports arbitrary nesting depth:**
+- Simple: `trace::entry::pdf_extractor`
+- Nested: `trace::entry::pdf_extractor::pdf_extraction::pdfium_pages_to_numpy_0`
 
 **Example:**
 ```json

--- a/src/nv_ingest/api/v2/ingest.py
+++ b/src/nv_ingest/api/v2/ingest.py
@@ -459,7 +459,7 @@ def _aggregate_parent_traces(chunk_traces: Dict[str, Any]) -> Dict[str, Any]:
             continue
 
         parts = key.split("::")
-        if len(parts) != 4:  # chunk_N::trace::entry/exit::stage_name
+        if len(parts) < 4:  # Minimum: chunk_N::trace::entry/exit::stage_name
             continue
 
         if parts[1] != "trace":  # Ensure it's a trace key
@@ -472,7 +472,10 @@ def _aggregate_parent_traces(chunk_traces: Dict[str, Any]) -> Dict[str, Any]:
             continue
 
         event_type = parts[2]  # "entry" or "exit"
-        stage_name = parts[3]  # "pdf_extractor"
+
+        # Stage name is everything after trace::entry:: or trace::exit::
+        # Handles both simple (pdf_extractor) and nested (pdf_extractor::pdf_extraction::pdfium_0)
+        stage_name = "::".join(parts[3:])  # Join remaining parts
 
         if event_type not in ("entry", "exit"):
             continue


### PR DESCRIPTION
## Description

Enhanced the V2 API to automatically aggregate trace/annotation data from PDF subjobs into parent-level metrics, matching V1 structure while providing granular per-chunk details in metadata.

## Motivation

When V2 splits a multi-page PDF into subjobs, each subjob generates its own trace/annotation telemetry. Previously, these were only available in `metadata.trace_segments[]`, making them:
- Difficult to access with the client library
- Incompatible with V1 trace analysis code
- Requiring manual aggregation for overall performance metrics

## Changes

### 1. Production Code (`src/nv_ingest/api/v2/ingest.py`)

**Added `_aggregate_parent_traces()` function:**
- Pure function that computes parent-level metrics from chunk traces
- For each stage: calculates `entry` (min), `exit` (max), and `resident_time` (sum of durations)
- Handles edge cases: incomplete pairs, malformed keys, empty input

**Updated `_build_aggregated_response()`:**
- Computes parent-level trace aggregations from `trace_segments`
- Sets top-level `trace` dict to contain **only** parent aggregations (clean, V1-compatible)
- Chunk traces remain in `metadata.trace_segments[]` for detailed analysis

### 2. Testing (`tests/service_tests/api/v2/test_aggregation_helpers.py`)

Added comprehensive unit tests for `_aggregate_parent_traces()`:
- 8 test cases covering basic aggregation, multiple stages, edge cases, precision
- All passing ✅

### 3. Documentation (`src/nv_ingest/api/v2/README.md`)

Updated with:
- Clear explanation of parent-level trace metrics
- Example showing both top-level aggregations and metadata details
- Note about accessing chunk traces via `metadata.trace_segments[]`

## Response Structure

### Top-Level Trace (V1 Compatible)

```json
{
  "trace": {
    "trace::entry::pdf_extractor": 1000,
    "trace::exit::pdf_extractor": 2150,
    "trace::resident_time::pdf_extractor": 250
  }
}
```

**Metrics per stage:**
- `trace::entry::<stage>` - Earliest entry time across all chunks (when processing started)
- `trace::exit::<stage>` - Latest exit time across all chunks (when processing finished)  
- `trace::resident_time::<stage>` - Sum of chunk durations (total compute time)

### Metadata (Detailed Per-Chunk View)

```json
{
  "metadata": {
    "trace_segments": [
      {
        "job_id": "...",
        "chunk_index": 1,
        "start_page": 1,
        "end_page": 32,
        "trace": {
          "trace::entry::pdf_extractor": 1000,
          "trace::exit::pdf_extractor": 1100
        }
      }
    ]
  }
}
```

## Key Design Decisions

### Why Sum Durations (resident_time) vs Min/Max?

Consider a file split into 2 chunks processed at different times:
```
Time 0:    Chunk 1 enters pdf_extractor
Time 100:  Chunk 1 exits pdf_extractor  (duration: 100)
Time 500:  [Other files process]
Time 5000: Chunk 2 enters pdf_extractor
Time 5100: Chunk 2 exits pdf_extractor  (duration: 100)
```

- `max(exit) - min(entry)` = 5100 (includes idle time, incorrect)
- `sum(durations)` = 200 (actual compute time, correct)

### Why Separate Top-Level and Metadata?

**Top-level `trace`:**
- Clean, concise
- V1-compatible structure
- Easy to use for high-level analysis

**Metadata `trace_segments`:**
- Full chunk-level detail (all timing data)
- Page ranges for correlation
- Advanced debugging and per-chunk analysis

## Benefits

**V1 Compatibility** - Existing trace analysis code works with V2  
**Zero Extra Network Calls** - Aggregation happens server-side during fetch  
**Efficient** - Batched async operations, no performance impact  
**Backward Compatible** - Non-split PDFs return V1-style responses unchanged  
**Comprehensive** - Both high-level summary and granular details available  

## Verification

**Unit Tests:**
```bash
pytest tests/service_tests/api/v2/test_aggregation_helpers.py::TestAggregateParentTraces -v
# 8 passed
```

## Migration Impact

**For V1 Users:**
- No changes needed - V2 structure matches V1

**For Existing V2 Users:**
- Top-level `trace`/`annotations` now available (previously only in metadata)
- New `resident_time` metric provides total compute insight
- Chunk details still in `metadata.trace_segments[]` (no change)

## Files Modified

- `src/nv_ingest/api/v2/ingest.py` - Core aggregation logic
- `tests/service_tests/api/v2/test_aggregation_helpers.py` - Unit tests
- `src/nv_ingest/api/v2/README.md` - Documentation

## Related Documentation

See `src/nv_ingest/api/v2/README.md` for detailed API documentation and examples.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
