### PR TITLE
(retriever) change ExtractParams default to true

### DIFF
--- a/nemo_retriever/src/nemo_retriever/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/params/models.py
@@ -151,18 +151,24 @@ class GpuAllocationParams(_ParamsModel):
 
 
 class ExtractParams(_ParamsModel):
+    # Extraction flags
+    extract_text: bool = True
+    extract_images: bool = True
+    extract_tables: bool = True
+    extract_charts: bool = True
+    extract_infographics: bool = True
+    extract_page_as_image: Optional[bool] = None
+
+    # Extraction options
     method: Optional[str] = None
-    extract_text: bool = False
-    extract_images: bool = False
-    extract_tables: bool = False
     use_table_structure: bool = False
     table_output_format: Optional[Literal["pseudo_markdown", "markdown"]] = None
-    extract_charts: bool = False
     use_graphic_elements: bool = False
-    extract_infographics: bool = False
-    extract_page_as_image: Optional[bool] = None
     dpi: int = 200
+    inference_batch_size: int = 8
+    ocr_model_dir: Optional[str] = None
 
+    # Service endpoints
     invoke_url: Optional[str] = None
     api_key: Optional[str] = None
     request_timeout_s: float = 120.0
@@ -175,11 +181,10 @@ class ExtractParams(_ParamsModel):
     graphic_elements_invoke_url: Optional[str] = None
     table_structure_invoke_url: Optional[str] = None
 
-    inference_batch_size: int = 8
+    # Output columns
     output_column: str = "page_elements_v3"
     num_detections_column: str = "page_elements_v3_num_detections"
     counts_by_label_column: str = "page_elements_v3_counts_by_label"
-    ocr_model_dir: Optional[str] = None
 
     remote_retry: RemoteRetryParams = Field(default_factory=RemoteRetryParams)
     batch_tuning: BatchTuningParams = Field(default_factory=BatchTuningParams)


### PR DESCRIPTION
## Description
This PR changes `ExtractParams` defaults to True for `extract_text`, `extract_images`, `extract_tables`, `extract_charts`, and `extract_infographics` matching the API library defaults.

The nv-ingest main pipeline defaults:
https://github.com/NVIDIA/NeMo-Retriever/blob/549b2d9d632e10a87da6920b044c8939893d5a1c/client/src/nv_ingest_client/client/interface.py#L1082-L1085
https://github.com/NVIDIA/NeMo-Retriever/blob/549b2d9d632e10a87da6920b044c8939893d5a1c/api/src/nv_ingest_api/interface/extract.py#L49-L53

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
