### PR TITLE
Kheiss/nonexistant paths

### DIFF
--- a/docs/docs/extraction/nemoretriever-parse.md
+++ b/docs/docs/extraction/nemoretriever-parse.md
@@ -118,7 +118,7 @@ To enable `nemotron-parse` in the batch pipeline, set each of the following opti
 For example, to run the batch pipeline on a directory of PDFs with `nemotron-parse` turned on, use the following code:
 
 ```shell
-python ./retriever/src/retriever/examples/batch_pipeline.py /path/to/pdfs \
+python nemo_retriever/src/nemo_retriever/examples/batch_pipeline.py /path/to/pdfs \
   --nemotron-parse-workers 16 \
   --gpu-nemotron-parse .25 \
   --nemotron-parse-batch-size 32


### PR DESCRIPTION
Title
Docs: Fix batch_pipeline.py path in nemoretriever-parse.md (retriever → nemo_retriever)

Description
Bug: 5965583 — nemoretriever-parse.md batch pipeline example used a path that no longer exists after the retriever → nemo_retriever rename.

Change: Updated the "Run the Ray batch pipeline with nemotron-parse" example in docs/docs/extraction/nemoretriever-parse.md (line 121) to use the correct script path.

Before	After
python ./retriever/src/retriever/examples/batch_pipeline.py	python nemo_retriever/src/nemo_retriever/examples/batch_pipeline.py
Impact: Users following the doc can run the nemotron-parse batch pipeline without hitting FileNotFoundError. No other docs referenced the old path.

Testing: N/A — documentation-only change.

