### PR TITLE
NIM Operator Updates

### DIFF
--- a/helm/templates/llama-3.2-nv-embedqa-1b-v2.yaml
+++ b/helm/templates/llama-3.2-nv-embedqa-1b-v2.yaml
@@ -1,8 +1,10 @@
-{{- if .Values.nimOperator.embedqa.enabled }}
+{{ if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq .Values.nimOperator.embedqa.enabled true) -}}
 apiVersion: apps.nvidia.com/v1alpha1
 kind: NIMCache
 metadata:
   name: llama-3.2-nv-embedqa-1b-v2
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   source:
     ngc:

--- a/helm/templates/llama-3.2-nv-rerankqa-1b-v2.yaml
+++ b/helm/templates/llama-3.2-nv-rerankqa-1b-v2.yaml
@@ -1,8 +1,10 @@
-{{- if .Values.nimOperator.llama_3_2_nv_rerankqa_1b_v2.enabled }}
+{{ if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq .Values.nimOperator.llama_3_2_nv_rerankqa_1b_v2.enabled true) -}}
 apiVersion: apps.nvidia.com/v1alpha1
 kind: NIMCache
 metadata:
   name: llama-3.2-nv-rerankqa-1b-v2
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   source:
     ngc:

--- a/helm/templates/nemoretriever-graphic-elements-v1.yaml
+++ b/helm/templates/nemoretriever-graphic-elements-v1.yaml
@@ -1,8 +1,10 @@
-{{- if .Values.nimOperator.graphic_elements.enabled }}
+{{ if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq .Values.nimOperator.graphic_elements.enabled true) -}}
 apiVersion: apps.nvidia.com/v1alpha1
 kind: NIMCache
 metadata:
   name: nemoretriever-graphic-elements-v1
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   source:
     ngc:

--- a/helm/templates/nemoretriever-ocr-v1.yaml
+++ b/helm/templates/nemoretriever-ocr-v1.yaml
@@ -1,8 +1,10 @@
-{{- if .Values.nimOperator.nemoretriever_ocr_v1.enabled }}
+{{ if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq .Values.nimOperator.nemoretriever_ocr_v1.enabled true) -}}
 apiVersion: apps.nvidia.com/v1alpha1
 kind: NIMCache
 metadata:
   name: nemoretriever-ocr-v1
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   source:
     ngc:

--- a/helm/templates/nemoretriever-page-elements-v3.yaml
+++ b/helm/templates/nemoretriever-page-elements-v3.yaml
@@ -1,8 +1,10 @@
-{{- if .Values.nimOperator.page_elements.enabled }}
+{{ if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq .Values.nimOperator.page_elements.enabled true) -}}
 apiVersion: apps.nvidia.com/v1alpha1
 kind: NIMCache
 metadata:
   name: nemoretriever-page-elements-v3
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   source:
     ngc:

--- a/helm/templates/nemoretriever-table-structure-v1.yaml
+++ b/helm/templates/nemoretriever-table-structure-v1.yaml
@@ -1,9 +1,11 @@
-{{- if .Values.nimOperator.table_structure.enabled }}
+{{ if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq .Values.nimOperator.table_structure.enabled true) -}}
 apiVersion: apps.nvidia.com/v1alpha1
 kind: NIMCache
 metadata:
   name: nemoretriever-table-structure-v1
-spec:
+  annotations:
+    helm.sh/resource-policy: keep
+spec: 
   source:
     ngc:
       modelPuller: "{{ .Values.nimOperator.table_structure.image.repository }}:{{ .Values.nimOperator.table_structure.image.tag }}"

--- a/helm/templates/nemotron-nano-12b-v2-vl.yaml
+++ b/helm/templates/nemotron-nano-12b-v2-vl.yaml
@@ -1,8 +1,10 @@
-{{- if .Values.nimOperator.nemotron_nano_12b_v2_vl.enabled }}
+{{ if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq .Values.nimOperator.nemotron_nano_12b_v2_vl.enabled true) -}}
 apiVersion: apps.nvidia.com/v1alpha1
 kind: NIMCache
 metadata:
   name: nemotron-nano-12b-v2-vl
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   source:
     ngc:

--- a/helm/templates/paddle-ocr.yaml
+++ b/helm/templates/paddle-ocr.yaml
@@ -1,8 +1,10 @@
-{{- if .Values.nimOperator.paddleocr.enabled }}
+{{ if and (.Capabilities.APIVersions.Has "apps.nvidia.com/v1alpha1") (eq .Values.nimOperator.paddleocr.enabled true) -}}
 apiVersion: apps.nvidia.com/v1alpha1
 kind: NIMCache
 metadata:
   name: paddleocr
+  annotations:
+    helm.sh/resource-policy: keep
 spec:
   source:
     ngc:


### PR DESCRIPTION
## Description

Description
This PR modifies the existing nv-ingest NIM Operator Manifests

This PR 
1. Keep NIMCache if helm chart is uninstalled and it will save time when helm chart re installed again on the same cluster as it will just launch the NIMService using existing NIMCache (this is one of the main usage of NIM Operator)
2. helm template validate if NIM Operator CRD is installed on the cluster before trigger the installation 


<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
