### PR TITLE
Add LanceDB hybrid search (dense + FTS) for retriever recall

### DIFF
--- a/retriever/src/retriever/examples/batch_pipeline.py
+++ b/retriever/src/retriever/examples/batch_pipeline.py
@@ -331,7 +331,7 @@ def _hit_key_and_distance(hit: dict) -> tuple[str | None, float | None]:
         return None, float(hit.get("_distance")) if "_distance" in hit else None
 
     key = f"{Path(str(source_id)).stem}_{page_number}"
-    dist = float(hit.get("_distance")) if "_distance" in hit else None
+    dist = float(hit["_distance"]) if "_distance" in hit else float(hit["_score"]) if "_score" in hit else None
     return key, dist
 
 
@@ -531,6 +531,11 @@ def main(
         dir_okay=False,
         help="Optional JSON file path to write end-of-run detection counts summary.",
     ),
+    hybrid: bool = typer.Option(
+        False,
+        "--hybrid/--no-hybrid",
+        help="Enable LanceDB hybrid mode (dense + FTS text).",
+    ),
 ) -> None:
     log_handle, original_stdout, original_stderr = _configure_logging(log_file)
     try:
@@ -578,6 +583,7 @@ def main(
                             "table_name": LANCEDB_TABLE,
                             "overwrite": True,
                             "create_index": True,
+                            "hybrid": hybrid,
                         }
                     )
                 )
@@ -599,6 +605,7 @@ def main(
                             "table_name": LANCEDB_TABLE,
                             "overwrite": True,
                             "create_index": True,
+                            "hybrid": hybrid,
                         }
                     )
                 )
@@ -656,6 +663,7 @@ def main(
                             "table_name": LANCEDB_TABLE,
                             "overwrite": True,
                             "create_index": True,
+                            "hybrid": hybrid,
                         }
                     )
                 )
@@ -712,6 +720,7 @@ def main(
                             "table_name": LANCEDB_TABLE,
                             "overwrite": True,
                             "create_index": True,
+                            "hybrid": hybrid,
                         }
                     )
                 )
@@ -784,6 +793,7 @@ def main(
             embedding_model=_recall_model,
             top_k=10,
             ks=(1, 5, 10),
+            hybrid=hybrid,
         )
 
         _df_query, _gold, _raw_hits, _retrieved_keys, metrics = retrieve_and_score(query_csv=query_csv, cfg=cfg)

--- a/retriever/src/retriever/ingest_modes/batch.py
+++ b/retriever/src/retriever/ingest_modes/batch.py
@@ -984,6 +984,16 @@ class BatchIngestor(Ingestor):
         except Exception as e:
             print(f"Warning: failed to create LanceDB index (continuing without index): {e}")
 
+        if kw.get("hybrid", False):
+            text_column = str(kw.get("text_column", "text"))
+            fts_language = str(kw.get("fts_language", "English"))
+            try:
+                table.create_fts_index(text_column, language=fts_language)
+            except Exception as e:
+                print(
+                    f"Warning: FTS index creation failed on column {text_column!r} (continuing with vector-only): {e}"
+                )
+
         for index_stub in table.list_indices():
             table.wait_for_index([index_stub.name], timeout=timedelta(seconds=600))
 

--- a/retriever/src/retriever/params/models.py
+++ b/retriever/src/retriever/params/models.py
@@ -85,6 +85,8 @@ class LanceDbParams(_ParamsModel):
     embedding_key: str = "embedding"
     include_text: bool = True
     text_column: str = "text"
+    hybrid: bool = False
+    fts_language: str = "English"
 
 
 class BatchTuningParams(_ParamsModel):

--- a/retriever/src/retriever/vector_store/__init__.py
+++ b/retriever/src/retriever/vector_store/__init__.py
@@ -3,11 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .__main__ import app
-from .lancedb_store import LanceDBConfig, write_embeddings_to_lancedb, write_text_embeddings_dir_to_lancedb
+from .lancedb_store import (
+    LanceDBConfig,
+    create_lancedb_index,
+    write_embeddings_to_lancedb,
+    write_text_embeddings_dir_to_lancedb,
+)
 
 __all__ = [
     "app",
     "LanceDBConfig",
+    "create_lancedb_index",
     "write_embeddings_to_lancedb",
     "write_text_embeddings_dir_to_lancedb",
 ]


### PR DESCRIPTION
## Description

Enable combined dense vector + full-text search via --hybrid flag in the batch pipeline. When enabled, ingestion creates both IVF_HNSW_SQ and FTS indices, and recall uses RRF reranking to merge results.

On jp20 (20 PDFs, 115 queries):
  Dense:  recall@1=0.61, recall@5=0.90, recall@10=0.96
  Hybrid: recall@1=0.65, recall@5=0.94, recall@10=0.96

bo767 hybrid:
Recall metrics (matching retriever.recall.core):
  recall@1: 0.5863
  recall@5: 0.8285
  recall@10: 0.8920
Pages processed: 50556

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
