### PR TITLE
(harness) Add instructions / requirements for pip install

### DIFF
--- a/tools/harness/README.md
+++ b/tools/harness/README.md
@@ -19,6 +19,8 @@ cd tools/harness/
 uv pip install -e .
 ```
 
+**Vanilla pip:** Install the project with `pip install -e .` (from repo root, install `nv-ingest`, `nv-ingest-api`, and `nv-ingest-client` first if needed). The harness env already includes the nemotron packages; to get nightly versions from Test PyPI, install on top: `pip install -r tools/harness/nemotron-nightly.txt --force-reinstall --no-deps`.
+
 ### Run Your First Test
 
 ```bash
@@ -523,7 +525,7 @@ Metrics are also logged via `kv_event_log()`:
 
 ## Model Testing
 
-The harness includes benchmark test cases for Nemotron document analysis models. These cases benchmark inference performance on image datasets without requiring the full nv-ingest service infrastructure. The default install includes the nemotron-* packages (`nemotron-page-elements-v3`, `nemotron-graphic-elements-v1`, `nemotron-table-structure-v1`, `nemotron-ocr`).
+The harness includes benchmark test cases for Nemotron document analysis models. These cases benchmark inference performance on image datasets without requiring the full nv-ingest service infrastructure. The default install (via `uv pip install -e .`) includes the nemotron-* packages from Test PyPI (`nemotron-page-elements-v3`, `nemotron-graphic-elements-v1`, `nemotron-table-structure-v1`, `nemotron-ocr`). With vanilla pip, install the standard harness env first, then `pip install -r tools/harness/nemotron-nightly.txt --force-reinstall --no-deps` to get the nightly Nemotron packages from Test PyPI.
 
 ### Available Model Benchmarks
 

--- a/tools/harness/nemotron-nightly.txt
+++ b/tools/harness/nemotron-nightly.txt
@@ -1,0 +1,9 @@
+# Nemotron nightly/dev packages from Test PyPI. For vanilla pip: harness env already has these
+# packages; install this file on top with --force-reinstall --no-deps to pull them from Test PyPI.
+# Usage: pip install -r tools/harness/nemotron-nightly.txt --force-reinstall --no-deps
+--index-url https://test.pypi.org/simple/
+
+nemotron-page-elements-v3>=0.dev0
+nemotron-graphic-elements-v1>=0.dev0
+nemotron-table-structure-v1>=0.dev0
+nemotron-ocr>=0.dev0

--- a/tools/harness/plans/NIGHTLY.md
+++ b/tools/harness/plans/NIGHTLY.md
@@ -10,6 +10,10 @@ cd tools/harness
 # Install the harness
 uv pip install -e .
 
+# Vanilla pip: install the harness with pip, then add nightly Nemotron from Test PyPI:
+#   pip install -e .   # (after installing nv-ingest, nv-ingest-api, nv-ingest-client)
+#   pip install -r nemotron-nightly.txt --force-reinstall --no-deps
+
 export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..."
 uv run nv-ingest-harness-nightly
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Through troubleshooting, it was found that the uv-specifics of the harness requirements aren't able to be honored by standard pip; adds a requirements file and instructions for installation of nightly nemotron packages using pip 

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
