### PR TITLE
(retriever) suppress input_embeds and pynvml warnings

### DIFF
--- a/nemo_retriever/src/nemo_retriever/__init__.py
+++ b/nemo_retriever/src/nemo_retriever/__init__.py
@@ -6,6 +6,19 @@
 
 from __future__ import annotations
 
+import sys
+import warnings
+
+# Suppress the pynvml deprecation FutureWarning before any submodule imports torch.
+# The pynvml 13.x shim installs a PynvmlFinder via .pth at Python startup that warns
+# on every `import pynvml`.  We both add a warnings filter and mark the finder as
+# already warned so that spawned subprocesses (which get a fresh finder) stay quiet.
+warnings.filterwarnings("ignore", message="The pynvml package is deprecated", category=FutureWarning)
+for _finder in sys.meta_path:
+    if type(_finder).__name__ == "PynvmlFinder":
+        _finder.has_warned_pynvml = True
+        break
+
 from .retriever import retriever as _retriever_cls
 
 __all__ = ["__version__", "create_ingestor", "get_version", "get_version_info", "ingestor", "retriever"]

--- a/nemo_retriever/src/nemo_retriever/model/local/llama_nemotron_embed_1b_v2_embedder.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/llama_nemotron_embed_1b_v2_embedder.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Sequence
@@ -71,7 +72,8 @@ class LlamaNemotronEmbed1BV2Embedder:
         dev = self._device
 
         outs: List[torch.Tensor] = []
-        with torch.inference_mode():
+        with torch.inference_mode(), warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="`input_embeds` is deprecated", category=FutureWarning)
             with torch.autocast(device_type="cuda"):
                 for i in range(0, len(texts), max(1, int(batch_size))):
                     chunk = texts[i : i + max(1, int(batch_size))]


### PR DESCRIPTION
## Description

Every inference call produces two categories of FutureWarning that clutter logs:
```
/root/.cache/huggingface/modules/transformers_modules/nvidia/llama_hyphen_3_dot_2_hyphen_nv_hyphen_embedqa_hyphen_1b_hyphen_v2/cefc2394cc541737b7867df197984cf23f05367f/llama_bidirectional_model.py:120: FutureWarning: `input_embeds` is deprecated and will be removed in version 5.6.0 for `create_bidirectional_mask`. Use `inputs_embeds` instead.
  return create_bidirectional_mask(
```
and
```
  /usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did
  not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
    import pynvml  # type: ignore[import]
```
This PR cleans up the logs by suppressesing these warnings.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
