### PR TITLE
Fixed summarization UDF to work with latest upstream changes

### DIFF
--- a/config/custom_summarization_pipeline.yaml
+++ b/config/custom_summarization_pipeline.yaml
@@ -70,14 +70,14 @@ stages:
           $YOLOX_HTTP_ENDPOINT|"http://page-elements:8000/v1/infer",
         ]
         yolox_infer_protocol: $YOLOX_INFER_PROTOCOL|grpc
-      nemoretriever_parse_config:
+      nemotron_parse_config:
         auth_token: $NGC_API_KEY|$NVIDIA_API_KEY
-        nemoretriever_parse_endpoints: [
-          $NEMORETRIEVER_PARSE_GRPC_ENDPOINT|"",
-          $NEMORETRIEVER_PARSE_HTTP_ENDPOINT|"http://nemoretriever-parse:8000/v1/chat/completions",
+        nemotron_parse_endpoints: [
+          $NEMOTRON_PARSE_GRPC_ENDPOINT|"",
+          $NEMOTRON_PARSE_HTTP_ENDPOINT|"http://nemotron-parse:8000/v1/chat/completions",
         ]
-        nemoretriever_parse_infer_protocol: $NEMORETRIEVER_PARSE_INFER_PROTOCOL|http
-        nemoretriever_parse_model_name: $NEMORETRIEVER_PARSE_MODEL_NAME|"nvidia/nemoretriever-parse"
+        nemotron_parse_infer_protocol: $NEMOTRON_PARSE_INFER_PROTOCOL|http
+        nemotron_parse_model_name: $NEMOTRON_PARSE_MODEL_NAME|"nvidia/nemotron-parse"
         yolox_endpoints: [
           $YOLOX_GRPC_ENDPOINT|"page-elements:8001",
           $YOLOX_HTTP_ENDPOINT|"http://page-elements:8000/v1/infer",


### PR DESCRIPTION
## Description

Fixed changes within summarization UDF

1. Pre Split (32 pages) was causing multiple summaries per file depending on the length. Example if total pages in PDF is 32-64 it will 2 summaries, if it has 64-96 pages it will have 3 summaries, ... 
   - Added simple logic to skip non-first sections, so only the first and last chunk of the first section (1-32 pages) will be used for summarization. 

2. Fixed custom pipeline to use nemotron_parse* from depreciated nemoretriever-parse*
3. Minor upstream fixes 
   - Now using httpx instead of openai for API calls to build since we have removed that dep with https://github.com/NVIDIA/nv-ingest/pull/1101/changes
   - Changed max token limit to 4000, since the max token limit for the `nvidia/nemotron-mini-4b-instruct` is 4096

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
