### PR TITLE
Explicitly override miniforge base python version with 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
 # Install Mamba, a faster alternative to conda, within the base environment
 RUN --mount=type=cache,target=/opt/conda/pkgs \
     --mount=type=cache,target=/root/.cache/pip \
-    conda install -y mamba conda-build==24.5.1 conda-merge -n base -c conda-forge
+    conda install -y python=3.12 mamba conda-build==24.5.1 conda-merge -n base -c conda-forge
 
 COPY conda/environments/nv_ingest_environment.base.yml /workspace/nv_ingest_environment.base.yml
 COPY conda/environments/nv_ingest_environment.linux_64.yml /workspace/nv_ingest_environment.linux_64.yml


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

The latest Miniforge3 release we're pulling now defaults to python 3.13:

https://github.com/conda-forge/miniforge/releases/tag/26.1.0-0

Which causes our Docker build to now fail to solve at the Conda stage:

https://github.com/NVIDIA/nv-ingest/actions/runs/21873718042/job/63141279188?pr=1393#step:6:19416

Work around this by explicitly pinning python=3.12 in the initial conda update

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
