### PR TITLE
Adding shm size to vlm and nr parse in docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -176,6 +176,7 @@ services:
 
   nemoretriever-parse:
     image: ${NEMORETRIEVER_PARSE_IMAGE:-nvcr.io/nvidia/nemo-microservices/nemoretriever-parse}:${NEMORETRIEVER_PARSE_TAG:-latest}
+    shm_size: 16gb
     ports:
       - "8015:8000"
       - "8016:8001"
@@ -199,6 +200,7 @@ services:
 
   vlm:
     image: ${VLM_IMAGE:-nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl}:${VLM_TAG:-latest}
+    shm_size: 16gb
     ports:
       - "8018:8000"
     user: root


### PR DESCRIPTION
## Description
In response to https://nvbugspro.nvidia.com/bug/5730562



## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
