### PR TITLE
(helm) Add override files to match Compose

### DIFF
--- a/helm/overrides/values-a100-40gb.yaml
+++ b/helm/overrides/values-a100-40gb.yaml
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# GPU-specific overrides for A100 40GB (loaded by harness when --deployment-type helm --sku a100-40gb).
+# Sets NIM_TRITON_MAX_BATCH_SIZE=1 per NIM to match docker-compose.a100-40gb.yaml.
+
+nimOperator:
+  page_elements:
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: NIM_TRITON_LOG_VERBOSE
+        value: "1"
+      - name: NIM_TRITON_MAX_BATCH_SIZE
+        value: "1"
+      - name: NIM_TRITON_CPU_THREADS_PRE_PROCESSOR
+        value: "2"
+      - name: OMP_NUM_THREADS
+        value: "2"
+      - name: NIM_TRITON_CPU_THREADS_POST_PROCESSOR
+        value: "1"
+      - name: NIM_ENABLE_OTEL
+        value: "true"
+      - name: NIM_OTEL_SERVICE_NAME
+        value: "page-elements"
+      - name: NIM_OTEL_TRACES_EXPORTER
+        value: "otlp"
+      - name: NIM_OTEL_METRICS_EXPORTER
+        value: "console"
+      - name: NIM_OTEL_EXPORTER_OTLP_ENDPOINT
+        value: "http://otel-collector:4318"
+      - name: TRITON_OTEL_URL
+        value: "http://otel-collector:4318/v1/traces"
+      - name: TRITON_OTEL_RATE
+        value: "1"
+
+  graphic_elements:
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: NIM_TRITON_LOG_VERBOSE
+        value: "1"
+      - name: NIM_TRITON_RATE_LIMIT
+        value: "3"
+      - name: NIM_TRITON_MAX_BATCH_SIZE
+        value: "1"
+      - name: NIM_TRITON_CUDA_MEMORY_POOL_MB
+        value: "2048"
+      - name: OMP_NUM_THREADS
+        value: "1"
+
+  table_structure:
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: NIM_TRITON_LOG_VERBOSE
+        value: "1"
+      - name: NIM_TRITON_RATE_LIMIT
+        value: "3"
+      - name: NIM_TRITON_MAX_BATCH_SIZE
+        value: "1"
+      - name: NIM_TRITON_CUDA_MEMORY_POOL_MB
+        value: "2048"
+      - name: OMP_NUM_THREADS
+        value: "1"
+
+  nemoretriever_ocr_v1:
+    env:
+      - name: OMP_NUM_THREADS
+        value: "8"
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: NIM_TRITON_LOG_VERBOSE
+        value: "1"
+      - name: NIM_TRITON_MAX_BATCH_SIZE
+        value: "1"
+
+  llama_3_2_nv_rerankqa_1b_v2:
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: NIM_TRITON_LOG_VERBOSE
+        value: "1"
+      - name: NIM_TRITON_MAX_BATCH_SIZE
+        value: "1"

--- a/helm/overrides/values-a10g.yaml
+++ b/helm/overrides/values-a10g.yaml
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# GPU-specific overrides for A10G (loaded by harness when --deployment-type helm --sku a10g).
+# Sets NIM_TRITON_MAX_BATCH_SIZE=1 per NIM to match docker-compose.a10g.yaml.
+
+nimOperator:
+  page_elements:
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: NIM_TRITON_LOG_VERBOSE
+        value: "1"
+      - name: NIM_TRITON_MAX_BATCH_SIZE
+        value: "1"
+      - name: NIM_TRITON_CPU_THREADS_PRE_PROCESSOR
+        value: "2"
+      - name: OMP_NUM_THREADS
+        value: "2"
+      - name: NIM_TRITON_CPU_THREADS_POST_PROCESSOR
+        value: "1"
+      - name: NIM_ENABLE_OTEL
+        value: "true"
+      - name: NIM_OTEL_SERVICE_NAME
+        value: "page-elements"
+      - name: NIM_OTEL_TRACES_EXPORTER
+        value: "otlp"
+      - name: NIM_OTEL_METRICS_EXPORTER
+        value: "console"
+      - name: NIM_OTEL_EXPORTER_OTLP_ENDPOINT
+        value: "http://otel-collector:4318"
+      - name: TRITON_OTEL_URL
+        value: "http://otel-collector:4318/v1/traces"
+      - name: TRITON_OTEL_RATE
+        value: "1"
+
+  graphic_elements:
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: NIM_TRITON_LOG_VERBOSE
+        value: "1"
+      - name: NIM_TRITON_RATE_LIMIT
+        value: "3"
+      - name: NIM_TRITON_MAX_BATCH_SIZE
+        value: "1"
+      - name: NIM_TRITON_CUDA_MEMORY_POOL_MB
+        value: "2048"
+      - name: OMP_NUM_THREADS
+        value: "1"
+
+  table_structure:
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: NIM_TRITON_LOG_VERBOSE
+        value: "1"
+      - name: NIM_TRITON_RATE_LIMIT
+        value: "3"
+      - name: NIM_TRITON_MAX_BATCH_SIZE
+        value: "1"
+      - name: NIM_TRITON_CUDA_MEMORY_POOL_MB
+        value: "2048"
+      - name: OMP_NUM_THREADS
+        value: "1"
+
+  nemoretriever_ocr_v1:
+    env:
+      - name: OMP_NUM_THREADS
+        value: "8"
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: NIM_TRITON_LOG_VERBOSE
+        value: "1"
+      - name: NIM_TRITON_MAX_BATCH_SIZE
+        value: "1"
+
+  llama_3_2_nv_rerankqa_1b_v2:
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: NIM_TRITON_LOG_VERBOSE
+        value: "1"
+      - name: NIM_TRITON_MAX_BATCH_SIZE
+        value: "1"

--- a/helm/overrides/values-l40s.yaml
+++ b/helm/overrides/values-l40s.yaml
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+# GPU-specific overrides for L40S (loaded by harness when --deployment-type helm --sku l40s).
+# Sets NIM_TRITON_MAX_BATCH_SIZE=1 per NIM to match docker-compose.l40s.yaml.
+
+nimOperator:
+  page_elements:
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: NIM_TRITON_LOG_VERBOSE
+        value: "1"
+      - name: NIM_TRITON_MAX_BATCH_SIZE
+        value: "1"
+      - name: NIM_TRITON_CPU_THREADS_PRE_PROCESSOR
+        value: "2"
+      - name: OMP_NUM_THREADS
+        value: "2"
+      - name: NIM_TRITON_CPU_THREADS_POST_PROCESSOR
+        value: "1"
+      - name: NIM_ENABLE_OTEL
+        value: "true"
+      - name: NIM_OTEL_SERVICE_NAME
+        value: "page-elements"
+      - name: NIM_OTEL_TRACES_EXPORTER
+        value: "otlp"
+      - name: NIM_OTEL_METRICS_EXPORTER
+        value: "console"
+      - name: NIM_OTEL_EXPORTER_OTLP_ENDPOINT
+        value: "http://otel-collector:4318"
+      - name: TRITON_OTEL_URL
+        value: "http://otel-collector:4318/v1/traces"
+      - name: TRITON_OTEL_RATE
+        value: "1"
+
+  graphic_elements:
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: NIM_TRITON_LOG_VERBOSE
+        value: "1"
+      - name: NIM_TRITON_RATE_LIMIT
+        value: "3"
+      - name: NIM_TRITON_MAX_BATCH_SIZE
+        value: "1"
+      - name: NIM_TRITON_CUDA_MEMORY_POOL_MB
+        value: "2048"
+      - name: OMP_NUM_THREADS
+        value: "1"
+
+  table_structure:
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: NIM_TRITON_LOG_VERBOSE
+        value: "1"
+      - name: NIM_TRITON_RATE_LIMIT
+        value: "3"
+      - name: NIM_TRITON_MAX_BATCH_SIZE
+        value: "1"
+      - name: NIM_TRITON_CUDA_MEMORY_POOL_MB
+        value: "2048"
+      - name: OMP_NUM_THREADS
+        value: "1"
+
+  nemoretriever_ocr_v1:
+    env:
+      - name: OMP_NUM_THREADS
+        value: "8"
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: NIM_TRITON_LOG_VERBOSE
+        value: "1"
+      - name: NIM_TRITON_MAX_BATCH_SIZE
+        value: "1"
+
+  llama_3_2_nv_rerankqa_1b_v2:
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: NIM_TRITON_LOG_VERBOSE
+        value: "1"
+      - name: NIM_TRITON_MAX_BATCH_SIZE
+        value: "1"

--- a/tools/harness/README.md
+++ b/tools/harness/README.md
@@ -782,7 +782,7 @@ uv run nv-ingest-harness-run --case=e2e --dataset=bo767 --managed --no-dump-logs
 
 ### GPU-Specific Configuration (SKU Override)
 
-The harness supports GPU-specific configuration overrides for Docker Compose deployments via the `--sku` option:
+The harness supports GPU-specific configuration overrides via the `--sku` option for both Docker Compose and Helm deployments:
 
 ```bash
 # A10G GPU settings
@@ -796,15 +796,10 @@ uv run nv-ingest-harness-run --case=e2e --dataset=bo767 --managed --sku=a100-40g
 ```
 
 **How it works:**
-- Loads GPU-specific override file: `docker-compose.<sku>.yaml`
-- Merges with base `docker-compose.yaml` configuration
-- Override settings take precedence (typically batch sizes, memory limits, etc.)
-- Only applies to Docker Compose deployments (ignored for Helm)
+- **Compose:** Loads `docker-compose.<sku>.yaml` and merges with base `docker-compose.yaml` (override takes precedence).
+- **Helm:** Loads `helm/overrides/values-<sku>.yaml` via `helm upgrade -f`; merged with chart defaults (and any `helm_values_file` / `helm_values` still override).
 
-**Available SKUs:**
-- `a10g` - NVIDIA A10G GPU settings
-- `l40s` - NVIDIA L40S GPU settings
-- `a100-40gb` - NVIDIA A100 40GB GPU settings
+**Available SKUs:** `a10g` (NVIDIA A10G), `l40s` (NVIDIA L40S), `a100-40gb` (NVIDIA A100 40GB).
 
 ## Nightly Benchmarks
 

--- a/tools/harness/src/nv_ingest_harness/cli/run.py
+++ b/tools/harness/src/nv_ingest_harness/cli/run.py
@@ -354,8 +354,8 @@ def run_case(case_name: str, stdout_path: str, config, doc_analysis: bool = Fals
     "--sku",
     type=str,
     default=None,
-    help="GPU SKU for Docker Compose override file (e.g., a10g, a100-40gb, l40s). Only applies to managed Compose "
-    "services.",
+    help="GPU SKU for override file (Compose: docker-compose.<sku>.yaml; Helm: helm/overrides/values-<sku>.yaml). "
+    "Applies to managed Compose and Helm deployments (e.g., a10g, a100-40gb, l40s).",
 )
 @click.option(
     "--dump-logs/--no-dump-logs",

--- a/tools/harness/src/nv_ingest_harness/service_manager/__init__.py
+++ b/tools/harness/src/nv_ingest_harness/service_manager/__init__.py
@@ -14,7 +14,8 @@ def create_service_manager(config, repo_root: Path, sku: str | None = None) -> S
     Args:
         config: Configuration object with deployment_type attribute
         repo_root: Path to the repository root
-        sku: Optional GPU SKU for Docker Compose override file (e.g., a10g, a100-40gb, l40s)
+        sku: Optional GPU SKU for override file (Compose: docker-compose.<sku>.yaml;
+            Helm: helm/overrides/values-<sku>.yaml)
 
     Returns:
         ServiceManager instance (DockerComposeManager or HelmManager)
@@ -27,7 +28,7 @@ def create_service_manager(config, repo_root: Path, sku: str | None = None) -> S
     if deployment_type == "compose":
         return DockerComposeManager(config, repo_root, sku=sku)
     elif deployment_type == "helm":
-        return HelmManager(config, repo_root)
+        return HelmManager(config, repo_root, sku=sku)
     else:
         raise ValueError(f"Unknown deployment_type: {deployment_type}. Must be 'compose' or 'helm'")
 


### PR DESCRIPTION
Introduces SKU-specific override values for the Helm deployment, along with support for them in the harness so that both Compose & Helm managed runs can be overridden with a `--sku` option