### PR TITLE
Enabled readiness probe by default for Helm chart

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -514,7 +514,7 @@ livenessProbe:
 ## @param readinessProbe.successThreshold Success threshold for `readinessProbe`
 ## @param readinessProbe.failureThreshold Failure threshold for `readinessProbe`
 readinessProbe:
-  enabled: false
+  enabled: true
   httpGet:
     path: /v1/health/ready
     port: http


### PR DESCRIPTION
## Description
Previously the kubernetes readiness probe was disabled by default. This had simply gone un-noticed until now.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
