### PR TITLE
Update Attu service to v2.5.3

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -489,10 +489,10 @@ services:
     # Turn on to leverage the `vdb_upload` task
     restart: always
     container_name: milvus-attu
-    image: zilliz/attu:v2.3.5
+    image: zilliz/attu:v2.5.3
     hostname: attu
     environment:
-      MILVUS_URL: http://milvus:19530
+      MILVUS_URL: milvus:19530
     ports:
       - "3001:3000"
     depends_on:


### PR DESCRIPTION
## Description
- Bumps Attu version to match the Milvus version
  https://github.com/NVIDIA/nv-ingest/blob/ffa227794e8d003335635688a902c6bedb327389/docker-compose.yaml#L456
- Adjusts `MILVUS_URL` from `http://milvus:19530` to `milvus:19530`, which aligns with Attu’s expected connection string format (`milvus:19530`, not `http://milvus:19530`) and avoids issues with the built-in health check / connectivity logic

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
