### PR TITLE
Warn instead of fail on milvus no records to insert

### DIFF
--- a/client/src/nv_ingest_client/util/vdb/milvus.py
+++ b/client/src/nv_ingest_client/util/vdb/milvus.py
@@ -1049,7 +1049,8 @@ def write_to_nvingest_collection(
     )
     num_elements = len(cleaned_records)
     if num_elements == 0:
-        raise ValueError("No records with Embeddings to insert detected.")
+        logger.warning("No records with Embeddings to insert detected.")
+        return
     logger.info(f"{num_elements} elements to insert to milvus")
     logger.info(f"threshold for streaming is {threshold}")
     if num_elements < threshold:


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This makes is so that when something fails in an ingestion pipeline, the ingestor object is able to return errors and results with details of that failure instead of throwing an exception during the `vdb_upload` stage

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
