### PR TITLE
Add verbose flag to HF twine upload

### DIFF
--- a/ci/scripts/nightly_build_publish.py
+++ b/ci/scripts/nightly_build_publish.py
@@ -259,6 +259,7 @@ def _twine_upload(dist_dir: Path, repository_url: str, token: str, *, skip_exist
         "-m",
         "twine",
         "upload",
+        "--verbose",
         "--non-interactive",
         "--repository-url",
         repository_url,


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Investigating failures uploading the HF nightlies:

https://github.com/NVIDIA/nv-ingest/actions/runs/21832456814/job/62994355854

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
