### PR TITLE
change alias default

### DIFF
--- a/client/src/nv_ingest_client/util/vdb/milvus.py
+++ b/client/src/nv_ingest_client/util/vdb/milvus.py
@@ -2038,7 +2038,7 @@ class Milvus(VDB):
             password (str, optional): The password for Milvus authentication. Defaults to None.
             no_wait_index (bool, optional): When true, the index creation will not wait for completion.
                 Defaults to False.
-            alias (str, optional): The alias for the Milvus connection. Defaults to default.
+            alias (str, optional): The alias for the Milvus connection. Defaults to None.
             **kwargs: Additional keyword arguments for customization.
         """
         kwargs = locals().copy()


### PR DESCRIPTION
## Description
ensure alias default is "default" as that is the default alias created in pymilvus.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
