### PR TITLE
Add docker compose override file for l40s

### DIFF
--- a/docker-compose.l40s.yaml
+++ b/docker-compose.l40s.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+services:
+  page-elements:
+    environment:
+      - NIM_TRITON_MAX_BATCH_SIZE=1
+
+  graphic-elements:
+    environment:
+      - NIM_TRITON_MAX_BATCH_SIZE=1
+
+  table-structure:
+    environment:
+      - NIM_TRITON_MAX_BATCH_SIZE=1
+
+  ocr:
+    environment:
+      - NIM_TRITON_MAX_BATCH_SIZE=1
+
+  embedding:
+    environment:
+      - NIM_TRITON_MAX_SEQ_LENGTH=128
+
+  reranker:
+    environment:
+      - NIM_TRITON_MAX_BATCH_SIZE=1


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
This adds a docker compose override file for l40s that is the same as the a10g override.


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
