### PR TITLE
remove conda llama package ref

### DIFF
--- a/conda/environments/nv_ingest_environment.base.yml
+++ b/conda/environments/nv_ingest_environment.base.yml
@@ -45,7 +45,6 @@ dependencies:
   - universal_pathlib
   - pip
   - pip:
-      - llama-index-embeddings-nvidia
       - milvus-lite==2.4.12
       - opencv-python # For some reason conda cant solve our req set with py-opencv so we need to use pip
       - prometheus-client


### PR DESCRIPTION
## Description
removes the llama-index-embeddings-nvidia package from the conda env file.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
