### PR TITLE
fix: catch ImportError instead of bare except for optional import

### DIFF
--- a/tests/service_tests/modules/injectors/test_task_injector.py
+++ b/tests/service_tests/modules/injectors/test_task_injector.py
@@ -10,7 +10,7 @@ try:
     from nv_ingest.framework.orchestration.morpheus.modules.injectors.task_injection import on_data
 
     morpheus_import = True
-except:
+except ImportError:
     morpheus_import = False
 
 


### PR DESCRIPTION
Replace bare `except:` with `except ImportError:` in `test_task_injector.py`. The morpheus import guard should only catch `ImportError`, not `KeyboardInterrupt` or `SystemExit`.