### PR TITLE
Added nvidia/llama-nemotron-embed-1b-v2 to the hf_model_registry.py file

### DIFF
--- a/nemo_retriever/src/nemo_retriever/utils/hf_model_registry.py
+++ b/nemo_retriever/src/nemo_retriever/utils/hf_model_registry.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 HF_MODEL_REVISIONS: dict[str, str] = {
     "nvidia/llama-3.2-nv-embedqa-1b-v2": "cefc2394cc541737b7867df197984cf23f05367f",
+    "nvidia/llama-nemotron-embed-1b-v2": "cefc2394cc541737b7867df197984cf23f05367f",
     "nvidia/parakeet-ctc-1.1b": "a707e818195cb97c8f7da2fc36b221a29f69a5db",
     "nvidia/NVIDIA-Nemotron-Parse-v1.2": "f42c8040b12ee64370922d108778ab655b722c5d",
     "nvidia/llama-nemotron-embed-vl-1b-v2": "859e1f2dac29c56c37a5279cf55f53f3e74efc6b",


### PR DESCRIPTION
Added nvidia/llama-nemotron-embed-1b-v2 to the hf_model_registry.py file

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
