### PR TITLE
Pass HF token when downloading e5-large-unsupervised tokenizer

### DIFF
--- a/docker/scripts/post_build_triggers.py
+++ b/docker/scripts/post_build_triggers.py
@@ -11,5 +11,5 @@ else:
     tokenizer_path = os.path.join(os.environ.get("MODEL_PREDOWNLOAD_PATH"), "e5-large-unsupervised/tokenizer/")
     os.makedirs(tokenizer_path)
 
-    tokenizer = AutoTokenizer.from_pretrained("intfloat/e5-large-unsupervised")
+    tokenizer = AutoTokenizer.from_pretrained("intfloat/e5-large-unsupervised", token=os.getenv("HF_ACCESS_TOKEN"))
     tokenizer.save_pretrained(tokenizer_path)


### PR DESCRIPTION
## Description

Docker builds can intermittently fail with `429 Too Many Requests` errors when downloading the `e5-large-unsupervised` tokenizer from HuggingFace during the `post_build_triggers.py` step.

## Root Cause

The default tokenizer path downloads `e5-large-unsupervised` without passing an HF token. While this model is public and doesn't *require* authentication, unauthenticated requests have significantly lower rate limits.

## Fix

Pass `token=os.getenv("HF_ACCESS_TOKEN")` to the `AutoTokenizer.from_pretrained()` call for the e5 branch, matching the existing behavior in the Llama branch. This gives authenticated users higher rate limits, making builds more reliable.

## Notes

- `e5-large-unsupervised` is public, so the token is optional for access but beneficial for rate limits
- If `HF_ACCESS_TOKEN` is not set, `os.getenv()` returns `None`, which is handled gracefully by the HuggingFace library

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
