### PR TITLE
Kheiss/vlm caption

### DIFF
--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -444,7 +444,7 @@ For RTX Pro 6000 Server Edition and other GPUs with limited VRAM, use the overri
 Infographics often combine text, charts, and diagrams into complex visuals. Vision-language model (VLM) captioning generates natural language descriptions that capture this complexity, making the content searchable and more accessible for downstream applications.
 
 To use VLM captioning for infographics, start NeMo Retriever extraction with both the `retrieval` and `vlm` profiles by running the following code.
-```
+```shell
 docker compose \
   -f docker-compose.yaml \
   --profile retrieval \


### PR DESCRIPTION
PR: #1369 – Document VLM Captioning for Infographics

Expected updated docs files (based on the PR commit list in GitHub):

docs/docs/extraction/nv-ingest-python-api.md

docs/docs/extraction/quickstart-guide.md

docs/docs/extraction/vlm-embed.md

Actual state on upstream/main:

Only docs/docs/extraction/nv-ingest-python-api.md and docs/docs/extraction/vlm-embed.md shows changes associated with commit a44d64f1 Document VLM Captioning for Infographics (#1369).

docs/docs/extraction/quickstart-guide.md do not contain the VLM-related updates authored in the PR and must be recreated.

I will reapply the intended VLM documentation changes to quickstart-guide.md and vlm-embed.md in a follow-up PR