### PR TITLE
Kheiss/5963638

### DIFF
--- a/docs/docs/extraction/custom-metadata.md
+++ b/docs/docs/extraction/custom-metadata.md
@@ -60,7 +60,7 @@ For more information about the `Ingestor` class, see [Use the NeMo Retriever Lib
 For more information about the `vdb_upload` method, see [Upload Data](data-store.md).
 
 ```python
-from nemo_retriever.client import Ingestor
+from nv_ingest_client.client import Ingestor
 
 hostname="localhost"
 collection_name = "nemo_retriever_collection"
@@ -142,7 +142,7 @@ you can use the `content_metadata` field to filter search results.
 The following example uses a filter expression to narrow results by department.
 
 ```python
-from nemo_retriever.util.milvus import query
+from nv_ingest_client.util.vdb.milvus import nvingest_retrieval
 
 hostname="localhost"
 collection_name = "nemo_retriever_collection"
@@ -156,15 +156,15 @@ queries = ["this is expensive"]
 q_results = []
 for que in queries:
     q_results.append(
-        query(
-            [que], 
-            collection_name, 
-            milvus_uri=f"http://{hostname}:19530", 
-            embedding_endpoint=f"http://{hostname}:8012/v1",  
-            hybrid=sparse, 
-            top_k=top_k, 
-            model_name=model_name, 
-            gpu_search=False, 
+        nvingest_retrieval(
+            [que],
+            collection_name=collection_name,
+            milvus_uri=f"http://{hostname}:19530",
+            embedding_endpoint=f"http://{hostname}:8012/v1",
+            hybrid=sparse,
+            top_k=top_k,
+            model_name=model_name,
+            gpu_search=False,
             _filter=filter_expr
         )
     )

--- a/docs/docs/extraction/nimclient.md
+++ b/docs/docs/extraction/nimclient.md
@@ -12,7 +12,7 @@ The NimClient architecture consists of two main components:
 1. **NimClient**: The client class that handles communication with NIM endpoints via gRPC or HTTP protocols
 2. **ModelInterface**: An abstract base class that defines how to format input data, parse output responses, and process inference results for specific models
 
-For advanced usage patterns, see the existing model interfaces in `api/src/nemo_retriever/internal/primitives/nim/model_interface/`.
+For advanced usage patterns, see the existing model interfaces in `api/src/nv_ingest_api/internal/primitives/nim/model_interface/`.
 
 
 ## Quick Start
@@ -20,8 +20,8 @@ For advanced usage patterns, see the existing model interfaces in `api/src/nemo_
 ### Basic NimClient Creation
 
 ```python
-from nemo_retriever.util.nim import create_inference_client
-from nemo_retriever.internal.primitives.nim import ModelInterface
+from nv_ingest_api.util.nim import create_inference_client
+from nv_ingest_api.internal.primitives.nim import ModelInterface
 
 # Create a custom model interface (see examples below)
 model_interface = MyCustomModelInterface()
@@ -48,7 +48,7 @@ results = client.infer(data, model_name="your-model-name")
 
 ```python
 import os
-from nemo_retriever.util.nim import create_inference_client
+from nv_ingest_api.util.nim import create_inference_client
 
 # Use environment variables for configuration
 auth_token = os.getenv("NGC_API_KEY")
@@ -71,7 +71,7 @@ To integrate a new NIM, you need to create a custom `ModelInterface` subclass th
 ```python
 from typing import Dict, Any, List, Tuple, Optional
 import numpy as np
-from nemo_retriever.internal.primitives.nim import ModelInterface
+from nv_ingest_api.internal.primitives.nim import ModelInterface
 
 class MyCustomModelInterface(ModelInterface):
     """
@@ -305,7 +305,7 @@ class TextGenerationModelInterface(ModelInterface):
 
 ```python
 import base64
-from nemo_retriever.util.image_processing.transforms import numpy_to_base64
+from nv_ingest_api.util.image_processing.transforms import numpy_to_base64
 
 class ImageAnalysisModelInterface(ModelInterface):
     """Interface for image analysis NIMs (e.g., vision models)."""
@@ -382,8 +382,8 @@ class ImageAnalysisModelInterface(ModelInterface):
 ### Basic UDF with NimClient
 
 ```python
-from nemo_retriever.internal.primitives.control_message import IngestControlMessage
-from nemo_retriever.util.nim import create_inference_client
+from nv_ingest_api.internal.primitives.control_message import IngestControlMessage
+from nv_ingest_api.util.nim import create_inference_client
 import os
 
 def analyze_document_with_nim(control_message: IngestControlMessage) -> IngestControlMessage:
@@ -570,7 +570,7 @@ If memory issues persist, you can reduce the `NIM_TRITON_RATE_LIMIT` value — e
 import logging
 
 # Enable debug logging
-logging.getLogger("nemo_retriever.internal.primitives.nim").setLevel(logging.DEBUG)
+logging.getLogger("nv_ingest_api.internal.primitives.nim").setLevel(logging.DEBUG)
 
 # Test your model interface separately
 model_interface = MyCustomModelInterface()

--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -131,8 +131,8 @@ The following examples demonstrate how to extract text, charts, tables, and imag
 <a id="ingest_python_example"></a>
 ```python
 import logging, os, time
-from nemo_retriever.client import Ingestor, NemoRetrieverClient
-from nemo_retriever.util.process_json_files import ingest_json_results_to_blob
+from nv_ingest_client.client import Ingestor, NemoRetrieverClient
+from nv_ingest_client.util.process_json_files import ingest_json_results_to_blob
 client = NemoRetrieverClient(                                                                         
     message_client_port=7670,                                                               
     message_client_hostname="localhost"        

--- a/docs/docs/extraction/quickstart-library-mode.md
+++ b/docs/docs/extraction/quickstart-library-mode.md
@@ -81,16 +81,16 @@ On a 4 CPU core low end laptop, the following code should take about 10 seconds.
 ```python
 import time
 
-from nemo_retriever.framework.orchestration.ray.util.pipeline.pipeline_runners import run_pipeline
-from nemo_retriever.client import Ingestor, NemoRetrieverClient
-from nemo_retriever.util.message_brokers.simple_message_broker import SimpleClient
-from nemo_retriever.util.process_json_files import ingest_json_results_to_blob
+from nv_ingest.framework.orchestration.ray.util.pipeline.pipeline_runners import run_pipeline
+from nv_ingest_client.client import Ingestor, NemoRetrieverClient
+from nv_ingest_api.util.message_brokers.simple_message_broker import SimpleClient
+from nv_ingest_client.util.process_json_files import ingest_json_results_to_blob
 
 def main():
     # Start the pipeline subprocess for library mode
     run_pipeline(block=False, disable_dynamic_scaling=True, run_in_subprocess=True)
 
-    client = NvIngestClient(
+    client = NemoRetrieverClient(
         message_client_allocator=SimpleClient,
         message_client_port=7671,
         message_client_hostname="localhost",
@@ -190,7 +190,7 @@ To query for relevant snippets of the ingested content, and use them with an LLM
 ```python
 import os
 from openai import OpenAI
-from nemo_retriever.util.milvus import query
+from nv_ingest_client.util.vdb.milvus import nvingest_retrieval
 
 milvus_uri = "milvus.db"
 collection_name = "test"
@@ -198,16 +198,16 @@ sparse=False
 
 queries = ["Which animal is responsible for the typos?"]
 
-retrieved_docs = query(
+retrieved_docs = nvingest_retrieval(
     queries,
-    collection_name,
+    collection_name=collection_name,
     milvus_uri=milvus_uri,
     hybrid=sparse,
     top_k=1,
 )
 
 # simple generation example
-extract = retrieved_docs[0][0]["entity"]["text"]
+extract = retrieved_docs[0][0].get("entity", retrieved_docs[0][0]).get("text", "")
 client = OpenAI(
   base_url = "https://integrate.api.nvidia.com/v1",
   api_key = os.environ["NVIDIA_API_KEY"]
@@ -307,8 +307,8 @@ It listens for ingestion requests on port `7671` from an external client.
 import logging
 import os
 
-from nemo_retriever.framework.orchestration.ray.util.pipeline.pipeline_runners import run_pipeline
-from nemo_retriever.util.logging.configuration import configure_logging as configure_local_logging
+from nv_ingest.framework.orchestration.ray.util.pipeline.pipeline_runners import run_pipeline
+from nv_ingest_api.util.logging.configuration import configure_logging as configure_local_logging
 
 # Configure the logger
 logger = logging.getLogger(__name__)
@@ -353,11 +353,11 @@ import logging
 import os
 import time
 
-from nemo_retriever.framework.orchestration.ray.util.pipeline.pipeline_runners import run_pipeline
-from nemo_retriever.util.logging.configuration import configure_logging as configure_local_logging
-from nemo_retriever.util.message_brokers.simple_message_broker import SimpleClient
-from nemo_retriever.client import Ingestor
-from nemo_retriever.client import NemoRetrieverClient
+from nv_ingest.framework.orchestration.ray.util.pipeline.pipeline_runners import run_pipeline
+from nv_ingest_api.util.logging.configuration import configure_logging as configure_local_logging
+from nv_ingest_api.util.message_brokers.simple_message_broker import SimpleClient
+from nv_ingest_client.client import Ingestor
+from nv_ingest_client.client import NemoRetrieverClient
 
 # Configure the logger
 logger = logging.getLogger(__name__)
@@ -374,7 +374,7 @@ def run_ingestor():
     Set up and run the ingestion process to send traffic against the pipeline.
     """
     logger.info("Setting up Ingestor client...")
-    client = NvIngestClient(
+    client = NemoRetrieverClient(
         message_client_allocator=SimpleClient, message_client_port=7671, message_client_hostname="localhost"
     )
 

--- a/docs/docs/extraction/user-defined-functions.md
+++ b/docs/docs/extraction/user-defined-functions.md
@@ -16,7 +16,7 @@ This guide covers how to write, validate, and submit UDFs using both the CLI and
 Create a Python function that accepts an `IngestControlMessage` and returns a modified `IngestControlMessage`:
 
 ```python
-from nemo_retriever.internal.primitives.ingest_control_message import IngestControlMessage
+from nv_ingest_api.internal.primitives.ingest_control_message import IngestControlMessage
 
 def my_custom_processor(control_message: IngestControlMessage) -> IngestControlMessage:
     """Add custom metadata to all documents."""
@@ -77,7 +77,7 @@ nemo-retriever \
 ### 3. Submit via Python Client
 
 ```python
-from nemo_retriever.client.interface import Ingestor
+from nv_ingest_client.client import Ingestor
 
 # Create an Ingestor instance with default client
 ingestor = Ingestor()
@@ -461,9 +461,9 @@ NVIDIA Inference Microservices (NIMs) provide powerful AI capabilities that can 
 ### Quick NIM Integration
 
 ```python
-from nemo_retriever.internal.primitives.control_message import IngestControlMessage
-from nemo_retriever.util.nim import create_inference_client
-from nemo_retriever.internal.primitives.nim.model_interface.vlm import VLMModelInterface
+from nv_ingest_api.internal.primitives.control_message import IngestControlMessage
+from nv_ingest_api.util.nim import create_inference_client
+from nv_ingest_api.internal.primitives.nim.model_interface.vlm import VLMModelInterface
 import os
 
 def document_analysis_with_nim(control_message: IngestControlMessage) -> IngestControlMessage:
@@ -873,7 +873,7 @@ Test your UDF functions in isolation before deploying them to the pipeline:
 
 ```python
 import pandas as pd
-from nemo_retriever.internal.primitives.ingest_control_message import IngestControlMessage
+from nv_ingest_api.internal.primitives.ingest_control_message import IngestControlMessage
 
 def test_my_udf():
     # Create test data

--- a/docs/docs/extraction/user-defined-stages.md
+++ b/docs/docs/extraction/user-defined-stages.md
@@ -44,8 +44,8 @@ The following example demonstrates how to create a valid Lambda function and con
 ```python
 import pandas as pd
 from pydantic import BaseModel
-from nemo_retriever.internal.primitives.ingest_control_message import IngestControlMessage
-from nemo_retriever.internal.schemas.meta.metadata_schema import validate_metadata
+from nv_ingest_api.internal.primitives.ingest_control_message import IngestControlMessage
+from nv_ingest_api.internal.schemas.meta.metadata_schema import validate_metadata
 
 # Config schema for your stage
 class MyToyConfig(BaseModel):
@@ -166,7 +166,7 @@ After you change any metadata, you can validate it by using the `validate_metada
 as demonstrated in the following code example.
 
 ```python
-from nemo_retriever.internal.schemas.meta.metadata_schema import validate_metadata
+from nv_ingest_api.internal.schemas.meta.metadata_schema import validate_metadata
 
 def edit_metadata(control_message: IngestControlMessage, stage_config: MyToyConfig) -> IngestControlMessage:
   df = control_message.payload()
@@ -235,8 +235,8 @@ The  following example adds user-defined stages to your NeMo Retriever Library p
     ```python
     # my_pipeline/stages.py
     from pydantic import BaseModel
-    from nemo_retriever.internal.primitives.ingest_control_message import IngestControlMessage
-    from nemo_retriever.internal.schemas.meta.metadata_schema import validate_metadata
+    from nv_ingest_api.internal.primitives.ingest_control_message import IngestControlMessage
+    from nv_ingest_api.internal.schemas.meta.metadata_schema import validate_metadata
 
     class DoubleConfig(BaseModel):
     multiply_by: int = 2


### PR DESCRIPTION
# Fix for Bug 5963638: doc examples no longer use non-existent nemo_retriever.* submodules and instead use the real packages.

Impact – Before: examples failed on first import; after: they use the correct packages and run when deps are installed.

Import mapping table – Doc prefix → actual package → install name for all updated imports.

Per-file changes – For each of the six extraction docs:

Which imports were changed
Any API change (e.g. query → nvingest_retrieval, client class name, logger name).
Testing – Install nv-ingest / nv-ingest-api / nv-ingest-client and run the snippets to confirm no import errors.

Notes – Only code imports/callables were changed; log output, env names, and collection name strings were left as-is.

“Also on this branch” – The existing MkDocs nav and link fixes (invalid api-docs nav, default_pipeline.yaml link, content-metadata anchors) are summarized at the end so one PR description covers both the 5963638 fix and the build/link fixes.