### PR TITLE
fix: use conda instead of apt-get to install make in docs stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -224,13 +224,11 @@ CMD ["/bin/bash"]
 
 FROM nv_ingest_install AS docs
 
-# Install dependencies needed for docs generation
-# Clear stale apt lists and use --fix-missing to handle repository issues
-RUN rm -rf /var/lib/apt/lists/* \
-    && apt-get update --fix-missing \
-    && apt-get install -y --no-install-recommends make \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+# Install make via conda to avoid apt repository issues
+# (deb-src repos enabled in base stage can cause apt-get update failures)
+RUN --mount=type=cache,target=/opt/conda/pkgs \
+    source activate nv_ingest_runtime \
+    && mamba install -y -c conda-forge make
 
 COPY docs docs
 


### PR DESCRIPTION
The deb-src repositories enabled in the base stage (line 69) cause apt-get update to fail with exit code 100 when those source repos are unavailable.

Instead of fighting apt repository issues, use conda/mamba to install make from conda-forge. This is more reliable since conda is already set up in the image and doesn't depend on external apt mirrors.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
