### PR TITLE
Milvus stream wait off

### DIFF
--- a/client/src/nv_ingest_client/util/vdb/milvus.py
+++ b/client/src/nv_ingest_client/util/vdb/milvus.py
@@ -1055,7 +1055,7 @@ def write_to_nvingest_collection(
             client,
             collection_name,
         )
-        if not local_index or no_wait_index:
+        if not local_index or not no_wait_index:
             # Make sure all rows are indexed, decided not to wrap in a timeout because we dont
             # know how long this should take, it is num_elements dependent.
             wait_for_index(collection_name, expected_rows, client)


### PR DESCRIPTION
## Description
This PR adds a boolean switch to milvus vdb operator to not wait when streaming

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
