### PR TITLE
feat(harness): Add jp20 dataset support for recall evaluation

### DIFF
--- a/tools/harness/README.md
+++ b/tools/harness/README.md
@@ -94,6 +94,15 @@ datasets:
     extract_infographics: false
     recall_dataset: bo767  # Evaluator for recall testing
   
+  jp20:
+    path: /path/to/jp20
+    extract_text: true
+    extract_tables: true
+    extract_charts: true
+    extract_images: false
+    extract_infographics: true
+    recall_dataset: jp20  # bo10k evaluator filtered to jp20 subset
+
   bo20:
     path: /raid/jioffe/bo20
     extract_text: true
@@ -135,6 +144,7 @@ uv run nv-ingest-harness-run --case=e2e --dataset=/custom/path
 | Dataset | Text | Tables | Charts | Images | Infographics | Recall |
 |---------|------|--------|--------|--------|--------------|--------|
 | `bo767` | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
+| `jp20` | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
 | `earnings` | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
 | `bo20` | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ |
 | `financebench` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |

--- a/tools/harness/src/nv_ingest_harness/reporting/baselines.py
+++ b/tools/harness/src/nv_ingest_harness/reporting/baselines.py
@@ -31,6 +31,10 @@ DATASET_BASELINES: dict[str, dict[str, dict[str, Any]]] = {
             "min": 0.80,  # observed: 0.910
         },
     },
+    "jp20": {
+        "result_count": {"expected": 20, "required": True},
+        "failure_count": {"expected": 0, "required": True},
+    },
     "earnings": {
         "result_count": {"expected": 514, "required": True},
         "total_pages": {"expected": 12988, "required": True},

--- a/tools/harness/src/nv_ingest_harness/utils/recall.py
+++ b/tools/harness/src/nv_ingest_harness/utils/recall.py
@@ -649,6 +649,21 @@ def bo10k_load_ground_truth(ground_truth_dir: Optional[str] = None) -> pd.DataFr
     return df.reset_index(drop=True)
 
 
+def jp20_load_ground_truth(ground_truth_dir: Optional[str] = None) -> pd.DataFrame:
+    """Load bo10k ground truth filtered to jp20 documents."""
+    df = bo10k_load_ground_truth(ground_truth_dir=ground_truth_dir)
+
+    dataset_dir = os.environ.get("JP20_DATASET_DIR") or os.path.join(get_repo_root(), "data", "jp20")
+    jp20_pdfs = {
+        os.path.splitext(name)[0]
+        for name in os.listdir(dataset_dir)
+        if name.lower().endswith(".pdf")
+    }
+    filtered = df[df["pdf"].isin(jp20_pdfs)].reset_index(drop=True)
+
+    return filtered
+
+
 def bo10k_recall(
     collection_name: str,
     hostname: str = "localhost",
@@ -666,6 +681,39 @@ def bo10k_recall(
     """Evaluate recall@k for bo10k dataset."""
     return evaluate_recall_orchestrator(
         loader_func=bo10k_load_ground_truth,
+        scorer_func=get_recall_scores,
+        collection_name=collection_name,
+        hostname=hostname,
+        sparse=sparse,
+        model_name=model_name,
+        top_k=top_k,
+        gpu_search=gpu_search,
+        nv_ranker=nv_ranker,
+        ground_truth_dir=ground_truth_dir,
+        nv_ranker_endpoint=nv_ranker_endpoint,
+        nv_ranker_model_name=nv_ranker_model_name,
+        vdb_backend=vdb_backend,
+        table_path=table_path,
+    )
+
+
+def jp20_recall(
+    collection_name: str,
+    hostname: str = "localhost",
+    sparse: bool = True,
+    model_name: str = None,
+    top_k: int = 10,
+    gpu_search: bool = False,
+    nv_ranker: bool = False,
+    ground_truth_dir: Optional[str] = None,
+    nv_ranker_endpoint: Optional[str] = None,
+    nv_ranker_model_name: Optional[str] = None,
+    vdb_backend: str = "milvus",
+    table_path: Optional[str] = None,
+) -> Dict[int, float]:
+    """Evaluate recall@k for jp20 dataset (bo10k subset)."""
+    return evaluate_recall_orchestrator(
+        loader_func=jp20_load_ground_truth,
         scorer_func=get_recall_scores,
         collection_name=collection_name,
         hostname=hostname,
@@ -716,6 +764,7 @@ def get_dataset_evaluator(dataset_name: str) -> Optional[Callable]:
         "earnings": earnings_recall,
         "audio": audio_recall,
         "bo10k": bo10k_recall,
+        "jp20": jp20_recall,
     }
 
     return evaluators.get(dataset_name.lower())

--- a/tools/harness/test_configs.yaml
+++ b/tools/harness/test_configs.yaml
@@ -167,3 +167,12 @@ datasets:
     extract_images: false
     extract_infographics: true
     recall_dataset: bo10k
+
+  jp20:
+    path: /path/to/jp20
+    extract_text: true
+    extract_tables: true
+    extract_charts: true
+    extract_images: false
+    extract_infographics: true
+    recall_dataset: jp20


### PR DESCRIPTION
## Description

Add jp20 as a 20-document subset of bo10k for faster recall testing. The dataset uses bo10k ground truth filtered to the jp20 document set.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
