### PR TITLE
Increase default Redis TTL to 48h to prevent job expiry during VLM captioning

### DIFF
--- a/src/nv_ingest/framework/util/service/impl/ingest/redis_ingest_service.py
+++ b/src/nv_ingest/framework/util/service/impl/ingest/redis_ingest_service.py
@@ -64,8 +64,8 @@ class RedisIngestService(IngestServiceMeta):
             redis_task_queue: str = os.getenv("REDIS_INGEST_TASK_QUEUE", "ingest_task_queue")
 
             fetch_mode: "FetchMode" = get_fetch_mode_from_env()
-            result_data_ttl: int = int(os.getenv("RESULT_DATA_TTL_SECONDS", "3600"))
-            state_ttl: int = int(os.getenv("STATE_TTL_SECONDS", "7200"))
+            result_data_ttl: int = int(os.getenv("RESULT_DATA_TTL_SECONDS", "172800"))
+            state_ttl: int = int(os.getenv("STATE_TTL_SECONDS", "172800"))
 
             cache_config: Dict[str, Any] = {
                 "directory": os.getenv("FETCH_CACHE_DIR", "./.fetch_cache"),


### PR DESCRIPTION
## Summary
- Increases default `STATE_TTL_SECONDS` from 7200s (2h) to 172800s (48h)
- Increases default `RESULT_DATA_TTL_SECONDS` from 3600s (1h) to 172800s (48h)
- Prevents job state expiry during long-running VLM captioning pipelines

## Problem
Large PDFs with VLM captioning enabled can take 2-22+ hours depending on hardware and document size. The Redis job state TTL is only refreshed on state transitions (e.g., `SUBMITTED`), but **not** during continuous processing within a stage. Since the caption stage is the longest phase and triggers no state transitions, the TTL countdown runs uninterrupted — causing the job state to expire before the client can fetch results.

The client receives `404: "Job ID not found or state has expired"` even though the pipeline completed successfully. This is data loss.

## Root Cause
`redis_ingest_service.py` lines 67-68: default TTL values of 1h/2h are too short for VLM workloads. The TTL acts as a static ceiling on total pipeline time with no heartbeat mechanism to refresh it during processing.

## Why 48 hours?
- Worst observed case: 22 hours (customer bug 5914605, H100/L40 with time-sliced GPUs)
- 48h provides 2x headroom over the worst case
- No impact on fast-completing jobs (results are fetched long before TTL matters)
- Negligible Redis memory cost for abandoned jobs (~100 bytes per key lingering longer)
- Users can still override via `STATE_TTL_SECONDS` and `RESULT_DATA_TTL_SECONDS` env vars

## Test plan
- [ ] Verify default TTL values are 172800 in `RedisIngestService.__init__`
- [ ] Verify env var overrides still work (`STATE_TTL_SECONDS=3600` should override the default)
- [ ] Run existing integration tests to confirm no regressions

Fixes: Customer bug 5914605

🤖 Generated with [Claude Code](https://claude.com/claude-code)