### PR TITLE
feat(harness): Docker Infrastructure Sweep Support for Test Harness

### DIFF
--- a/tools/harness/src/nv_ingest_harness/config.py
+++ b/tools/harness/src/nv_ingest_harness/config.py
@@ -314,3 +314,33 @@ def list_presets(config_file: str = "test_configs.yaml") -> List[str]:
         yaml_data = yaml.safe_load(f)
 
     return list(yaml_data.get("presets", {}).keys())
+
+
+def get_sweep_config(sweep_name: str, config_file: str = "test_configs.yaml") -> List[dict]:
+    """
+    Get sweep configuration by name.
+
+    Args:
+        sweep_name: Name of the sweep configuration
+        config_file: Config file name
+
+    Returns:
+        List of environment variable dictionaries
+
+    Raises:
+        ValueError: If sweep name not found
+    """
+    config_path = Path(__file__).resolve().parents[2] / config_file
+
+    if not config_path.exists():
+        # Fallback for when running from different directories
+        config_path = Path(__file__).parent / config_file
+
+    with open(config_path) as f:
+        yaml_data = yaml.safe_load(f)
+
+    sweeps = yaml_data.get("sweeps", {})
+    if sweep_name not in sweeps:
+        raise ValueError(f"Sweep '{sweep_name}' not found in {config_file}. Available sweeps: {list(sweeps.keys())}")
+
+    return sweeps[sweep_name]

--- a/tools/harness/test_configs.yaml
+++ b/tools/harness/test_configs.yaml
@@ -59,6 +59,18 @@ recall:
   recall_top_k: 10
   ground_truth_dir: null
 
+# Sweep configuration
+# Define sets of environment variables to sweep through
+# Usage: uv run nv-ingest-harness-run --case=e2e --dataset=bo767 --sweep=batch_size
+sweeps:
+  batch_size:
+    - PAGE_ELEMENTS_BATCH_SIZE: 32
+      GRAPHIC_ELEMENTS_BATCH_SIZE: 32
+      TABLE_STRUCTURE_BATCH_SIZE: 32
+    - PAGE_ELEMENTS_BATCH_SIZE: 64
+      GRAPHIC_ELEMENTS_BATCH_SIZE: 64
+      TABLE_STRUCTURE_BATCH_SIZE: 64
+
 # Pre-configured datasets
 # Each dataset includes path, extraction settings, and recall evaluator
 # Use: uv run nv-ingest-harness-run --case=e2e --dataset=bo767


### PR DESCRIPTION
## Description
Adds infrastructure sweeping capabilities to the test harness, enabling automated validation of the ingestion pipeline across varying environment configurations (e.g., GPU memory pools, batch sizes) without manual intervention.

Changes
Harness (tools/harness/cli/run.py): Implements a --sweep flag that iterates through defined configurations, restarting Docker services (--managed mode) for each iteration.
Config (tools/harness/config.py, test_configs.yaml): Introduces a sweeps schema to define sets of environment variables.
Reporting: Injects active sweep configuration into results.json for traceability.
Docker (docker-compose.yaml): Exposes relevant tuning parameters (batch sizes, memory pools) as environment variables with safe defaults.

Usage
`uv run nv-ingest-harness-run --case=e2e --dataset=bo767 --sweep=batch_size
`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
