### PR TITLE
Fix client default batch_size

### DIFF
--- a/client/src/nv_ingest_client/client/client.py
+++ b/client/src/nv_ingest_client/client/client.py
@@ -1269,7 +1269,7 @@ class NvIngestClient:
         ----------
         batch_size : Optional[int]
             The batch_size value to validate. None uses value from
-            NV_INGEST_BATCH_SIZE environment variable or default 32.
+            NV_INGEST_BATCH_SIZE environment variable or default 16.
 
         Returns
         -------
@@ -1279,18 +1279,18 @@ class NvIngestClient:
         # Handle None/default case
         if batch_size is None:
             try:
-                batch_size = int(os.getenv("NV_INGEST_CLIENT_BATCH_SIZE", "32"))
+                batch_size = int(os.getenv("NV_INGEST_CLIENT_BATCH_SIZE", "16"))
             except ValueError:
-                batch_size = 32
+                batch_size = 16
 
         # Validate type and range
         if not isinstance(batch_size, int):
-            logger.warning(f"batch_size must be an integer, got {type(batch_size).__name__}. Using default 32.")
-            return 32
+            logger.warning(f"batch_size must be an integer, got {type(batch_size).__name__}. Using default 16.")
+            return 16 
 
         if batch_size < 1:
-            logger.warning(f"batch_size must be >= 1, got {batch_size}. Using default 32.")
-            return 32
+            logger.warning(f"batch_size must be >= 1, got {batch_size}. Using default 16.")
+            return 16
 
         # Performance guidance warnings
         if batch_size < 8:


### PR DESCRIPTION
## Description
Lowering default batch_size for files on client, from 32 to 16. This is done to ensure out of the box execution on the least supported resource profile with video.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
