### PR TITLE
updated docker overrides

### DIFF
--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -450,7 +450,7 @@ docker compose \
   --profile retrieval up
 ```
 
-**Example — A10G:**
+### Example with A10G
 
 ```shell
 docker compose \
@@ -459,7 +459,7 @@ docker compose \
   --profile retrieval up
 ```
 
-**Example — L40S:**
+### Example with L40S
 
 ```shell
 docker compose \
@@ -499,8 +499,6 @@ This syntax and structure can be repeated for each NIM model used by CAS, ensuri
 !!! important
 
     Advanced features require additional GPU support and disk space. For more information, refer to [Support Matrix](support-matrix.md).
-
-
 
 ## Related Topics
 


### PR DESCRIPTION
# Summary

1. Tip in Step 1f (Start core services)

Tip that explains overrides in one sentence and links to the new section:
"Use a docker compose override file to reduce VRAM usage. Override files typically lower per-service memory allocation, batch sizes, or concurrency..."

2. New section: "Docker Compose override files"

- Added a dedicated section (after Profile Information, before Specify MIG slices) that:
- Explains overrides: When default compose exceeds VRAM, override files reduce memory/batch size/concurrency so the pipeline fits on one GPU.
- Explains usage: Use a second -f with the override file; Docker Compose merges and the override wins.
- Lists all current override files in a table:

| Override file | GPU target |
|---------------|------------|
| docker-compose.a10g.yaml | NVIDIA A10G |
| docker-compose.a100-40gb.yaml | NVIDIA A100-SXM4-40GB |
| docker-compose.l40s.yaml | NVIDIA L40S |

- Covers RTX Pro 6000 Server Edition: Notes that for this GPU and others with limited VRAM, users should pick the override that best matches GPU memory (e.g. docker-compose.l40s.yaml or docker-compose.a10g.yaml). (There is no docker-compose.rtx-pro-6000.yaml in the repo.)

Adds examples for A100 40GB, A10G, and L40S.
