### PR TITLE
(retriever) follow up markdown review

### DIFF
--- a/nemo_retriever/src/nemo_retriever/io/markdown.py
+++ b/nemo_retriever/src/nemo_retriever/io/markdown.py
@@ -59,11 +59,11 @@ def to_markdown_by_page(results: object) -> dict[int, str]:
     return rendered
 
 
-def to_markdown(results: object) -> str:
+def to_markdown(results: object) -> str | None:
     """Render a single document result as one markdown document."""
     pages = to_markdown_by_page(results)
     if not pages:
-        return f"# {_DOCUMENT_TITLE}\n\n_No content found._"
+        return None
     return f"# {_DOCUMENT_TITLE}\n\n" + "\n\n".join(pages.values())
 
 
@@ -109,6 +109,9 @@ def _records_from_mapping(results: Mapping[str, Any]) -> list[dict[str, Any]]:
     if _looks_like_record(results):
         return [dict(results)]
     raise ValueError("Markdown rendering expects a document row, row list, or saved results payload.")
+
+    # TODO(jioffe): Centralize retriever result-shape detection so helpers and
+    # actor outputs do not rely on duplicated key-based heuristics.
 
 
 def _looks_like_record(record: Mapping[str, Any]) -> bool:

--- a/nemo_retriever/tests/test_io_markdown.py
+++ b/nemo_retriever/tests/test_io_markdown.py
@@ -120,8 +120,8 @@ def test_to_markdown_reads_saved_records_wrapper(tmp_path: Path) -> None:
     assert "### Table 1" in markdown
 
 
-def test_to_markdown_empty_results_returns_placeholder() -> None:
-    assert to_markdown([]) == "# Extracted Content\n\n_No content found._"
+def test_to_markdown_empty_results_returns_none() -> None:
+    assert to_markdown([]) is None
 
 
 def test_to_markdown_rejects_multi_document_results() -> None:


### PR DESCRIPTION
## Description


- return None from to_markdown when no content is present
- add TODO to centralize result-shape detection heuristics



## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
