### PR TITLE
fix: add trust_remote_code=True to AutoTokenizer for embedqa model

### DIFF
--- a/nemo_retriever/src/nemo_retriever/model/local/llama_nemotron_embed_1b_v2_embedder.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/llama_nemotron_embed_1b_v2_embedder.py
@@ -45,7 +45,7 @@ class LlamaNemotronEmbed1BV2Embedder:
         MODEL_ID = self.model_id or "nvidia/llama-3.2-nv-embedqa-1b-v2"
         dev = torch.device(self.device or ("cuda" if torch.cuda.is_available() else "cpu"))
         hf_cache_dir = self.hf_cache_dir or str(Path.home() / ".cache" / "huggingface")
-        self._tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, cache_dir=hf_cache_dir)
+        self._tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, trust_remote_code=True, cache_dir=hf_cache_dir)
         self._model = AutoModel.from_pretrained(MODEL_ID, trust_remote_code=True, cache_dir=hf_cache_dir)
         self._model = self._model.to(dev)
         self._model.eval()


### PR DESCRIPTION
## Description

The AutoModel.from_pretrained call already passes trust_remote_code=True, but the AutoTokenizer.from_pretrained call was missing it. This causes an interactive [y/N] prompt that hangs non-interactive contexts (CI, batch jobs, production pipelines).

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
