### PR TITLE
Adding dataset sweeping functionality to mimic run_once.sh

### DIFF
--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -15,14 +15,14 @@ A configurable, dataset-agnostic testing framework for end-to-end validation of 
 # 1. Navigate to the tests directory
 cd scripts/tests
 
-# 2. Edit the configuration
-vim test_configs.yaml  # Update dataset_dir to point to your data
+# 2. Run with a pre-configured dataset (assumes services are running)
+python run.py --case=e2e --dataset=bo767
 
-# 3. Run the test (assumes services are already running)
-python run.py --case=e2e
+# Or use a custom path that uses the "active" configuration
+python run.py --case=e2e --dataset=/path/to/your/data
 
-# Or override settings via CLI
-python run.py --case=e2e --dataset=/path/to/data --api-version=v2
+# With managed infrastructure (starts/stops services)
+python run.py --case=e2e --dataset=bo767 --managed
 ```
 
 **Important**: All test commands should be run from the `scripts/tests/` directory.
@@ -78,37 +78,90 @@ active:
   collection_name: null
 ```
 
-#### Dataset Shortcuts
+#### Pre-Configured Datasets
 
-Define common dataset paths for quick access:
+Each dataset includes its path, extraction settings, and recall evaluator in one place:
 
 ```yaml
 datasets:
-  bo20: /path/to/bo20
-  bo767: /path/to/bo767
-  single: data/multimodal_test.pdf
+  bo767:
+    path: /raid/jioffe/bo767
+    extract_text: true
+    extract_tables: true
+    extract_charts: true
+    extract_images: false
+    extract_infographics: false
+    recall_dataset: bo767  # Evaluator for recall testing
+  
+  bo20:
+    path: /raid/jioffe/bo20
+    extract_text: true
+    extract_tables: true
+    extract_charts: true
+    extract_images: true
+    extract_infographics: false
+    recall_dataset: null  # bo20 does not have recall
+  
+  earnings:
+    path: /raid/jioffe/earnings_conusulting
+    extract_text: true
+    extract_tables: true
+    extract_charts: true
+    extract_images: false
+    extract_infographics: false
+    recall_dataset: earnings  # Evaluator for recall testing
 ```
 
-Usage:
+**Automatic Configuration**: When you use `--dataset=bo767`, the framework automatically:
+- Sets the dataset path
+- Applies the correct extraction settings (text, tables, charts, images, infographics)
+- Configures the recall evaluator (if applicable)
+
+**Usage:**
 ```bash
-python run.py --case=e2e --dataset=bo767  # Uses /path/to/bo767
+# Single dataset - configs applied automatically
+python run.py --case=e2e --dataset=bo767
+
+# Multiple datasets (sweeping) - each gets its own config
+python run.py --case=e2e --dataset=bo767,earnings,bo20
+
+# Custom path still works (uses active section config)
+python run.py --case=e2e --dataset=/custom/path
 ```
+
+**Dataset Extraction Settings:**
+
+| Dataset | Text | Tables | Charts | Images | Infographics | Recall |
+|---------|------|--------|--------|--------|--------------|--------|
+| `bo767` | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
+| `earnings` | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
+| `bo20` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ |
+| `financebench` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `single` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 
 ### Configuration Precedence
 
 Settings are applied in order of priority:
 
-**CLI arguments > Environment variables > YAML active config**
+**Environment variables > Dataset-specific config (path + extraction + recall_dataset) > YAML active config**
+
+**Note**: CLI arguments are only used for runtime decisions (which test to run, which dataset, execution mode). All configuration values come from YAML or environment variables.
 
 Example:
 ```bash
-# YAML has api_version: v1
-# Override via environment variable
-API_VERSION=v2 python run.py --case=e2e
-
-# Override via CLI (highest priority)
-python run.py --case=e2e --api-version=v2
+# YAML active section has api_version: v1
+# Dataset bo767 has extract_images: false
+# Override via environment variable (highest priority)
+EXTRACT_IMAGES=true API_VERSION=v2 python run.py --case=e2e --dataset=bo767
+# Result: Uses bo767 path, but extract_images=true (env override) and api_version=v2 (env override)
 ```
+
+**Precedence Details:**
+1. **Environment variables** - Highest priority, useful for CI/CD overrides
+2. **Dataset-specific config** - Applied automatically when using `--dataset=<name>`
+   - Includes: path, extraction settings, recall_dataset
+   - Only applies if dataset is defined in `datasets` section
+3. **YAML active config** - Base configuration, used as fallback
 
 ### Configuration Options Reference
 
@@ -143,7 +196,7 @@ python run.py --case=e2e --api-version=v2
 #### Storage Options
 - `spill_dir` (string): Temporary processing directory
 - `artifacts_dir` (string): Test output directory (auto-generated if null)
-- `collection_name` (string): Milvus collection name (auto-generated if null)
+- `collection_name` (string): Milvus collection name (auto-generated as `{test_name}_multimodal` if null, deterministic - no timestamp)
 
 ### Valid Configuration Values
 
@@ -160,31 +213,45 @@ Configuration is validated on load with helpful error messages.
 ### Basic Usage
 
 ```bash
-# Run with default YAML configuration
-python run.py --case=e2e
+# Run with default YAML configuration (assumes services are running)
+python run.py --case=e2e --dataset=bo767
 
 # With document-level analysis
-python run.py --case=e2e --doc-analysis
+python run.py --case=e2e --dataset=bo767 --doc-analysis
 
-# With managed infrastructure (starts/stops Docker)
-python run.py --case=e2e --managed
+# With managed infrastructure (starts/stops services)
+python run.py --case=e2e --dataset=bo767 --managed
 ```
 
-### Using CLI Overrides
+### Dataset Sweeping
+
+Run multiple datasets in a single command - each dataset automatically gets its native extraction configuration:
 
 ```bash
-# Override dataset
-python run.py --case=e2e --dataset=/path/to/data
+# Sweep multiple datasets
+python run.py --case=e2e --dataset=bo767,earnings,bo20
 
-# Override API version
-python run.py --case=e2e --api-version=v2
+# Each dataset runs sequentially with its own:
+# - Extraction settings (from dataset config)
+# - Artifact directory (timestamped per dataset)
+# - Results summary at the end
 
-# Override readiness timeout
-python run.py --case=e2e --readiness-timeout=300
+# With managed infrastructure (services start once, shared across all datasets)
+python run.py --case=e2e --dataset=bo767,earnings,bo20 --managed
 
-# Combine multiple overrides
-python run.py --case=e2e --dataset=/data/pdfs --api-version=v2 --doc-analysis
+# E2E+Recall sweep (each dataset ingests then evaluates recall)
+python run.py --case=e2e_recall --dataset=bo767,earnings
+
+# Recall-only sweep (evaluates existing collections)
+python run.py --case=recall --dataset=bo767,earnings
 ```
+
+**Sweep Behavior:**
+- Services start once (if `--managed`) before the sweep
+- Each dataset gets its own artifact directory
+- Each dataset automatically applies its extraction config from `datasets` section
+- Summary printed at end showing success/failure for each dataset
+- Services stop once at end (unless `--keep-up`)
 
 ### Using Environment Variables
 
@@ -213,8 +280,10 @@ DATASET_DIR=/custom/path python run.py --case=e2e
 
 **For E2E-only users:**
 - Only configure `active` section
-- `collection_name` in active: auto-generates with timestamp if `null`, or use custom name
+- `collection_name` in active: auto-generates from `test_name` or dataset basename if `null` (deterministic, no timestamp)
+- Collection name pattern: `{test_name}_multimodal` (e.g., `bo767_multimodal`, `earnings_consulting_multimodal`)
 - `recall` section is optional (not used unless running recall tests)
+- **Note**: You can run `recall` later against the same collection created by `e2e`
 
 **For Recall-only users:**
 - Configure `active` section: `hostname`, `sparse`, `gpu_search`, etc. (for evaluation)
@@ -305,10 +374,36 @@ Three modes via `reranker_mode` setting:
 
 ### Collection Naming
 
-A single multimodal collection is created for recall evaluation:
+**Deterministic Collection Names (No Timestamps)**
+
+All test cases use deterministic collection names (no timestamps) to enable:
+- Reusing collections across test runs
+- Running recall evaluation after e2e ingestion
+- Consistent collection naming patterns
+
+**Collection Name Patterns:**
+
+All test cases use the same consistent pattern: `{test_name}_multimodal`
+
+| Test Case | Pattern | Example |
+|-----------|---------|---------|
+| `e2e` | `{test_name}_multimodal` | `bo767_multimodal` |
+| `e2e_with_llm_summary` | `{test_name}_multimodal` | `bo767_multimodal` |
+| `e2e_recall` | `{test_name}_multimodal` | `bo767_multimodal` |
+| `recall` | `{test_name}_multimodal` | `bo767_multimodal` |
+
+**Benefits:**
+- ✅ Run `e2e` then `recall` separately - they use the same collection
+- ✅ Consistent naming across all test cases
+- ✅ Deterministic names (no timestamps) enable collection reuse
+
+**Recall Collections:**
+- A single multimodal collection is created for recall evaluation
 - Pattern: `{test_name}_multimodal`
 - Example: `bo767_multimodal`
 - All datasets evaluate against this multimodal collection (no modality-specific collections)
+
+**Note**: Artifact directories still use timestamps for tracking over time (e.g., `bo767_20251106_180859_UTC`), but collection names are deterministic.
 
 ### Multimodal-Only Evaluation
 
@@ -350,27 +445,33 @@ recall:
 **Recall-only (existing collections):**
 ```bash
 # Evaluate existing bo767 collections (no reranker)
-python run.py --case=recall --test-name=bo767
+# recall_dataset automatically set from dataset config
+python run.py --case=recall --dataset=bo767
 
-# With reranker only
-python run.py --case=recall --test-name=bo767 --reranker-mode=with
+# With reranker only (set reranker_mode in YAML recall section)
+python run.py --case=recall --dataset=bo767
 
-# Both modes for comparison
-python run.py --case=recall --test-name=bo767 --reranker-mode=both
+# Sweep multiple datasets for recall evaluation
+python run.py --case=recall --dataset=bo767,earnings
 ```
 
 **E2E + Recall (fresh ingestion):**
 ```bash
 # Fresh ingestion with recall evaluation
-python run.py --case=e2e_recall --dataset=/raid/jioffe/bo767
+# recall_dataset automatically set from dataset config
+python run.py --case=e2e_recall --dataset=bo767
+
+# Sweep multiple datasets (each ingests then evaluates)
+python run.py --case=e2e_recall --dataset=bo767,earnings
 ```
 
 **Dataset configuration:**
-- `dataset_dir` (active section): Where PDFs are located (for ingestion)
-- `test_name` (active section): Used to generate collection name `{test_name}_multimodal`
-- `recall_dataset` (recall section): **Required** - Which evaluator to use (bo767, finance_bench, earnings, audio)
-  - Set in `test_configs.yaml` recall section: `recall_dataset: bo767`
-  - Or via environment variable: `RECALL_DATASET=bo767`
+- **Dataset path**: Automatically set from `datasets` section when using `--dataset=<name>`
+- **Extraction settings**: Automatically applied from `datasets` section
+- **recall_dataset**: Automatically set from `datasets` section (e.g., `bo767`, `earnings`, `finance_bench`)
+  - Can be overridden via environment variable: `RECALL_DATASET=bo767`
+- **test_name**: Auto-generated from dataset name or basename of path (can set in YAML `active` section)
+- **Collection naming**: `{test_name}_multimodal` (automatically generated for recall cases)
 - All datasets evaluate against the same `{test_name}_multimodal` collection (multimodal-only)
 
 ### Output
@@ -403,30 +504,43 @@ Metrics are also logged via `kv_event_log()`:
 
 ## Sweeping Parameters
 
+### Dataset Sweeping (Recommended)
+
+The easiest way to test multiple datasets is using dataset sweeping:
+
+```bash
+# Test multiple datasets - each gets its native config automatically
+python run.py --case=e2e --dataset=bo767,earnings,bo20
+
+# Each dataset runs with its pre-configured extraction settings
+# Results are organized in separate artifact directories
+```
+
+### Parameter Sweeping
+
 To sweep through different parameter values:
 
 1. **Edit** `test_configs.yaml` - Update values in the `active` section
-2. **Run** the test: `python run.py --case=e2e`
+2. **Run** the test: `python run.py --case=e2e --dataset=<name>`
 3. **Analyze** results in `artifacts/<test_name>_<timestamp>/`
 4. **Repeat** steps 1-3 for next parameter combination
 
-Example sweep workflow:
+Example parameter sweep workflow:
 ```bash
 # Test 1: Baseline V1
 vim test_configs.yaml  # Set: api_version=v1, extract_tables=true
-python run.py --case=e2e --dataset=/data/pdfs
+python run.py --case=e2e --dataset=bo767
 
 # Test 2: V2 with 32-page splitting
 vim test_configs.yaml  # Set: api_version=v2, pdf_split_page_count=32
-python run.py --case=e2e --dataset=/data/pdfs
+python run.py --case=e2e --dataset=bo767
 
 # Test 3: V2 with 8-page splitting
 vim test_configs.yaml  # Set: pdf_split_page_count=8
-python run.py --case=e2e --dataset=/data/pdfs
+python run.py --case=e2e --dataset=bo767
 
-# Test 4: Tables disabled
-vim test_configs.yaml  # Set: extract_tables=false
-python run.py --case=e2e --dataset=/data/pdfs
+# Test 4: Tables disabled (override via env var)
+EXTRACT_TABLES=false python run.py --case=e2e --dataset=bo767
 ```
 
 **Note**: Each test run creates a new timestamped artifact directory, so you can compare results across sweeps.
@@ -436,33 +550,34 @@ python run.py --case=e2e --dataset=/data/pdfs
 ### Attach Mode (Default)
 
 ```bash
-python run.py --case=e2e
+python run.py --case=e2e --dataset=bo767
 ```
 
-- Assumes services are already running (typical development workflow)
-- Runs test case only
+- **Default behavior**: Assumes services are already running
+- Runs test case only (no service management)
 - Faster for iterative testing
-- Use when Docker services are already up (e.g., via `nv-start`)
+- Use when Docker services are already up
+- `--no-build` and `--keep-up` flags are ignored in attach mode
 
 ### Managed Mode
 
 ```bash
-python run.py --case=e2e --managed
+python run.py --case=e2e --dataset=bo767 --managed
 ```
 
 - Starts Docker services automatically
 - Waits for service readiness (configurable timeout)
 - Runs test case
 - Collects artifacts
-- Optionally tears down services (use `--keep-up` to preserve)
+- Stops services after test (unless `--keep-up`)
 
-Additional managed mode options:
+**Managed mode options:**
 ```bash
 # Skip Docker image rebuild (faster startup)
-python run.py --case=e2e --managed --no-build
+python run.py --case=e2e --dataset=bo767 --managed --no-build
 
-# Keep services running after test
-python run.py --case=e2e --managed --keep-up
+# Keep services running after test (useful for multi-test scenarios)
+python run.py --case=e2e --dataset=bo767 --managed --keep-up
 ```
 
 ## Artifacts and Logging
@@ -475,6 +590,8 @@ scripts/tests/artifacts/<test_name>_<timestamp>_UTC/
 ├── stdout.txt          # Complete test output
 └── e2e.json            # Structured metrics and events
 ```
+
+**Note**: Artifact directories use timestamps for tracking test runs over time, while collection names are deterministic (no timestamps) to enable collection reuse and recall evaluation.
 
 ### Results Structure
 
@@ -534,6 +651,16 @@ This provides:
 - `cases/e2e_with_llm_summary.py` - E2E with LLM (✅ YAML-based)
   - Adds UDF-based LLM summarization
   - Same config-based architecture as e2e.py
+- `cases/recall.py` - Recall evaluation (✅ YAML-based)
+  - Evaluates retrieval accuracy against existing collections
+  - Requires `recall_dataset` in config (from dataset config or env var)
+  - Supports reranker comparison modes (none, with, both)
+  - Multimodal-only evaluation against `{test_name}_multimodal` collection
+- `cases/e2e_recall.py` - E2E + Recall (✅ YAML-based)
+  - Combines ingestion (via e2e.py) with recall evaluation (via recall.py)
+  - Automatically creates collection during ingestion
+  - Requires `recall_dataset` in config (from dataset config or env var)
+  - Merges ingestion and recall metrics in results
 
 **4. Shared Utilities**
 - `interact.py` - Common testing utilities
@@ -547,9 +674,21 @@ This provides:
 
 ```
 test_configs.yaml → load_config() → TestConfig object → test case
-                         ↑                    ↑
-                    Env overrides        CLI overrides
+    (active +        (applies          (validated,
+     datasets)        dataset config)    type-safe)
+         ↑                    ↑
+    Env overrides      Dataset configs
+    (highest)          (auto-applied)
 ```
+
+**Configuration Loading:**
+1. Start with `active` section from YAML
+2. If `--dataset=<name>` matches a configured dataset:
+   - Apply dataset path
+   - Apply dataset extraction settings
+   - Apply dataset `recall_dataset` (if set)
+3. Apply environment variable overrides (if any)
+4. Validate and create `TestConfig` object
 
 All test cases receive a validated `TestConfig` object with typed fields, eliminating string parsing errors.
 
@@ -644,30 +783,38 @@ To add new configurable parameters:
 
 The framework is dataset-agnostic and supports multiple approaches:
 
-**Option 1: Edit YAML directly**
-```yaml
-active:
-  dataset_dir: /path/to/your/dataset
+**Option 1: Use pre-configured dataset (Recommended)**
+```bash
+# Dataset configs automatically applied
+python run.py --case=e2e --dataset=bo767
 ```
 
-**Option 2: Use CLI override**
+**Option 2: Add new dataset to YAML**
+```yaml
+datasets:
+  my_dataset:
+    path: /path/to/your/dataset
+    extract_text: true
+    extract_tables: true
+    extract_charts: true
+    extract_images: false
+    extract_infographics: false
+    recall_dataset: null  # or set to evaluator name if applicable
+```
+Then use: `python run.py --case=e2e --dataset=my_dataset`
+
+**Option 3: Use custom path (uses active section config)**
 ```bash
 python run.py --case=e2e --dataset=/path/to/your/dataset
 ```
 
-**Option 3: Add dataset shortcut**
-```yaml
-datasets:
-  my_dataset: /path/to/your/dataset
-```
-Then use: `python run.py --case=e2e --dataset=my_dataset`
-
-**Option 4: Environment variable**
+**Option 4: Environment variable override**
 ```bash
-DATASET_DIR=/path/to/your/dataset python run.py --case=e2e
+# Override specific settings via env vars
+EXTRACT_IMAGES=true python run.py --case=e2e --dataset=bo767
 ```
 
-Choose the approach that fits your workflow. For repeated testing, add a dataset shortcut. For one-off tests, use CLI override.
+**Best Practice**: For repeated testing, add your dataset to the `datasets` section with its native extraction settings. This ensures consistent configuration and enables dataset sweeping.
 
 ## Additional Resources
 

--- a/scripts/tests/cases/e2e_with_llm_summary.py
+++ b/scripts/tests/cases/e2e_with_llm_summary.py
@@ -25,7 +25,7 @@ try:
 except Exception:
     MilvusClient = None  # Optional; stats logging will be skipped if unavailable
 
-from utils import default_collection_name, get_repo_root
+from utils import get_repo_root
 
 
 def main(config=None, log_path: str = "test_results") -> int:
@@ -50,7 +50,15 @@ def main(config=None, log_path: str = "test_results") -> int:
     spill_dir = config.spill_dir
     os.makedirs(spill_dir, exist_ok=True)
 
-    collection_name = config.collection_name or default_collection_name()
+    # Use consistent collection naming with recall pattern
+    # If collection_name not set, generate from test_name or dataset basename
+    if config.collection_name:
+        collection_name = config.collection_name
+    else:
+        from recall_utils import get_recall_collection_name
+
+        test_name = config.test_name or os.path.basename(config.dataset_dir.rstrip("/"))
+        collection_name = get_recall_collection_name(test_name)
     hostname = config.hostname
     sparse = config.sparse
     gpu_search = config.gpu_search

--- a/scripts/tests/config.py
+++ b/scripts/tests/config.py
@@ -7,7 +7,7 @@ Loads test configuration from test_configs.yaml with support for:
 - Environment variable overrides
 - CLI argument overrides
 
-Precedence: CLI args > Env vars > YAML active config
+Precedence: CLI args > Env vars > Dataset-specific config (path + extraction + recall_dataset) > YAML active config
 """
 
 import os
@@ -118,11 +118,33 @@ class TestConfig:
         return errors
 
 
+def _get_dataset_config(yaml_data: dict, dataset_name: str) -> dict:
+    """
+    Get complete dataset configuration including path and extraction settings.
+
+    Args:
+        yaml_data: Parsed YAML data
+        dataset_name: Dataset shortcut name
+
+    Returns:
+        Dictionary with dataset path and extraction config, or empty dict if not found
+    """
+    datasets = yaml_data.get("datasets", {})
+    dataset_config = datasets.get(dataset_name, {})
+
+    # Handle backward compatibility: if datasets is a simple dict (name -> path)
+    # convert to new format
+    if isinstance(dataset_config, str):
+        return {"path": dataset_config}
+
+    return dataset_config
+
+
 def load_config(config_file: str = "test_configs.yaml", case: Optional[str] = None, **cli_overrides) -> TestConfig:
     """
     Load test configuration from YAML with overrides.
 
-    Precedence: CLI args > Env vars > YAML active config (+ recall section if recall case)
+    Precedence: CLI args > Env vars > Dataset-specific config > YAML active config
 
     Args:
         config_file: Path to YAML config file (relative to this script)
@@ -160,12 +182,23 @@ def load_config(config_file: str = "test_configs.yaml", case: Optional[str] = No
             # Merge recall section (recall section overrides active section for conflicts)
             config_dict.update(recall_section)
 
-    # Handle dataset shortcuts
+    # Handle dataset shortcuts and apply dataset-specific extraction configs
     if "dataset" in cli_overrides:
-        dataset = cli_overrides.pop("dataset")
-        if dataset is not None:  # Only override if actually provided
-            datasets = yaml_data.get("datasets", {})
-            config_dict["dataset_dir"] = datasets.get(dataset, dataset)
+        dataset_name = cli_overrides.pop("dataset")
+        if dataset_name is not None:  # Only override if actually provided
+            dataset_config = _get_dataset_config(yaml_data, dataset_name)
+
+            if dataset_config and "path" in dataset_config:
+                # Configured dataset: extract path and apply extraction settings
+                config_dict["dataset_dir"] = dataset_config["path"]
+
+                # Apply dataset-specific configs (extraction settings + recall_dataset, excluding path)
+                dataset_specific_config = {k: v for k, v in dataset_config.items() if k != "path"}
+                if dataset_specific_config:
+                    config_dict.update(dataset_specific_config)
+            else:
+                # Not a configured dataset, treat dataset_name as direct path
+                config_dict["dataset_dir"] = dataset_name
 
     # Apply environment variable overrides
     env_overrides = _load_env_overrides()

--- a/scripts/tests/run.py
+++ b/scripts/tests/run.py
@@ -70,6 +70,165 @@ def create_artifacts_dir(base: str | None, dataset_name: str | None = None) -> s
     return path
 
 
+def run_datasets(
+    case,
+    dataset_list,
+    managed,
+    no_build,
+    keep_up,
+    doc_analysis,
+) -> int:
+    """Run test for one or more datasets sequentially."""
+    results = []
+
+    # Start services once if managed mode
+    if managed:
+        # Load config for first dataset to get profiles
+        first_config = load_config(
+            case=case,
+            dataset=dataset_list[0],
+        )
+
+        # Start services
+        compose_cmd = ["docker", "compose", "-f", COMPOSE_FILE, "--profile"]
+        profile_list = first_config.profiles
+        if not profile_list:
+            print("No profiles specified")
+            return 1
+        cmd = compose_cmd + [profile_list[0]]
+        for p in profile_list[1:]:
+            cmd += ["--profile", p]
+
+        if not no_build:
+            cmd += ["up", "--build", "-d"]
+        else:
+            cmd += ["up", "-d"]
+
+        if run_cmd(cmd) != 0:
+            print("Failed to start services")
+            return 1
+
+        # Wait for readiness
+        if not readiness_wait(first_config.readiness_timeout):
+            print("Services failed to become ready")
+            stop_services()
+            return 1
+
+    # Run each dataset
+    for dataset_name in dataset_list:
+        print(f"\n{'='*60}")
+        print(f"Running {case} for dataset: {dataset_name}")
+        print(f"{'='*60}\n")
+
+        # Load config for this dataset (applies dataset-specific extraction configs)
+        try:
+            config = load_config(
+                case=case,
+                dataset=dataset_name,
+            )
+        except (FileNotFoundError, ValueError) as e:
+            print(f"Configuration error for {dataset_name}: {e}", file=sys.stderr)
+            results.append({"dataset": dataset_name, "status": "config_error", "rc": 1, "artifact_dir": "N/A"})
+            continue
+
+        # Determine artifact name
+        artifact_name = config.test_name
+        if not artifact_name:
+            artifact_name = os.path.basename(config.dataset_dir.rstrip("/"))
+
+        out_dir = create_artifacts_dir(config.artifacts_dir, artifact_name)
+        stdout_path = os.path.join(out_dir, "stdout.txt")
+
+        print(f"Dataset: {config.dataset_dir}")
+        print(f"Artifacts: {out_dir}")
+        print()
+
+        # For recall case, validate recall_dataset and set collection_name
+        if case in ("recall", "e2e_recall"):
+            recall_dataset = getattr(config, "recall_dataset", None)
+            if not recall_dataset:
+                print(f"ERROR: Dataset '{dataset_name}' does not have recall_dataset configured", file=sys.stderr)
+                print(f"  This dataset cannot be used with --case={case}", file=sys.stderr)
+                print(
+                    "  Set recall_dataset in test_configs.yaml datasets section or use a different dataset",
+                    file=sys.stderr,
+                )
+                results.append({"dataset": dataset_name, "status": "config_error", "rc": 1, "artifact_dir": "N/A"})
+                continue
+
+            # Set collection_name from dataset if not set
+            if case == "recall" and not config.collection_name:
+                from cases.recall_utils import get_recall_collection_name
+
+                # Use same logic as recall.py: test_name from config, or basename of dataset_dir
+                test_name_for_collection = config.test_name or os.path.basename(config.dataset_dir.rstrip("/"))
+                config.collection_name = get_recall_collection_name(test_name_for_collection)
+
+        # Run the test case
+        if case in CASES:
+            rc = run_case(case, stdout_path, config, doc_analysis)
+        else:
+            print(f"Unknown case: {case}")
+            rc = 2
+
+        # Consolidate runner metadata + test results into single results.json
+        consolidated = {
+            "case": case,
+            "timestamp": now_timestr(),
+            "latest_commit": last_commit(),
+            "infrastructure": "managed" if managed else "attach",
+            "api_version": config.api_version,
+            "pdf_split_page_count": config.pdf_split_page_count,
+            "return_code": rc,
+        }
+
+        if managed:
+            consolidated["profiles"] = config.profiles
+
+        # Merge test results if available
+        test_results_file = os.path.join(out_dir, "_test_results.json")
+        if os.path.exists(test_results_file):
+            try:
+                with open(test_results_file) as f:
+                    test_data = json.load(f)
+                    consolidated.update(test_data)
+                # Clean up intermediate file
+                os.remove(test_results_file)
+            except (json.JSONDecodeError, IOError) as e:
+                print(f"Warning: Could not read test results: {e}")
+
+        # Write consolidated results.json
+        results_path = os.path.join(out_dir, "results.json")
+        with open(results_path, "w") as f:
+            json.dump(consolidated, f, indent=2)
+
+        print(f"\n{'='*60}")
+        print(f"Results written to: {results_path}")
+        print(f"{'='*60}")
+
+        # Collect results
+        results.append(
+            {"dataset": dataset_name, "artifact_dir": out_dir, "rc": rc, "status": "success" if rc == 0 else "failed"}
+        )
+
+    # Stop services if managed mode and not keeping up
+    if managed and not keep_up:
+        stop_services()
+
+    # Print summary
+    print("\n" + "=" * 60)
+    print("Test Summary")
+    print("=" * 60)
+    for result in results:
+        status_icon = "✓" if result["rc"] == 0 else "✗"
+        artifact_info = f" (artifacts: {result['artifact_dir']})" if result.get("artifact_dir") != "N/A" else ""
+        print(f"{status_icon} {result['dataset']}: {result['status']}{artifact_info}")
+    print("=" * 60)
+
+    # Return non-zero if any test failed
+    return 0 if all(r["rc"] == 0 for r in results) else 1
+
+
 def run_case(case_name: str, stdout_path: str, config, doc_analysis: bool = False) -> int:
     """Run a test case directly in the same process with real-time output."""
     import importlib.util
@@ -143,136 +302,43 @@ def run_case(case_name: str, stdout_path: str, config, doc_analysis: bool = Fals
 
 @click.command()
 @click.option("--case", default="e2e", help="Test case name to run")
-@click.option("--managed", is_flag=True, help="Use managed infrastructure (starts/stops Docker services)")
-@click.option("--dataset", help="Dataset name (shortcut) or path")
-@click.option("--test-name", help="Override test name for artifacts and collection naming")
-@click.option("--api-version", help="Override API version (v1 or v2)")
-@click.option("--pdf-split-page-count", type=int, help="V2 API: Override PDF pages per chunk (1-128)")
-@click.option("--no-build", is_flag=True, help="Skip building Docker images")
-@click.option("--keep-up", is_flag=True, help="Keep services running after test")
+@click.option(
+    "--managed", is_flag=True, help="Manage Docker services (start/stop). Default: attach to existing services"
+)
+@click.option(
+    "--dataset", help="Dataset name(s) - single name, comma-separated list, or path (e.g., bo767 or bo767,earnings)"
+)
+@click.option("--no-build", is_flag=True, help="Skip building Docker images (managed mode only)")
+@click.option("--keep-up", is_flag=True, help="Keep services running after test (managed mode only)")
 @click.option("--doc-analysis", is_flag=True, help="Show per-document element breakdown")
-@click.option("--readiness-timeout", type=int, help="Override service readiness timeout in seconds")
-@click.option("--artifacts-dir", help="Override artifacts output directory")
 def main(
     case,
     managed,
     dataset,
-    test_name,
-    api_version,
-    pdf_split_page_count,
     no_build,
     keep_up,
     doc_analysis,
-    readiness_timeout,
-    artifacts_dir,
 ):
 
-    # Load configuration from YAML with CLI overrides
-    try:
-        config = load_config(
-            case=case,
-            dataset=dataset,
-            test_name=test_name,
-            api_version=api_version,
-            pdf_split_page_count=pdf_split_page_count,
-            readiness_timeout=readiness_timeout,
-            artifacts_dir=artifacts_dir,
-        )
-    except (FileNotFoundError, ValueError) as e:
-        print(f"Configuration error: {e}", file=sys.stderr)
+    if not dataset:
+        print("Error: --dataset is required. Use --dataset=<name> or --dataset=<name1>,<name2>", file=sys.stderr)
         return 1
 
-    # Use TEST_NAME for artifacts (consistent with collection naming), fallback to dataset dir
-    artifact_name = config.test_name
-    if not artifact_name:
-        artifact_name = os.path.basename(config.dataset_dir.rstrip("/"))
+    # Parse dataset(s) - handle both single and comma-separated
+    dataset_list = [d.strip() for d in dataset.split(",") if d.strip()]
+    if not dataset_list:
+        print("Error: No valid datasets found", file=sys.stderr)
+        return 1
 
-    out_dir = create_artifacts_dir(config.artifacts_dir, artifact_name)
-    stdout_path = os.path.join(out_dir, "stdout.txt")
-
-    # Display test runner info
-    print("=" * 60)
-    print(f"Test Runner: {case} | API: {config.api_version} | Mode: {'managed' if managed else 'attach'}")
-    print(f"Dataset: {config.dataset_dir}")
-    print(f"Artifacts: {out_dir}")
-    print("=" * 60)
-    print()
-
-    rc = 1
-    try:
-        if managed:
-            compose_cmd = [
-                "docker",
-                "compose",
-                "-f",
-                COMPOSE_FILE,
-                "--profile",
-            ]
-            # Apply the first profile with --profile, remaining as repeated flags
-            profile_list = config.profiles
-            if not profile_list:
-                print("No profiles specified")
-                return 1
-            cmd = compose_cmd + [profile_list[0]]
-            for p in profile_list[1:]:
-                cmd += ["--profile", p]
-            cmd += ["up", "-d"]
-            if not no_build:
-                cmd.append("--build")
-            rc = run_cmd(cmd)
-            if rc != 0:
-                return rc
-            # Start readiness timer AFTER compose finishes
-            if not readiness_wait(config.readiness_timeout):
-                print(f"Runtime not ready within {config.readiness_timeout}s after compose")
-                return 1
-
-        # Run case
-        if case in CASES:
-            rc = run_case(case, stdout_path, config, doc_analysis)
-        else:
-            print(f"Unknown case: {case}")
-            rc = 2
-
-        # Consolidate runner metadata + test results into single results.json
-        consolidated = {
-            "case": case,
-            "timestamp": now_timestr(),
-            "latest_commit": last_commit(),
-            "infrastructure": "managed" if managed else "attach",
-            "api_version": config.api_version,
-            "pdf_split_page_count": config.pdf_split_page_count,
-            "return_code": rc,
-        }
-
-        if managed:
-            consolidated["profiles"] = config.profiles
-
-        # Merge test results if available
-        test_results_file = os.path.join(out_dir, "_test_results.json")
-        if os.path.exists(test_results_file):
-            try:
-                with open(test_results_file) as f:
-                    test_data = json.load(f)
-                    consolidated.update(test_data)
-                # Clean up intermediate file
-                os.remove(test_results_file)
-            except (json.JSONDecodeError, IOError) as e:
-                print(f"Warning: Could not read test results: {e}")
-
-        # Write consolidated results.json
-        results_path = os.path.join(out_dir, "results.json")
-        with open(results_path, "w") as f:
-            json.dump(consolidated, f, indent=2)
-
-        print(f"\n{'='*60}")
-        print(f"Results written to: {results_path}")
-        print(f"{'='*60}")
-
-        return rc
-    finally:
-        if managed and not keep_up:
-            stop_services()
+    # Use run_datasets() for both single and multiple datasets
+    return run_datasets(
+        case=case,
+        dataset_list=dataset_list,
+        managed=managed,
+        no_build=no_build,
+        keep_up=keep_up,
+        doc_analysis=doc_analysis,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_configs.yaml
+++ b/scripts/tests/test_configs.yaml
@@ -8,7 +8,7 @@ active:
   test_name: null  # Auto-generated if null
 
   # API configuration
-  api_version: v1  # v1 or v2
+  api_version: v1 # v1 or v2
   pdf_split_page_count: null  # V2 only: pages per chunk (null = default 32)
 
   # Infrastructure
@@ -54,3 +54,53 @@ recall:
   # Recall evaluation settings
   recall_top_k: 10
   ground_truth_dir: null
+
+# Pre-configured datasets
+# Each dataset includes path, extraction settings, and recall evaluator
+# Use: python run.py --case=e2e --dataset=bo767
+datasets:
+  bo767:
+    path: /path/to/bo767
+    extract_text: true
+    extract_tables: true
+    extract_charts: true
+    extract_images: false
+    extract_infographics: false
+    recall_dataset: bo767  # Evaluator for recall testing
+
+  earnings:
+    path: /path/to/earnings_consulting
+    extract_text: true
+    extract_tables: true
+    extract_charts: true
+    extract_images: false
+    extract_infographics: false
+    recall_dataset: earnings  # Evaluator for recall testing
+
+  bo20:
+    path: /path/to/bo20
+    extract_text: true
+    extract_tables: true
+    extract_charts: true
+    extract_images: true
+    extract_infographics: false
+    recall_dataset: null  # bo20 does not have recall
+
+  financebench:
+    path: /path/to/financebench_full
+    extract_text: true
+    extract_tables: true
+    extract_charts: true
+    extract_images: true
+    extract_infographics: true
+    recall_dataset: finance_bench  # Evaluator for recall testing
+
+  # Single file example
+  single:
+    path: data/multimodal_test.pdf
+    extract_text: true
+    extract_tables: true
+    extract_charts: true
+    extract_images: true
+    extract_infographics: true
+    recall_dataset: null  # No recall evaluator for single file


### PR DESCRIPTION
## Description
Continuing development on intra-ingest RCI.

simplifying run.py a bit but also adding sweeping functionality for testing across multiple datasets in the same case. 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
