### PR TITLE
Expose health check and internal metrics endpoints

### DIFF
--- a/config/otel-collector-config.yaml
+++ b/config/otel-collector-config.yaml
@@ -37,6 +37,7 @@ processors:
 
 extensions:
   health_check:
+    endpoint: "0.0.0.0:13133"
   zpages:
 
 service:
@@ -45,8 +46,13 @@ service:
     logs:
       level: "debug"
     metrics:
-      level: "basic"
-      # listen_address: "0.0.0.0:8888"  # optional if you want to override default
+      level: "detailed"
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: "0.0.0.0"
+                port: 9988
   pipelines:
     traces:
       receivers: [otlp]


### PR DESCRIPTION
## Description

Updates the OpenTelemetry Collector configuration to fix connectivity issues reported by QA:

- Configures the `health_check` extension to listen on `0.0.0.0:13133`, making it accessible from the host machine.
- Adds a Prometheus pull reader on port 9988 and increases telemetry verbosity to 'detailed'. This resolves the issue where the internal `otel-collector:9988` target was reported as DOWN.

<img width="1917" height="357" alt="image" src="https://github.com/user-attachments/assets/fd3ca97d-0e26-485b-a3c4-e6836c40f62b" />

<img width="1917" height="357" alt="image" src="https://github.com/user-attachments/assets/a003ee7d-245d-497d-b5b0-90be59b8f8c1" />

<img width="1917" height="357" alt="image" src="https://github.com/user-attachments/assets/e64efb8a-43c1-47e8-bf43-70fc36a8e201" />


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
