### PR TITLE
updating all vlm v1 refs to v2

### DIFF
--- a/api/src/nv_ingest_api/internal/schemas/transform/transform_image_caption_schema.py
+++ b/api/src/nv_ingest_api/internal/schemas/transform/transform_image_caption_schema.py
@@ -10,7 +10,7 @@ class ImageCaptionExtractionSchema(BaseModel):
     api_key: str = Field(default="", repr=False)
     endpoint_url: str = "https://integrate.api.nvidia.com/v1/chat/completions"
     prompt: str = "Caption the content of this image:"
-    model_name: str = "nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
+    model_name: str = "nvidia/nemotron-nano-12b-v2-vl"
     raise_on_failure: bool = False
     model_config = ConfigDict(extra="forbid")
 

--- a/config/default_pipeline.yaml
+++ b/config/default_pipeline.yaml
@@ -302,7 +302,7 @@ stages:
     actor: "nv_ingest.framework.orchestration.ray.stages.transforms.image_caption:ImageCaptionTransformStage"
     config:
       api_key: $NGC_API_KEY|$NVIDIA_API_KEY
-      model_name: $VLM_CAPTION_MODEL_NAME|"nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
+      model_name: $VLM_CAPTION_MODEL_NAME|"nvidia/nemotron-nano-12b-v2-vl"
       prompt: "Caption the content of this image:"
     replicas:
       min_replicas: 0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -200,7 +200,7 @@ services:
       - nemoretriever-parse
 
   vlm:
-    image: ${VLM_IMAGE:-nvcr.io/nim/nvidia/llama-3.1-nemotron-nano-vl-8b-v1}:${VLM_TAG:-latest}
+    image: ${VLM_IMAGE:-nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl}:${VLM_TAG:-latest}
     ports:
       - "8018:8000"
     user: root
@@ -338,7 +338,7 @@ services:
       - YOLOX_TABLE_STRUCTURE_HTTP_ENDPOINT=http://table-structure:8000/v1/infer
       - YOLOX_TABLE_STRUCTURE_INFER_PROTOCOL=grpc
       - VLM_CAPTION_ENDPOINT=http://vlm:8000/v1/chat/completions
-      - VLM_CAPTION_MODEL_NAME=nvidia/llama-3.1-nemotron-nano-vl-8b-v1
+      - VLM_CAPTION_MODEL_NAME=nvidia/nemotron-nano-12b-v2-vl
       - MODEL_PREDOWNLOAD_PATH=${MODEL_PREDOWNLOAD_PATH:-/workspace/models/}
       # "ready" check configuration.
       # 1. COMPONENTS_TO_READY_CHECK= to disable and readiness checking

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -284,7 +284,7 @@ nemoretriever-table-structure-v1:
 ## @param nim-vlm-image-captioning.fullnameOverride [default: "nim-vlm-image-captioning"] Override the full name of the deployment
 ## @param nim-vlm-image-captioning.customCommand [default: []] Custom command to run in the container
 ## @param nim-vlm-image-captioning.customArgs [default: []] Custom arguments to pass to the container command
-## @param nim-vlm-image-captioning.image.repository [default: "nvcr.io/nim/nvidia/llama-3.1-nemotron-nano-vl-8b-v1"] The container image repository
+## @param nim-vlm-image-captioning.image.repository [default: "nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl"] The container image repository
 ## @param nim-vlm-image-captioning.image.tag [default: "latest"] The container image tag
 ## @param nim-vlm-image-captioning.podSecurityContext [default: {}] Pod security context configuration
 ## @param nim-vlm-image-captioning.replicaCount [default: 1] Number of replicas to deploy
@@ -302,7 +302,7 @@ nim-vlm-image-captioning:
   customCommand: []
   customArgs: []
   image:
-    repository: nvcr.io/nim/nvidia/llama-3.1-nemotron-nano-vl-8b-v1
+    repository: nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl
     tag: "1"
   podSecurityContext:
     runAsUser: 1000
@@ -1009,7 +1009,7 @@ prometheus:
 ## @param envVars.EMBEDDING_NIM_MODEL_NAME [default: "nvidia/llama-3.2-nv-embedqa-1b-v2"] Model name for embedding service
 ## @param envVars.MILVUS_ENDPOINT [default: "http://nv-ingest-milvus:19530"] Endpoint for Milvus vector database
 ## @param envVars.VLM_CAPTION_ENDPOINT [default: "https://integrate.api.nvidia.com/v1/chat/completions"] Endpoint for VLM caption service
-## @param envVars.VLM_CAPTION_MODEL_NAME [default: "nvidia/llama-3.1-nemotron-nano-vl-8b-v1"] Model name for VLM caption service
+## @param envVars.VLM_CAPTION_MODEL_NAME [default: "nvidia/nemotron-nano-12b-v2-vl"] Model name for VLM caption service
 ## @param envVars.AUDIO_GRPC_ENDPOINT [default: "nv-ingest-riva-nim:50051"] gRPC endpoint for audio service
 ## @param envVars.AUDIO_INFER_PROTOCOL [default: "grpc"] Protocol for audio service
 ## @param envVars.COMPONENTS_TO_READY_CHECK [default: "ALL"] Components to check during readiness probe
@@ -1060,7 +1060,7 @@ envVars:
   # sets this value to "nim-vlm-image-captioning:8001" to use the locally deployed NIM if the nim-vlm-image-captioning.deployed
   # condition is true, otherwise it is set to "https://integrate.api.nvidia.com/v1/chat/completions" to use the NGC hosted NIM
   # VLM_CAPTION_ENDPOINT: "DO_NOT_USE_HERE_FOR_REFERENCE_ONLY"
-  VLM_CAPTION_MODEL_NAME: "nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
+  VLM_CAPTION_MODEL_NAME: "nvidia/nemotron-nano-12b-v2-vl"
 
   AUDIO_GRPC_ENDPOINT: "nv-ingest-riva-nim:50051"
   AUDIO_INFER_PROTOCOL: "grpc"

--- a/src/nv_ingest/framework/orchestration/ray/examples/pipeline_test_harness.py
+++ b/src/nv_ingest/framework/orchestration/ray/examples/pipeline_test_harness.py
@@ -152,11 +152,11 @@ if __name__ == "__main__":
     os.environ["OCR_MODEL_NAME"] = "paddle"
     os.environ["NEMORETRIEVER_PARSE_HTTP_ENDPOINT"] = "https://integrate.api.nvidia.com/v1/chat/completions"
     os.environ["VLM_CAPTION_ENDPOINT"] = "https://integrate.api.nvidia.com/v1/chat/completions"
-    os.environ["VLM_CAPTION_MODEL_NAME"] = "nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
+    os.environ["VLM_CAPTION_MODEL_NAME"] = "nvidia/nemotron-nano-12b-v2-vl"
     logger.info("Environment variables set.")
 
     image_caption_endpoint_url = "https://integrate.api.nvidia.com/v1/chat/completions"
-    model_name = "nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
+    model_name = "nvidia/nemotron-nano-12b-v2-vl"
     yolox_grpc, yolox_http, yolox_auth, yolox_protocol = get_nim_service("yolox")
     (
         yolox_table_structure_grpc,

--- a/src/nv_ingest/pipeline/default_libmode_pipeline_impl.py
+++ b/src/nv_ingest/pipeline/default_libmode_pipeline_impl.py
@@ -318,8 +318,8 @@ stages:
     actor: "nv_ingest.framework.orchestration.ray.stages.transforms.image_caption:ImageCaptionTransformStage"
     config:
       api_key: $NGC_API_KEY|$NVIDIA_API_KEY
-      endpoint_url: $VLM_CAPTION_ENDPOINT|"https://integrate.api.nvidia.com/v1/chat/completions"
-      model_name: $VLM_CAPTION_MODEL_NAME|"nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
+      endpoint_url: $VLM_CAPTION_ENDPOINT|"http://vlm:8000/v1/chat/completions"
+      model_name: $VLM_CAPTION_MODEL_NAME|"nvidia/nemotron-nano-12b-v2-vl"
       prompt: "Caption the content of this image:"
     replicas:
       min_replicas: 0

--- a/src/nv_ingest/pipeline/default_pipeline_impl.py
+++ b/src/nv_ingest/pipeline/default_pipeline_impl.py
@@ -317,7 +317,7 @@ stages:
     actor: "nv_ingest.framework.orchestration.ray.stages.transforms.image_caption:ImageCaptionTransformStage"
     config:
       api_key: $NGC_API_KEY|$NVIDIA_API_KEY
-      model_name: $VLM_CAPTION_MODEL_NAME|"nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
+      model_name: $VLM_CAPTION_MODEL_NAME|"nvidia/nemotron-nano-12b-v2-vl"
       endpoint_url: $VLM_CAPTION_ENDPOINT|"http://vlm:8000/v1/chat/completions"
       prompt: "Caption the content of this image:"
     replicas:

--- a/tests/service_tests/schemas/test_image_caption_extraction_schema.py
+++ b/tests/service_tests/schemas/test_image_caption_extraction_schema.py
@@ -15,7 +15,7 @@ def test_valid_schema():
     assert schema.api_key == "your-api-key-here"
     assert schema.endpoint_url == "https://integrate.api.nvidia.com/v1/chat/completions"
     assert schema.prompt == "Caption the content of this image:"
-    assert schema.model_name == "nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
+    assert schema.model_name == "nvidia/nemotron-nano-12b-v2-vl"
     assert schema.raise_on_failure is False
 
 


### PR DESCRIPTION
## Description
Newest VLM release: 

https://build.nvidia.com/nvidia/nemotron-nano-12b-v2-vl/modelcard

https://catalog.ngc.nvidia.com/orgs/nim/teams/nvidia/containers/nemotron-nano-12b-v2-vl?version=1

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
