### PR TITLE
Build Nemotron OCR with specific Nvidia GPU ARCH support

### DIFF
--- a/.github/workflows/huggingface-nightly.yml
+++ b/.github/workflows/huggingface-nightly.yml
@@ -175,6 +175,7 @@ jobs:
           CUDA_HOME: /usr/local/cuda
           BUILD_CPP_EXTENSION: "1"
           BUILD_CPP_FORCE: "1"
+          TORCH_CUDA_ARCH_LIST: "8.0;8.6;8.9;9.0;10.0;12.0+PTX"
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Description
Build Nemotron OCR with specific Nvidia GPU ARCH support

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
