### PR TITLE
Kheiss/3 methods

### DIFF
--- a/docs/docs/extraction/nemoretriever-parse.md
+++ b/docs/docs/extraction/nemoretriever-parse.md
@@ -4,7 +4,7 @@ For scanned documents, or documents with complex layouts,
 we recommend that you use [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse). 
 Nemotron parse provides higher-accuracy text extraction. 
 
-This documentation describes the following two methods 
+This documentation describes the following three methods
 to run [NeMo Retriever Library](overview.md) with nemotron-parse.
 
 - Run the NIM locally by using Docker Compose


### PR DESCRIPTION
Fix docs: "two methods" → "three methods" in nemoretriever-parse.md
Bug: [5965574](https://nvbugs.nvidia.com/bug/5965574) – [nv-ingest-26.03][Docs] nemoretriever-parse.md says "two methods" but lists three

Summary:
The intro in docs/docs/extraction/nemoretriever-parse.md said "the following two methods" while the bullet list described three ways to run NeMo Retriever Library with nemotron-parse. The third option (Ray batch pipeline / library mode) was added later and the intro text was never updated.

Change:
Updated the intro from "two methods" to "three methods" so it matches the list:

Run the NIM locally by using Docker Compose
Use NVIDIA Cloud Functions (NVCF) endpoints for cloud-based inference
Run the Ray batch pipeline with nemotron-parse (library mode)
Impact:
P2 – Reduces confusion; no functional change. Fixes regression introduced when the third method was added.

Files changed:

docs/docs/extraction/nemoretriever-parse.md (lines 7–8)