### PR TITLE
add bucket name check for setup

### DIFF
--- a/client/client_tests/util/test_milvus_util.py
+++ b/client/client_tests/util/test_milvus_util.py
@@ -523,3 +523,14 @@ class TestVDBUpload(unittest.TestCase):
         # Try to add an invalid VDB operator
         with self.assertRaises(ValueError):
             ingestor.vdb_upload(vdb_op="not_a_vdb_op")
+
+
+def test_milvus_bucket_name_validation():
+    """Test that providing a bucket_name different from the environment variable raises a ValueError."""
+    from nv_ingest_client.util.vdb.milvus import Milvus
+
+    # Attempt to create a Milvus instance with a different bucket_name
+    with pytest.raises(ValueError) as excinfo:
+        Milvus(bucket_name="different-bucket")
+
+    assert "You must use the environment variable MINIO_BUCKET to specify bucket_name" in str(excinfo.value)

--- a/client/src/nv_ingest_client/util/vdb/milvus.py
+++ b/client/src/nv_ingest_client/util/vdb/milvus.py
@@ -2005,6 +2005,12 @@ class Milvus(VDB):
         """
         kwargs = locals().copy()
         kwargs.pop("self", None)
+        bucket_name = kwargs.get("bucket_name", None)
+        if bucket_name is not None and bucket_name != ClientConfigSchema().minio_bucket_name:
+            raise ValueError(
+                "You must use the environment variable MINIO_BUCKET to specify bucket_name, detected:",
+                f"`bucket_name`: {bucket_name} and MINIO_BUCKET: {ClientConfigSchema().minio_bucket_name}",
+            )
         super().__init__(**kwargs)
 
     def create_index(self, **kwargs):


### PR DESCRIPTION
## Description
This PR adds a check when instantiating a milvus operator the prevents a user from setting a bucket_name in the operator directly that is different from the MINIO_BUCKET env var value. This will prevent bad service setups that lead to incorrect bucket usage.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
