### PR TITLE
Filter filtered images by default in filter task

### DIFF
--- a/client/client_tests/primitives/tasks/test_filter.py
+++ b/client/client_tests/primitives/tasks/test_filter.py
@@ -97,7 +97,7 @@ def test_filter_task_default_params():
         "min_size: 128",
         "max_aspect_ratio: 5.0",
         "min_aspect_ratio: 0.2",
-        "filter: False",
+        "filter: True",
     ]
     for expected_part in expected_str_contains:
         assert expected_part in str(task)
@@ -106,7 +106,7 @@ def test_filter_task_default_params():
         "type": "filter",
         "task_properties": {
             "content_type": "image",
-            "params": {"min_size": 128, "max_aspect_ratio": 5.0, "min_aspect_ratio": 0.2, "filter": False},
+            "params": {"min_size": 128, "max_aspect_ratio": 5.0, "min_aspect_ratio": 0.2, "filter": True},
         },
     }
     assert task.to_dict() == expected_dict

--- a/client/src/nv_ingest_client/primitives/tasks/filter.py
+++ b/client/src/nv_ingest_client/primitives/tasks/filter.py
@@ -31,7 +31,7 @@ class FilterTask(Task):
         min_size: int = 128,
         max_aspect_ratio: Union[int, float] = 5.0,
         min_aspect_ratio: Union[int, float] = 0.2,
-        filter: bool = False,
+        filter: bool = True,
     ) -> None:
         """
         Setup Filter Task Config


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Currently, by default, the filter task still returns images that have been filtered in the final metadata, but marked as info messages instead of as images. This has caused some confusion, so this PR changes the default behavior of the filter task to fully remove any filtered images from the metadata that gets returned.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
