### PR TITLE
Refactor duplicated version extraction in conda build script

### DIFF
--- a/conda/build_conda_packages.sh
+++ b/conda/build_conda_packages.sh
@@ -57,7 +57,7 @@ if [[ "${BUILD_NV_INGEST_API}" -eq 1 ]]; then
 
     # Generate the version if not specified
     if [ -z "$RELEASE_VERSION" ]; then
-        NV_INGEST_API_VERSION=$(python3 -c "import sys, importlib.util; spec = importlib.util.spec_from_file_location('version', '$SCRIPT_PATH'); version = importlib.util.module_from_spec(spec); spec.loader.exec_module(version); print(version.get_version())")
+        NV_INGEST_API_VERSION=$(get_package_version "$SCRIPT_PATH")
     else
         NV_INGEST_API_VERSION=$RELEASE_VERSION
     fi
@@ -77,7 +77,7 @@ if [[ "${BUILD_NV_INGEST}" -eq 1 ]]; then
 
     # Generate the version if not specified
     if [ -z "$RELEASE_VERSION" ]; then
-        NV_INGEST_SERVICE_VERSION=$(python3 -c "import sys, importlib.util; spec = importlib.util.spec_from_file_location('version', '$SCRIPT_PATH'); version = importlib.util.module_from_spec(spec); spec.loader.exec_module(version); print(version.get_version())")
+        NV_INGEST_SERVICE_VERSION=$(get_package_version "$SCRIPT_PATH")
     else
         NV_INGEST_SERVICE_VERSION=$RELEASE_VERSION
     fi
@@ -97,7 +97,7 @@ if [[ "${BUILD_NV_INGEST_CLIENT}" -eq 1 ]]; then
 
     # Generate the version if not specified
     if [ -z "$RELEASE_VERSION" ]; then
-        NV_INGEST_CLIENT_VERSION=$(python3 -c "import sys, importlib.util; spec = importlib.util.spec_from_file_location('version', '$SCRIPT_PATH'); version = importlib.util.module_from_spec(spec); spec.loader.exec_module(version); print(version.get_version())")
+        NV_INGEST_CLIENT_VERSION=$(get_package_version "$SCRIPT_PATH")
     else
         NV_INGEST_CLIENT_VERSION=$RELEASE_VERSION
     fi

--- a/conda/scripts/helper_functions.sh
+++ b/conda/scripts/helper_functions.sh
@@ -30,6 +30,17 @@ validate_conda_build_environment() {
     fi
 }
 
+get_package_version() {
+    local version_script=$1
+    python3 -c "
+import importlib.util
+spec = importlib.util.spec_from_file_location('version', '$version_script')
+version = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(version)
+print(version.get_version())
+"
+}
+
 determine_git_root() {
     ##############################
     # Determine Git Root


### PR DESCRIPTION
The same Python version extraction one-liner was copy-pasted three times in conda/build_conda_packages.sh. Extracted it into a reusable get_package_version() helper in
  helper_functions.sh to reduce duplication. No behavioral changes.