### PR TITLE
Add missing pdfium_hybrid option for page-elements-v3

### DIFF
--- a/client/src/nv_ingest_client/primitives/tasks/extract.py
+++ b/client/src/nv_ingest_client/primitives/tasks/extract.py
@@ -61,6 +61,7 @@ _Type_Extract_Method_PDF = Literal[
     "tika",
     "unstructured_io",
     "unstructured_local",
+    "pdfium_hybrid",
     "ocr",
 ]
 


### PR DESCRIPTION
## Description
This PR adds `pdfium_hybrid` to the list of PDF extraction options in the client. `pdfium_hybrid` is a valid option that was added in https://github.com/NVIDIA/nv-ingest/pull/1130, but it was accidentally dropped while fixing a merge conflict. 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
