### PR TITLE
(retriever) Add conda env + instructions to source libcudart.so.13 for OCR

### DIFF
--- a/conda/environments/retriever_libcudart.yml
+++ b/conda/environments/retriever_libcudart.yml
@@ -1,0 +1,7 @@
+name: retriever_libcudart
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12.*
+  - cuda-cudart=13.*
+  - uv

--- a/retriever/README.md
+++ b/retriever/README.md
@@ -4,7 +4,7 @@ RAG ingestion pipeline for PDFs: extract structure (text, tables, charts, infogr
 
 ## Prerequisites
 
-- **CUDA 13**
+- **CUDA 13** — required for **OCR** (Nemotron); text extraction and other stages may work without it.
 - **Python 3.12**
 - **UV** (required) — [install UV](https://docs.astral.sh/uv/getting-started/installation/) (e.g. `curl -LsSf https://astral.sh/uv/install.sh | sh`)
 
@@ -23,6 +23,36 @@ uv pip install -e ./retriever
 
 This installs the retriever in editable mode and its in-repo dependencies. Core dependencies (see `retriever/pyproject.toml`) include Ray, pypdfium2, pandas, LanceDB, PyYAML, torch, transformers, and the Nemotron packages (page-elements, graphic-elements, table-structure). The retriever also depends on the sibling packages `nv-ingest`, `nv-ingest-api`, and `nv-ingest-client` in this repo.
 
+### OCR and CUDA 13 runtime (conda)
+
+The Nemotron OCR native extension requires **libcudart.so.13** (CUDA 13 runtime). If you see:
+
+```text
+ImportError: libcudart.so.13: cannot open shared object file: No such file or directory
+```
+
+your system CUDA Toolkit is missing or older than 13. Use the provided conda environment to get the CUDA 13 runtime and UV without changing the system CTK:
+
+1. From the **nv-ingest root**:
+   ```bash
+   conda env create -f conda/environments/retriever_libcudart.yml
+   ```
+   (If the env already exists, use `conda env update -f conda/environments/retriever_libcudart.yml --name retriever_libcudart` to refresh it.)
+
+2. Activate the environment:
+   ```bash
+   conda activate retriever_libcudart
+   ```
+
+3. Expose the conda env's CUDA runtime so the OCR extension can load it (needed because conda does not set `LD_LIBRARY_PATH` for this env by default):
+   ```bash
+   export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
+   ```
+
+4. Follow the **Installation** steps above unchanged: `uv venv .retriever`, `source .retriever/bin/activate`, `uv pip install -e ./retriever`. The conda env supplies the `uv` binary and the CUDA 13 runtime (the dynamic linker finds `libcudart.so.13` in the conda env's `lib`).
+
+If your system already has a suitable CUDA 13 (or you are not using OCR), you can use the UV-only path above without the conda env.
+
 ## Quick start
 
 From the nv-ingest root, install with UV then run the batch pipeline with a directory of PDFs:
@@ -35,7 +65,7 @@ uv pip install -e ./retriever
 uv run python retriever/src/retriever/examples/batch_pipeline.py /path/to/pdfs
 ```
 
-Pass the directory that contains your PDFs as the first argument (`input-dir`). For recall evaluation, the pipeline uses `bo767_query_gt.csv` in the current directory by default; override with `--query-csv <path>`. Recall is skipped if the query CSV file does not exist. By default, per-query details (query, gold, hits) are printed; use `--no-recall-details` to print only the missed-gold summary and recall metrics. To use an existing Ray cluster, pass `--ray-address auto`.
+Pass the directory that contains your PDFs as the first argument (`input-dir`). For recall evaluation, the pipeline uses `bo767_query_gt.csv` in the current directory by default; override with `--query-csv <path>`. Recall is skipped if the query CSV file does not exist. By default, per-query details (query, gold, hits) are printed; use `--no-recall-details` to print only the missed-gold summary and recall metrics. To use an existing Ray cluster, pass `--ray-address auto`. If OCR fails with a missing `libcudart.so.13`, use the conda-based workflow under **OCR and CUDA 13 runtime (conda)** above.
 
 ### Starting a Ray cluster
 


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

With latest OCR nightlies being built with CTK 13 (https://github.com/NVIDIA/nv-ingest/pull/1414), we now require a system installation of CUDA runtime >= 13 for basic retriever functionality

This PR takes a stab at adding a basic conda env spec that pulls `cuda-cudart=13.*`, along with instructions on how to activate this environment for use with retriever if the system requirements aren't met

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
