### PR TITLE
feature: adding missing endpoint url

### DIFF
--- a/src/nv_ingest/pipeline/default_pipeline_impl.py
+++ b/src/nv_ingest/pipeline/default_pipeline_impl.py
@@ -318,6 +318,7 @@ stages:
     config:
       api_key: $NGC_API_KEY|$NVIDIA_API_KEY
       model_name: $VLM_CAPTION_MODEL_NAME|"nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
+      endpoint_url: $VLM_CAPTION_ENDPOINT|"http://vlm:8000/v1/chat/completions"
       prompt: "Caption the content of this image:"
     replicas:
       min_replicas: 0


### PR DESCRIPTION
## Description
In investigating we found a bug in ingest making it so that VLM caption requests always use the [build.nvidia.com](http://build.nvidia.com/) hosted endpoints.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
