### PR TITLE
allow for multi writes to milvus

### DIFF
--- a/client/src/nv_ingest_client/util/vdb/milvus.py
+++ b/client/src/nv_ingest_client/util/vdb/milvus.py
@@ -925,7 +925,7 @@ def wait_for_index(collection_name: str, expected_rows_dict: dict, client: Milvu
                 indexed_rows = client.describe_index(collection_name, index_name)["indexed_rows"]
                 time.sleep(1)
                 logger.info(f"Indexed rows, {collection_name}, {index_name} -  {indexed_rows} / {rows_expected}")
-                if indexed_rows == rows_expected:
+                if indexed_rows >= rows_expected:
                     break
                 # check if indexed_rows is staying the same, too many times means something is wrong
                 if indexed_rows == prev_indexed_rows:


### PR DESCRIPTION
## Description
This PR applies a bandaid for a problem the arises when multiple sessions are ingesting documents into the same collection. Need to figure out if there is a better resolution to this problem (more controlled). 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
