### PR TITLE
harness: Add extract and chunk observability artifacts

### DIFF
--- a/nemo_retriever/.rayignore
+++ b/nemo_retriever/.rayignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -247,6 +247,9 @@ Each harness run writes a compact artifact set (no full stdout/stderr log persis
 - `results.json` (normalized metrics + pass/fail + config snapshot + `run_metadata`)
 - `command.txt` (exact invoked command)
 - `runtime_metrics/` (Ray runtime summary + timeline files)
+- `observability/extracts/` (JSONL snapshots of per-run extract outputs)
+- `observability/chunks/` (JSONL snapshots of the exact pre-embed chunk rows)
+- `ingest_errors.json` (only written when ingest error rows are detected)
 
 Recall metrics in `results.json` are normalized as `recall_1`, `recall_5`, and `recall_10`.
 Nightly/sweep rollups intentionally focus on compact `summary_metrics`:
@@ -260,6 +263,9 @@ By default, detection totals are embedded into `results.json` under `detection_s
 If you want a separate detection file for ad hoc inspection, set `write_detection_file: true` in
 `nemo_retriever/harness/test_configs.yaml`.
 When tags are supplied with `--tag`, they are persisted in `results.json` and in session rollups for sweep/nightly runs.
+By default, harness runs also mirror the extract/chunk observability snapshots to
+`/datasets/nv-ingest/nemo_retriever/harness_observability/<session-or-run>/...` so regressions can be diffed
+across nightly runs even after repo-local artifact cleanup.
 
 `results.json` also includes a nested `run_metadata` block for lightweight environment context:
 

--- a/nemo_retriever/harness/test_configs.yaml
+++ b/nemo_retriever/harness/test_configs.yaml
@@ -14,6 +14,9 @@ active:
   hybrid: false
   embed_model_name: nvidia/llama-nemotron-embed-1b-v2
   write_detection_file: false
+  write_extract_artifacts: true
+  write_chunk_manifest: true
+  observability_archive_dir: /datasets/nv-ingest/nemo_retriever/harness_observability
 
 presets:
   single_gpu:

--- a/nemo_retriever/src/nemo_retriever/examples/batch_pipeline.py
+++ b/nemo_retriever/src/nemo_retriever/examples/batch_pipeline.py
@@ -22,6 +22,7 @@ from nemo_retriever import create_ingestor
 from nemo_retriever.ingest_modes.batch import BatchIngestor
 from nemo_retriever.params import EmbedParams
 from nemo_retriever.params import ExtractParams
+from nemo_retriever.params import HtmlChunkParams
 from nemo_retriever.params import IngestExecuteParams
 from nemo_retriever.params import IngestorCreateParams
 from nemo_retriever.params import TextChunkParams
@@ -116,7 +117,7 @@ def _to_int(value: object, default: int = 0) -> int:
 
 
 def _collect_detection_summary(uri: str, table_name: str) -> Optional[dict]:
-    """Collect per-model detection totals deduped by (source_id, page_number)."""
+    """Collect per-model detection totals deduped by (source, page_number)."""
     from nemo_retriever.utils.detection_summary import collect_detection_summary_from_lancedb
 
     return collect_detection_summary_from_lancedb(uri, table_name)
@@ -187,27 +188,16 @@ def _count_materialized_rows(dataset: object) -> int:
     return len(dataset)  # type: ignore[arg-type]
 
 
-def _ensure_lancedb_table(uri: str, table_name: str) -> None:
-    """Ensure the local LanceDB URI exists and table can be opened.
-
-    Creates an empty table with the expected schema if it does not exist yet.
-    """
-    from nemo_retriever.ingest_modes.lancedb_utils import lancedb_schema
-
+def _ensure_lancedb_table(uri: str, table_name: str) -> bool:
+    """Ensure the LanceDB URI exists and report whether the table is already present."""
     Path(uri).mkdir(parents=True, exist_ok=True)
 
     db = _lancedb().connect(uri)
     try:
         db.open_table(table_name)
-        return
+        return True
     except Exception:
-        pass
-
-    import pyarrow as pa  # type: ignore
-
-    schema = lancedb_schema(2048)
-    empty = pa.table({f.name: [] for f in schema}, schema=schema)
-    db.create_table(table_name, data=empty, schema=schema, mode="create")
+        return False
 
 
 @app.command()
@@ -229,6 +219,45 @@ def main(
         path_type=Path,
         dir_okay=False,
         help="Optional JSON file path to write end-of-run detection counts summary.",
+    ),
+    extract_output_dir: Optional[Path] = typer.Option(
+        None,
+        "--extract-output-dir",
+        path_type=Path,
+        file_okay=False,
+        dir_okay=True,
+        help="Optional directory where per-run extract snapshots are written as JSONL.",
+    ),
+    durable_extract_output_dir: Optional[Path] = typer.Option(
+        None,
+        "--durable-extract-output-dir",
+        path_type=Path,
+        file_okay=False,
+        dir_okay=True,
+        help="Optional durable mirror directory for extract snapshots.",
+    ),
+    chunk_manifest_dir: Optional[Path] = typer.Option(
+        None,
+        "--chunk-manifest-dir",
+        path_type=Path,
+        file_okay=False,
+        dir_okay=True,
+        help="Optional directory where pre-embed chunk manifests are written as JSONL.",
+    ),
+    durable_chunk_manifest_dir: Optional[Path] = typer.Option(
+        None,
+        "--durable-chunk-manifest-dir",
+        path_type=Path,
+        file_okay=False,
+        dir_okay=True,
+        help="Optional durable mirror directory for chunk manifests.",
+    ),
+    ingest_errors_file: Optional[Path] = typer.Option(
+        None,
+        "--ingest-errors-file",
+        path_type=Path,
+        dir_okay=False,
+        help="Optional JSON file path where ingest error rows are written on failure.",
     ),
     recall_match_mode: str = typer.Option(
         "pdf_page",
@@ -490,6 +519,17 @@ def main(
         os.environ["RAY_LOG_TO_DRIVER"] = "1" if ray_log_to_driver else "0"
         # Use an absolute path so driver and Ray actors resolve the same LanceDB URI.
         lancedb_uri = str(Path(lancedb_uri).expanduser().resolve())
+        extract_output_dir = extract_output_dir.expanduser().resolve() if extract_output_dir is not None else None
+        durable_extract_output_dir = (
+            durable_extract_output_dir.expanduser().resolve() if durable_extract_output_dir is not None else None
+        )
+        chunk_manifest_dir = chunk_manifest_dir.expanduser().resolve() if chunk_manifest_dir is not None else None
+        durable_chunk_manifest_dir = (
+            durable_chunk_manifest_dir.expanduser().resolve()
+            if durable_chunk_manifest_dir is not None
+            else None
+        )
+        ingest_errors_file = ingest_errors_file.expanduser().resolve() if ingest_errors_file is not None else None
         _ensure_lancedb_table(lancedb_uri, LANCEDB_TABLE)
 
         # Remote endpoints don't need local model GPUs for their stage.
@@ -527,189 +567,141 @@ def main(
             ),
         )
 
+        extract_snapshot_drop_columns: list[str] = []
+        chunk_snapshot_drop_columns = [
+            "bytes",
+            "page_image",
+            "_image_b64",
+            "page_elements_v3",
+            "table",
+            "chart",
+            "infographic",
+            "text_embeddings_1b_v2",
+        ]
+
+        ingestor = ingestor.files(file_patterns)
         if input_type == "txt":
-            ingestor = (
-                ingestor.files(file_patterns)
-                .extract_txt(TextChunkParams(max_tokens=512, overlap_tokens=0))
-                .embed(
-                    EmbedParams(
-                        model_name=str(embed_model_name),
-                        embed_invoke_url=embed_invoke_url,
-                        embed_modality=embed_modality,
-                        text_elements_modality=text_elements_modality,
-                        structured_elements_modality=structured_elements_modality,
-                        embed_granularity=embed_granularity,
-                    )
-                )
-                .vdb_upload(
-                    VdbUploadParams(
-                        lancedb={
-                            "lancedb_uri": lancedb_uri,
-                            "table_name": LANCEDB_TABLE,
-                            "overwrite": True,
-                            "create_index": True,
-                            "hybrid": hybrid,
-                        }
-                    )
-                )
-            )
+            ingestor = ingestor.extract_txt(TextChunkParams(max_tokens=512, overlap_tokens=0))
         elif input_type == "html":
-            ingestor = (
-                ingestor.files(file_patterns)
-                .extract_html(TextChunkParams(max_tokens=512, overlap_tokens=0))
-                .embed(
-                    EmbedParams(
-                        model_name=str(embed_model_name),
-                        embed_invoke_url=embed_invoke_url,
-                        embed_modality=embed_modality,
-                        text_elements_modality=text_elements_modality,
-                        structured_elements_modality=structured_elements_modality,
-                        embed_granularity=embed_granularity,
-                    )
-                )
-                .vdb_upload(
-                    VdbUploadParams(
-                        lancedb={
-                            "lancedb_uri": lancedb_uri,
-                            "table_name": LANCEDB_TABLE,
-                            "overwrite": True,
-                            "create_index": True,
-                            "hybrid": hybrid,
-                        }
-                    )
-                )
-            )
+            ingestor = ingestor.extract_html(HtmlChunkParams(max_tokens=512, overlap_tokens=0))
         elif input_type == "doc":
-            ingestor = (
-                ingestor.files(file_patterns)
-                .extract(
-                    ExtractParams(
-                        extract_text=True,
-                        extract_tables=True,
-                        extract_charts=True,
-                        extract_infographics=False,
-                        use_graphic_elements=use_graphic_elements,
-                        graphic_elements_invoke_url=graphic_elements_invoke_url,
-                        inference_batch_size=page_elements_batch_size,
-                        use_table_structure=use_table_structure,
-                        table_output_format=table_output_format,
-                        table_structure_invoke_url=table_structure_invoke_url,
-                        page_elements_invoke_url=page_elements_invoke_url,
-                        ocr_invoke_url=ocr_invoke_url,
-                        batch_tuning={
-                            "debug_run_id": str(runtime_metrics_prefix or "unknown"),
-                            "pdf_extract_workers": pdf_extract_tasks,
-                            "pdf_extract_num_cpus": pdf_extract_cpus_per_task,
-                            "pdf_split_batch_size": pdf_split_batch_size,
-                            "pdf_extract_batch_size": pdf_extract_batch_size,
-                            "page_elements_batch_size": page_elements_batch_size,
-                            "page_elements_workers": page_elements_actors,
-                            "detect_workers": ocr_actors,
-                            "detect_batch_size": ocr_batch_size,
-                            "ocr_inference_batch_size": ocr_batch_size,
-                            "page_elements_cpus_per_actor": page_elements_cpus_per_actor,
-                            "ocr_cpus_per_actor": ocr_cpus_per_actor,
-                            "gpu_page_elements": page_elements_gpus_per_actor,
-                            "gpu_ocr": ocr_gpus_per_actor,
-                            "gpu_embed": embed_gpus_per_actor,
-                            "nemotron_parse_workers": nemotron_parse_actors,
-                            "gpu_nemotron_parse": nemotron_parse_gpus_per_actor,
-                            "nemotron_parse_batch_size": nemotron_parse_batch_size,
-                        },
-                    )
-                )
-                .embed(
-                    EmbedParams(
-                        model_name=str(embed_model_name),
-                        embed_invoke_url=embed_invoke_url,
-                        embed_modality=embed_modality,
-                        text_elements_modality=text_elements_modality,
-                        structured_elements_modality=structured_elements_modality,
-                        batch_tuning={
-                            "embed_workers": embed_actors,
-                            "embed_batch_size": int(embed_batch_size),
-                            "embed_cpus_per_actor": float(embed_cpus_per_actor),
-                        },
-                    )
-                )
-                .vdb_upload(
-                    VdbUploadParams(
-                        lancedb={
-                            "lancedb_uri": lancedb_uri,
-                            "table_name": LANCEDB_TABLE,
-                            "overwrite": True,
-                            "create_index": True,
-                            "hybrid": hybrid,
-                        }
-                    )
+            extract_snapshot_drop_columns = ["bytes", "page_image"]
+            ingestor = ingestor.extract(
+                ExtractParams(
+                    extract_text=True,
+                    extract_tables=True,
+                    extract_charts=True,
+                    extract_infographics=False,
+                    use_graphic_elements=use_graphic_elements,
+                    graphic_elements_invoke_url=graphic_elements_invoke_url,
+                    inference_batch_size=page_elements_batch_size,
+                    use_table_structure=use_table_structure,
+                    table_output_format=table_output_format,
+                    table_structure_invoke_url=table_structure_invoke_url,
+                    page_elements_invoke_url=page_elements_invoke_url,
+                    ocr_invoke_url=ocr_invoke_url,
+                    batch_tuning={
+                        "debug_run_id": str(runtime_metrics_prefix or "unknown"),
+                        "pdf_extract_workers": pdf_extract_tasks,
+                        "pdf_extract_num_cpus": pdf_extract_cpus_per_task,
+                        "pdf_split_batch_size": pdf_split_batch_size,
+                        "pdf_extract_batch_size": pdf_extract_batch_size,
+                        "page_elements_batch_size": page_elements_batch_size,
+                        "page_elements_workers": page_elements_actors,
+                        "detect_workers": ocr_actors,
+                        "detect_batch_size": ocr_batch_size,
+                        "ocr_inference_batch_size": ocr_batch_size,
+                        "page_elements_cpus_per_actor": page_elements_cpus_per_actor,
+                        "ocr_cpus_per_actor": ocr_cpus_per_actor,
+                        "gpu_page_elements": page_elements_gpus_per_actor,
+                        "gpu_ocr": ocr_gpus_per_actor,
+                        "gpu_embed": embed_gpus_per_actor,
+                        "nemotron_parse_workers": nemotron_parse_actors,
+                        "gpu_nemotron_parse": nemotron_parse_gpus_per_actor,
+                        "nemotron_parse_batch_size": nemotron_parse_batch_size,
+                    },
                 )
             )
         else:
-            ingestor = (
-                ingestor.files(file_patterns)
-                .extract(
-                    ExtractParams(
-                        extract_text=True,
-                        extract_tables=True,
-                        extract_charts=True,
-                        extract_infographics=False,
-                        use_graphic_elements=use_graphic_elements,
-                        graphic_elements_invoke_url=graphic_elements_invoke_url,
-                        inference_batch_size=page_elements_batch_size,
-                        use_table_structure=use_table_structure,
-                        table_output_format=table_output_format,
-                        table_structure_invoke_url=table_structure_invoke_url,
-                        page_elements_invoke_url=page_elements_invoke_url,
-                        ocr_invoke_url=ocr_invoke_url,
-                        batch_tuning={
-                            "debug_run_id": str(runtime_metrics_prefix or "unknown"),
-                            "pdf_extract_workers": pdf_extract_tasks,
-                            "pdf_extract_num_cpus": pdf_extract_cpus_per_task,
-                            "pdf_split_batch_size": pdf_split_batch_size,
-                            "pdf_extract_batch_size": pdf_extract_batch_size,
-                            "page_elements_batch_size": page_elements_batch_size,
-                            "inference_batch_size": page_elements_batch_size,
-                            "page_elements_workers": page_elements_actors,
-                            "detect_workers": ocr_actors,
-                            "detect_batch_size": ocr_batch_size,
-                            "ocr_inference_batch_size": ocr_batch_size,
-                            "page_elements_cpus_per_actor": page_elements_cpus_per_actor,
-                            "ocr_cpus_per_actor": ocr_cpus_per_actor,
-                            "gpu_page_elements": page_elements_gpus_per_actor,
-                            "gpu_ocr": ocr_gpus_per_actor,
-                            "gpu_embed": embed_gpus_per_actor,
-                            "nemotron_parse_workers": nemotron_parse_actors,
-                            "gpu_nemotron_parse": nemotron_parse_gpus_per_actor,
-                            "nemotron_parse_batch_size": nemotron_parse_batch_size,
-                        },
-                    )
-                )
-                .embed(
-                    EmbedParams(
-                        model_name=str(embed_model_name),
-                        embed_invoke_url=embed_invoke_url,
-                        embed_modality=embed_modality,
-                        text_elements_modality=text_elements_modality,
-                        structured_elements_modality=structured_elements_modality,
-                        batch_tuning={
-                            "embed_workers": embed_actors,
-                            "embed_batch_size": int(embed_batch_size),
-                            "embed_cpus_per_actor": float(embed_cpus_per_actor),
-                        },
-                    )
-                )
-                .vdb_upload(
-                    VdbUploadParams(
-                        lancedb={
-                            "lancedb_uri": lancedb_uri,
-                            "table_name": LANCEDB_TABLE,
-                            "overwrite": True,
-                            "create_index": True,
-                            "hybrid": hybrid,
-                        }
-                    )
+            extract_snapshot_drop_columns = ["bytes", "page_image"]
+            ingestor = ingestor.extract(
+                ExtractParams(
+                    extract_text=True,
+                    extract_tables=True,
+                    extract_charts=True,
+                    extract_infographics=False,
+                    use_graphic_elements=use_graphic_elements,
+                    graphic_elements_invoke_url=graphic_elements_invoke_url,
+                    inference_batch_size=page_elements_batch_size,
+                    use_table_structure=use_table_structure,
+                    table_output_format=table_output_format,
+                    table_structure_invoke_url=table_structure_invoke_url,
+                    page_elements_invoke_url=page_elements_invoke_url,
+                    ocr_invoke_url=ocr_invoke_url,
+                    batch_tuning={
+                        "debug_run_id": str(runtime_metrics_prefix or "unknown"),
+                        "pdf_extract_workers": pdf_extract_tasks,
+                        "pdf_extract_num_cpus": pdf_extract_cpus_per_task,
+                        "pdf_split_batch_size": pdf_split_batch_size,
+                        "pdf_extract_batch_size": pdf_extract_batch_size,
+                        "page_elements_batch_size": page_elements_batch_size,
+                        "inference_batch_size": page_elements_batch_size,
+                        "page_elements_workers": page_elements_actors,
+                        "detect_workers": ocr_actors,
+                        "detect_batch_size": ocr_batch_size,
+                        "ocr_inference_batch_size": ocr_batch_size,
+                        "page_elements_cpus_per_actor": page_elements_cpus_per_actor,
+                        "ocr_cpus_per_actor": ocr_cpus_per_actor,
+                        "gpu_page_elements": page_elements_gpus_per_actor,
+                        "gpu_ocr": ocr_gpus_per_actor,
+                        "gpu_embed": embed_gpus_per_actor,
+                        "nemotron_parse_workers": nemotron_parse_actors,
+                        "gpu_nemotron_parse": nemotron_parse_gpus_per_actor,
+                        "nemotron_parse_batch_size": nemotron_parse_batch_size,
+                    },
                 )
             )
+
+        if extract_output_dir is not None:
+            ingestor = ingestor.write_observability_snapshot(
+                str(extract_output_dir),
+                stage_name="extract",
+                durable_output_dir=str(durable_extract_output_dir) if durable_extract_output_dir is not None else None,
+                drop_columns=extract_snapshot_drop_columns,
+            )
+
+        ingestor = ingestor.embed(
+            EmbedParams(
+                model_name=str(embed_model_name),
+                embed_invoke_url=embed_invoke_url,
+                embed_modality=embed_modality,
+                text_elements_modality=text_elements_modality,
+                structured_elements_modality=structured_elements_modality,
+                embed_granularity=embed_granularity,
+                batch_tuning={
+                    "embed_workers": embed_actors,
+                    "embed_batch_size": int(embed_batch_size),
+                    "embed_cpus_per_actor": float(embed_cpus_per_actor),
+                },
+            ),
+            chunk_manifest_output_dir=str(chunk_manifest_dir) if chunk_manifest_dir is not None else None,
+            durable_chunk_manifest_dir=(
+                str(durable_chunk_manifest_dir) if durable_chunk_manifest_dir is not None else None
+            ),
+            chunk_manifest_drop_columns=chunk_snapshot_drop_columns,
+        )
+
+        ingestor = ingestor.vdb_upload(
+            VdbUploadParams(
+                lancedb={
+                    "lancedb_uri": lancedb_uri,
+                    "table_name": LANCEDB_TABLE,
+                    "overwrite": True,
+                    "create_index": True,
+                    "hybrid": hybrid,
+                }
+            )
+        )
 
         logger.info("Running extraction...")
         ingest_start = time.perf_counter()
@@ -735,13 +727,23 @@ def main(
             f"{ingest_elapsed_s:.2f} seconds. {rows_processed/ingest_elapsed_s:.2f} PPS"
         )
 
+        if detection_summary_file is not None:
+            try:
+                detection_summary = _collect_detection_summary(lancedb_uri, LANCEDB_TABLE)
+            except Exception:
+                logger.exception("Failed collecting detection summary from LanceDB.")
+                detection_summary = None
+            _write_detection_summary(detection_summary_file, detection_summary)
+            _print_detection_summary(detection_summary)
+
         if isinstance(ingestor, BatchIngestor):
             error_rows = ingestor.get_error_rows(dataset=ingest_results).materialize()
             error_count = int(error_rows.count())
 
             # Error out, stop processing, and write top 5 errors rows to a local file for analysis.
             if error_count > 0:
-                error_file = Path("ingest_errors.json").resolve()
+                error_file = ingest_errors_file or Path("ingest_errors.json").resolve()
+                error_file.parent.mkdir(parents=True, exist_ok=True)
                 max_error_rows_to_write = 5
                 error_rows_to_write = error_rows.take(min(max_error_rows_to_write, error_count))
                 with error_file.open("w", encoding="utf-8") as fh:

--- a/nemo_retriever/src/nemo_retriever/examples/common.py
+++ b/nemo_retriever/src/nemo_retriever/examples/common.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 
 def estimate_processed_pages(uri: str, table_name: str) -> Optional[int]:
-    """Estimate pages processed by counting unique (source_id, page_number) pairs.
+    """Estimate pages processed by counting unique (source, page_number) pairs.
 
     Falls back to table row count if page-level fields are unavailable.
     """
@@ -23,8 +23,15 @@ def estimate_processed_pages(uri: str, table_name: str) -> Optional[int]:
         return None
 
     try:
-        df = table.to_pandas()[["source_id", "page_number"]]
-        return int(df.dropna(subset=["source_id", "page_number"]).drop_duplicates().shape[0])
+        df = table.to_pandas()
+        source_col = "source" if "source" in df.columns else "path" if "path" in df.columns else "source_id"
+        if source_col not in df.columns or "page_number" not in df.columns:
+            raise KeyError("Missing source/page_number columns")
+        return int(
+            df.dropna(subset=[source_col, "page_number"])
+            .drop_duplicates(subset=[source_col, "page_number"])
+            .shape[0]
+        )
     except Exception:
         try:
             return int(table.count_rows())

--- a/nemo_retriever/src/nemo_retriever/harness/config.py
+++ b/nemo_retriever/src/nemo_retriever/harness/config.py
@@ -15,6 +15,7 @@ NEMO_RETRIEVER_ROOT = Path(__file__).resolve().parents[3]
 REPO_ROOT = NEMO_RETRIEVER_ROOT.parent
 DEFAULT_TEST_CONFIG_PATH = NEMO_RETRIEVER_ROOT / "harness" / "test_configs.yaml"
 DEFAULT_NIGHTLY_CONFIG_PATH = NEMO_RETRIEVER_ROOT / "harness" / "nightly_config.yaml"
+DEFAULT_OBSERVABILITY_ARCHIVE_DIR = "/datasets/nv-ingest/nemo_retriever/harness_observability"
 VALID_RECALL_ADAPTERS = {"none", "page_plus_one", "financebench_json"}
 DEFAULT_NIGHTLY_SLACK_METRIC_KEYS = [
     "pages",
@@ -61,6 +62,9 @@ class HarnessConfig:
     hybrid: bool = False
     embed_model_name: str = "nvidia/llama-nemotron-embed-1b-v2"
     write_detection_file: bool = False
+    write_extract_artifacts: bool = True
+    write_chunk_manifest: bool = True
+    observability_archive_dir: str | None = DEFAULT_OBSERVABILITY_ARCHIVE_DIR
 
     pdf_extract_workers: int = 8
     pdf_extract_num_cpus: float = 2.0
@@ -100,6 +104,9 @@ class HarnessConfig:
 
         if self.recall_adapter not in VALID_RECALL_ADAPTERS:
             errors.append(f"recall_adapter must be one of {sorted(VALID_RECALL_ADAPTERS)}")
+
+        if self.observability_archive_dir is not None and not str(self.observability_archive_dir).strip():
+            errors.append("observability_archive_dir must be a non-empty string when set")
 
         for name in TUNING_FIELDS:
             val = getattr(self, name)
@@ -207,6 +214,9 @@ def _apply_env_overrides(config_dict: dict[str, Any]) -> None:
         "HARNESS_HYBRID": ("hybrid", _parse_bool),
         "HARNESS_EMBED_MODEL_NAME": ("embed_model_name", str),
         "HARNESS_WRITE_DETECTION_FILE": ("write_detection_file", _parse_bool),
+        "HARNESS_WRITE_EXTRACT_ARTIFACTS": ("write_extract_artifacts", _parse_bool),
+        "HARNESS_WRITE_CHUNK_MANIFEST": ("write_chunk_manifest", _parse_bool),
+        "HARNESS_OBSERVABILITY_ARCHIVE_DIR": ("observability_archive_dir", str),
     }
 
     for key in TUNING_FIELDS:
@@ -308,6 +318,12 @@ def load_harness_config(
 
     if merged.get("artifacts_dir") is not None:
         merged["artifacts_dir"] = _resolve_path_like(str(merged["artifacts_dir"]), REPO_ROOT)
+
+    if merged.get("observability_archive_dir") is not None:
+        merged["observability_archive_dir"] = _resolve_path_like(
+            str(merged["observability_archive_dir"]),
+            REPO_ROOT,
+        )
 
     if merged.get("lancedb_uri") is None:
         merged["lancedb_uri"] = "lancedb"

--- a/nemo_retriever/src/nemo_retriever/harness/run.py
+++ b/nemo_retriever/src/nemo_retriever/harness/run.py
@@ -188,7 +188,46 @@ def _resolve_lancedb_uri(cfg: HarnessConfig, artifact_dir: Path) -> str:
     return str(p)
 
 
-def _build_command(cfg: HarnessConfig, artifact_dir: Path, run_id: str) -> tuple[list[str], Path, Path, Path]:
+def _resolve_observability_archive_run_dir(cfg: HarnessConfig, artifact_dir: Path) -> Path | None:
+    raw = cfg.observability_archive_dir
+    if raw is None:
+        return None
+
+    root = Path(str(raw)).expanduser()
+    if not root.is_absolute():
+        root = (Path.cwd() / root).resolve()
+
+    parent_name = artifact_dir.parent.name.strip()
+    run_name = artifact_dir.name.strip() or "run"
+    if parent_name and parent_name != run_name:
+        return root / parent_name / run_name
+    return root / run_name
+
+
+def _resolve_observability_artifacts(cfg: HarnessConfig, artifact_dir: Path) -> dict[str, Path]:
+    artifacts: dict[str, Path] = {
+        "ingest_errors_file": artifact_dir / "ingest_errors.json",
+    }
+    observability_dir = artifact_dir / "observability"
+    if cfg.write_extract_artifacts:
+        artifacts["extract_artifacts_dir"] = observability_dir / "extracts"
+    if cfg.write_chunk_manifest:
+        artifacts["chunk_manifest_dir"] = observability_dir / "chunks"
+
+    durable_run_dir = _resolve_observability_archive_run_dir(cfg, artifact_dir)
+    if durable_run_dir is not None:
+        if cfg.write_extract_artifacts:
+            artifacts["durable_extract_artifacts_dir"] = durable_run_dir / "extracts"
+        if cfg.write_chunk_manifest:
+            artifacts["durable_chunk_manifest_dir"] = durable_run_dir / "chunks"
+    return artifacts
+
+
+def _build_command(
+    cfg: HarnessConfig,
+    artifact_dir: Path,
+    run_id: str,
+) -> tuple[list[str], Path, Path, Path, dict[str, Path]]:
     runtime_dir = artifact_dir / "runtime_metrics"
     runtime_dir.mkdir(parents=True, exist_ok=True)
     if cfg.write_detection_file:
@@ -201,6 +240,7 @@ def _build_command(cfg: HarnessConfig, artifact_dir: Path, run_id: str) -> tuple
         recall_adapter=cfg.recall_adapter,
         output_dir=runtime_dir,
     )
+    observability_artifacts = _resolve_observability_artifacts(cfg, artifact_dir)
 
     cmd = [
         sys.executable,
@@ -256,14 +296,24 @@ def _build_command(cfg: HarnessConfig, artifact_dir: Path, run_id: str) -> tuple
         str(detection_summary_file),
         "--lancedb-uri",
         _resolve_lancedb_uri(cfg, artifact_dir),
+        "--ingest-errors-file",
+        str(observability_artifacts["ingest_errors_file"]),
     ]
 
     if cfg.ray_address:
         cmd += ["--ray-address", cfg.ray_address]
     if cfg.hybrid:
         cmd += ["--hybrid"]
+    if cfg.write_extract_artifacts and "extract_artifacts_dir" in observability_artifacts:
+        cmd += ["--extract-output-dir", str(observability_artifacts["extract_artifacts_dir"])]
+    if "durable_extract_artifacts_dir" in observability_artifacts:
+        cmd += ["--durable-extract-output-dir", str(observability_artifacts["durable_extract_artifacts_dir"])]
+    if cfg.write_chunk_manifest and "chunk_manifest_dir" in observability_artifacts:
+        cmd += ["--chunk-manifest-dir", str(observability_artifacts["chunk_manifest_dir"])]
+    if "durable_chunk_manifest_dir" in observability_artifacts:
+        cmd += ["--durable-chunk-manifest-dir", str(observability_artifacts["durable_chunk_manifest_dir"])]
 
-    return cmd, runtime_dir, detection_summary_file, query_csv
+    return cmd, runtime_dir, detection_summary_file, query_csv, observability_artifacts
 
 
 def _evaluate_run_outcome(
@@ -352,7 +402,9 @@ def _run_subprocess_with_tty(cmd: list[str], metrics: StreamMetrics) -> int:
 
 
 def _run_single(cfg: HarnessConfig, artifact_dir: Path, run_id: str, tags: list[str] | None = None) -> dict[str, Any]:
-    cmd, runtime_dir, detection_summary_file, effective_query_csv = _build_command(cfg, artifact_dir, run_id)
+    cmd, runtime_dir, detection_summary_file, effective_query_csv, observability_artifacts = _build_command(
+        cfg, artifact_dir, run_id
+    )
     command_text = " ".join(shlex.quote(token) for token in cmd)
     (artifact_dir / "command.txt").write_text(command_text + "\n", encoding="utf-8")
 
@@ -407,6 +459,9 @@ def _run_single(cfg: HarnessConfig, artifact_dir: Path, run_id: str, tags: list[
             "hybrid": cfg.hybrid,
             "embed_model_name": cfg.embed_model_name,
             "write_detection_file": cfg.write_detection_file,
+            "write_extract_artifacts": cfg.write_extract_artifacts,
+            "write_chunk_manifest": cfg.write_chunk_manifest,
+            "observability_archive_dir": cfg.observability_archive_dir,
             "lancedb_uri": _resolve_lancedb_uri(cfg, artifact_dir),
             "tuning": {field: getattr(cfg, field) for field in sorted(TUNING_FIELDS)},
         },
@@ -426,6 +481,7 @@ def _run_single(cfg: HarnessConfig, artifact_dir: Path, run_id: str, tags: list[
         "artifacts": {
             "command_file": str((artifact_dir / "command.txt").resolve()),
             "runtime_metrics_dir": str(runtime_dir.resolve()),
+            **{key: str(path.resolve()) for key, path in observability_artifacts.items()},
         },
     }
     if cfg.write_detection_file:

--- a/nemo_retriever/src/nemo_retriever/ingest_modes/batch.py
+++ b/nemo_retriever/src/nemo_retriever/ingest_modes/batch.py
@@ -15,9 +15,10 @@ import glob
 import json
 import logging
 import os
-from typing import Any, Dict, List, Optional
 from datetime import timedelta
 from functools import partial
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 from typing import Union
 
@@ -49,6 +50,7 @@ from ..params import TextChunkParams
 from ..params import VdbUploadParams
 
 logger = logging.getLogger(__name__)
+REPO_ROOT = Path(__file__).resolve().parents[4]
 
 
 def _setup_batch_debug_logger(enabled: bool) -> logging.Logger:
@@ -82,6 +84,132 @@ def _runtime_env_vars() -> dict[str, str]:
     return {key: value for key, value in env_vars.items() if isinstance(value, str)}
 
 
+def _runtime_env() -> dict[str, Any]:
+    return {
+        "env_vars": _runtime_env_vars(),
+        "working_dir": str(REPO_ROOT),
+        "excludes": [
+            ".git/",
+            "nemo_retriever/.venv/",
+            "nemo_retriever/artifacts/",
+            "**/__pycache__/",
+        ],
+    }
+
+
+def _observability_to_jsonable(value: Any) -> Any:
+    """Convert snapshot payloads into JSON-safe values without keeping large binaries."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+
+    if isinstance(value, (bytes, bytearray)):
+        return {"omitted_bytes": int(len(value))}
+
+    if isinstance(value, dict):
+        out: Dict[str, Any] = {}
+        for raw_key, raw_value in value.items():
+            child_key = str(raw_key)
+            if child_key == "image_b64" and isinstance(raw_value, str):
+                out["image_b64_chars"] = int(len(raw_value))
+                out["image_b64_omitted"] = True
+                continue
+            if child_key == "embedding":
+                try:
+                    dim = len(raw_value)  # type: ignore[arg-type]
+                except Exception:
+                    dim = None
+                out["embedding_dimensions"] = int(dim) if dim is not None else None
+                out["embedding_omitted"] = True
+                continue
+            out[child_key] = _observability_to_jsonable(raw_value)
+        return out
+
+    if isinstance(value, (list, tuple)):
+        return [_observability_to_jsonable(item) for item in value]
+
+    item = getattr(value, "item", None)
+    if callable(item):
+        try:
+            return _observability_to_jsonable(item())
+        except Exception:
+            pass
+
+    tolist = getattr(value, "tolist", None)
+    if callable(tolist):
+        try:
+            return _observability_to_jsonable(tolist())
+        except Exception:
+            pass
+
+    return str(value)
+
+
+def _normalize_snapshot_record(record: dict[str, Any], *, drop_columns: set[str]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for key, value in record.items():
+        if key in drop_columns:
+            continue
+        out[str(key)] = _observability_to_jsonable(value)
+    return out
+
+
+def _atomic_write_snapshot(path: Path, payload: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(path.name + ".tmp")
+    with tmp_path.open("w", encoding="utf-8") as fh:
+        fh.write(payload)
+        fh.flush()
+        try:
+            os.fsync(fh.fileno())
+        except Exception:
+            pass
+    tmp_path.replace(path)
+
+
+class _DatasetSnapshotWriterActor:
+    """Write sanitized JSONL batch snapshots while passing the batch through."""
+
+    def __init__(
+        self,
+        *,
+        output_dir: str,
+        stage_name: str,
+        durable_output_dir: str | None = None,
+        drop_columns: list[str] | None = None,
+    ) -> None:
+        self._stage_name = str(stage_name).strip() or "snapshot"
+        self._drop_columns = {str(col) for col in (drop_columns or [])}
+        self._counter = 0
+
+        target_dirs = [Path(output_dir).expanduser().resolve()]
+        if durable_output_dir:
+            durable_path = Path(durable_output_dir).expanduser().resolve()
+            if durable_path not in target_dirs:
+                target_dirs.append(durable_path)
+        self._target_dirs = target_dirs
+        for target_dir in self._target_dirs:
+            target_dir.mkdir(parents=True, exist_ok=True)
+
+    def __call__(self, batch_df: Any) -> Any:
+        raw_records = batch_df.to_dict(orient="records")
+        if not raw_records:
+            return batch_df
+
+        records = [
+            _normalize_snapshot_record(record, drop_columns=self._drop_columns)
+            for record in raw_records
+        ]
+        if not records:
+            return batch_df
+
+        self._counter += 1
+        file_name = f"{self._stage_name}-{self._counter:05d}.jsonl"
+        payload = "".join(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n" for record in records)
+        for target_dir in self._target_dirs:
+            _atomic_write_snapshot(target_dir / file_name, payload)
+        return batch_df
+
+
 class _LanceDBWriteActor:
     """Ray Data actor that streams batches into LanceDB as they arrive.
 
@@ -91,8 +219,6 @@ class _LanceDBWriteActor:
     """
 
     def __init__(self, params: VdbUploadParams | None = None) -> None:
-        from nemo_retriever.ingest_modes.lancedb_utils import lancedb_schema
-
         lancedb_params = (params or VdbUploadParams()).lancedb
 
         self._lancedb_uri = lancedb_params.lancedb_uri
@@ -107,15 +233,7 @@ class _LanceDBWriteActor:
 
         self._db = lancedb.connect(uri=self._lancedb_uri)
         self._total_rows = 0
-
-        # Use a default dim for the initial empty table; rows are appended via add().
-        self._schema = lancedb_schema(2048)
-        mode = "overwrite" if self._overwrite else "create"
-        self._table = self._db.create_table(
-            self._table_name,
-            schema=self._schema,
-            mode=mode,
-        )
+        self._table = None
 
     def _build_rows(self, df: Any) -> list:
         """Build LanceDB rows from a pandas DataFrame batch."""
@@ -130,12 +248,28 @@ class _LanceDBWriteActor:
         )
 
     def __call__(self, batch_df: Any) -> Any:
+        from nemo_retriever.ingest_modes.lancedb_utils import (
+            create_or_append_lancedb_table,
+            infer_vector_dim,
+            lancedb_schema,
+        )
+
         rows = self._build_rows(batch_df)
         if rows:
-            # Infer schema from first batch
             if self._table is None:
-                self._table = self._db.open_table(self._table_name)
-            self._table.add(rows)
+                dim = infer_vector_dim(rows)
+                if dim <= 0:
+                    raise ValueError("Failed to infer embedding dimension from LanceDB batch rows.")
+                schema = lancedb_schema(dim)
+                self._table = create_or_append_lancedb_table(
+                    self._db,
+                    str(self._table_name),
+                    rows,
+                    schema,
+                    overwrite=bool(self._overwrite),
+                )
+            else:
+                self._table.add(rows)
 
             self._total_rows += len(rows)
 
@@ -210,7 +344,7 @@ class BatchIngestor(Ingestor):
             address=ray_address or "local",
             ignore_reinit_error=True,
             log_to_driver=bool(ray_log_to_driver),
-            runtime_env={"env_vars": _runtime_env_vars()},
+            runtime_env=_runtime_env(),
         )
 
         # Use the new Rich progress UI instead of verbose tqdm bars.
@@ -710,6 +844,10 @@ class BatchIngestor(Ingestor):
                 "No Ray Dataset to embed. Provide input_dataset or run .files(...) / .extract(...) first."
             )
 
+        chunk_manifest_output_dir = kwargs.pop("chunk_manifest_output_dir", None)
+        durable_chunk_manifest_dir = kwargs.pop("durable_chunk_manifest_dir", None)
+        chunk_manifest_drop_columns = kwargs.pop("chunk_manifest_drop_columns", None)
+
         from nemo_retriever.params.utils import build_embed_kwargs
 
         resolved = _coerce_params(params, EmbedParams, kwargs)
@@ -745,6 +883,23 @@ class BatchIngestor(Ingestor):
             batch_format="pandas",
             num_cpus=1,
         )
+
+        if chunk_manifest_output_dir:
+            actor_kwargs: dict[str, Any] = {
+                "output_dir": str(chunk_manifest_output_dir),
+                "stage_name": "chunk-manifest",
+            }
+            if durable_chunk_manifest_dir:
+                actor_kwargs["durable_output_dir"] = str(durable_chunk_manifest_dir)
+            if chunk_manifest_drop_columns:
+                actor_kwargs["drop_columns"] = list(chunk_manifest_drop_columns)
+            self._rd_dataset = self._rd_dataset.map_batches(
+                _DatasetSnapshotWriterActor,
+                batch_format="pandas",
+                num_cpus=1,
+                compute=rd.ActorPoolStrategy(size=1),
+                fn_constructor_kwargs=actor_kwargs,
+            )
 
         # When using a remote NIM endpoint, no GPU is needed for embedding.
         endpoint = (kwargs.get("embedding_endpoint") or kwargs.get("embed_invoke_url") or "").strip()
@@ -801,6 +956,39 @@ class BatchIngestor(Ingestor):
             fn_constructor_kwargs={"params": p},
         )
 
+        return self
+
+    def write_observability_snapshot(
+        self,
+        output_dir: str,
+        *,
+        stage_name: str,
+        durable_output_dir: str | None = None,
+        drop_columns: list[str] | None = None,
+    ) -> "BatchIngestor":
+        """Persist the current dataset as JSONL snapshots without adding a second pipeline pass."""
+        if not isinstance(output_dir, str) or not output_dir.strip():
+            raise ValueError(f"output_dir must be a non-empty string, got {output_dir!r}")
+        if self._rd_dataset is None:
+            raise RuntimeError("No Ray Dataset to snapshot. Call .files(...) and a pipeline stage first.")
+
+        actor_kwargs: dict[str, Any] = {
+            "output_dir": output_dir,
+            "stage_name": stage_name,
+        }
+        if durable_output_dir is not None:
+            actor_kwargs["durable_output_dir"] = durable_output_dir
+        if drop_columns:
+            actor_kwargs["drop_columns"] = list(drop_columns)
+
+        # Use one writer actor so file numbering is deterministic across a run.
+        self._rd_dataset = self._rd_dataset.map_batches(
+            _DatasetSnapshotWriterActor,
+            batch_format="pandas",
+            num_cpus=1,
+            compute=rd.ActorPoolStrategy(size=1),
+            fn_constructor_kwargs=actor_kwargs,
+        )
         return self
 
     def save_intermediate_results(self, output_dir: str) -> "BatchIngestor":
@@ -996,8 +1184,14 @@ class BatchIngestor(Ingestor):
             print(f"Warning: failed to create LanceDB index (continuing without index): {e}")
 
         if kw.get("hybrid", False):
-            text_column = str(kw.get("text_column", "text"))
+            configured_text_column = str(kw.get("text_column", "text"))
+            text_column = "text"
             fts_language = str(kw.get("fts_language", "English"))
+            if configured_text_column != "text":
+                print(
+                    "Warning: LanceDB rows are stored in column 'text'; "
+                    f"ignoring configured text_column={configured_text_column!r} for FTS indexing."
+                )
             try:
                 table.create_fts_index(text_column, language=fts_language)
             except Exception as e:

--- a/nemo_retriever/src/nemo_retriever/ingest_modes/inprocess.py
+++ b/nemo_retriever/src/nemo_retriever/ingest_modes/inprocess.py
@@ -184,6 +184,9 @@ def explode_content_to_rows(
             page_row = _deep_copy_row(row_dict)
             page_row["_embed_modality"] = text_mod
             page_row["_content_type"] = "text"
+            page_row["_content_index"] = 0
+            page_row["_content_id"] = "text:0"
+            page_row["_embed_granularity"] = "element"
             if text_mod in IMAGE_MODALITIES:
                 page_row["_image_b64"] = page_image_b64
             new_rows.append(page_row)
@@ -194,7 +197,7 @@ def explode_content_to_rows(
             content_list = row_dict.get(col)
             if not isinstance(content_list, list):
                 continue
-            for item in content_list:
+            for item_idx, item in enumerate(content_list):
                 if not isinstance(item, dict):
                     continue
                 t = item.get("text", "")
@@ -204,6 +207,9 @@ def explode_content_to_rows(
                 content_row[text_column] = t.strip()
                 content_row["_embed_modality"] = struct_mod
                 content_row["_content_type"] = col
+                content_row["_content_index"] = int(item_idx)
+                content_row["_content_id"] = f"{col}:{item_idx}"
+                content_row["_embed_granularity"] = "element"
                 if struct_mod in IMAGE_MODALITIES and page_image_b64:
                     bbox = item.get("bbox_xyxy_norm")
                     if bbox and len(bbox) == 4:
@@ -221,6 +227,9 @@ def explode_content_to_rows(
             preserved = _deep_copy_row(row_dict)
             preserved["_embed_modality"] = text_mod
             preserved["_content_type"] = "text"
+            preserved["_content_index"] = 0
+            preserved["_content_id"] = "text:0"
+            preserved["_embed_granularity"] = "element"
             if text_mod in IMAGE_MODALITIES:
                 preserved["_image_b64"] = page_image_b64
             new_rows.append(preserved)
@@ -272,6 +281,10 @@ def collapse_content_to_page_rows(
             batch_df["_image_b64"] = None
 
     batch_df["_embed_modality"] = modality
+    batch_df["_content_type"] = "page"
+    batch_df["_content_index"] = -1
+    batch_df["_content_id"] = "page"
+    batch_df["_embed_granularity"] = "page"
     return batch_df
 
 

--- a/nemo_retriever/src/nemo_retriever/ingest_modes/lancedb_utils.py
+++ b/nemo_retriever/src/nemo_retriever/ingest_modes/lancedb_utils.py
@@ -100,6 +100,40 @@ def _build_detection_metadata(row: Any) -> Dict[str, Any]:
     return out
 
 
+def _build_provenance_metadata(row: Any, *, text_column: str) -> Dict[str, Any]:
+    """Capture stable chunk provenance for later LanceDB-to-chunk diffs."""
+    out: Dict[str, Any] = {}
+
+    content_type = getattr(row, "_content_type", None)
+    if isinstance(content_type, str) and content_type.strip():
+        out["content_type"] = content_type.strip()
+
+    content_id = getattr(row, "_content_id", None)
+    if isinstance(content_id, str) and content_id.strip():
+        out["content_id"] = content_id.strip()
+
+    content_index = getattr(row, "_content_index", None)
+    try:
+        if content_index is not None:
+            out["content_index"] = int(content_index)
+    except Exception:
+        pass
+
+    embed_modality = getattr(row, "_embed_modality", None)
+    if isinstance(embed_modality, str) and embed_modality.strip():
+        out["embed_modality"] = embed_modality.strip()
+
+    embed_granularity = getattr(row, "_embed_granularity", None)
+    if isinstance(embed_granularity, str) and embed_granularity.strip():
+        out["embed_granularity"] = embed_granularity.strip()
+
+    text_value = getattr(row, text_column, None)
+    if isinstance(text_value, str):
+        out["text_length"] = int(len(text_value))
+
+    return out
+
+
 def build_lancedb_row(
     row: Any,
     *,
@@ -122,13 +156,17 @@ def build_lancedb_row(
     pdf_basename = p.stem if p is not None else ""
     pdf_page = f"{pdf_basename}_{page_number}" if (pdf_basename and page_number >= 0) else ""
     source_id = path or filename or pdf_basename
+    source_value = str(path or source_id)
 
-    metadata_obj: Dict[str, Any] = {"page_number": int(page_number) if page_number is not None else -1}
+    metadata_obj: Dict[str, Any] = {
+        "page_number": int(page_number) if page_number is not None else -1,
+        "source_id": str(source_id),
+        "source_path": source_value,
+    }
     if pdf_page:
         metadata_obj["pdf_page"] = pdf_page
     metadata_obj.update(_build_detection_metadata(row))
-
-    source_obj: Dict[str, Any] = {"source_id": str(path)}
+    metadata_obj.update(_build_provenance_metadata(row, text_column=text_column))
 
     row_out: Dict[str, Any] = {
         "vector": emb,
@@ -136,10 +174,9 @@ def build_lancedb_row(
         "filename": filename,
         "pdf_basename": pdf_basename,
         "page_number": int(page_number) if page_number is not None else -1,
-        "source_id": str(source_id),
-        "path": str(path),
+        "source": source_value,
+        "path": source_value,
         "metadata": json.dumps(metadata_obj, ensure_ascii=False),
-        "source": json.dumps(source_obj, ensure_ascii=False),
     }
 
     if include_text:
@@ -178,7 +215,7 @@ def build_lancedb_rows(
     return rows
 
 
-def lancedb_schema(vector_dim: int) -> Any:
+def lancedb_schema(vector_dim: int = 2048) -> Any:
     """Return a PyArrow schema for the standard LanceDB table layout."""
     import pyarrow as pa  # type: ignore
 
@@ -189,11 +226,10 @@ def lancedb_schema(vector_dim: int) -> Any:
             pa.field("filename", pa.string()),
             pa.field("pdf_basename", pa.string()),
             pa.field("page_number", pa.int32()),
-            pa.field("source_id", pa.string()),
+            pa.field("source", pa.string()),
             pa.field("path", pa.string()),
             pa.field("text", pa.string()),
             pa.field("metadata", pa.string()),
-            pa.field("source", pa.string()),
         ]
     )
 

--- a/nemo_retriever/src/nemo_retriever/recall/core.py
+++ b/nemo_retriever/src/nemo_retriever/recall/core.py
@@ -220,29 +220,91 @@ def _search_lancedb(
             from lancedb.rerankers import RRFReranker  # type: ignore
 
             text = query_texts[i]
-            hits = (
+            base_query = (
                 table.search(query_type="hybrid")
                 .vector(q)
                 .text(text)
                 .nprobes(effective_nprobes)
                 .refine_factor(refine_factor)
-                .select(["text", "metadata", "source"])
-                .limit(top_k)
-                .rerank(RRFReranker())
-                .to_list()
+            )
+            selected_fields = ["text", "metadata", "source", "page_number", "_score"]
+            try:
+                hits = base_query.select(selected_fields).limit(top_k).rerank(RRFReranker()).to_list()
+            except Exception:
+                selected_fields = ["text", "metadata", "source", "page_number"]
+                hits = base_query.select(selected_fields).limit(top_k).rerank(RRFReranker()).to_list()
+            logger.debug(
+                "LanceDB search mode=hybrid query_index=%d nprobes=%d refine_factor=%d "
+                "selected_fields=%s returned_hits=%d has_score=%s",
+                i,
+                effective_nprobes,
+                int(refine_factor),
+                selected_fields,
+                len(hits),
+                any("_score" in hit for hit in hits),
             )
         else:
             hits = (
                 table.search(q, vector_column_name=vector_column_name)
                 .nprobes(effective_nprobes)
                 .refine_factor(refine_factor)
-                .select(["text", "metadata", "source", "_distance"])
+                .select(["text", "metadata", "source", "page_number", "_distance"])
                 .limit(top_k)
                 .to_list()
+            )
+            logger.debug(
+                "LanceDB search mode=vector query_index=%d nprobes=%d refine_factor=%d "
+                "selected_fields=%s returned_hits=%d has_distance=%s",
+                i,
+                effective_nprobes,
+                int(refine_factor),
+                ["text", "metadata", "source", "_distance"],
+                len(hits),
+                any("_distance" in hit for hit in hits),
             )
 
         results.append(hits)
     return results
+
+
+def _source_path_from_hit(hit: dict) -> str | None:
+    source = hit.get("source")
+    if isinstance(source, str):
+        stripped = source.strip()
+        if not stripped:
+            return None
+        try:
+            parsed = json.loads(stripped)
+        except Exception:
+            return stripped
+        if isinstance(parsed, dict):
+            source_id = parsed.get("source_id") or parsed.get("path")
+            return str(source_id) if source_id else None
+        return stripped
+    if isinstance(source, dict):
+        source_id = source.get("source_id") or source.get("path")
+        return str(source_id) if source_id else None
+    return None
+
+
+def _page_number_from_hit(hit: dict) -> int | None:
+    page_number = hit.get("page_number")
+    try:
+        if page_number is not None:
+            return int(page_number)
+    except Exception:
+        pass
+
+    try:
+        res = json.loads(hit.get("metadata", "{}"))
+    except Exception:
+        return None
+    try:
+        if isinstance(res, dict) and res.get("page_number") is not None:
+            return int(res.get("page_number"))
+    except Exception:
+        pass
+    return None
 
 
 def _hits_to_keys(raw_hits: List[List[Dict[str, Any]]]) -> List[List[str]]:
@@ -250,12 +312,11 @@ def _hits_to_keys(raw_hits: List[List[Dict[str, Any]]]) -> List[List[str]]:
     for hits in raw_hits:
         keys: List[str] = []
         for h in hits:
-            res = json.loads(h["metadata"])
-            source = json.loads(h["source"])
-            # Prefer explicit `pdf_page` column; fall back to derived form.
-            if res.get("page_number") is not None and source.get("source_id"):
-                filename = Path(source["source_id"]).stem
-                keys.append(filename + "_" + str(res["page_number"]))
+            page_number = _page_number_from_hit(h)
+            source_path = _source_path_from_hit(h)
+            if page_number is not None and source_path:
+                filename = Path(source_path).stem
+                keys.append(f"{filename}_{page_number}")
             else:
                 logger.warning(
                     "Skipping hit with missing page_number or source_id: metadata=%s source=%s",
@@ -314,18 +375,12 @@ def hit_key_and_distance(hit: dict) -> tuple[str | None, float | None]:
     Supports both ``_distance`` and ``_score`` fields for compatibility across
     LanceDB query types (vector vs hybrid).
     """
-    try:
-        res = json.loads(hit.get("metadata", "{}"))
-        source = json.loads(hit.get("source", "{}"))
-    except Exception:
-        return None, None
-
-    source_id = source.get("source_id")
-    page_number = res.get("page_number")
-    if not source_id or page_number is None:
+    source_path = _source_path_from_hit(hit)
+    page_number = _page_number_from_hit(hit)
+    if not source_path or page_number is None:
         return None, float(hit.get("_distance")) if "_distance" in hit else None
 
-    key = f"{Path(str(source_id)).stem}_{page_number}"
+    key = f"{Path(str(source_path)).stem}_{page_number}"
     dist = float(hit["_distance"]) if "_distance" in hit else float(hit["_score"]) if "_score" in hit else None
     return key, dist
 

--- a/nemo_retriever/src/nemo_retriever/recall/vdb_recall.py
+++ b/nemo_retriever/src/nemo_retriever/recall/vdb_recall.py
@@ -12,7 +12,14 @@ import typer
 import pandas as pd  # noqa: F401
 from rich.console import Console
 
-from .core import RecallConfig, evaluate_recall, retrieve_and_score, _normalize_query_df  # noqa: F401
+from .core import (  # noqa: F401
+    RecallConfig,
+    _normalize_query_df,
+    _page_number_from_hit,
+    _source_path_from_hit,
+    evaluate_recall,
+    retrieve_and_score,
+)
 
 app = typer.Typer(help="Embed query CSV rows, search LanceDB, print hits, and compute recall@k.")
 console = Console()
@@ -182,10 +189,11 @@ def recall_with_main(
         print(f"\tTop-k Results:")  # noqa: F541
 
         for i, h in enumerate(hits[:top_k]):
-            meta = json.loads(h["metadata"]) if isinstance(h["metadata"], str) else h["metadata"]
-            src = json.loads(h["source"]) if isinstance(h["source"], str) else h["source"]
-            pdf_name = Path(src["source_id"]).stem
-            page_number = meta.get("page_number", -1)
+            source_path = _source_path_from_hit(h) or ""
+            pdf_name = Path(source_path).stem if source_path else "unknown"
+            page_number = _page_number_from_hit(h)
+            if page_number is None:
+                page_number = -1
             print(f"\tResult {i}: {pdf_name} - {page_number}")
 
             if page_number == -1:

--- a/nemo_retriever/src/nemo_retriever/utils/detection_summary.py
+++ b/nemo_retriever/src/nemo_retriever/utils/detection_summary.py
@@ -35,7 +35,7 @@ def compute_detection_summary(
     Each element is ``(page_key, metadata_dict, row_dict)`` where:
 
     - *page_key* is a hashable value used to deduplicate exploded content rows
-      (e.g. ``(source_id, page_number)``).
+      (e.g. ``(source_path, page_number)``).
     - *metadata_dict* is the parsed JSON metadata (may contain counters from the
       LanceDB metadata column or from direct DataFrame columns).
     - *row_dict* is the raw row dict, used as fallback for counters stored as
@@ -98,16 +98,47 @@ def compute_detection_summary(
     }
 
 
+def _source_path_from_lancedb_row(row_dict: Dict[str, Any], metadata_dict: Dict[str, Any]) -> str:
+    source = row_dict.get("source")
+    if isinstance(source, str) and source.strip():
+        stripped = source.strip()
+        try:
+            parsed = json.loads(stripped)
+        except Exception:
+            return stripped
+        if isinstance(parsed, dict):
+            value = parsed.get("source_id") or parsed.get("path")
+            if value:
+                return str(value)
+        return stripped
+
+    if isinstance(source, dict):
+        value = source.get("source_id") or source.get("path")
+        if value:
+            return str(value)
+
+    for key in ("path", "source_id"):
+        value = row_dict.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    for key in ("source_path", "source_id"):
+        value = metadata_dict.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    return ""
+
+
 def iter_lancedb_rows(uri: str, table_name: str):
     """Yield ``(page_key, meta, row_dict)`` tuples from a LanceDB table."""
     import lancedb  # type: ignore
 
     db = lancedb.connect(uri)
     table = db.open_table(table_name)
-    df = table.to_pandas()[["source_id", "page_number", "metadata"]]
+    df = table.to_pandas()
 
     for row in df.itertuples(index=False):
-        source_id = str(getattr(row, "source_id", "") or "")
         page_number = _safe_int(getattr(row, "page_number", -1), default=-1)
         raw_metadata = getattr(row, "metadata", None)
         meta: dict = {}
@@ -118,7 +149,9 @@ def iter_lancedb_rows(uri: str, table_name: str):
                     meta = parsed
             except Exception:
                 pass
-        yield (source_id, page_number), meta, {}
+        row_dict = row._asdict()
+        source_path = _source_path_from_lancedb_row(row_dict, meta)
+        yield (source_path, page_number), meta, row_dict
 
 
 def iter_dataframe_rows(df):
@@ -158,7 +191,7 @@ def print_detection_summary(summary: Optional[Dict[str, Any]]) -> None:
     if summary is None:
         print("Detection summary: unavailable (could not read metadata).")
         return
-    print("\nDetection summary (deduped by source_id/page_number):")
+    print("\nDetection summary (deduped by source/page_number):")
     print(f"  Pages seen: {summary['pages_seen']}")
     print(f"  PageElements v3 total detections: {summary['page_elements_v3_total_detections']}")
     print(f"  OCR table detections: {summary['ocr_table_total_detections']}")

--- a/nemo_retriever/tests/test_batch_pipeline.py
+++ b/nemo_retriever/tests/test_batch_pipeline.py
@@ -1,8 +1,10 @@
+from types import SimpleNamespace
+
 import pytest
 
 pytest.importorskip("ray")
 
-from nemo_retriever.examples.batch_pipeline import _count_materialized_rows
+from nemo_retriever.examples.batch_pipeline import _count_materialized_rows, _ensure_lancedb_table
 from nemo_retriever.utils.input_files import resolve_input_patterns
 
 
@@ -29,3 +31,19 @@ def test_resolve_input_file_patterns_recurses_for_directory_inputs(tmp_path) -> 
     assert pdf_patterns == [str(dataset_dir / "**" / "*.pdf")]
     assert txt_patterns == [str(dataset_dir / "**" / "*.txt")]
     assert doc_patterns == [str(dataset_dir / "**" / "*.docx"), str(dataset_dir / "**" / "*.pptx")]
+
+
+def test_ensure_lancedb_table_only_creates_uri_dir(monkeypatch, tmp_path) -> None:
+    lancedb_dir = tmp_path / "lancedb"
+
+    class _FakeDb:
+        def open_table(self, _name: str):
+            raise RuntimeError("missing")
+
+    monkeypatch.setattr(
+        "nemo_retriever.examples.batch_pipeline._lancedb",
+        lambda: SimpleNamespace(connect=lambda _uri: _FakeDb()),
+    )
+
+    assert _ensure_lancedb_table(str(lancedb_dir), "nv-ingest") is False
+    assert lancedb_dir.exists()

--- a/nemo_retriever/tests/test_harness_config.py
+++ b/nemo_retriever/tests/test_harness_config.py
@@ -63,6 +63,9 @@ def test_load_harness_config_precedence(tmp_path: Path, monkeypatch: pytest.Monk
     assert cfg.gpu_ocr == 0.7  # sweep override
     assert cfg.gpu_embed == 0.9  # env override (highest)
     assert cfg.recall_required is True
+    assert cfg.write_extract_artifacts is True
+    assert cfg.write_chunk_manifest is True
+    assert cfg.observability_archive_dir == harness_config.DEFAULT_OBSERVABILITY_ARCHIVE_DIR
 
 
 def test_load_harness_config_fails_when_recall_required_without_query(tmp_path: Path) -> None:

--- a/nemo_retriever/tests/test_harness_run.py
+++ b/nemo_retriever/tests/test_harness_run.py
@@ -51,8 +51,15 @@ def test_build_command_uses_hidden_detection_file_by_default(tmp_path: Path) -> 
         query_csv=str(query_csv),
         write_detection_file=False,
     )
-    cmd, runtime_dir, detection_file, effective_query_csv = _build_command(cfg, tmp_path, run_id="r1")
+    cmd, runtime_dir, detection_file, effective_query_csv, observability_artifacts = _build_command(
+        cfg, tmp_path, run_id="r1"
+    )
     assert "--detection-summary-file" in cmd
+    assert "--extract-output-dir" in cmd
+    assert "--chunk-manifest-dir" in cmd
+    assert "--durable-extract-output-dir" in cmd
+    assert "--durable-chunk-manifest-dir" in cmd
+    assert "--ingest-errors-file" in cmd
     assert "--recall-match-mode" in cmd
     assert "pdf_page" in cmd
     assert "--pdf-extract-tasks" in cmd
@@ -74,6 +81,11 @@ def test_build_command_uses_hidden_detection_file_by_default(tmp_path: Path) -> 
     assert detection_file.parent == runtime_dir
     assert detection_file.name == ".detection_summary.json"
     assert effective_query_csv == query_csv
+    assert observability_artifacts["extract_artifacts_dir"] == tmp_path / "observability" / "extracts"
+    assert observability_artifacts["chunk_manifest_dir"] == tmp_path / "observability" / "chunks"
+    assert observability_artifacts["durable_extract_artifacts_dir"].name == "extracts"
+    assert observability_artifacts["durable_chunk_manifest_dir"].name == "chunks"
+    assert observability_artifacts["ingest_errors_file"] == tmp_path / "ingest_errors.json"
 
 
 def test_build_command_uses_top_level_detection_file_when_enabled(tmp_path: Path) -> None:
@@ -89,11 +101,14 @@ def test_build_command_uses_top_level_detection_file_when_enabled(tmp_path: Path
         query_csv=str(query_csv),
         write_detection_file=True,
     )
-    cmd, runtime_dir, detection_file, effective_query_csv = _build_command(cfg, tmp_path, run_id="r1")
+    cmd, runtime_dir, detection_file, effective_query_csv, observability_artifacts = _build_command(
+        cfg, tmp_path, run_id="r1"
+    )
     assert "--detection-summary-file" in cmd
     assert detection_file.parent == tmp_path
     assert detection_file.name == "detection_summary.json"
     assert effective_query_csv == query_csv
+    assert observability_artifacts["extract_artifacts_dir"] == tmp_path / "observability" / "extracts"
 
 
 def test_build_command_applies_page_plus_one_adapter(tmp_path: Path) -> None:
@@ -109,7 +124,9 @@ def test_build_command_applies_page_plus_one_adapter(tmp_path: Path) -> None:
         query_csv=str(query_csv),
         recall_adapter="page_plus_one",
     )
-    cmd, runtime_dir, _detection_file, effective_query_csv = _build_command(cfg, tmp_path, run_id="r1")
+    cmd, runtime_dir, _detection_file, effective_query_csv, _observability_artifacts = _build_command(
+        cfg, tmp_path, run_id="r1"
+    )
 
     assert effective_query_csv.parent == runtime_dir
     assert effective_query_csv.name == "query_adapter.page_plus_one.csv"
@@ -143,7 +160,13 @@ def test_run_single_writes_tags_to_results_json(monkeypatch, tmp_path: Path) -> 
     monkeypatch.setattr(
         harness_run,
         "_build_command",
-        lambda *_args, **_kwargs: (["python", "-V"], runtime_dir, runtime_dir / ".detection_summary.json", query_csv),
+        lambda *_args, **_kwargs: (
+            ["python", "-V"],
+            runtime_dir,
+            runtime_dir / ".detection_summary.json",
+            query_csv,
+            {"ingest_errors_file": tmp_path / "ingest_errors.json"},
+        ),
     )
 
     def _fake_run_subprocess(_cmd: list[str], metrics) -> int:
@@ -301,6 +324,13 @@ def test_run_single_writes_results_with_run_metadata(monkeypatch, tmp_path: Path
     detection_file.write_text(json.dumps({"total_detections": 7}), encoding="utf-8")
     runtime_summary_file = runtime_dir / "jp20_single.runtime.summary.json"
     runtime_summary_file.write_text(json.dumps({"elapsed_secs": 12.5}), encoding="utf-8")
+    observability_artifacts = {
+        "extract_artifacts_dir": artifact_dir / "observability" / "extracts",
+        "chunk_manifest_dir": artifact_dir / "observability" / "chunks",
+        "durable_extract_artifacts_dir": tmp_path / "durable" / "extracts",
+        "durable_chunk_manifest_dir": tmp_path / "durable" / "chunks",
+        "ingest_errors_file": artifact_dir / "ingest_errors.json",
+    }
 
     cfg = HarnessConfig(
         dataset_dir=str(dataset_dir),
@@ -318,6 +348,7 @@ def test_run_single_writes_results_with_run_metadata(monkeypatch, tmp_path: Path
             runtime_dir,
             detection_file,
             query_csv,
+            observability_artifacts,
         ),
     )
 
@@ -369,6 +400,9 @@ def test_run_single_writes_results_with_run_metadata(monkeypatch, tmp_path: Path
             "hybrid": cfg.hybrid,
             "embed_model_name": cfg.embed_model_name,
             "write_detection_file": True,
+            "write_extract_artifacts": True,
+            "write_chunk_manifest": True,
+            "observability_archive_dir": cfg.observability_archive_dir,
             "lancedb_uri": str((artifact_dir / "lancedb").resolve()),
             "tuning": {field: getattr(cfg, field) for field in sorted(harness_run.TUNING_FIELDS)},
         },
@@ -400,6 +434,11 @@ def test_run_single_writes_results_with_run_metadata(monkeypatch, tmp_path: Path
             "command_file": str((artifact_dir / "command.txt").resolve()),
             "runtime_metrics_dir": str(runtime_dir.resolve()),
             "detection_summary_file": str(detection_file.resolve()),
+            "extract_artifacts_dir": str(observability_artifacts["extract_artifacts_dir"].resolve()),
+            "chunk_manifest_dir": str(observability_artifacts["chunk_manifest_dir"].resolve()),
+            "durable_extract_artifacts_dir": str(observability_artifacts["durable_extract_artifacts_dir"].resolve()),
+            "durable_chunk_manifest_dir": str(observability_artifacts["durable_chunk_manifest_dir"].resolve()),
+            "ingest_errors_file": str(observability_artifacts["ingest_errors_file"].resolve()),
         },
     }
 
@@ -427,6 +466,13 @@ def test_run_single_allows_missing_optional_summary_files(monkeypatch, tmp_path:
         write_detection_file=False,
         recall_required=False,
     )
+    observability_artifacts = {
+        "extract_artifacts_dir": artifact_dir / "observability" / "extracts",
+        "chunk_manifest_dir": artifact_dir / "observability" / "chunks",
+        "durable_extract_artifacts_dir": tmp_path / "durable" / "extracts",
+        "durable_chunk_manifest_dir": tmp_path / "durable" / "chunks",
+        "ingest_errors_file": artifact_dir / "ingest_errors.json",
+    }
 
     monkeypatch.setattr(
         harness_run,
@@ -436,6 +482,7 @@ def test_run_single_allows_missing_optional_summary_files(monkeypatch, tmp_path:
             runtime_dir,
             detection_file,
             query_csv,
+            observability_artifacts,
         ),
     )
 
@@ -465,6 +512,7 @@ def test_run_single_allows_missing_optional_summary_files(monkeypatch, tmp_path:
         "recall_5": None,
     }
     assert "detection_summary_file" not in result["artifacts"]
+    assert result["artifacts"]["ingest_errors_file"] == str(observability_artifacts["ingest_errors_file"].resolve())
 
 
 def test_resolve_summary_metrics_falls_back_to_dataset_page_count(monkeypatch, tmp_path: Path) -> None:

--- a/nemo_retriever/tests/test_lancedb_utils.py
+++ b/nemo_retriever/tests/test_lancedb_utils.py
@@ -126,7 +126,6 @@ class TestBuildLancedbRow:
             "filename",
             "pdf_basename",
             "page_number",
-            "source_id",
             "path",
             "metadata",
             "source",
@@ -156,6 +155,13 @@ class TestBuildLancedbRow:
         meta = json.loads(result["metadata"])
         assert meta["page_number"] == 1
         assert meta["pdf_page"] == "test_1"
+        assert meta["source_id"] == "/docs/test.pdf"
+        assert meta["source_path"] == "/docs/test.pdf"
+
+    def test_source_column_carries_path(self):
+        result = build_lancedb_row(self._row())
+        assert result["source"] == "/docs/test.pdf"
+        assert result["path"] == "/docs/test.pdf"
 
     def test_returns_none_when_no_embedding(self):
         row = SimpleNamespace(metadata=None, path="/x.pdf", page_number=1, text="hi")
@@ -172,6 +178,24 @@ class TestBuildLancedbRow:
         assert meta["page_elements_v3_num_detections"] == 5
         assert meta["page_elements_v3_counts_by_label"] == {"text": 3, "figure": 2}
         assert meta["ocr_table_detections"] == 2
+
+    def test_provenance_metadata_included(self):
+        row = self._row(
+            _content_type="table",
+            _content_index=2,
+            _content_id="table:2",
+            _embed_modality="text_image",
+            _embed_granularity="element",
+            text="table body",
+        )
+        result = build_lancedb_row(row)
+        meta = json.loads(result["metadata"])
+        assert meta["content_type"] == "table"
+        assert meta["content_index"] == 2
+        assert meta["content_id"] == "table:2"
+        assert meta["embed_modality"] == "text_image"
+        assert meta["embed_granularity"] == "element"
+        assert meta["text_length"] == len("table body")
 
 
 class TestBuildLancedbRows:
@@ -198,7 +222,8 @@ class TestLancedbSchema:
         assert "text" in names
         assert "metadata" in names
         assert "source" in names
-        assert len(names) == 10
+        assert "source_id" not in names
+        assert len(names) == 9
 
 
 class TestInferVectorDim:

--- a/nemo_retriever/tests/test_multimodal_embed.py
+++ b/nemo_retriever/tests/test_multimodal_embed.py
@@ -202,6 +202,10 @@ class TestExplodeContentToRows:
 
         assert "_embed_modality" in result.columns
         assert list(result["_embed_modality"]) == ["text", "text"]
+        assert list(result["_content_type"]) == ["text", "table"]
+        assert list(result["_content_index"]) == [0, 0]
+        assert list(result["_content_id"]) == ["text:0", "table:0"]
+        assert list(result["_embed_granularity"]) == ["element", "element"]
         assert "_image_b64" not in result.columns
 
     @patch("nemo_retriever.ingest_modes.inprocess._crop_b64_image_by_norm_bbox")
@@ -259,6 +263,10 @@ class TestCollapseContentToPageRows:
         assert len(result) == 1
         assert result["text"].iloc[0] == "Hello world\n\ntable data\n\nchart data"
         assert result["_embed_modality"].iloc[0] == "text"
+        assert result["_content_type"].iloc[0] == "page"
+        assert result["_content_index"].iloc[0] == -1
+        assert result["_content_id"].iloc[0] == "page"
+        assert result["_embed_granularity"].iloc[0] == "page"
 
     def test_full_page_image_used(self):
         """In image modalities, _image_b64 is the full page image (no cropping)."""

--- a/nemo_retriever/tests/test_recall_core.py
+++ b/nemo_retriever/tests/test_recall_core.py
@@ -1,7 +1,11 @@
+import sys
+from types import ModuleType
+from types import SimpleNamespace
+
 import pandas as pd
 import pytest
 
-from nemo_retriever.recall.core import _normalize_query_df, is_hit_at_k
+from nemo_retriever.recall.core import _normalize_query_df, _search_lancedb, hit_key_and_distance, is_hit_at_k
 
 
 @pytest.mark.parametrize(
@@ -27,3 +31,124 @@ def test_normalize_query_df_modes(match_mode: str, df: pd.DataFrame, expected: l
 )
 def test_is_hit_at_k_modes(match_mode: str, golden: str, retrieved: list[str], k: int, expected: bool) -> None:
     assert is_hit_at_k(golden, retrieved, k, match_mode=match_mode) is expected
+
+
+def test_hit_key_and_distance_supports_score() -> None:
+    hit = {
+        "metadata": '{"page_number": 4}',
+        "source": "/tmp/Doc_A.pdf",
+        "page_number": 4,
+        "_score": 0.87,
+    }
+    key, distance = hit_key_and_distance(hit)
+    assert key == "Doc_A_4"
+    assert distance == 0.87
+
+
+def test_hit_key_and_distance_supports_legacy_source_json() -> None:
+    hit = {
+        "metadata": '{"page_number": 7}',
+        "source": '{"source_id": "/tmp/Legacy.pdf"}',
+        "_distance": 0.12,
+    }
+    key, distance = hit_key_and_distance(hit)
+    assert key == "Legacy_7"
+    assert distance == 0.12
+
+
+class _FakeQuery:
+    def __init__(self, *, hybrid: bool, fail_score_select: bool = False) -> None:
+        self.hybrid = hybrid
+        self.fail_score_select = fail_score_select
+        self.selected_fields: list[str] | None = None
+
+    def vector(self, _vector):
+        return self
+
+    def text(self, _text: str):
+        return self
+
+    def nprobes(self, _n: int):
+        return self
+
+    def refine_factor(self, _factor: int):
+        return self
+
+    def select(self, fields: list[str]):
+        self.selected_fields = list(fields)
+        if self.fail_score_select and "_score" in fields:
+            raise RuntimeError("score select unsupported")
+        return self
+
+    def limit(self, _k: int):
+        return self
+
+    def rerank(self, _reranker):
+        return self
+
+    def to_list(self):
+        if self.hybrid:
+            return [{"text": "hello", "metadata": "{}", "source": "{}", "_score": 0.9}]
+        return [{"text": "hello", "metadata": "{}", "source": "{}", "_distance": 0.1}]
+
+
+class _FakeTable:
+    def __init__(self, *, fail_score_select: bool = False) -> None:
+        self.fail_score_select = fail_score_select
+        self.last_query: _FakeQuery | None = None
+
+    def list_indices(self):
+        return []
+
+    def search(self, *_args, **kwargs):
+        self.last_query = _FakeQuery(
+            hybrid=kwargs.get("query_type") == "hybrid",
+            fail_score_select=self.fail_score_select,
+        )
+        return self.last_query
+
+
+def _install_fake_lancedb(monkeypatch: pytest.MonkeyPatch, table: _FakeTable) -> None:
+    fake_db = SimpleNamespace(open_table=lambda _name: table)
+    lancedb_mod = ModuleType("lancedb")
+    lancedb_mod.connect = lambda _uri: fake_db  # type: ignore[attr-defined]
+    rerankers_mod = ModuleType("lancedb.rerankers")
+    rerankers_mod.RRFReranker = lambda: object()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "lancedb", lancedb_mod)
+    monkeypatch.setitem(sys.modules, "lancedb.rerankers", rerankers_mod)
+
+
+def test_search_lancedb_hybrid_selects_score_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    table = _FakeTable()
+    _install_fake_lancedb(monkeypatch, table)
+
+    hits = _search_lancedb(
+        lancedb_uri="/tmp/lancedb",
+        table_name="nv-ingest",
+        query_vectors=[[1.0, 2.0]],
+        top_k=5,
+        query_texts=["hello world"],
+        hybrid=True,
+    )
+
+    assert hits[0][0]["_score"] == 0.9
+    assert table.last_query is not None
+    assert table.last_query.selected_fields == ["text", "metadata", "source", "page_number", "_score"]
+
+
+def test_search_lancedb_hybrid_falls_back_without_score_select(monkeypatch: pytest.MonkeyPatch) -> None:
+    table = _FakeTable(fail_score_select=True)
+    _install_fake_lancedb(monkeypatch, table)
+
+    hits = _search_lancedb(
+        lancedb_uri="/tmp/lancedb",
+        table_name="nv-ingest",
+        query_vectors=[[1.0, 2.0]],
+        top_k=5,
+        query_texts=["hello world"],
+        hybrid=True,
+    )
+
+    assert hits[0][0]["_score"] == 0.9
+    assert table.last_query is not None
+    assert table.last_query.selected_fields == ["text", "metadata", "source", "page_number"]


### PR DESCRIPTION
## Description

This adds per-run extract and chunk dumps to the retriever harness and records where those artifacts were written. It also hardens the batch Ray/LanceDB path enough to validate the feature with full DGX runs.

- Save extract snapshots and pre-embed chunk manifests for each run
- Mirror observability artifacts to durable storage and surface paths in results.json
- Align batch runtime/LanceDB behavior and add full-run/test coverage

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
