### PR TITLE
nemo_retriever: Add retriever harness CLI and artifact flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,6 +229,7 @@ scripts/private_local/
 test_results/
 sweep_results/
 artifacts/
+nemo_retriever/artifacts/
 
 # Ignore cursor rules
 .cursor

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -54,6 +54,76 @@ Pass the directory that contains your PDFs as the first argument (`input-dir`). 
 
 For **HTML** or **text** ingestion, use `--input-type html` or `--input-type txt` with the same examples (e.g. `batch_pipeline.py <dir> --input-type html`). HTML files are converted to markdown via markitdown, then chunked with the same tokenizer as .txt. Staged CLI: `retriever html run --input-dir <dir>` writes `*.html_extraction.json`; then `retriever local stage5 run --input-dir <dir> --pattern "*.html_extraction.json"` and `retriever local stage6 run --input-dir <dir>`.
 
+## Harness (run, sweep, nightly)
+
+`nemo_retriever` includes a lightweight harness for benchmark orchestration without Docker.
+
+- Config files:
+  - `nemo_retriever/harness/test_configs.yaml`
+  - `nemo_retriever/harness/nightly_config.yaml`
+- CLI entrypoint is nested under `retriever harness`.
+- First pass is LanceDB-only and enforces recall-required pass/fail by default.
+- Single-run artifact directories default to `<dataset>_<timestamp>`.
+
+### Single run
+
+```bash
+# Dataset preset from test_configs.yaml (recall-required example)
+retriever harness run --dataset jp20 --preset single_gpu
+
+# Direct dataset path
+retriever harness run --dataset /datasets/nv-ingest/bo767 --preset single_gpu
+```
+
+### Sweep runs (explicit runs list)
+
+```bash
+retriever harness sweep --runs-config nemo_retriever/harness/nightly_config.yaml
+```
+
+### Nightly session
+
+```bash
+retriever harness nightly --runs-config nemo_retriever/harness/nightly_config.yaml
+retriever harness nightly --dry-run
+```
+
+### Harness artifacts
+
+Each run writes a compact artifact set (no full stdout/stderr log persistence):
+
+- `results.json` (normalized metrics + pass/fail + config snapshot)
+- `command.txt` (exact invoked command)
+- `runtime_metrics/` (Ray runtime summary + timeline files)
+
+By default, detection totals are embedded into `results.json` under `detection_summary`.
+If you want a separate detection file for ad hoc inspection, set `write_detection_file: true` in
+`nemo_retriever/harness/test_configs.yaml`.
+
+Sweep/nightly sessions additionally write:
+
+- `session_summary.json` (overall pass/fail rollup)
+
+### Runtime metrics interpretation
+
+`runtime_metrics/` currently includes:
+
+- `run.runtime.summary.json`: high-level run totals (input files, pages, elapsed seconds)
+- `run.ray.timeline.json`: detailed Ray execution timeline for deeper profiling
+- `run.rd_dataset.stats.txt`: Ray dataset stats dump (can be empty on some runs)
+
+For routine benchmark comparison, `results.json` is the primary source.
+Use `runtime_metrics/` when investigating throughput regressions or stage-level behavior.
+
+### Artifact size profile
+
+Current observed runs show that per-run LanceDB data dominates footprint:
+
+- `bo20`: ~9.0 MiB total, ~8.6 MiB LanceDB (~96%)
+- `jp20`: ~36.8 MiB total, ~36.2 MiB LanceDB (~98%)
+
+So storage growth is mostly driven by `lancedb/`, not the summary JSON artifacts.
+
 ### Audio pipeline
 
 Audio ingestion uses `.files("mp3/*.mp3").extract_audio(...).embed().vdb_upload().ingest()` in batch, inprocess, or fused mode. **ASR** (speech-to-text) can be:

--- a/nemo_retriever/harness/HANDOFF.md
+++ b/nemo_retriever/harness/HANDOFF.md
@@ -1,0 +1,154 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Nemo Retriever Harness Handoff
+
+This document is a planning handoff for ongoing `nemo_retriever` harness iterations.
+It captures what exists now, what was intentionally chosen, and what to iterate next.
+
+## Current Scope and Intent
+
+- Harness is standalone under `nemo_retriever` (not based on `tools/harness`).
+- It wraps `nemo_retriever.examples.batch_pipeline`.
+- Primary use case is benchmark orchestration for local/cluster runs without Docker orchestration.
+- Vector DB is LanceDB only.
+- Recall gating is supported and enforced by config (`recall_required`).
+
+## Key Files
+
+- `nemo_retriever/src/nemo_retriever/harness/run.py`
+  - CLI run/sweep/nightly orchestration, subprocess execution, metrics extraction, artifact writes.
+- `nemo_retriever/src/nemo_retriever/harness/config.py`
+  - YAML + CLI/env merge logic and `HarnessConfig`.
+- `nemo_retriever/src/nemo_retriever/harness/parsers.py`
+  - Stream parsing for ingest/throughput/recall metrics.
+- `nemo_retriever/src/nemo_retriever/harness/artifacts.py`
+  - Artifact/session directory creation and session summary writing.
+- `nemo_retriever/harness/test_configs.yaml`
+  - Active defaults, presets, dataset presets.
+- `nemo_retriever/harness/nightly_config.yaml`
+  - Ordered run list for sweep/nightly.
+
+## Current Config Defaults
+
+- Active default dataset: `jp20` (recall-required workflow).
+- `bo20` remains ingestion-only (`query_csv: null`, `recall_required: false`).
+- Two main presets are available:
+  - `single_gpu`
+  - `dgx_8gpu`
+
+## Current CLI Usage
+
+From repo root:
+
+```bash
+source ~/setup_env.sh
+source .retriever/bin/activate
+uv pip install -e ./nemo_retriever
+```
+
+Single run:
+
+```bash
+retriever harness run --dataset jp20 --preset single_gpu
+```
+
+Sweep:
+
+```bash
+retriever harness sweep --runs-config nemo_retriever/harness/nightly_config.yaml
+```
+
+Nightly:
+
+```bash
+retriever harness nightly --runs-config nemo_retriever/harness/nightly_config.yaml
+retriever harness nightly --dry-run
+```
+
+## Artifact Contract (Current)
+
+Per run:
+
+- `results.json` (authoritative run record)
+- `command.txt`
+- `runtime_metrics/`
+- `lancedb/`
+
+Session-level:
+
+- `session_summary.json` only
+
+Notes:
+
+- `detection_summary` is embedded into `results.json`.
+- Standalone `detection_summary.json` is optional via `write_detection_file: true`.
+- `sweep_results.json` was removed to avoid duplicated session outputs.
+
+## Recent Cleanup Decisions
+
+1. **Session naming cleaned**
+   - Session run directories now use run name directly (for example `jp20_single`).
+   - Removed redundant suffix style like `jp20_single_jp20`.
+
+2. **Session output deduped**
+   - Kept `session_summary.json`.
+   - Removed `sweep_results.json` generation.
+
+3. **TTY-backed subprocess retained**
+   - Harness runs batch pipeline through a PTY so Ray progress remains rich/pretty by default.
+
+## Known Behavior to Remember
+
+- If a dataset has no ground-truth CSV and `recall_required` is false, run can still pass on ingest metrics.
+- If `recall_required` is true and recall metrics are missing, harness marks failure (`missing_recall_metrics`).
+- LanceDB directories dominate artifact size; JSON overhead is small.
+
+## Current Validation Status
+
+Harness-focused tests pass:
+
+```bash
+pytest -q nemo_retriever/tests/test_harness_parsers.py \
+  nemo_retriever/tests/test_harness_config.py \
+  nemo_retriever/tests/test_harness_run.py
+```
+
+## Recommended Next Iterations
+
+### P0 (next)
+
+- Add run-level metadata fields useful for long-term tracking:
+  - `host`, `gpu_count`, `cuda_driver`, `ray_version`, `python_version`.
+- Add optional run tag support (for example `--tag nightly`, `--tag candidate`) into `results.json`.
+- Add one command to print a compact table from a session (`session_summary.json`) for quick review.
+
+### P1
+
+- Add a stable compare utility for two sessions (delta pages/sec and recall deltas by run name).
+- Add preset inheritance or scaling helper to reduce duplicated numeric tuning in YAML.
+- Add an artifact retention helper (manual command) to prune old sessions by age/size.
+
+### P2
+
+- Optional matrix expansion for runs config (keep explicit run list as default UX).
+- Export-to-csv summary utility for spreadsheet and trend analysis.
+- Optional stricter validation mode that fails on unknown config keys.
+
+## Planning Checklist for New Iterations
+
+When adding harness features, keep this order:
+
+1. Update config schema/load logic (`config.py`) and defaults in `test_configs.yaml`.
+2. Update run orchestration (`run.py`) and artifact payloads (`results.json`/`session_summary.json`).
+3. Add/extend unit tests in `nemo_retriever/tests/test_harness_*.py`.
+4. Update `nemo_retriever/README.md` harness section.
+5. Run harness tests and at least one `--dry-run` CLI check.
+
+## Suggested "Done" Criteria Per Iteration
+
+- No regressions in harness test suite.
+- Artifact schema changes are intentional and documented.
+- README command examples still execute as written.
+- Session output remains concise and non-duplicative.
+- At least one real run or dry run validates the new behavior.

--- a/nemo_retriever/harness/nightly_config.yaml
+++ b/nemo_retriever/harness/nightly_config.yaml
@@ -1,0 +1,12 @@
+runs:
+  - name: jp20_single
+    dataset: jp20
+    preset: single_gpu
+
+  - name: bo20_single
+    dataset: bo20
+    preset: single_gpu
+
+  # - name: bo767_single
+  #   dataset: bo767
+  #   preset: single_gpu

--- a/nemo_retriever/harness/test_configs.yaml
+++ b/nemo_retriever/harness/test_configs.yaml
@@ -1,0 +1,70 @@
+# Harness config for nemo_retriever benchmarks.
+
+active:
+  dataset: jp20
+  preset: single_gpu
+  query_csv: data/jp20_query_gt.csv
+  input_type: pdf
+  recall_required: true
+  artifacts_dir: null
+  ray_address: null
+  lancedb_uri: lancedb
+  hybrid: false
+  embed_model_name: nvidia/llama-3.2-nv-embedqa-1b-v2
+  write_detection_file: false
+
+presets:
+  single_gpu:
+    pdf_extract_workers: 8
+    pdf_extract_num_cpus: 2.0
+    pdf_extract_batch_size: 4
+    pdf_split_batch_size: 1
+    page_elements_batch_size: 4
+    page_elements_workers: 3
+    ocr_workers: 3
+    ocr_batch_size: 16
+    embed_workers: 3
+    embed_batch_size: 256
+    page_elements_cpus_per_actor: 1.0
+    ocr_cpus_per_actor: 1.0
+    embed_cpus_per_actor: 1.0
+    gpu_page_elements: 0.1
+    gpu_ocr: 0.1
+    gpu_embed: 0.25
+
+  dgx_8gpu:
+    pdf_extract_workers: 64
+    pdf_extract_num_cpus: 2.0
+    pdf_extract_batch_size: 4
+    pdf_split_batch_size: 1
+    page_elements_batch_size: 32
+    page_elements_workers: 24
+    ocr_workers: 24
+    ocr_batch_size: 16
+    embed_workers: 24
+    embed_batch_size: 256
+    page_elements_cpus_per_actor: 1.0
+    ocr_cpus_per_actor: 1.0
+    embed_cpus_per_actor: 1.0
+    gpu_page_elements: 0.1
+    gpu_ocr: 0.1
+    gpu_embed: 0.25
+
+datasets:
+  bo20:
+    path: /datasets/nv-ingest/bo20
+    query_csv: null
+    input_type: pdf
+    recall_required: false
+
+  bo767:
+    path: /datasets/nv-ingest/bo767
+    query_csv: data/bo767_query_gt.csv
+    input_type: pdf
+    recall_required: true
+
+  jp20:
+    path: /datasets/nv-ingest/jp20
+    query_csv: data/jp20_query_gt.csv
+    input_type: pdf
+    recall_required: true

--- a/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
+++ b/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
@@ -10,6 +10,7 @@ from nemo_retriever.audio import app as audio_app
 from nemo_retriever.utils.benchmark import app as benchmark_app
 from nemo_retriever.chart import app as chart_app
 from nemo_retriever.utils.compare import app as compare_app
+from nemo_retriever.harness import app as harness_app
 from nemo_retriever.html import __main__ as html_main
 from nemo_retriever.utils.image import app as image_app
 from nemo_retriever.local import app as local_app
@@ -28,6 +29,7 @@ app.add_typer(local_app, name="local")
 app.add_typer(chart_app, name="chart")
 app.add_typer(compare_app, name="compare")
 app.add_typer(benchmark_app, name="benchmark")
+app.add_typer(harness_app, name="harness")
 app.add_typer(vector_store_app, name="vector-store")
 app.add_typer(recall_app, name="recall")
 app.add_typer(txt_main.app, name="txt")

--- a/nemo_retriever/src/nemo_retriever/harness/__init__.py
+++ b/nemo_retriever/src/nemo_retriever/harness/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from .__main__ import app, main
+
+__all__ = ["app", "main"]

--- a/nemo_retriever/src/nemo_retriever/harness/__main__.py
+++ b/nemo_retriever/src/nemo_retriever/harness/__main__.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import typer
+
+from nemo_retriever.harness.nightly import nightly_command
+from nemo_retriever.harness.run import run_command, sweep_command
+
+app = typer.Typer(help="Harness commands for benchmark orchestration.")
+app.command("run")(run_command)
+app.command("sweep")(sweep_command)
+app.command("nightly")(nightly_command)
+
+
+def main() -> None:
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/nemo_retriever/src/nemo_retriever/harness/artifacts.py
+++ b/nemo_retriever/src/nemo_retriever/harness/artifacts.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+NEMO_RETRIEVER_ROOT = Path(__file__).resolve().parents[3]
+DEFAULT_ARTIFACTS_ROOT = NEMO_RETRIEVER_ROOT / "artifacts"
+
+
+def now_timestr() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_UTC")
+
+
+def last_commit() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=str(NEMO_RETRIEVER_ROOT.parent),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except Exception:
+        return "unknown"
+
+    if result.returncode != 0:
+        return "unknown"
+    return (result.stdout or "").strip() or "unknown"
+
+
+def get_artifacts_root(base_dir: str | None = None) -> Path:
+    if base_dir:
+        return Path(base_dir).expanduser().resolve()
+    return DEFAULT_ARTIFACTS_ROOT
+
+
+def create_run_artifact_dir(dataset_label: str, run_name: str | None = None, base_dir: str | None = None) -> Path:
+    root = get_artifacts_root(base_dir)
+    label = run_name or dataset_label or "run"
+    out_dir = root / f"{label}_{now_timestr()}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir
+
+
+def create_session_dir(prefix: str, base_dir: str | None = None) -> Path:
+    root = get_artifacts_root(base_dir)
+    session_dir = root / f"{prefix}_{now_timestr()}"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    return session_dir
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def write_session_summary(
+    session_dir: Path,
+    run_results: list[dict[str, Any]],
+    *,
+    session_type: str,
+    config_path: str,
+) -> Path:
+    payload = {
+        "session_type": session_type,
+        "timestamp": now_timestr(),
+        "latest_commit": last_commit(),
+        "config_path": config_path,
+        "all_passed": all(bool(item.get("success")) for item in run_results),
+        "results": run_results,
+    }
+    out_path = session_dir / "session_summary.json"
+    write_json(out_path, payload)
+    return out_path

--- a/nemo_retriever/src/nemo_retriever/harness/config.py
+++ b/nemo_retriever/src/nemo_retriever/harness/config.py
@@ -1,0 +1,283 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+NEMO_RETRIEVER_ROOT = Path(__file__).resolve().parents[3]
+REPO_ROOT = NEMO_RETRIEVER_ROOT.parent
+DEFAULT_TEST_CONFIG_PATH = NEMO_RETRIEVER_ROOT / "harness" / "test_configs.yaml"
+DEFAULT_NIGHTLY_CONFIG_PATH = NEMO_RETRIEVER_ROOT / "harness" / "nightly_config.yaml"
+
+TUNING_FIELDS = {
+    "pdf_extract_workers",
+    "pdf_extract_num_cpus",
+    "pdf_extract_batch_size",
+    "pdf_split_batch_size",
+    "page_elements_batch_size",
+    "page_elements_workers",
+    "ocr_workers",
+    "ocr_batch_size",
+    "embed_workers",
+    "embed_batch_size",
+    "page_elements_cpus_per_actor",
+    "ocr_cpus_per_actor",
+    "embed_cpus_per_actor",
+    "gpu_page_elements",
+    "gpu_ocr",
+    "gpu_embed",
+}
+
+
+@dataclass
+class HarnessConfig:
+    dataset_dir: str
+    dataset_label: str
+    preset: str
+
+    query_csv: str | None = None
+    input_type: str = "pdf"
+    recall_required: bool = True
+
+    artifacts_dir: str | None = None
+    ray_address: str | None = None
+    lancedb_uri: str = "lancedb"
+    hybrid: bool = False
+    embed_model_name: str = "nvidia/llama-3.2-nv-embedqa-1b-v2"
+    write_detection_file: bool = False
+
+    pdf_extract_workers: int = 8
+    pdf_extract_num_cpus: float = 2.0
+    pdf_extract_batch_size: int = 4
+    pdf_split_batch_size: int = 1
+    page_elements_batch_size: int = 4
+    page_elements_workers: int = 3
+    ocr_workers: int = 3
+    ocr_batch_size: int = 16
+    embed_workers: int = 3
+    embed_batch_size: int = 256
+    page_elements_cpus_per_actor: float = 1.0
+    ocr_cpus_per_actor: float = 1.0
+    embed_cpus_per_actor: float = 1.0
+    gpu_page_elements: float = 0.1
+    gpu_ocr: float = 0.1
+    gpu_embed: float = 0.25
+
+    def validate(self) -> list[str]:
+        errors: list[str] = []
+        if not self.dataset_dir:
+            errors.append("dataset_dir is required")
+        elif not Path(self.dataset_dir).exists():
+            errors.append(f"dataset_dir does not exist: {self.dataset_dir}")
+
+        if self.query_csv is not None and not Path(self.query_csv).exists():
+            errors.append(f"query_csv does not exist: {self.query_csv}")
+
+        if self.recall_required and not self.query_csv:
+            errors.append("recall_required=true requires query_csv")
+
+        if self.input_type not in {"pdf", "txt", "html", "doc"}:
+            errors.append(f"input_type must be one of pdf/txt/html/doc, got '{self.input_type}'")
+
+        for name in TUNING_FIELDS:
+            val = getattr(self, name)
+            if name.startswith("gpu_") and float(val) < 0.0:
+                errors.append(f"{name} must be >= 0.0")
+            elif name.endswith("_workers") and int(val) < 1:
+                errors.append(f"{name} must be >= 1")
+
+        return errors
+
+
+def _parse_bool(value: str) -> bool:
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _parse_number(value: str) -> int | float:
+    if "." in value:
+        return float(value)
+    return int(value)
+
+
+def _resolve_config_path(config_file: str | None, default_path: Path) -> Path:
+    if config_file is None:
+        return default_path
+    p = Path(config_file).expanduser()
+    if not p.is_absolute():
+        p = (Path.cwd() / p).resolve()
+    return p
+
+
+def _read_yaml_mapping(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Config file not found: {path}")
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError(f"YAML config must be a mapping/object at top-level: {path}")
+    return data
+
+
+def _resolve_path_like(value: str | None, base_path: Path = REPO_ROOT) -> str | None:
+    if value is None:
+        return None
+    p = Path(value).expanduser()
+    if not p.is_absolute():
+        p = (base_path / p).resolve()
+    return str(p)
+
+
+def _apply_env_overrides(config_dict: dict[str, Any]) -> None:
+    env_map: dict[str, tuple[str, Any]] = {
+        "HARNESS_DATASET": ("dataset", str),
+        "HARNESS_DATASET_DIR": ("dataset_dir", str),
+        "HARNESS_PRESET": ("preset", str),
+        "HARNESS_QUERY_CSV": ("query_csv", str),
+        "HARNESS_INPUT_TYPE": ("input_type", str),
+        "HARNESS_RECALL_REQUIRED": ("recall_required", _parse_bool),
+        "HARNESS_ARTIFACTS_DIR": ("artifacts_dir", str),
+        "HARNESS_RAY_ADDRESS": ("ray_address", str),
+        "HARNESS_LANCEDB_URI": ("lancedb_uri", str),
+        "HARNESS_HYBRID": ("hybrid", _parse_bool),
+        "HARNESS_EMBED_MODEL_NAME": ("embed_model_name", str),
+        "HARNESS_WRITE_DETECTION_FILE": ("write_detection_file", _parse_bool),
+    }
+
+    for key in TUNING_FIELDS:
+        env_map[f"HARNESS_{key.upper()}"] = (key, _parse_number)
+
+    for env_key, (cfg_key, parser) in env_map.items():
+        raw = os.getenv(env_key)
+        if raw is None or raw == "":
+            continue
+        config_dict[cfg_key] = parser(raw)
+
+
+def _parse_cli_overrides(overrides: list[str] | None) -> dict[str, Any]:
+    parsed: dict[str, Any] = {}
+    for item in overrides or []:
+        if "=" not in item:
+            raise ValueError(f"Override must be KEY=VALUE, got: {item}")
+        key, raw_val = item.split("=", 1)
+        key = key.strip()
+        raw_val = raw_val.strip()
+        if not key:
+            raise ValueError(f"Invalid override key in: {item}")
+
+        low = raw_val.lower()
+        if low in {"true", "false"}:
+            parsed[key] = _parse_bool(raw_val)
+        else:
+            try:
+                parsed[key] = _parse_number(raw_val)
+            except ValueError:
+                parsed[key] = raw_val
+    return parsed
+
+
+def load_harness_config(
+    *,
+    config_file: str | None = None,
+    dataset: str | None = None,
+    preset: str | None = None,
+    sweep_overrides: dict[str, Any] | None = None,
+    cli_overrides: list[str] | None = None,
+    cli_recall_required: bool | None = None,
+) -> HarnessConfig:
+    config_path = _resolve_config_path(config_file, DEFAULT_TEST_CONFIG_PATH)
+    yaml_cfg = _read_yaml_mapping(config_path)
+
+    active = dict(yaml_cfg.get("active", {}))
+    datasets = dict(yaml_cfg.get("datasets", {}))
+    presets = dict(yaml_cfg.get("presets", {}))
+
+    sweep_data = dict(sweep_overrides or {})
+    cli_override_map = _parse_cli_overrides(cli_overrides)
+
+    dataset_ref = active.get("dataset")
+    if "dataset" in sweep_data:
+        dataset_ref = sweep_data["dataset"]
+    if dataset is not None:
+        dataset_ref = dataset
+    if os.getenv("HARNESS_DATASET"):
+        dataset_ref = os.environ["HARNESS_DATASET"]
+
+    preset_ref = active.get("preset", "single_gpu")
+    if "preset" in sweep_data:
+        preset_ref = sweep_data["preset"]
+    if preset is not None:
+        preset_ref = preset
+    if os.getenv("HARNESS_PRESET"):
+        preset_ref = os.environ["HARNESS_PRESET"]
+
+    merged: dict[str, Any] = dict(active)
+    merged["preset"] = preset_ref
+
+    dataset_label: str | None = None
+    if dataset_ref:
+        if dataset_ref in datasets:
+            dataset_label = str(dataset_ref)
+            dataset_cfg = dict(datasets[dataset_ref])
+            path_val = dataset_cfg.pop("path", None)
+            if path_val is not None:
+                merged["dataset_dir"] = str(path_val)
+            merged.update(dataset_cfg)
+        else:
+            dataset_label = Path(str(dataset_ref)).name
+            merged["dataset_dir"] = str(dataset_ref)
+
+    preset_values = dict(presets.get(str(preset_ref), {}))
+    merged.update(preset_values)
+    merged.update({k: v for k, v in sweep_data.items() if k not in {"dataset", "preset"}})
+    merged.update(cli_override_map)
+    if cli_recall_required is not None:
+        merged["recall_required"] = cli_recall_required
+    _apply_env_overrides(merged)
+
+    dataset_dir = merged.get("dataset_dir")
+    if dataset_dir is None:
+        raise ValueError("dataset is required via active.dataset, --dataset, or sweep run")
+    merged["dataset_dir"] = _resolve_path_like(str(dataset_dir), REPO_ROOT)
+    merged["query_csv"] = _resolve_path_like(merged.get("query_csv"), REPO_ROOT)
+
+    if merged.get("artifacts_dir") is not None:
+        merged["artifacts_dir"] = _resolve_path_like(str(merged["artifacts_dir"]), REPO_ROOT)
+
+    if merged.get("lancedb_uri") is None:
+        merged["lancedb_uri"] = "lancedb"
+
+    merged["dataset_label"] = dataset_label or Path(str(merged["dataset_dir"])).name
+    merged["preset"] = str(merged.get("preset") or "single_gpu")
+
+    if "query_csv" not in merged:
+        merged["query_csv"] = None
+
+    cfg = HarnessConfig(**{k: v for k, v in merged.items() if k in HarnessConfig.__dataclass_fields__})
+    errors = cfg.validate()
+    if errors:
+        raise ValueError("Configuration validation failed:\n" + "\n".join(f"  - {err}" for err in errors))
+    return cfg
+
+
+def load_runs_config(config_file: str | None = None) -> list[dict[str, Any]]:
+    config_path = _resolve_config_path(config_file, DEFAULT_NIGHTLY_CONFIG_PATH)
+    yaml_cfg = _read_yaml_mapping(config_path)
+    runs = yaml_cfg.get("runs", [])
+    if not isinstance(runs, list):
+        raise ValueError(f"'runs' must be a list in {config_path}")
+    normalized: list[dict[str, Any]] = []
+    for idx, run in enumerate(runs):
+        if not isinstance(run, dict):
+            raise ValueError(f"Run entry at index {idx} must be a mapping")
+        if "dataset" not in run:
+            raise ValueError(f"Run entry at index {idx} missing required key: dataset")
+        normalized.append(dict(run))
+    return normalized

--- a/nemo_retriever/src/nemo_retriever/harness/nightly.py
+++ b/nemo_retriever/src/nemo_retriever/harness/nightly.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from nemo_retriever.harness.artifacts import write_session_summary
+from nemo_retriever.harness.config import DEFAULT_NIGHTLY_CONFIG_PATH, load_runs_config
+from nemo_retriever.harness.run import execute_runs
+
+
+def nightly_command(
+    config: str | None = typer.Option(None, "--config", help="Path to harness test config YAML."),
+    runs_config: str = typer.Option(
+        str(DEFAULT_NIGHTLY_CONFIG_PATH), "--runs-config", help="Path to nightly runs YAML."
+    ),
+    preset: str | None = typer.Option(None, "--preset", help="Force preset for all nightly runs."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Print nightly run plan without executing."),
+) -> None:
+    runs = load_runs_config(runs_config)
+    if dry_run:
+        typer.echo("Nightly dry run:")
+        for idx, run in enumerate(runs):
+            typer.echo(
+                f"  {idx + 1:03d}: name={run.get('name')} dataset={run.get('dataset')} preset={run.get('preset')}"
+            )
+        raise typer.Exit(code=0)
+
+    session_dir, run_results = execute_runs(
+        runs=runs,
+        config_file=config,
+        session_prefix="nightly",
+        preset_override=preset,
+    )
+    summary_path = write_session_summary(
+        session_dir,
+        run_results,
+        session_type="nightly",
+        config_path=str(Path(runs_config).expanduser().resolve()),
+    )
+
+    typer.echo(f"\nNightly session: {session_dir}")
+    typer.echo(f"Session summary: {summary_path}")
+    failed = [r for r in run_results if not r["success"]]
+    raise typer.Exit(code=0 if not failed else 1)

--- a/nemo_retriever/src/nemo_retriever/harness/parsers.py
+++ b/nemo_retriever/src/nemo_retriever/harness/parsers.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+DONE_RE = re.compile(r"\[done\]\s+(?P<files>\d+)\s+files,\s+(?P<pages>\d+)\s+pages\s+in\s+(?P<secs>[0-9.]+)s")
+PAGES_PER_SEC_RE = re.compile(r"Pages/sec \(ingest only; excludes Ray startup and recall\):\s*(?P<val>[0-9.]+)")
+RECALL_RE = re.compile(r"^\s*(?P<metric>recall@\d+):\s*(?P<val>[0-9.]+)\s*$")
+
+
+@dataclass
+class StreamMetrics:
+    files: int | None = None
+    pages: int | None = None
+    ingest_secs: float | None = None
+    pages_per_sec_ingest: float | None = None
+    recall_metrics: dict[str, float] = field(default_factory=dict)
+    _in_recall_block: bool = False
+
+    def consume(self, line: str) -> None:
+        done_match = DONE_RE.search(line)
+        if done_match:
+            self.files = int(done_match.group("files"))
+            self.pages = int(done_match.group("pages"))
+            self.ingest_secs = float(done_match.group("secs"))
+
+        pps_match = PAGES_PER_SEC_RE.search(line)
+        if pps_match:
+            self.pages_per_sec_ingest = float(pps_match.group("val"))
+
+        if "Recall metrics (matching nemo_retriever.recall.core):" in line:
+            self._in_recall_block = True
+            return
+
+        if self._in_recall_block:
+            recall_match = RECALL_RE.match(line)
+            if recall_match:
+                metric = recall_match.group("metric")
+                self.recall_metrics[metric] = float(recall_match.group("val"))
+                return
+
+            if line.strip() and not line.startswith(" "):
+                self._in_recall_block = False
+
+
+def parse_stream_text(stdout_text: str) -> StreamMetrics:
+    metrics = StreamMetrics()
+    for line in stdout_text.splitlines():
+        metrics.consume(line)
+    return metrics

--- a/nemo_retriever/src/nemo_retriever/harness/run.py
+++ b/nemo_retriever/src/nemo_retriever/harness/run.py
@@ -1,0 +1,402 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+import pty
+import re
+import select
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import typer
+
+from nemo_retriever.harness.artifacts import (
+    create_run_artifact_dir,
+    create_session_dir,
+    last_commit,
+    now_timestr,
+    write_json,
+    write_session_summary,
+)
+from nemo_retriever.harness.config import (
+    DEFAULT_NIGHTLY_CONFIG_PATH,
+    HarnessConfig,
+    TUNING_FIELDS,
+    load_harness_config,
+    load_runs_config,
+)
+from nemo_retriever.harness.parsers import StreamMetrics
+
+ANSI_ESCAPE_RE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+
+def _resolve_lancedb_uri(cfg: HarnessConfig, artifact_dir: Path) -> str:
+    raw = str(cfg.lancedb_uri or "lancedb")
+    if raw == "lancedb":
+        return str((artifact_dir / "lancedb").resolve())
+    p = Path(raw).expanduser()
+    if not p.is_absolute():
+        p = (Path.cwd() / p).resolve()
+    return str(p)
+
+
+def _build_command(cfg: HarnessConfig, artifact_dir: Path, run_id: str) -> tuple[list[str], Path, Path]:
+    runtime_dir = artifact_dir / "runtime_metrics"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    if cfg.write_detection_file:
+        detection_summary_file = artifact_dir / "detection_summary.json"
+    else:
+        # Keep detection summary out of top-level artifacts unless explicitly requested.
+        detection_summary_file = runtime_dir / ".detection_summary.json"
+    query_csv = Path(cfg.query_csv) if cfg.query_csv else (artifact_dir / "__query_csv_missing__.csv")
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "nemo_retriever.examples.batch_pipeline",
+        str(Path(cfg.dataset_dir).resolve()),
+        "--input-type",
+        cfg.input_type,
+        "--query-csv",
+        str(query_csv),
+        "--no-recall-details",
+        "--pdf-extract-workers",
+        str(cfg.pdf_extract_workers),
+        "--pdf-extract-num-cpus",
+        str(cfg.pdf_extract_num_cpus),
+        "--pdf-extract-batch-size",
+        str(cfg.pdf_extract_batch_size),
+        "--pdf-split-batch-size",
+        str(cfg.pdf_split_batch_size),
+        "--page-elements-batch-size",
+        str(cfg.page_elements_batch_size),
+        "--page-elements-workers",
+        str(cfg.page_elements_workers),
+        "--ocr-workers",
+        str(cfg.ocr_workers),
+        "--ocr-batch-size",
+        str(cfg.ocr_batch_size),
+        "--embed-workers",
+        str(cfg.embed_workers),
+        "--embed-batch-size",
+        str(cfg.embed_batch_size),
+        "--page-elements-cpus-per-actor",
+        str(cfg.page_elements_cpus_per_actor),
+        "--ocr-cpus-per-actor",
+        str(cfg.ocr_cpus_per_actor),
+        "--embed-cpus-per-actor",
+        str(cfg.embed_cpus_per_actor),
+        "--gpu-page-elements",
+        str(cfg.gpu_page_elements),
+        "--gpu-ocr",
+        str(cfg.gpu_ocr),
+        "--gpu-embed",
+        str(cfg.gpu_embed),
+        "--embed-model-name",
+        cfg.embed_model_name,
+        "--runtime-metrics-dir",
+        str(runtime_dir),
+        "--runtime-metrics-prefix",
+        run_id,
+        "--detection-summary-file",
+        str(detection_summary_file),
+        "--lancedb-uri",
+        _resolve_lancedb_uri(cfg, artifact_dir),
+    ]
+
+    if cfg.ray_address:
+        cmd += ["--ray-address", cfg.ray_address]
+    if cfg.hybrid:
+        cmd += ["--hybrid"]
+
+    return cmd, runtime_dir, detection_summary_file
+
+
+def _evaluate_run_outcome(
+    process_rc: int, recall_required: bool, recall_metrics: dict[str, float]
+) -> tuple[int, str, bool]:
+    if process_rc != 0:
+        reason = f"subprocess_exit_{process_rc}"
+        return process_rc, reason, False
+    if recall_required and not recall_metrics:
+        return 98, "missing_recall_metrics", False
+    return 0, "", True
+
+
+def _read_json_if_exists(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def _consume_parseable_output(metrics: StreamMetrics, parse_buffer: str) -> str:
+    while "\n" in parse_buffer:
+        line, parse_buffer = parse_buffer.split("\n", 1)
+        cleaned = ANSI_ESCAPE_RE.sub("", line)
+        metrics.consume(cleaned + "\n")
+    return parse_buffer
+
+
+def _run_subprocess_with_tty(cmd: list[str], metrics: StreamMetrics) -> int:
+    """
+    Run command in a pseudo-terminal so Ray renders rich progress.
+
+    We still parse lines from the PTY stream to extract benchmark metrics.
+    """
+    master_fd, slave_fd = pty.openpty()
+    parse_buffer = ""
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdin=None,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            close_fds=True,
+        )
+    finally:
+        os.close(slave_fd)
+
+    try:
+        while True:
+            read_fds, _, _ = select.select([master_fd], [], [], 0.1)
+            if master_fd not in read_fds:
+                if proc.poll() is not None:
+                    break
+                continue
+
+            try:
+                chunk = os.read(master_fd, 4096)
+            except OSError as exc:
+                # PTY EOF on Linux often appears as EIO.
+                if exc.errno == errno.EIO:
+                    break
+                raise
+
+            if not chunk:
+                break
+
+            text = chunk.decode("utf-8", errors="replace")
+            sys.stdout.write(text)
+            sys.stdout.flush()
+
+            parse_buffer += text.replace("\r", "\n")
+            parse_buffer = _consume_parseable_output(metrics, parse_buffer)
+
+        if parse_buffer:
+            cleaned_tail = ANSI_ESCAPE_RE.sub("", parse_buffer)
+            metrics.consume(cleaned_tail)
+
+        return proc.wait()
+    finally:
+        os.close(master_fd)
+
+
+def _run_single(cfg: HarnessConfig, artifact_dir: Path, run_id: str) -> dict[str, Any]:
+    cmd, runtime_dir, detection_summary_file = _build_command(cfg, artifact_dir, run_id)
+    command_text = " ".join(shlex.quote(token) for token in cmd)
+    (artifact_dir / "command.txt").write_text(command_text + "\n", encoding="utf-8")
+
+    typer.echo(f"\n=== Running {run_id} ===")
+    typer.echo(command_text)
+
+    metrics = StreamMetrics()
+    process_rc = _run_subprocess_with_tty(cmd, metrics)
+    runtime_summary_path = runtime_dir / f"{run_id}.runtime.summary.json"
+    runtime_summary = _read_json_if_exists(runtime_summary_path)
+    detection_summary = _read_json_if_exists(detection_summary_file)
+    if not cfg.write_detection_file and detection_summary_file.exists():
+        detection_summary_file.unlink()
+
+    recall_metrics_normalized: dict[str, float] = {}
+    for key, val in metrics.recall_metrics.items():
+        normalized = key.replace("@", "_").replace("-", "_")
+        recall_metrics_normalized[f"recall_{normalized}"] = val
+
+    effective_rc, failure_reason, success = _evaluate_run_outcome(
+        process_rc=process_rc,
+        recall_required=bool(cfg.recall_required),
+        recall_metrics=metrics.recall_metrics,
+    )
+
+    result_payload: dict[str, Any] = {
+        "timestamp": now_timestr(),
+        "latest_commit": last_commit(),
+        "success": success,
+        "return_code": effective_rc,
+        "failure_reason": failure_reason or None,
+        "test_config": {
+            "dataset_label": cfg.dataset_label,
+            "dataset_dir": cfg.dataset_dir,
+            "preset": cfg.preset,
+            "query_csv": cfg.query_csv,
+            "input_type": cfg.input_type,
+            "recall_required": cfg.recall_required,
+            "ray_address": cfg.ray_address,
+            "hybrid": cfg.hybrid,
+            "embed_model_name": cfg.embed_model_name,
+            "write_detection_file": cfg.write_detection_file,
+            "lancedb_uri": _resolve_lancedb_uri(cfg, artifact_dir),
+            "tuning": {field: getattr(cfg, field) for field in sorted(TUNING_FIELDS)},
+        },
+        "metrics": {
+            "files": metrics.files,
+            "pages": metrics.pages,
+            "ingest_secs": metrics.ingest_secs,
+            "pages_per_sec_ingest": metrics.pages_per_sec_ingest,
+            **recall_metrics_normalized,
+        },
+        "runtime_summary": runtime_summary,
+        "detection_summary": detection_summary,
+        "artifacts": {
+            "command_file": str((artifact_dir / "command.txt").resolve()),
+            "runtime_metrics_dir": str(runtime_dir.resolve()),
+        },
+    }
+    if cfg.write_detection_file:
+        result_payload["artifacts"]["detection_summary_file"] = str(detection_summary_file.resolve())
+
+    write_json(artifact_dir / "results.json", result_payload)
+    return result_payload
+
+
+def _run_entry(
+    *,
+    run_name: str | None,
+    config_file: str | None,
+    session_dir: Path | None,
+    dataset: str | None,
+    preset: str | None,
+    sweep_overrides: dict[str, Any] | None = None,
+    cli_overrides: list[str] | None = None,
+    recall_required: bool | None = None,
+) -> dict[str, Any]:
+    cfg = load_harness_config(
+        config_file=config_file,
+        dataset=dataset,
+        preset=preset,
+        sweep_overrides=sweep_overrides,
+        cli_overrides=cli_overrides,
+        cli_recall_required=recall_required,
+    )
+
+    if session_dir is None:
+        artifact_dir = create_run_artifact_dir(cfg.dataset_label, run_name=run_name, base_dir=cfg.artifacts_dir)
+    else:
+        resolved_run_name = run_name or cfg.dataset_label
+        artifact_dir = session_dir / resolved_run_name
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    resolved_run_name = run_name or cfg.dataset_label
+    result = _run_single(cfg, artifact_dir, run_id=resolved_run_name)
+    return {
+        "run_name": resolved_run_name,
+        "dataset": cfg.dataset_label,
+        "preset": cfg.preset,
+        "artifact_dir": str(artifact_dir.resolve()),
+        "success": bool(result["success"]),
+        "return_code": int(result["return_code"]),
+        "failure_reason": result.get("failure_reason"),
+        "metrics": dict(result.get("metrics", {})),
+    }
+
+
+def execute_runs(
+    *,
+    runs: list[dict[str, Any]],
+    config_file: str | None,
+    session_prefix: str,
+    preset_override: str | None,
+    base_artifacts_dir: str | None = None,
+) -> tuple[Path, list[dict[str, Any]]]:
+    session_dir = create_session_dir(session_prefix, base_dir=base_artifacts_dir)
+    run_results: list[dict[str, Any]] = []
+
+    for idx, run in enumerate(runs):
+        run_name = str(run.get("name") or f"run_{idx + 1:03d}")
+        run_result = _run_entry(
+            run_name=run_name,
+            config_file=config_file,
+            session_dir=session_dir,
+            dataset=run.get("dataset"),
+            preset=run.get("preset") if preset_override is None else preset_override,
+            sweep_overrides=run.get("overrides") if isinstance(run.get("overrides"), dict) else run,
+            recall_required=run.get("recall_required"),
+        )
+        run_results.append(run_result)
+
+    return session_dir, run_results
+
+
+def run_command(
+    dataset: str = typer.Option(..., "--dataset", help="Dataset name from config or direct path."),
+    preset: str | None = typer.Option(None, "--preset", help="Preset override."),
+    config: str | None = typer.Option(None, "--config", help="Path to harness test config YAML."),
+    run_name: str | None = typer.Option(None, "--run-name", help="Optional run name label."),
+    override: list[str] = typer.Option([], "--override", help="Override values with KEY=VALUE."),
+    recall_required: bool | None = typer.Option(
+        None, "--recall-required/--no-recall-required", help="Override recall-required gate for this run."
+    ),
+) -> None:
+    result = _run_entry(
+        run_name=run_name,
+        config_file=config,
+        session_dir=None,
+        dataset=dataset,
+        preset=preset,
+        cli_overrides=override,
+        recall_required=recall_required,
+    )
+    typer.echo(
+        f"\nResult: {'PASS' if result['success'] else 'FAIL'} | "
+        f"return_code={result['return_code']} | artifact_dir={result['artifact_dir']}"
+    )
+    raise typer.Exit(code=0 if result["success"] else 1)
+
+
+def sweep_command(
+    config: str | None = typer.Option(None, "--config", help="Path to harness test config YAML."),
+    runs_config: str = typer.Option(str(DEFAULT_NIGHTLY_CONFIG_PATH), "--runs-config", help="Path to sweep runs YAML."),
+    preset: str | None = typer.Option(None, "--preset", help="Force preset for all sweep runs."),
+    session_prefix: str = typer.Option("sweep", "--session-prefix", help="Session directory prefix."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Print run plan without executing."),
+) -> None:
+    runs = load_runs_config(runs_config)
+    if dry_run:
+        typer.echo("Sweep dry run:")
+        for idx, run in enumerate(runs):
+            typer.echo(
+                f"  {idx + 1:03d}: name={run.get('name')} dataset={run.get('dataset')} preset={run.get('preset')}"
+            )
+        raise typer.Exit(code=0)
+
+    session_dir, run_results = execute_runs(
+        runs=runs,
+        config_file=config,
+        session_prefix=session_prefix,
+        preset_override=preset,
+    )
+    summary_path = write_session_summary(
+        session_dir,
+        run_results,
+        session_type="sweep",
+        config_path=str(Path(runs_config).expanduser().resolve()),
+    )
+
+    typer.echo(f"\nSweep session: {session_dir}")
+    typer.echo(f"Session summary: {summary_path}")
+    failed = [r for r in run_results if not r["success"]]
+    raise typer.Exit(code=0 if not failed else 1)

--- a/nemo_retriever/tests/test_harness_config.py
+++ b/nemo_retriever/tests/test_harness_config.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+
+import pytest
+
+from nemo_retriever.harness.config import load_harness_config, load_runs_config
+
+
+def _write_harness_config(path: Path, dataset_dir: Path, query_csv: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "active:",
+                "  dataset: tiny",
+                "  preset: base",
+                "  query_csv: null",
+                "  input_type: pdf",
+                "  recall_required: false",
+                "presets:",
+                "  base:",
+                "    pdf_extract_workers: 4",
+                "    page_elements_workers: 2",
+                "    page_elements_batch_size: 8",
+                "    ocr_workers: 2",
+                "    embed_workers: 2",
+                "    gpu_page_elements: 0.1",
+                "    gpu_ocr: 0.2",
+                "    gpu_embed: 0.3",
+                "datasets:",
+                "  tiny:",
+                f"    path: {dataset_dir}",
+                f"    query_csv: {query_csv}",
+                "    input_type: pdf",
+                "    recall_required: true",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_load_harness_config_precedence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    query_csv = tmp_path / "query.csv"
+    query_csv.write_text("query,source,page\nq,a,1\n", encoding="utf-8")
+    cfg_path = tmp_path / "test_configs.yaml"
+    _write_harness_config(cfg_path, dataset_dir, query_csv)
+
+    monkeypatch.setenv("HARNESS_PRESET", "base")
+    monkeypatch.setenv("HARNESS_GPU_EMBED", "0.9")
+
+    cfg = load_harness_config(
+        config_file=str(cfg_path),
+        dataset="tiny",
+        preset="base",
+        sweep_overrides={"gpu_ocr": 0.7},
+        cli_overrides=["gpu_page_elements=0.6"],
+    )
+
+    assert cfg.dataset_dir == str(dataset_dir.resolve())
+    assert cfg.query_csv == str(query_csv.resolve())
+    assert cfg.gpu_page_elements == 0.6  # CLI override
+    assert cfg.gpu_ocr == 0.7  # sweep override
+    assert cfg.gpu_embed == 0.9  # env override (highest)
+    assert cfg.recall_required is True
+
+
+def test_load_harness_config_fails_when_recall_required_without_query(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    cfg_path = tmp_path / "test_configs.yaml"
+    cfg_path.write_text(
+        "\n".join(
+            [
+                "active:",
+                f"  dataset_dir: {dataset_dir}",
+                "  preset: base",
+                "  recall_required: true",
+                "presets:",
+                "  base: {}",
+                "datasets: {}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="recall_required=true requires query_csv"):
+        load_harness_config(config_file=str(cfg_path))
+
+
+def test_load_runs_config_parses_runs_list(tmp_path: Path) -> None:
+    runs_path = tmp_path / "nightly.yaml"
+    runs_path.write_text(
+        "\n".join(
+            [
+                "runs:",
+                "  - name: r1",
+                "    dataset: bo20",
+                "    preset: single_gpu",
+                "    overrides:",
+                "      gpu_embed: 0.25",
+                "  - name: r2",
+                "    dataset: bo767",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    runs = load_runs_config(str(runs_path))
+    assert len(runs) == 2
+    assert runs[0]["name"] == "r1"
+    assert runs[0]["overrides"]["gpu_embed"] == 0.25

--- a/nemo_retriever/tests/test_harness_parsers.py
+++ b/nemo_retriever/tests/test_harness_parsers.py
@@ -1,0 +1,31 @@
+from nemo_retriever.harness.parsers import StreamMetrics, parse_stream_text
+
+
+def test_parse_stream_text_extracts_done_recall_and_pages_per_second() -> None:
+    stdout = """
+[done] 20 files, 3181 pages in 122.3s
+Recall metrics (matching nemo_retriever.recall.core):
+  recall@1: 0.6087
+  recall@5: 0.9043
+  recall@10: 0.9565
+Pages/sec (ingest only; excludes Ray startup and recall): 15.77
+"""
+    metrics = parse_stream_text(stdout)
+    assert metrics.files == 20
+    assert metrics.pages == 3181
+    assert metrics.ingest_secs == 122.3
+    assert metrics.pages_per_sec_ingest == 15.77
+    assert metrics.recall_metrics == {
+        "recall@1": 0.6087,
+        "recall@5": 0.9043,
+        "recall@10": 0.9565,
+    }
+
+
+def test_stream_metrics_handles_non_recall_lines_after_recall_block() -> None:
+    metrics = StreamMetrics()
+    metrics.consume("Recall metrics (matching nemo_retriever.recall.core):\n")
+    metrics.consume("  recall@5: 0.9043\n")
+    metrics.consume("Pages processed: 1933\n")
+    metrics.consume("  recall@10: 0.9565\n")
+    assert metrics.recall_metrics == {"recall@5": 0.9043}

--- a/nemo_retriever/tests/test_harness_run.py
+++ b/nemo_retriever/tests/test_harness_run.py
@@ -1,0 +1,132 @@
+from pathlib import Path
+
+from nemo_retriever.harness.artifacts import create_run_artifact_dir
+from nemo_retriever.harness.config import HarnessConfig
+from nemo_retriever.harness import run as harness_run
+from nemo_retriever.harness.run import _build_command, _evaluate_run_outcome
+
+
+def test_evaluate_run_outcome_passes_when_process_succeeds_and_recall_present() -> None:
+    rc, reason, success = _evaluate_run_outcome(0, True, {"recall@5": 0.9})
+    assert rc == 0
+    assert reason == ""
+    assert success is True
+
+
+def test_evaluate_run_outcome_fails_when_recall_required_and_missing() -> None:
+    rc, reason, success = _evaluate_run_outcome(0, True, {})
+    assert rc == 98
+    assert reason == "missing_recall_metrics"
+    assert success is False
+
+
+def test_evaluate_run_outcome_uses_subprocess_error_code() -> None:
+    rc, reason, success = _evaluate_run_outcome(2, True, {"recall@5": 0.9})
+    assert rc == 2
+    assert reason == "subprocess_exit_2"
+    assert success is False
+
+
+def test_create_run_artifact_dir_defaults_to_dataset_label(tmp_path: Path) -> None:
+    out = create_run_artifact_dir("jp20", run_name=None, base_dir=str(tmp_path))
+    assert out.name.startswith("jp20_")
+
+
+def test_build_command_uses_hidden_detection_file_by_default(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    query_csv = tmp_path / "query.csv"
+    query_csv.write_text("q,s,p\nx,y,1\n", encoding="utf-8")
+
+    cfg = HarnessConfig(
+        dataset_dir=str(dataset_dir),
+        dataset_label="jp20",
+        preset="single_gpu",
+        query_csv=str(query_csv),
+        write_detection_file=False,
+    )
+    cmd, runtime_dir, detection_file = _build_command(cfg, tmp_path, run_id="r1")
+    assert "--detection-summary-file" in cmd
+    assert detection_file.parent == runtime_dir
+    assert detection_file.name == ".detection_summary.json"
+
+
+def test_build_command_uses_top_level_detection_file_when_enabled(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    query_csv = tmp_path / "query.csv"
+    query_csv.write_text("q,s,p\nx,y,1\n", encoding="utf-8")
+
+    cfg = HarnessConfig(
+        dataset_dir=str(dataset_dir),
+        dataset_label="jp20",
+        preset="single_gpu",
+        query_csv=str(query_csv),
+        write_detection_file=True,
+    )
+    cmd, runtime_dir, detection_file = _build_command(cfg, tmp_path, run_id="r1")
+    assert "--detection-summary-file" in cmd
+    assert detection_file.parent == tmp_path
+    assert detection_file.name == "detection_summary.json"
+
+
+def test_run_entry_session_artifact_dir_uses_run_name(monkeypatch, tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+
+    cfg = HarnessConfig(
+        dataset_dir=str(dataset_dir),
+        dataset_label="jp20",
+        preset="single_gpu",
+    )
+    monkeypatch.setattr(harness_run, "load_harness_config", lambda **_: cfg)
+
+    def _fake_run_single(_cfg: HarnessConfig, _artifact_dir: Path, run_id: str) -> dict:
+        return {
+            "success": True,
+            "return_code": 0,
+            "failure_reason": None,
+            "metrics": {"files": 0, "pages": 0},
+        }
+
+    monkeypatch.setattr(harness_run, "_run_single", _fake_run_single)
+
+    result = harness_run._run_entry(
+        run_name="jp20_single",
+        config_file=None,
+        session_dir=tmp_path,
+        dataset="jp20",
+        preset="single_gpu",
+    )
+
+    assert Path(result["artifact_dir"]).name == "jp20_single"
+
+
+def test_execute_runs_does_not_write_sweep_results_file(monkeypatch, tmp_path: Path) -> None:
+    session_dir = tmp_path / "nightly_session"
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(harness_run, "create_session_dir", lambda *_args, **_kwargs: session_dir)
+
+    def _fake_run_entry(**_kwargs) -> dict:
+        return {
+            "run_name": "jp20_single",
+            "dataset": "jp20",
+            "preset": "single_gpu",
+            "artifact_dir": str((session_dir / "jp20_single").resolve()),
+            "success": True,
+            "return_code": 0,
+            "failure_reason": None,
+            "metrics": {"files": 20, "pages": 3181},
+        }
+
+    monkeypatch.setattr(harness_run, "_run_entry", _fake_run_entry)
+
+    harness_run.execute_runs(
+        runs=[{"name": "jp20_single", "dataset": "jp20", "preset": "single_gpu"}],
+        config_file=None,
+        session_prefix="nightly",
+        preset_override=None,
+    )
+
+    assert not (session_dir / "sweep_results.json").exists()


### PR DESCRIPTION
Introduces the first pass of the `nemo_retriever` harness for run/sweep/nightly orchestration with structured artifacts and docs. This keeps scope focused on harness foundations so dataset-specific recall adapters can land in follow-up PRs.

Description
- Add retriever harness modules and CLI wiring (`config`, `run`, `nightly`, `parsers`, `artifacts`) under `retriever harness`.
- Add baseline harness configuration/docs (`test_configs.yaml`, `nightly_config.yaml`, `HANDOFF.md`, and README harness usage).
- Add harness unit tests covering config precedence, parser extraction, and run orchestration behavior.

Test plan
- [x] `pytest -q nemo_retriever/tests/test_harness_parsers.py nemo_retriever/tests/test_harness_config.py nemo_retriever/tests/test_harness_run.py`