### PR TITLE
Stop running 26.1.2 libmode tests on all PRs / pushes

### DIFF
--- a/.github/workflows/test-library-mode.yml
+++ b/.github/workflows/test-library-mode.yml
@@ -1,7 +1,7 @@
 name: Test Nv-Ingest Library Mode
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize
@@ -9,11 +9,11 @@ on:
       # Adding 'labeled' to the list of activity types that trigger this event
       # (default: opened, synchronize, reopened) so that we can run this
       # workflow when the 'ok-to-test' label is added.
-      # Reference: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+      # Reference: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
       - labeled
   push:
     branches:
-      - main
+      - release/26.1.2
 
 jobs:
   build:
@@ -24,7 +24,7 @@ jobs:
       - name: Check access
         if:
           ${{
-            github.event_name == 'pull_request_target' &&
+            github.event_name == 'pull_request' &&
             github.event.pull_request.author_association != 'MEMBER' &&
             github.event.pull_request.author_association != 'COLLABORATOR' &&
             github.event.pull_request.author_association != 'OWNER' &&
@@ -37,9 +37,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # For pull_request_target, checkout the PR head SHA.
+          # For pull_request, checkout the PR head SHA.
           # For push, checkout the pushed commit SHA.
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Build Conda Packages
         run: |
@@ -65,7 +65,7 @@ jobs:
       - name: Check access
         if:
           ${{
-            github.event_name == 'pull_request_target' &&
+            github.event_name == 'pull_request' &&
             github.event.pull_request.author_association != 'MEMBER' &&
             github.event.pull_request.author_association != 'COLLABORATOR' &&
             github.event.pull_request.author_association != 'OWNER' &&


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Modifying this branch's libmode test workflow so that it stops running on PRs / commits against `main`:

- `pull_request_target` -> `pull_request` so that this workflow is only triggered on PRs against `release/26.1.2`, rather than all PRs
- switching trigger branch to `release/26.1.2` so that this workflow is only triggered on commits to `release/26.1.2` and not commits to `main`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
