### PR TITLE
Merge harness dependency groups

### DIFF
--- a/tools/harness/README.md
+++ b/tools/harness/README.md
@@ -9,48 +9,20 @@ A configurable, dataset-agnostic testing framework for end-to-end validation of 
 - Python 3.12+ environment
 - Access to test datasets
 
-### Dependency Structure
-
-The harness uses optional dependency groups to avoid conflicts:
-
-| Extra | Use Case | Includes |
-|-------|----------|----------|
-| `[ingest]` | E2E ingestion benchmarking | nv-ingest packages, pymilvus, pypdfium2 |
-| `[nemotron-hf]` | Standalone model benchmarking | nemotron-* packages from HuggingFace |
-| Base (no extra) | Core utilities only | docker, pyyaml, requests, matplotlib |
-
-**Why separate?** The nv-ingest and nemotron packages have conflicting Pillow version requirements. Use the appropriate extra based on your test needs.
-
 ### Installation
-
-The harness has modular dependencies split into optional extras:
 
 ```bash
 # Navigate to the harness directory
 cd tools/harness/
 
-# Install for nv-ingest E2E benchmarking (includes pymilvus, pypdfium2)
-uv pip install -e '.[ingest]'
-
-# Install for standalone model benchmarking (nemotron-* packages)
-uv pip install -e '.[nemotron-hf]'
-
-# Install base harness only (no model dependencies)
+# Install the harness (includes nv-ingest packages, milvus-lite, pypdfium2, and nemotron-* model packages)
 uv pip install -e .
 ```
-
-**Dependency Groups:**
-- **Base**: Common utilities (docker, pyyaml, requests, matplotlib, pynvml)
-- **`[ingest]`**: nv-ingest packages + milvus-lite + pypdfium2 (for E2E tests)
-- **`[nemotron-hf]`**: Standalone Nemotron models from HuggingFace (for model benchmarks)
 
 ### Run Your First Test
 
 ```bash
-# 1. Install dependencies for E2E testing
-uv pip install -e '.[ingest]'
-
-# 2. Run with a pre-configured dataset (assumes services are running)
+# Run with a pre-configured dataset (assumes services are running)
 uv run nv-ingest-harness-run --case=e2e --dataset=bo767
 
 # Or use a custom path that uses the "active" configuration
@@ -551,24 +523,7 @@ Metrics are also logged via `kv_event_log()`:
 
 ## Model Testing
 
-The harness includes benchmark test cases for Nemotron document analysis models. These cases benchmark inference performance on image datasets without requiring the full nv-ingest service infrastructure.
-
-### Installation for Model Benchmarks
-
-Model benchmarks require the standalone Nemotron packages:
-
-```bash
-cd tools/harness/
-uv pip install -e '.[nemotron-hf]'
-```
-
-This installs:
-- `nemotron-page-elements-v3`
-- `nemotron-graphic-elements-v1`
-- `nemotron-table-structure-v1`
-- `nemotron-ocr`
-
-**Note**: These packages are separate from the nv-ingest dependencies to avoid dependency conflicts (e.g., Pillow version requirements).
+The harness includes benchmark test cases for Nemotron document analysis models. These cases benchmark inference performance on image datasets without requiring the full nv-ingest service infrastructure. The default install includes the nemotron-* packages (`nemotron-page-elements-v3`, `nemotron-graphic-elements-v1`, `nemotron-table-structure-v1`, `nemotron-ocr`).
 
 ### Available Model Benchmarks
 
@@ -1025,11 +980,11 @@ This provides:
   - `segment_results()` - Result categorization by type
   - `kv_event_log()` - Structured logging
   - `run_cmd()` - Command execution helpers
-- `milvus.py` - Milvus/vector database utilities (requires pymilvus via `[ingest]` extra)
+- `milvus.py` - Milvus/vector database utilities
   - `milvus_chunks()` - Vector database statistics
   - `load_collection()` - Load Milvus collection
   - `unload_collection()` - Unload Milvus collection
-- `pdfium.py` - PDF utilities (requires pypdfium2 via `[ingest]` extra)
+- `pdfium.py` - PDF utilities
   - `pdf_page_count()` - Dataset page counting
   - `pdf_page_count_glob()` - Glob-based PDF page counting
 

--- a/tools/harness/plans/NIGHTLY.md
+++ b/tools/harness/plans/NIGHTLY.md
@@ -7,8 +7,8 @@ Automated benchmarks with Slack reporting and historical tracking.
 ```bash
 cd tools/harness
 
-# Install dependencies for nightly benchmarks (E2E + Recall tests)
-uv pip install -e '.[ingest]'
+# Install the harness
+uv pip install -e .
 
 export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..."
 uv run nv-ingest-harness-nightly
@@ -19,8 +19,6 @@ uv run nv-ingest-harness-nightly --skip-fresh-start  # Use running services
 uv run nv-ingest-harness-nightly --dry-run           # Show config only
 uv run nv-ingest-harness-nightly --note "Testing new embedding model"
 ```
-
-**Note**: Nightly benchmarks use E2E and recall tests which require the `[ingest]` extra (includes nv-ingest packages, pymilvus, pypdfium2).
 
 ## Configuration
 
@@ -185,15 +183,9 @@ uv run nv-ingest-harness-nightly \
 
 ### Installation
 
-Ensure the correct dependencies are installed based on your test needs:
-
 ```bash
-# For nightly E2E + recall benchmarks
 cd tools/harness
-uv pip install -e '.[ingest]'
-
-# For standalone model benchmarks only
-uv pip install -e '.[nemotron-hf]'
+uv pip install -e .
 ```
 
 ### GitHub Actions
@@ -207,7 +199,7 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
       - uses: actions/checkout@v4
-      - run: cd tools/harness && uv pip install -e '.[ingest]' && uv run nv-ingest-harness-nightly
+      - run: cd tools/harness && uv pip install -e . && uv run nv-ingest-harness-nightly
 ```
 
 ### Cron
@@ -215,7 +207,7 @@ jobs:
 ```bash
 # Cron (2 AM daily)
 0 2 * * * cd /path/to/tools/harness && source ~/setup_env.sh && \
-  uv pip install -e '.[ingest]' && \
+  uv pip install -e . && \
   SLACK_WEBHOOK_URL="..." uv run nv-ingest-harness-nightly >> /var/log/nightly.log 2>&1
 ```
 

--- a/tools/harness/pyproject.toml
+++ b/tools/harness/pyproject.toml
@@ -10,17 +10,11 @@ dependencies = [
     "pyyaml>=6.0",
     "requests>=2.31.0",
     "pynvml>=11.5.0",
-]
-
-[project.optional-dependencies]
-ingest = [
     "nv-ingest",
     "nv-ingest-api",
     "nv-ingest-client",
     "milvus-lite==2.4.12",
     "pypdfium2",
-]
-nemotron-hf = [
     "nemotron-page-elements-v3>=0.dev0",
     "nemotron-graphic-elements-v1>=0.dev0",
     "nemotron-table-structure-v1>=0.dev0",
@@ -50,3 +44,4 @@ nemotron-ocr = { index = "test-pypi" }
 [[tool.uv.index]]
 name = "test-pypi"
 url = "https://test.pypi.org/simple/"
+explicit = true


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

With #1395 in we now no longer install moviepy with nv-ingest-api, so we can merge the HF / ingest test dependencies together without conflict 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
