### PR TITLE
fix(helm): update MIG values to use nimOperator format for 26.x

### DIFF
--- a/helm/mig/nv-ingest-mig-values-25x.yaml
+++ b/helm/mig/nv-ingest-mig-values-25x.yaml
@@ -1,0 +1,97 @@
+# MIG Values for NV-Ingest 25.9.0 and earlier (subchart format)
+# For NV-Ingest 26.x, use nv-ingest-mig-values.yaml (NIM Operator format)
+
+# Main NV-Ingest service resources - Using MIG
+resources:
+  limits:
+    nvidia.com/gpu: 0              # Set GPU to 0 when using MIG
+    nvidia.com/mig-1g.10gb: 1      # Use MIG instance
+  requests:
+    nvidia.com/gpu: 0              # Set GPU to 0 when using MIG
+    nvidia.com/mig-1g.10gb: 1      # Use MIG instance
+
+# Configure NIM components to use MIG
+nemoretriever-page-elements-v3:
+  resources:
+    limits:
+      nvidia.com/gpu: 0
+      nvidia.com/mig-1g.10gb: 1
+    requests:
+      nvidia.com/gpu: 0
+      nvidia.com/mig-1g.10gb: 1
+
+nemoretriever-graphic-elements-v1:
+  resources:
+    limits:
+      nvidia.com/gpu: 0
+      nvidia.com/mig-1g.10gb: 1
+    requests:
+      nvidia.com/gpu: 0
+      nvidia.com/mig-1g.10gb: 1
+
+nemoretriever-table-structure-v1:
+  resources:
+    limits:
+      nvidia.com/gpu: 0
+      nvidia.com/mig-1g.10gb: 1
+    requests:
+      nvidia.com/gpu: 0
+      nvidia.com/mig-1g.10gb: 1
+
+nvidia-nim-llama-32-nv-embedqa-1b-v2:
+  resources:
+    limits:
+      nvidia.com/gpu: 0
+      nvidia.com/mig-1g.10gb: 1
+    requests:
+      nvidia.com/gpu: 0
+      nvidia.com/mig-1g.10gb: 1
+
+nemoretriever-ocr:
+  resources:
+    limits:
+      nvidia.com/gpu: 0
+      nvidia.com/mig-1g.10gb: 1
+    requests:
+      nvidia.com/gpu: 0
+      nvidia.com/mig-1g.10gb: 1
+
+paddleocr-nim:
+  resources:
+    limits:
+      nvidia.com/gpu: 0
+      nvidia.com/mig-1g.10gb: 1
+    requests:
+      nvidia.com/gpu: 0
+      nvidia.com/mig-1g.10gb: 1
+
+# text-embedding-nim is disabled because we use llama-3.2-nv-embedqa-1b-v2 for embedding
+text-embedding-nim:
+  resources:
+    limits:
+      nvidia.com/gpu: 0
+      nvidia.com/mig-1g.10gb: 1
+    requests:
+      nvidia.com/gpu: 0
+      nvidia.com/mig-1g.10gb: 1
+
+# If you want to deploy llama-32-nv-rerankqa-1b-v2
+llama-32-nv-rerankqa-1b-v2:
+  resources:
+    limits:
+      nvidia.com/gpu: 0
+      nvidia.com/mig-1g.10gb: 1
+    requests:
+      nvidia.com/gpu: 0
+      nvidia.com/mig-1g.10gb: 1
+
+# Configure Milvus to use MIG
+milvus:
+  standalone:
+    resources:
+      limits:
+        nvidia.com/gpu: 0
+        nvidia.com/mig-1g.10gb: 1
+      requests:
+        nvidia.com/gpu: 0
+        nvidia.com/mig-1g.10gb: 1

--- a/helm/mig/nv-ingest-mig-values.yaml
+++ b/helm/mig/nv-ingest-mig-values.yaml
@@ -1,3 +1,5 @@
+# MIG Values for NV-Ingest 26.x (NIM Operator format)
+# For NV-Ingest 25.9.0 and earlier, use nv-ingest-mig-values-25x.yaml
 
 # Main NV-Ingest service resources - Using MIG
 resources:
@@ -8,80 +10,80 @@ resources:
     nvidia.com/gpu: 0              # Set GPU to 0 when using MIG
     nvidia.com/mig-1g.10gb: 1      # Use MIG instance
 
-# Configure NIM components to use MIG
-nemoretriever-page-elements-v3:
-  resources:
-    limits:
-      nvidia.com/gpu: 0
-      nvidia.com/mig-1g.10gb: 1
-    requests:
-      nvidia.com/gpu: 0
-      nvidia.com/mig-1g.10gb: 1
+# Configure NIM Operator components to use MIG
+nimOperator:
+  page_elements:
+    resources:
+      limits:
+        nvidia.com/gpu: "0"
+        nvidia.com/mig-1g.10gb: 1
+      requests:
+        nvidia.com/gpu: "0"
+        nvidia.com/mig-1g.10gb: 1
 
-nemoretriever-graphic-elements-v1:
-  resources:
-    limits:
-      nvidia.com/gpu: 0
-      nvidia.com/mig-1g.10gb: 1
-    requests:
-      nvidia.com/gpu: 0
-      nvidia.com/mig-1g.10gb: 1
+  graphic_elements:
+    resources:
+      limits:
+        nvidia.com/gpu: "0"
+        nvidia.com/mig-1g.10gb: 1
+      requests:
+        nvidia.com/gpu: "0"
+        nvidia.com/mig-1g.10gb: 1
 
-nemoretriever-table-structure-v1:
-  resources:
-    limits:
-      nvidia.com/gpu: 0
-      nvidia.com/mig-1g.10gb: 1
-    requests:
-      nvidia.com/gpu: 0
-      nvidia.com/mig-1g.10gb: 1
+  table_structure:
+    resources:
+      limits:
+        nvidia.com/gpu: "0"
+        nvidia.com/mig-1g.10gb: 1
+      requests:
+        nvidia.com/gpu: "0"
+        nvidia.com/mig-1g.10gb: 1
 
-nvidia-nim-llama-32-nv-embedqa-1b-v2:
-  resources:
-    limits:
-      nvidia.com/gpu: 0
-      nvidia.com/mig-1g.10gb: 1
-    requests:
-      nvidia.com/gpu: 0
-      nvidia.com/mig-1g.10gb: 1
+  embedqa:
+    resources:
+      limits:
+        nvidia.com/gpu: "0"
+        nvidia.com/mig-1g.10gb: 1
+      requests:
+        nvidia.com/gpu: "0"
+        nvidia.com/mig-1g.10gb: 1
 
-nemoretriever-ocr:
-  resources:
-    limits:
-      nvidia.com/gpu: 0
-      nvidia.com/mig-1g.10gb: 1
-    requests:
-      nvidia.com/gpu: 0
-      nvidia.com/mig-1g.10gb: 1
+  nemoretriever_ocr_v1:
+    resources:
+      limits:
+        nvidia.com/gpu: "0"
+        nvidia.com/mig-1g.10gb: 1
+      requests:
+        nvidia.com/gpu: "0"
+        nvidia.com/mig-1g.10gb: 1
 
-paddleocr-nim:
-  resources:
-    limits:
-      nvidia.com/gpu: 0
-      nvidia.com/mig-1g.10gb: 1
-    requests:
-      nvidia.com/gpu: 0
-      nvidia.com/mig-1g.10gb: 1
+  paddleocr:
+    resources:
+      limits:
+        nvidia.com/gpu: "0"
+        nvidia.com/mig-1g.10gb: 1
+      requests:
+        nvidia.com/gpu: "0"
+        nvidia.com/mig-1g.10gb: 1
 
-# text-embedding-nim is disabled because we use llama-3.2-nv-embedqa-1b-v2 for embedding
-text-embedding-nim:
-  resources:
-    limits:
-      nvidia.com/gpu: 0
-      nvidia.com/mig-1g.10gb: 1
-    requests:
-      nvidia.com/gpu: 0
-      nvidia.com/mig-1g.10gb: 1
+  # If you want to deploy llama-32-nv-rerankqa-1b-v2
+  llama_3_2_nv_rerankqa_1b_v2:
+    resources:
+      limits:
+        nvidia.com/gpu: "0"
+        nvidia.com/mig-1g.10gb: 1
+      requests:
+        nvidia.com/gpu: "0"
+        nvidia.com/mig-1g.10gb: 1
 
-# If you want to deploy llama-32-nv-rerankqa-1b-v2
-llama-32-nv-rerankqa-1b-v2:
-  resources:
-    limits:
-      nvidia.com/gpu: 0
-      nvidia.com/mig-1g.10gb: 1
-    requests:
-      nvidia.com/gpu: 0
-      nvidia.com/mig-1g.10gb: 1
+  nemotron_nano_12b_v2_vl:
+    resources:
+      limits:
+        nvidia.com/gpu: "0"
+        nvidia.com/mig-7g.80gb: 1
+      requests:
+        nvidia.com/gpu: "0"
+        nvidia.com/mig-7g.80gb: 1
 
 # Configure Milvus to use MIG
 milvus:


### PR DESCRIPTION
## Description

The MIG values file was using 25.x subchart naming (e.g.,nemoretriever-page-elements-v3) which is silently ignored in 26.x.
Updated to use nimOperator.* keys that match the helm templates.

Created nv-ingest-mig-values-25x.yaml for backward compatibility with 25.9.0 and earlier deployments.

Fixes: nv-ingest-26.01 MIG values incompatibility with NIM Operator

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
