### PR TITLE
Fix mil records

### DIFF
--- a/client/src/nv_ingest_client/util/vdb/milvus.py
+++ b/client/src/nv_ingest_client/util/vdb/milvus.py
@@ -904,6 +904,7 @@ def wait_for_index(collection_name: str, num_elements: int, client: MilvusClient
     indexed_rows = 0
     for index_name in index_names:
         indexed_rows = 0
+        already_indexed_rows = client.describe_index(collection_name, index_name)["indexed_rows"]
         while indexed_rows < num_elements:
             pos_movement = 10  # number of iteration allowed without noticing an increase in indexed_rows
             for i in range(20):
@@ -912,7 +913,7 @@ def wait_for_index(collection_name: str, num_elements: int, client: MilvusClient
                 logger.info(
                     f"polling for indexed rows, {collection_name}, {index_name} -  {new_indexed_rows} / {num_elements}"
                 )
-                if new_indexed_rows == num_elements:
+                if new_indexed_rows == already_indexed_rows + num_elements:
                     indexed_rows = new_indexed_rows
                     break
                 # check if indexed_rows is staying the same, too many times means something is wrong


### PR DESCRIPTION
## Description
This PR fixes an issue with the wait_for_index function for Milvus that shows up when you write multiple (separate) batches to the same collection.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
