### PR TITLE
fix: Handle Empty Subjob List in Redis Parent Job Mapping

### DIFF
--- a/src/nv_ingest/framework/util/service/impl/ingest/redis_ingest_service.py
+++ b/src/nv_ingest/framework/util/service/impl/ingest/redis_ingest_service.py
@@ -436,12 +436,13 @@ class RedisIngestService(IngestServiceMeta):
         metadata_key = f"parent:{parent_job_id}:metadata"
 
         try:
-            # Store subjob IDs as a set
-            await self._run_bounded_to_thread(
-                self._ingest_client.get_client().sadd,
-                parent_key,
-                *subjob_ids,
-            )
+            # Store subjob IDs as a set (only if there are subjobs)
+            if subjob_ids:
+                await self._run_bounded_to_thread(
+                    self._ingest_client.get_client().sadd,
+                    parent_key,
+                    *subjob_ids,
+                )
 
             # Store metadata as hash (including original subjob ordering for deterministic fetches)
             metadata_to_store = dict(metadata)


### PR DESCRIPTION
## Description
When storing metadata for non-split PDFs (where `subjob_ids = []`), the Redis `sadd` command was called with no values. This prevented page count metadata from being stored for non-split PDFs in the V2 API.


Follow-up fix to #1120 (page count metadata for V2 API)

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
