### PR TITLE
Bump otel-collector version in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -372,7 +372,7 @@ services:
               capabilities: [gpu]
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.91.0
+    image: otel/opentelemetry-collector-contrib:0.140.0
     hostname: otel-collector
     command: ["--config=/etc/otel-collector-config.yaml"]
     user: "${UID:-1000}:${GID:-1000}"


### PR DESCRIPTION
## Description
Bumps `otel-collector` version in docker-compose.yaml to match the version in Helm.
https://github.com/NVIDIA/nv-ingest/blob/cb014c014f95a13e954e80cc2d3010b87f33e8c1/helm/values.yaml#L375-L378

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
