### PR TITLE
fix(pdfium): Replace rev_byteorder with in-place cv2 channel swap

### DIFF
--- a/api/src/nv_ingest_api/internal/extract/pdf/engines/nemotron_parse.py
+++ b/api/src/nv_ingest_api/internal/extract/pdf/engines/nemotron_parse.py
@@ -520,7 +520,6 @@ def _convert_pdfium_page_to_numpy_for_parser(
         render_dpi=render_dpi,
         scale_tuple=scale_tuple,
         padding_tuple=padding_tuple,
-        render_rev_byteorder=True,
     )
 
     return page_images[0], padding_offsets[0]
@@ -535,7 +534,6 @@ def _convert_pdfium_page_to_numpy_for_yolox(
         [page],
         scale_tuple=scale_tuple,
         padding_tuple=padding_tuple,
-        render_rev_byteorder=True,
     )
 
     return page_images[0], padding_offsets[0]

--- a/api/src/nv_ingest_api/internal/extract/pdf/engines/pdfium.py
+++ b/api/src/nv_ingest_api/internal/extract/pdf/engines/pdfium.py
@@ -558,7 +558,6 @@ def pdfium_extractor(
                 image, _ = pdfium_pages_to_numpy(
                     [page],
                     scale_tuple=(16384, 16384),
-                    render_rev_byteorder=True,
                     trace_info=execution_trace_log,
                 )
                 base64_image = numpy_to_base64(image[0])
@@ -581,7 +580,6 @@ def pdfium_extractor(
                     [page],
                     scale_tuple=(YOLOX_PAGE_IMAGE_PREPROC_WIDTH, YOLOX_PAGE_IMAGE_PREPROC_HEIGHT),
                     padding_tuple=(YOLOX_PAGE_IMAGE_PREPROC_WIDTH, YOLOX_PAGE_IMAGE_PREPROC_HEIGHT),
-                    render_rev_byteorder=True,
                     trace_info=execution_trace_log,
                 )
                 pages_for_extractions.append((page_idx, image[0], padding_offsets[0]))


### PR DESCRIPTION
## Description
- `rev_byteorder=True` (from #1337/#1368) triggers a pdfium thread-safety bug in
    `GetDIBits()` that SIGTRAPs under concurrent rendering, creating zombie actors
- Replace numpy channel swap with in-place `cv2.cvtColor` — zero
    allocation, SIMD-optimized, thread-safe
- Remove dead `render_rev_byteorder` / `skip_channel_swap` parameters

## Test plan

- [x] Unit tests pass, no recall impact
- [x] Earnings (100 PDFs): 3 clean runs, 0 SIGTRAPs (previously crashed every run), bo10k clean
- [x] earnings: 2 pps improvement over rev_byteorder=False baseline

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
