### PR TITLE
Check HF nightlies workflow into default branch

### DIFF
--- a/.github/workflows/huggingface-nightly.yml
+++ b/.github/workflows/huggingface-nightly.yml
@@ -1,0 +1,220 @@
+name: huggingface-nightly-build-and-publish
+
+on:
+  schedule:
+    # Nightly at 03:17 UTC
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      upload_to:
+        description: "Where to upload (none/testpypi/pypi)"
+        required: true
+        default: "testpypi"
+        type: choice
+        options:
+          - none
+          - testpypi
+          - pypi
+      skip_existing:
+        description: "Skip already-uploaded versions"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repo:
+          - id: nemotron-page-elements-v3
+            url: https://huggingface.co/nvidia/nemotron-page-elements-v3
+            project_subdir: ""
+          - id: nemotron-table-structure-v1
+            url: https://huggingface.co/nvidia/nemotron-table-structure-v1
+            project_subdir: ""
+          - id: nemotron-graphic-elements-v1
+            url: https://huggingface.co/nvidia/nemotron-graphic-elements-v1
+            project_subdir: ""
+          - id: llama-nemotron-embed-1b-v2
+            url: https://huggingface.co/nvidia/llama-nemotron-embed-1b-v2
+            # Repo layout matches nemotron-ocr-v1: Python project is nested under a same-named subdir.
+            project_subdir: llama-nemotron-embed-1b-v2
+          - id: llama-nemotron-rerank-1b-v2
+            url: https://huggingface.co/nvidia/llama-nemotron-rerank-1b-v2
+            project_subdir: ""
+
+    steps:
+      - name: Checkout orchestrator repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install git-lfs
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git-lfs
+          git lfs install
+
+      - name: Decide upload target
+        id: target
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Default for scheduled runs: testpypi
+          upload_to="testpypi"
+          skip_existing="true"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            upload_to="${{ inputs.upload_to }}"
+            skip_existing="${{ inputs.skip_existing }}"
+          fi
+          echo "upload_to=${upload_to}" >> "$GITHUB_OUTPUT"
+          echo "skip_existing=${skip_existing}" >> "$GITHUB_OUTPUT"
+
+      - name: Build (and maybe upload)
+        env:
+          TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          upload_flag=""
+          repo_url="https://test.pypi.org/legacy/"
+          token_env="TEST_PYPI_API_TOKEN"
+          if [[ "${{ steps.target.outputs.upload_to }}" == "none" ]]; then
+            upload_flag=""
+          else
+            upload_flag="--upload"
+          fi
+          if [[ "${{ steps.target.outputs.upload_to }}" == "pypi" ]]; then
+            repo_url="https://upload.pypi.org/legacy/"
+            token_env="PYPI_API_TOKEN"
+          fi
+
+          skip_existing_flag=""
+          if [[ "${{ steps.target.outputs.skip_existing }}" == "true" ]]; then
+            skip_existing_flag="--skip-existing"
+          fi
+
+          python ci/scripts/nightly_build_publish.py \
+            --repo-id "${{ matrix.repo.id }}" \
+            --repo-url "${{ matrix.repo.url }}" \
+            --work-dir ".work" \
+            --dist-dir "dist-out" \
+            --project-subdir "${{ matrix.repo.project_subdir }}" \
+            ${upload_flag} \
+            --repository-url "${repo_url}" \
+            --token-env "${token_env}" \
+            ${skip_existing_flag}
+
+      - name: Upload build artifacts (GH Actions)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.repo.id }}
+          path: dist-out/${{ matrix.repo.id }}/*
+
+  build_ocr_cuda:
+    # nemotron-ocr-v1 needs nvcc/CUDA headers to build its extension.
+    runs-on: ubuntu-latest
+    container:
+      # IMPORTANT: CUDA toolkit must match the CUDA version PyTorch was built with
+      # (the nemotron-ocr build environment currently pulls a PyTorch CUDA 12.8 build).
+      # Use a PyTorch+CUDA "devel" image to avoid downloading huge torch wheels during build.
+      image: pytorch/pytorch:2.7.0-cuda12.8-cudnn9-devel
+    steps:
+      - name: Install system deps (git, lfs, build tools)
+        shell: bash
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates \
+            git \
+            git-lfs \
+            build-essential \
+            ninja-build \
+            python3 \
+            python3-venv \
+            python3-pip
+          git lfs install
+
+      - name: Checkout orchestrator repo
+        uses: actions/checkout@v4
+
+      - name: Decide upload target
+        id: target
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Default for scheduled runs: testpypi
+          upload_to="testpypi"
+          skip_existing="true"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            upload_to="${{ inputs.upload_to }}"
+            skip_existing="${{ inputs.skip_existing }}"
+          fi
+          echo "upload_to=${upload_to}" >> "$GITHUB_OUTPUT"
+          echo "skip_existing=${skip_existing}" >> "$GITHUB_OUTPUT"
+
+      - name: Build nemotron-ocr-v1 (and maybe upload)
+        env:
+          TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          CUDA_HOME: /usr/local/cuda
+          BUILD_CPP_EXTENSION: "1"
+          BUILD_CPP_FORCE: "1"
+          TORCH_CUDA_ARCH_LIST: "8.0;8.6;8.9;9.0;10.0;12.0+PTX"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          upload_flag=""
+          repo_url="https://test.pypi.org/legacy/"
+          token_env="TEST_PYPI_API_TOKEN"
+          if [[ "${{ steps.target.outputs.upload_to }}" == "none" ]]; then
+            upload_flag=""
+          else
+            upload_flag="--upload"
+          fi
+          if [[ "${{ steps.target.outputs.upload_to }}" == "pypi" ]]; then
+            repo_url="https://upload.pypi.org/legacy/"
+            token_env="PYPI_API_TOKEN"
+          fi
+
+          skip_existing_flag=""
+          if [[ "${{ steps.target.outputs.skip_existing }}" == "true" ]]; then
+            skip_existing_flag="--skip-existing"
+          fi
+
+          python3 ci/scripts/nightly_build_publish.py \
+            --repo-id "nemotron-ocr-v1" \
+            --repo-url "https://huggingface.co/nvidia/nemotron-ocr-v1" \
+            --work-dir ".work" \
+            --dist-dir "dist-out" \
+            --project-subdir "nemotron-ocr" \
+            --build-no-isolation \
+            --venv-system-site-packages \
+            --venv-pip-install "hatchling" \
+            --venv-pip-install "setuptools>=68" \
+            --build-env "BUILD_CPP_EXTENSION=1" \
+            --build-env "BUILD_CPP_FORCE=1" \
+            ${upload_flag} \
+            --repository-url "${repo_url}" \
+            --token-env "${token_env}" \
+            ${skip_existing_flag}
+
+      - name: Upload build artifacts (GH Actions)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-nemotron-ocr-v1
+          path: dist-out/nemotron-ocr-v1/*


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Checks the workflow introduced in #1349 into the default repo branch, so that we get nightly runs as expected

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
