### PR TITLE
Add optional FastAPI server for open-source NR-OCR

### DIFF
--- a/docker-compose.oss-ocr.yaml
+++ b/docker-compose.oss-ocr.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+services:
+  ocr:
+    build:
+      context: "docker/nemoretriever-ocr-v1"
+      dockerfile: "Dockerfile"
+      args:
+        HF_TOKEN: ${HF_ACCESS_TOKEN:-hfaccesstoken}
+    shm_size: 16gb
+    ports:
+      - "8009:8000"
+      - "8010:8001"
+      - "8011:8002"
+    user: root
+    environment:
+      - OMP_NUM_THREADS=${OCR_OMP_NUM_THREADS:-1}
+      - CUDA_VISIBLE_DEVICES=0
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0"]
+              capabilities: [gpu]
+    runtime: nvidia
+
+  nv-ingest-ms-runtime:
+    environment:
+      # Self-hosted ocr endpoints.
+      - OCR_HTTP_ENDPOINT=http://ocr:8000/v1/infer
+      - OCR_INFER_PROTOCOL=http
+      - OCR_MODEL_NAME=scene_text_ensemble

--- a/docker/nemoretriever-ocr-v1/Dockerfile
+++ b/docker/nemoretriever-ocr-v1/Dockerfile
@@ -1,0 +1,45 @@
+# Start from the official NVIDIA PyTorch container to ensure CUDA compatibility
+FROM nvcr.io/nvidia/pytorch:25.09-py3
+
+# Install Git and Git LFS
+RUN apt-get update && apt-get install -y git git-lfs && rm -rf /var/lib/apt/lists/*
+
+# This allows the token to be passed securely during the build process.
+# It will NOT be available in the final running container.
+ARG HF_TOKEN
+
+# Set the working directory
+WORKDIR /app
+
+# Clone the model repository from Hugging Face
+RUN git lfs install && \
+    git clone https://huggingface.co/nvidia/nemoretriever-ocr-v1
+
+# Set the working directory to the cloned repository
+WORKDIR /app/nemoretriever-ocr-v1/nemo-retriever-ocr
+
+## Install the model's custom dependencies
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -U pip hatchling "setuptools>=68" --root-user-action ignore
+
+# Ensure no prebuilt binaries/artifacts from the host are present
+RUN rm -f src/nemo_retriever_ocr_cpp/*.so || true \
+    && rm -rf build/ dist/
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    BUILD_CPP_FORCE=1 pip install -v . --no-build-isolation --root-user-action ignore
+
+WORKDIR /app/nemoretriever-ocr-v1
+
+# Copy our new server script into the container
+COPY server.py .
+
+# Install dependencies for our advanced FastAPI server
+# Pillow is needed for image processing from bytes
+RUN pip install fastapi uvicorn pydantic python-multipart pillow
+
+# Expose the port the server will listen on
+EXPOSE 8000
+
+# Define the command to start the Uvicorn server
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker/nemoretriever-ocr-v1/server.py
+++ b/docker/nemoretriever-ocr-v1/server.py
@@ -1,0 +1,227 @@
+import asyncio
+import base64
+from contextlib import asynccontextmanager
+from http import HTTPStatus
+from typing import List
+
+from fastapi import FastAPI, HTTPException, Response
+from pydantic import BaseModel, Field
+import io
+
+# Global variable to hold the loaded model
+# This will be populated during the application's lifespan startup.
+model_pipeline = None
+# An asyncio.Lock to ensure safe access and reloading of the model
+model_lock = asyncio.Lock()
+
+# --- Pydantic Data Models for API Schema ---
+
+
+class InputItem(BaseModel):
+    """Represents a single image item in the batch."""
+
+    type: str = Field("image_url", description="The type of input. Must be 'image_url'.")
+    url: str = Field(
+        ...,
+        description="A Data URL containing the base64-encoded image (e.g., 'data:image/png;base64,...').",
+    )
+
+
+class OCRRequest(BaseModel):
+    """Defines the structure for a batch OCR request."""
+
+    input: List[InputItem] = Field(..., description="A list of images to be processed.")
+    merge_levels: List[str] = Field(..., description="A list of merge levels, one for each image in the input list.")
+
+
+class Point(BaseModel):
+    x: float
+    y: float
+
+
+class Polygon(BaseModel):
+    points: List[Point]
+
+
+class Text(BaseModel):
+    text: str
+    confidence: float
+
+
+class TextDetection(BaseModel):
+    text_prediction: Text
+    bounding_box: Polygon
+
+
+class OCRResponseItem(BaseModel):
+    """Contains the OCR results for a single image from the batch."""
+
+    index: int
+    text_detections: List[TextDetection]
+
+
+class OCRResponse(BaseModel):
+    """The final response object containing results for the entire batch."""
+
+    data: List[OCRResponseItem]
+
+
+# --- Model Loading and Lifespan Management ---
+
+
+async def load_model():
+    """
+    Loads or reloads the OCR model. This function is separate
+    so it can be called on startup and during error recovery.
+    """
+    global model_pipeline
+    print("Loading OCR model...")
+    try:
+        from nemo_retriever_ocr.inference.pipeline import NemoRetrieverOCR
+
+        # Initialize the OCR model.
+        model_pipeline = NemoRetrieverOCR()
+        print("Model loaded successfully.")
+    except Exception as e:
+        print(f"FATAL: Could not load model: {e}")
+        model_pipeline = None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Handles startup and shutdown events."""
+    # Acquire lock before initial loading to ensure no requests come in until model is ready.
+    async with model_lock:
+        await load_model()
+
+    yield
+
+    print("Server shutting down...")
+    global model_pipeline
+    model_pipeline = None
+
+
+# --- FastAPI Application ---
+
+app = FastAPI(
+    title="NVIDIA Nemo Retriever OCR Inference Server",
+    description="A server for performing OCR using the nvidia/nemoretriever-ocr-v1 model.",
+    version="1.0.0",
+    lifespan=lifespan,
+)
+
+# --- API Endpoints ---
+
+
+@app.get("/v1/health/live", tags=["Health"])
+async def health_live(response: Response) -> dict:
+    """Check if the service is running."""
+    return {"live": True}
+
+
+@app.get("/v1/health/ready", tags=["Health"])
+async def health_ready(response: Response) -> dict:
+    """Check if the service is ready to receive traffic (i.e., model is loaded)."""
+    if model_pipeline is None:
+        response.status_code = HTTPStatus.SERVICE_UNAVAILABLE
+        return {"ready": False}
+    return {"ready": True}
+
+
+@app.post("/v1/infer", response_model=OCRResponse, tags=["Inference"])
+async def perform_inference(request: OCRRequest):
+    """
+    Performs OCR on a base64-encoded image.
+    """
+    # Use the lock to ensure exclusive access to the model during inference.
+    # If a reload is happening, this will wait until it's finished.
+    async with model_lock:
+        if model_pipeline is None:
+            raise HTTPException(
+                status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+                detail="Model is not loaded or failed to load.",
+            )
+
+    if not request.input or len(request.input) != len(request.merge_levels):
+        raise HTTPException(
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            detail="The 'input' and 'merge_levels' lists must be non-empty and have the same number of elements.",
+        )
+
+    images = []
+    for item in request.input:
+        try:
+            header, b64_string = item.url.split(",", 1)
+            image_bytes = base64.b64decode(b64_string)
+            images.append(io.BytesIO(image_bytes))
+        except (ValueError, IndexError):
+            raise HTTPException(
+                status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                detail="Invalid Data URL format or bad base64 content found in one of the input items.",
+            )
+
+    all_detections = []
+    for idx, (image, merge_level) in enumerate(zip(images, request.merge_levels)):
+        try:
+            async with model_lock:
+                predictions = model_pipeline(image, merge_level=merge_level)
+
+            text_detections = []
+            for pred in predictions:
+                left, upper, right, lower = (
+                    pred["left"],
+                    pred["upper"],
+                    pred["right"],
+                    pred["lower"],
+                )
+
+                points = [
+                    Point(x=left, y=upper),  # Top-left corner
+                    Point(x=right, y=upper),  # Top-right corner
+                    Point(x=right, y=lower),  # Bottom-right corner
+                    Point(x=left, y=lower),  # Bottom-left corner
+                ]
+
+                text_prediction = Text(text=pred["text"], confidence=pred["confidence"])
+                bounding_box = Polygon(points=points)
+
+                text_detection = TextDetection(text_prediction=text_prediction, bounding_box=bounding_box)
+                text_detections.append(text_detection)
+
+            all_detections.append(OCRResponseItem(index=idx, text_detections=text_detections))
+
+        except Exception as e:
+            error_str = str(e)
+            # Check for the specific, fatal CUDA error
+            if (
+                "CUDA error: an illegal memory access was encountered" in error_str
+                or "cudaErrorIllegalAddress" in error_str
+            ):
+
+                from uuid import uuid4
+
+                with open(f"/workspace/data/{str(uuid4())}.error", "w") as f:
+                    for item in request.input:
+                        f.write(f"{item.url}\n")
+
+                print(f"FATAL CUDA error detected: {error_str}")
+                print("Attempting to recover by reloading the model.")
+
+                # Use the lock to ensure no other requests can interfere with the reload
+                async with model_lock:
+                    await load_model()
+
+                # Inform the client that triggered the error to retry.
+                raise HTTPException(
+                    status_code=HTTPStatus.SERVICE_UNAVAILABLE,  # 503
+                    detail="The model has been reloaded due to CUDA error. Please try your request again.",
+                )
+            else:
+                # For all other errors, behave as before.
+                print(f"An unexpected, non-CUDA error occurred during inference: {e}")
+                raise HTTPException(
+                    status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    detail=f"An unexpected error occurred during inference: {str(e)}",
+                )
+
+    return OCRResponse(data=all_detections)


### PR DESCRIPTION
## Description
```shell
docker compose -f docker-compose.yaml -f docker-compose.oss-ocr.yaml \
  --profile table-structure --profile retrieval up -d --build
```
If you get rate-limited by Hugging Face, add your HF token in `.env`.
```
HF_ACCESS_TOKEN=<your access token here>
```

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
