### PR TITLE
Kheiss/qa review2

### DIFF
--- a/docs/docs/extraction/audio.md
+++ b/docs/docs/extraction/audio.md
@@ -27,7 +27,7 @@ to transcribe speech to text, which is then embedded by using the Nemotron embed
 
 !!! important
 
-    Due to limitations in available VRAM controls in the current release, the RIVA ASR NIM microservice must run on a [dedicated additional GPU](support-matrix.md). For the full list of requirements, refer to [Support Matrix](https://docs.nvidia.com/deeplearning/riva/user-guide/docs/support-matrix.html).
+    Due to limitations in available VRAM controls in the current release, the RIVA ASR NIM microservice must run on a [dedicated additional GPU](support-matrix.md). For the full list of requirements, refer to [Support Matrix](https://docs.nvidia.com/deeplearning/riva/user-guide/docs/support-matrix/support-matrix.html).
 
 This pipeline enables users to retrieve speech files at the segment level.
 

--- a/docs/docs/extraction/prerequisites.md
+++ b/docs/docs/extraction/prerequisites.md
@@ -11,6 +11,7 @@ Before you begin using [NeMo Retriever Library](overview.md), ensure the followi
 ## Software Requirements
 
 - Linux operating systems (Ubuntu 22.04 or later recommended)
+- **Python 3.12 or later** (required for NeMo Retriever Library packages; see note below)
 - [Docker](https://docs.docker.com/engine/install/)
 - [Docker Compose](https://docs.docker.com/compose/install/)
 - [Docker Buildx](https://docs.docker.com/build/concepts/overview/#buildx) `>= 0.17` (Compose 2.40+ enforces this)
@@ -21,7 +22,7 @@ Before you begin using [NeMo Retriever Library](overview.md), ensure the followi
 
 !!! note
 
-    You install Python later.
+    Install **Python 3.12 or later** before creating your environment. Using Python 3.10 or 3.11 will cause dependency resolution failures when installing NeMo Retriever Library packages.
 
 
 

--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -82,6 +82,12 @@ h. Run the command `docker ps`. You should see output similar to the following. 
 
     ```
     CONTAINER ID  IMAGE                                            COMMAND                 CREATED         STATUS                  PORTS            NAMES
+    ...
+    ```
+
+To run the NeMo Retriever Library Python client from your host machine, **Python 3.12 or later is required**. Create a virtual environment and install the client packages:
+
+```shell
 uv venv --python 3.12 nv-ingest-dev
 source nv-ingest-dev/bin/activate
 uv pip install nv-ingest==26.1.2 nv-ingest-api==26.1.2 nv-ingest-client==26.1.2
@@ -89,7 +95,7 @@ uv pip install nv-ingest==26.1.2 nv-ingest-api==26.1.2 nv-ingest-client==26.1.2
 
 !!! tip
 
-    To confirm that you have activated your Conda environment, run `which pip` and `which python`, and confirm that you see `nemo_retriever` in the result. You can do this before any pip or python command that you run.
+    To confirm that you have activated your virtual environment, run `which pip` and `which python`, and confirm that you see `nemo_retriever` or your venv path in the result. You can do this before any pip or python command that you run.
 
 
 !!! note
@@ -459,7 +465,7 @@ docker compose \
 
 ## Specify MIG slices for NIM models
 
-When you deploy NeMo Retriever Library with NIM models on MIG‑enabled GPUs, MIG device slices are requested and scheduled through the `values.yaml` file for the corresponding NIM microservice. For IBM Content-Aware Storage (CAS) deployments, this allows NeMo Retriever Library NIM pods to land only on nodes that expose the desired MIG profiles [raw.githubusercontent](https://raw.githubusercontent.com/NVIDIA/NeMo-Retriever/main/helm/README.md%E2%80%8B).​
+When you deploy NeMo Retriever Library with NIM models on MIG‑enabled GPUs, MIG device slices are requested and scheduled through the `values.yaml` file for the corresponding NIM microservice. For IBM Content-Aware Storage (CAS) deployments, this allows NeMo Retriever Library NIM pods to land only on nodes that expose the desired MIG profiles [raw.githubusercontent](https://raw.githubusercontent.com/NVIDIA/NeMo-Retriever/main/helm/README.md).​
 
 To target a specific MIG profile—for example, a 3g.20gb slice on an A100, which is a hardware-partitioned virtual GPU instance that gives your workload a fixed mid-sized share of the A100’s compute plus 20 GB of dedicated GPU memory and behaves like a smaller independent GPU—for a given NIM, configure the `resources` and `nodeSelector` under that NIM’s values path in `values.yaml`.
 

--- a/docs/docs/extraction/support-matrix.md
+++ b/docs/docs/extraction/support-matrix.md
@@ -7,12 +7,17 @@ Before you begin using [NeMo Retriever Library](overview.md), ensure that you ha
     NVIDIA Ingest (nv-ingest) has been renamed to the NeMo Retriever Library.
 
 
+## Software Requirements
+
+- **Python**: 3.12 or later. The NeMo Retriever Library core and harness require Python 3.12+; the client supports Python 3.11+. Using Python 3.10 or earlier will cause dependency resolution failures. For details, see [Prerequisites](prerequisites.md).
+
+
 ## Core and Advanced Pipeline Features
 
 The NeMo Retriever Library core pipeline features run on a single A10G or better GPU. 
 The core pipeline features include the following:
 
-- llama3.2-nv-embedqa-1b-v2 — Embedding model for converting text chunks into vectors.
+- llama-nemotron-embed-1b-v2 — Embedding model for converting text chunks into vectors.
 - nemotron-page-elements-v3 — Detects and classifies images on a page as a table, chart or infographic.
 - nemotron-table-structure-v1 — Detects rows, columns, and cells within a table to preserve table structure and convert to Markdown format. 
 - nemotron-graphic-elements-v1 — Detects graphic elements within chart images such as titles, legends, axes, and numerical values. 

--- a/docs/docs/extraction/vlm-embed.md
+++ b/docs/docs/extraction/vlm-embed.md
@@ -1,6 +1,6 @@
 # Use Multimodal Embedding with NeMo Retriever Library
 
-This guide explains how to use the [NeMo Retriever Library](https://www.perplexity.ai/search/overview.md) with the multimodal embedding model [Llama Nemotron Embed VL 1B v2](https://build.nvidia.com/nvidia/llama-nemotron-embed-vl-1b-v2).
+This guide explains how to use the [NeMo Retriever Library](overview.md) with the multimodal embedding model [Llama Nemotron Embed VL 1B v2](https://build.nvidia.com/nvidia/llama-nemotron-embed-vl-1b-v2).
 
 The `Llama Nemotron Embed VL 1B v2` model is optimized for multimodal question-answering and retrieval tasks.
 It can embed documents as text, images, or paired text-image combinations.


### PR DESCRIPTION
**Branch:** `kheiss/qa-review2`  
**Purpose:** Address open documentation bugs: prerequisite and URL corrections, Support Matrix and VLM link fixes, and MkDocs build/link fixes.

---

## Summary

This PR addresses documentation bugs in the extraction docs and MkDocs setup:

1. **“Addressing open documentation bugs” (commit 317e7cf6)** — Prerequisites (Python 3.12+), Support Matrix URL and embedding model name, quickstart venv/MIG link fixes, VLM overview link.
2. **MkDocs build and link fixes** — Remove invalid nav entry, fix broken links and anchors so `mkdocs build` completes cleanly.

---

## 1. Addressing open documentation bugs (commit 317e7cf6)

- **docs/docs/extraction/audio.md** — Corrected RIVA Support Matrix URL to `support-matrix/support-matrix.html`.
- **docs/docs/extraction/prerequisites.md** — Added Python 3.12+ to software requirements; clarified note that Python must be installed before creating the environment and that 3.10/3.11 cause dependency resolution failures.
- **docs/docs/extraction/quickstart-guide.md** — Added Python 3.12+ requirement before venv commands; updated tip from Conda to virtual environment; fixed MIG `raw.githubusercontent` link (removed errant character).
- **docs/docs/extraction/support-matrix.md** — Added “Software Requirements” section with Python 3.12+; updated embedding model name from `llama3.2-nv-embedqa-1b-v2` to `llama-nemotron-embed-1b-v2`.
- **docs/docs/extraction/vlm-embed.md** — Fixed NeMo Retriever Library link from external search URL to `overview.md`.

---

## 2. MkDocs build and link fixes

- **Navigation (`docs/mkdocs.yml`):** Removed invalid nav entry `API Reference: extraction/api-docs` (path does not exist).  
  **Optional (Bug 5966354):** If merging nav fixes for CLI/API reference pages, ensure “Use the CLI” → `extraction/cli-reference.md` and “Use the API” → `extraction/python-api-reference.md`, with redirects from `nv-ingest_cli.md` and `nv-ingest-python-api.md` (may already be present in your working tree).
- **Links:** In `user-defined-functions.md`, replaced broken relative link to `config/default_pipeline.yaml` with a GitHub URL. In `content-metadata.md`, added explicit fragment IDs for in-page anchors (`#nearbyobjectsschema`, `#errormetadataschema`, `#infomessagemetadataschema`).
- **Result:** `mkdocs build -f docs/mkdocs.yml` completes without the reported nav/link warnings.

---

## Files changed

| Area | Files |
|------|--------|
| **Docs (extraction)** | audio.md, prerequisites.md, quickstart-guide.md, support-matrix.md, vlm-embed.md |
| **Docs (config)** | mkdocs.yml (nav/redirects as noted above) |