### PR TITLE
(retriever) upload nightly wheels to test.pypi.org

### DIFF
--- a/.github/workflows/pypi-nightly-publish.yml
+++ b/.github/workflows/pypi-nightly-publish.yml
@@ -1,6 +1,5 @@
 name: Nv-Ingest Nightly PyPi Wheel Publish
 
-# Trigger for pull requests and pushing to main
 on:
   schedule:
     # Runs every day at 11:30PM (UTC)
@@ -11,16 +10,34 @@ on:
         description: 'Source branch to build wheel from'
         required: true
         default: 'main'
+        type: string
       VERSION:
         description: 'Version string for the release (e.g., 25.4.0)'
         required: true
+        default: ''
+        type: string
       RELEASE_TYPE:
         description: 'Whether the build is a nightly or release'
         required: true
+        default: dev
         type: choice
         options:
           - dev
           - release
+      upload_to:
+        description: 'Where to upload (none/testpypi/pypi)'
+        required: true
+        default: testpypi
+        type: choice
+        options:
+          - none
+          - testpypi
+          - pypi
+      skip_existing:
+        description: 'Skip already-uploaded versions'
+        required: true
+        default: true
+        type: boolean
 
 jobs:
   build:
@@ -28,8 +45,25 @@ jobs:
     container:
       image: rapidsai/ci-conda:cuda12.5.1-ubuntu22.04-py3.12
     steps:
-      - name: Determine source branch and release type to use for run
+      - name: Decide upload target
+        id: target
+        shell: bash
         run: |
+          set -euo pipefail
+          # Default for scheduled runs: testpypi
+          upload_to="testpypi"
+          skip_existing="true"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            upload_to="${{ inputs.upload_to }}"
+            skip_existing="${{ inputs.skip_existing }}"
+          fi
+          echo "upload_to=${upload_to}" >> "$GITHUB_OUTPUT"
+          echo "skip_existing=${skip_existing}" >> "$GITHUB_OUTPUT"
+
+      - name: Determine source branch and release type to use for run
+        shell: bash
+        run: |
+          set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "Setting build source to ${{ github.event.inputs.environment }}"
             echo "ENVIRONMENT=${{ github.event.inputs.environment }}" >> $GITHUB_ENV
@@ -61,22 +95,27 @@ jobs:
           ref: ${{ env.ENVIRONMENT }}
 
       - name: Install build dependencies
+        shell: bash
         run: |
           pip install build twine
 
       - name: Build nv-ingest-api wheel
+        shell: bash
         run: |
           cd api && NV_INGEST_RELEASE_TYPE=${{ env.RELEASE_TYPE }} NV_INGEST_VERSION=${{ env.VERSION }} python -m build
 
       - name: Build nv-ingest-client wheel
+        shell: bash
         run: |
           cd client && NV_INGEST_RELEASE_TYPE=${{ env.RELEASE_TYPE }} NV_INGEST_VERSION=${{ env.VERSION }} python -m build
 
       - name: Build nv-ingest service wheel
+        shell: bash
         run: |
           cd src && NV_INGEST_RELEASE_TYPE=${{ env.RELEASE_TYPE }} NV_INGEST_VERSION=${{ env.VERSION }} python -m build
 
       - name: Build retriever wheel
+        shell: bash
         run: |
           cd retriever
           python - <<'PY'
@@ -96,13 +135,33 @@ jobs:
           RETRIEVER_GIT_SHA=${{ github.sha }} \
           python -m build
 
-      - name: Publish wheels to Artifactory
+      - name: Publish wheels
         env:
-          ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
-          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        shell: bash
         run: |
-          twine upload --repository-url $ARTIFACTORY_URL -u $ARTIFACTORY_USERNAME -p $ARTIFACTORY_PASSWORD api/dist/* \
-          && twine upload --repository-url $ARTIFACTORY_URL -u $ARTIFACTORY_USERNAME -p $ARTIFACTORY_PASSWORD client/dist/* \
-          && twine upload --repository-url $ARTIFACTORY_URL -u $ARTIFACTORY_USERNAME -p $ARTIFACTORY_PASSWORD src/dist/* \
-          && twine upload --repository-url $ARTIFACTORY_URL -u $ARTIFACTORY_USERNAME -p $ARTIFACTORY_PASSWORD retriever/dist/*
+          set -euo pipefail
+
+          upload_to="${{ steps.target.outputs.upload_to }}"
+          repository_url="https://test.pypi.org/legacy/"
+          token="${TEST_PYPI_API_TOKEN:-}"
+          if [[ "${upload_to}" == "pypi" ]]; then
+            repository_url="https://upload.pypi.org/legacy/"
+            token="${PYPI_API_TOKEN:-}"
+          fi
+
+          if [[ "${upload_to}" == "none" ]]; then
+            echo "upload_to=none; skipping package upload."
+            exit 0
+          fi
+
+          skip_existing_flag=""
+          if [[ "${{ steps.target.outputs.skip_existing }}" == "true" ]]; then
+            skip_existing_flag="--skip-existing"
+          fi
+
+          twine upload ${skip_existing_flag} --repository-url "${repository_url}" -u __token__ -p "${token}" api/dist/* \
+          && twine upload ${skip_existing_flag} --repository-url "${repository_url}" -u __token__ -p "${token}" client/dist/* \
+          && twine upload ${skip_existing_flag} --repository-url "${repository_url}" -u __token__ -p "${token}" src/dist/* \
+          && twine upload ${skip_existing_flag} --repository-url "${repository_url}" -u __token__ -p "${token}" retriever/dist/*


### PR DESCRIPTION
## Description
Added manual dispatch inputs:
upload_to (none / testpypi / pypi, default testpypi)
skip_existing (boolean, default true)
Kept workflow_dispatch enabled, so this can be run manually at any time.
Added a new Decide upload target step that:
Defaults scheduled runs to testpypi
Uses manual input values when triggered via workflow_dispatch
Replaced Artifactory publishing with Twine publishing to:
https://test.pypi.org/legacy/ by default
https://upload.pypi.org/legacy/ when upload_to=pypi
Skips upload entirely when upload_to=none
Added --skip-existing handling based on the input.
Switched auth to token-based PyPI credentials via:
TEST_PYPI_API_TOKEN
PYPI_API_TOKEN

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
