### PR TITLE
Explicitly disable VLM KV-cache reuse

### DIFF
--- a/docker-compose.l40s.yaml
+++ b/docker-compose.l40s.yaml
@@ -22,3 +22,7 @@ services:
   reranker:
     environment:
       - NIM_TRITON_MAX_BATCH_SIZE=1
+
+  vlm:
+    environment:
+      - NIM_ENABLE_KV_CACHE_REUSE=0

--- a/helm/overrides/values-l40s.yaml
+++ b/helm/overrides/values-l40s.yaml
@@ -83,3 +83,12 @@ nimOperator:
         value: "1"
       - name: NIM_TRITON_MAX_BATCH_SIZE
         value: "1"
+
+  nemotron_nano_12b_v2_vl:
+    env:
+      - name: NIM_HTTP_API_PORT
+        value: "8000"
+      - name: NIM_TRITON_LOG_VERBOSE
+        value: "1"
+      - name: NIM_ENABLE_KV_CACHE_REUSE
+        value: "0"


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

With 1.6.0, nemotron-nano-12b-v2-vl is now setting `enable_prefix_caching=true` by default, leading to OOMs on hardware with smaller VRAM.
This PR explicitly overrides this default with `NIM_ENABLE_KV_CACHE_REUSE=0` on L40S where this situation was encountered.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
