### PR TITLE
[retriever] add remote NIM endpoint support in inprocess pipeline

### DIFF
--- a/retriever/src/retriever/examples/inprocess_pipeline.py
+++ b/retriever/src/retriever/examples/inprocess_pipeline.py
@@ -129,6 +129,21 @@ def main(
         "--num-gpus",
         help="Number of GPUs to use, starting from device 0 (e.g. --num-gpus 2 → GPUs 0,1). Mutually exclusive with --gpu-devices.",
     ),
+    page_elements_invoke_url: Optional[str] = typer.Option(
+        None,
+        "--page-elements-invoke-url",
+        help="Optional remote endpoint URL for page-elements model inference.",
+    ),
+    ocr_invoke_url: Optional[str] = typer.Option(
+        None,
+        "--ocr-invoke-url",
+        help="Optional remote endpoint URL for OCR model inference.",
+    ),
+    embed_invoke_url: Optional[str] = typer.Option(
+        None,
+        "--embed-invoke-url",
+        help="Optional remote endpoint URL for embedding model inference.",
+    ),
 ) -> None:
     if input_type == "txt":
         pass  # No NEMOTRON_OCR_MODEL_DIR needed for .txt
@@ -153,7 +168,7 @@ def main(
         ingestor = (
             ingestor.files(glob_pattern)
             .extract_txt(max_tokens=512, overlap_tokens=0)
-            .embed(model_name="nemo_retriever_v1")
+            .embed(model_name="nemo_retriever_v1", embed_invoke_url=embed_invoke_url)
             .vdb_upload(lancedb_uri=LANCEDB_URI, table_name=LANCEDB_TABLE, overwrite=True, create_index=True)
         )
     elif input_type == "doc":
@@ -168,8 +183,10 @@ def main(
                 extract_tables=True,
                 extract_charts=True,
                 extract_infographics=False,
+                page_elements_invoke_url=page_elements_invoke_url,
+                ocr_invoke_url=ocr_invoke_url,
             )
-            .embed(model_name="nemo_retriever_v1")
+            .embed(model_name="nemo_retriever_v1", embed_invoke_url=embed_invoke_url)
             .vdb_upload(lancedb_uri=LANCEDB_URI, table_name=LANCEDB_TABLE, overwrite=True, create_index=True)
         )
     else:
@@ -183,8 +200,13 @@ def main(
                 extract_tables=True,
                 extract_charts=True,
                 extract_infographics=False,
+                page_elements_invoke_url=page_elements_invoke_url,
+                ocr_invoke_url=ocr_invoke_url,
             )
-            .embed(model_name="nemo_retriever_v1")
+            .embed(
+                model_name="nemo_retriever_v1",
+                embed_invoke_url=embed_invoke_url,
+            )
             .vdb_upload(lancedb_uri=LANCEDB_URI, table_name=LANCEDB_TABLE, overwrite=True, create_index=True)
         )
 
@@ -218,6 +240,7 @@ def main(
         lancedb_uri=str(LANCEDB_URI),
         lancedb_table=str(LANCEDB_TABLE),
         embedding_model="nvidia/llama-3.2-nv-embedqa-1b-v2",
+        embedding_http_endpoint=embed_invoke_url,
         top_k=10,
         ks=(1, 5, 10),
     )

--- a/retriever/src/retriever/ingest_modes/gpu_pool.py
+++ b/retriever/src/retriever/ingest_modes/gpu_pool.py
@@ -115,9 +115,13 @@ def _extract_model_config(func: Callable, kwargs: dict[str, Any]) -> Any:
     from .inprocess import embed_text_main_text_embed, explode_content_to_rows
 
     if func is detect_page_elements_v3:
+        if kwargs.get("invoke_url"):
+            return None  # Remote endpoint, no local model
         return PageElementsModelConfig()
 
     if func is ocr_page_elements:
+        if kwargs.get("invoke_url"):
+            return None  # Remote endpoint, no local model
         model = kwargs.get("model")
         model_dir = ""
         if model is not None and hasattr(model, "_model_dir"):

--- a/retriever/src/retriever/ocr/ocr.py
+++ b/retriever/src/retriever/ocr/ocr.py
@@ -193,6 +193,10 @@ def _np_rgb_to_b64_png(crop_array: np.ndarray) -> str:
 
 def _extract_remote_ocr_item(response_item: Any) -> Any:
     if isinstance(response_item, dict):
+        # NIM text_detections format: return full list (not v[0])
+        td = response_item.get("text_detections")
+        if isinstance(td, list) and td:
+            return td
         for k in ("prediction", "predictions", "output", "outputs", "data"):
             v = response_item.get(k)
             if isinstance(v, list) and v:
@@ -244,6 +248,26 @@ def _parse_ocr_result(preds: Any) -> List[Dict[str, Any]]:
                     blocks.append({"text": item.strip(), "sort_y": 0.0, "sort_x": 0.0})
                 continue
             if not isinstance(item, dict):
+                continue
+
+            # NIM text_detections format:
+            # {"text_prediction": {"text": "...", "confidence": ...},
+            #  "bounding_box": {"points": [{"x": ..., "y": ...}, ...]}}
+            tp = item.get("text_prediction")
+            if isinstance(tp, dict):
+                txt0 = str(tp.get("text") or "").strip()
+                if txt0 and txt0 != "nan":
+                    sort_y, sort_x = 0.0, 0.0
+                    bb = item.get("bounding_box")
+                    if isinstance(bb, dict):
+                        pts = bb.get("points")
+                        if isinstance(pts, list) and pts:
+                            try:
+                                sort_x = float(pts[0].get("x", 0.0))
+                                sort_y = float(pts[0].get("y", 0.0))
+                            except Exception:
+                                pass
+                    blocks.append({"text": txt0, "sort_y": sort_y, "sort_x": sort_x})
                 continue
 
             # Nemotron OCR normalized-coord form
@@ -493,6 +517,7 @@ def ocr_page_elements(
                         infographic_items.append(entry)
 
         except BaseException as e:
+            print(f"Warning: OCR failed: {type(e).__name__}: {e}")
             row_error = {
                 "stage": "ocr_page_elements",
                 "type": e.__class__.__name__,


### PR DESCRIPTION
## Description
  - Add support for offloading page-elements detection, OCR, and embedding inference to remote NIM endpoints instead of requiring local GPU models                      
  - When a remote endpoint URL is provided, the pipeline skips local model instantiation and sends inference requests to the specified NIM service                                                                                                                                                 

### Usage example
```
python -m retriever.examples.inprocess_pipeline \
  /path/to/pdfs \
  --page-elements-invoke-url http://localhost:8000/v1/infer \
  --ocr-invoke-url http://localhost:8009/v1/infer \
  --embed-invoke-url http://localhost:8012/v1
```
Also works with batch mode `retriever/src/retriever/examples/batch_pipeline.py`.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
