### PR TITLE
Bump embedding image tag to 1.10.1

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -121,7 +121,7 @@ services:
 
   embedding:
     # NIM ON
-    image: ${EMBEDDING_IMAGE:-nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2}:${EMBEDDING_TAG:-1.10.0}
+    image: ${EMBEDDING_IMAGE:-nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2}:${EMBEDDING_TAG:-1.10.1}
     shm_size: 16gb
     ports:
       - "8012:8000"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -804,7 +804,7 @@ nimOperator:
     enabled: true
     image:
       repository: nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2
-      tag: 1.10.0
+      tag: 1.10.1
       pullPolicy: IfNotPresent
       pullSecrets:
         - ngc-secret


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
