### PR TITLE
Updating prereq docs to reflect builds changes

### DIFF
--- a/docs/docs/extraction/prerequisites.md
+++ b/docs/docs/extraction/prerequisites.md
@@ -8,6 +8,7 @@ Before you begin using [NeMo Retriever extraction](overview.md), ensure the foll
 - Linux operating systems (Ubuntu 22.04 or later recommended)
 - [Docker](https://docs.docker.com/engine/install/)
 - [Docker Compose](https://docs.docker.com/compose/install/)
+- [Docker Buildx](https://docs.docker.com/build/buildx/install/) `>= 0.17` (Compose 2.40+ enforces this)
 - [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads) (NVIDIA Driver >= `535`, CUDA >= `12.2`)
 - [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
 - [Conda Python environment and package manager](https://github.com/conda-forge/miniforge)


### PR DESCRIPTION
## Description
Response to https://nvbugspro.nvidia.com/bug/5723454

26.01 now requires buildx > 0.17

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
