### PR TITLE
Fallback to image only embeddings if text is empty

### DIFF
--- a/api/src/nv_ingest_api/internal/transform/embed_text.py
+++ b/api/src/nv_ingest_api/internal/transform/embed_text.py
@@ -365,7 +365,7 @@ def _get_pandas_table_content(row, modality="text"):
         if text:
             content = _format_text_image_pair_input_string(text, image)
         else:
-            content = _format_image_input_string(image) # Fallback to image only if text is empty
+            content = _format_image_input_string(image)  # Fallback to image only if text is empty
 
     return content
 
@@ -401,7 +401,7 @@ def _get_pandas_image_content(row, modality="text"):
         if text:
             content = _format_text_image_pair_input_string(text, image)
         else:
-            content = _format_image_input_string(image) # Fallback to image only if text is empty
+            content = _format_image_input_string(image)  # Fallback to image only if text is empty
 
     if subtype == "page_image":
         # A workaround to save memory for full page images.


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Currently, when embedding using the `"text_image"` modality, if text is empty (ex: page only contains images or graphics) embedding stage will fail. This PR makes it so that the embedding stage will fall back to image only embeddings when there's no text available.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
