### PR TITLE
(retrieval-bench) Improve pipeline performance and modality handling

### DIFF
--- a/retrieval-bench/README.md
+++ b/retrieval-bench/README.md
@@ -65,7 +65,7 @@ Backend-specific overrides can be passed via `--pipeline-args` JSON:
 retrieval-bench evaluate dense-retrieval \
   --dataset-name bright/biology \
   --backend llama-nv-embed-reasoning-3b \
-  --pipeline-args '{"model_id":"~/checkpoints/my_model","scoring_batch_size":2048}'
+  --pipeline-args '{"model_id":"~/checkpoints/my_model","max_scoring_batch_size":2048}'
 ```
 
 ## Agentic retrieval

--- a/retrieval-bench/src/retrieval_bench/pipelines/backends.py
+++ b/retrieval-bench/src/retrieval_bench/pipelines/backends.py
@@ -41,8 +41,7 @@ _BACKEND_DEFAULTS: Dict[str, Dict[str, Any]] = {
         "pooling": "mean",
         "score_scale": 100.0,
         "corpus_batch_size": 1,
-        "scoring_batch_size": 4096,
-        "preload_corpus_to_gpu": False,
+        "max_scoring_batch_size": 4096,
         "query_prefix_fallback": (
             "Instruct: Given the following post, retrieve relevant passages that help answer the post.\nQuery:"
         ),
@@ -51,8 +50,7 @@ _BACKEND_DEFAULTS: Dict[str, Dict[str, Any]] = {
         "model_id": "nvidia/llama-nemoretriever-colembed-3b-v1",
         "batch_size": 32,
         "corpus_batch_size": 32,
-        "corpus_chunk_size": 256,
-        "preload_corpus_to_gpu": True,
+        "max_scoring_batch_size": 256,
     },
     "llama-nemotron-embed-vl-1b-v2": {
         "model_id": "nvidia/llama-nemotron-embed-vl-1b-v2",
@@ -60,17 +58,16 @@ _BACKEND_DEFAULTS: Dict[str, Dict[str, Any]] = {
         "doc_modality": "image_text",
         "doc_max_length": "auto",
         "query_max_length": 10240,
-        "corpus_batch_size": 4,
-        "corpus_chunk_size": 4096,
-        "preload_corpus_to_gpu": False,
+        "corpus_batch_size": 32,
+        "max_scoring_batch_size": 4096,
         "max_input_tiles": 6,
         "use_thumbnail": True,
     },
     "nemotron-colembed-vl-8b-v2": {
         "model_id": "nvidia/nemotron-colembed-vl-8b-v2",
-        "corpus_batch_size": 8,
-        "corpus_chunk_size": 256,
-        "preload_corpus_to_gpu": False,
+        "corpus_batch_size": 32,
+        "max_scoring_batch_size": 3000,
+        "scoring_chunk_size": 1311,
         "max_input_tiles": 8,
         "use_thumbnail": True,
         "cache_dir": "cache/nemotron_colembed_vl_v2",
@@ -170,8 +167,10 @@ def init_backend(
         max_length = int(cfg.pop("max_length", 8192))
         score_scale = float(cfg.pop("score_scale", 100.0))
         corpus_batch_size = int(cfg.pop("corpus_batch_size", 1))
-        scoring_batch_size = int(cfg.pop("scoring_batch_size", 4096))
-        preload_corpus_to_gpu = bool(cfg.pop("preload_corpus_to_gpu", False))
+        max_scoring_batch_size = int(cfg.pop("max_scoring_batch_size", 4096))
+
+        if cfg:
+            raise ValueError(f"Unknown pipeline arg(s) for backend {backend!r}: {', '.join(sorted(cfg))}")
 
         retriever.init(
             dataset_name=dataset_name,
@@ -188,9 +187,8 @@ def init_backend(
             score_scale=score_scale,
             batch_size=1,
             corpus_batch_size=corpus_batch_size,
-            scoring_batch_size=scoring_batch_size,
+            max_scoring_batch_size=max_scoring_batch_size,
             cache_dir="cache/hf_dense",
-            preload_corpus_to_gpu=preload_corpus_to_gpu,
         )
         init_info.update(
             {
@@ -208,8 +206,10 @@ def init_backend(
     elif backend == "llama-nemoretriever-colembed-3b-v1":
         batch_size = int(cfg.pop("batch_size", 32))
         corpus_batch_size = int(cfg.pop("corpus_batch_size", 32))
-        corpus_chunk_size = int(cfg.pop("corpus_chunk_size", 256))
-        preload_corpus_to_gpu = bool(cfg.pop("preload_corpus_to_gpu", True))
+        max_scoring_batch_size = int(cfg.pop("max_scoring_batch_size", 256))
+
+        if cfg:
+            raise ValueError(f"Unknown pipeline arg(s) for backend {backend!r}: {', '.join(sorted(cfg))}")
 
         retriever.init(
             dataset_name=dataset_name,
@@ -219,9 +219,8 @@ def init_backend(
             top_k=top_k,
             batch_size=batch_size,
             corpus_batch_size=corpus_batch_size,
-            corpus_chunk_size=corpus_chunk_size,
+            max_scoring_batch_size=max_scoring_batch_size,
             cache_dir="cache",
-            preload_corpus_to_gpu=preload_corpus_to_gpu,
         )
         init_info.update({"model_id": model_id})
         return retriever, model_id, init_info
@@ -233,15 +232,17 @@ def init_backend(
 
         # Auto-detect: fall back to text-only when the corpus has no images
         # (e.g. BRIGHT text-only datasets).
-        if doc_modality != "text" and not any("image" in doc for doc in corpus[:5]):
+        if doc_modality != "text" and not any(doc.get("image") is not None for doc in corpus[:5]):
             doc_modality = "text"
 
         query_max_length = int(cfg.pop("query_max_length", 10240))
         corpus_batch_size = int(cfg.pop("corpus_batch_size", 4))
-        corpus_chunk_size = int(cfg.pop("corpus_chunk_size", 4096))
-        preload_corpus_to_gpu = bool(cfg.pop("preload_corpus_to_gpu", False))
+        max_scoring_batch_size = int(cfg.pop("max_scoring_batch_size", 4096))
         max_input_tiles = int(cfg.pop("max_input_tiles", 6))
         use_thumbnail = bool(cfg.pop("use_thumbnail", True))
+
+        if cfg:
+            raise ValueError(f"Unknown pipeline arg(s) for backend {backend!r}: {', '.join(sorted(cfg))}")
 
         retriever.init(
             dataset_name=dataset_name,
@@ -254,9 +255,8 @@ def init_backend(
             doc_max_length=doc_max_length,
             query_max_length=query_max_length,
             corpus_batch_size=corpus_batch_size,
-            corpus_chunk_size=corpus_chunk_size,
+            max_scoring_batch_size=max_scoring_batch_size,
             cache_dir="cache/nemotron_vl_dense",
-            preload_corpus_to_gpu=preload_corpus_to_gpu,
             max_input_tiles=max_input_tiles,
             use_thumbnail=use_thumbnail,
         )
@@ -270,20 +270,22 @@ def init_backend(
                 "max_input_tiles": max_input_tiles,
                 "use_thumbnail": use_thumbnail,
                 "corpus_batch_size": corpus_batch_size,
-                "corpus_chunk_size": corpus_chunk_size,
-                "preload_corpus_to_gpu": preload_corpus_to_gpu,
+                "max_scoring_batch_size": max_scoring_batch_size,
             }
         )
         active = _NemotronEmbedVLAdapter(retriever)
         return active, model_id, init_info
 
     else:  # nemotron-colembed-vl-8b-v2
-        corpus_batch_size = int(cfg.pop("corpus_batch_size", 8))
-        corpus_chunk_size = int(cfg.pop("corpus_chunk_size", 256))
-        preload_corpus_to_gpu = bool(cfg.pop("preload_corpus_to_gpu", False))
+        corpus_batch_size = int(cfg.pop("corpus_batch_size", 32))
+        max_scoring_batch_size = int(cfg.pop("max_scoring_batch_size", 3000))
+        scoring_chunk_size = int(cfg.pop("scoring_chunk_size", 1311))
         max_input_tiles = int(cfg.pop("max_input_tiles", 8))
         use_thumbnail = bool(cfg.pop("use_thumbnail", True))
         cache_dir = str(cfg.pop("cache_dir", "cache/nemotron_colembed_vl_v2"))
+
+        if cfg:
+            raise ValueError(f"Unknown pipeline arg(s) for backend {backend!r}: {', '.join(sorted(cfg))}")
 
         retriever.init(
             dataset_name=str(dataset_name),
@@ -293,9 +295,9 @@ def init_backend(
             device="cuda",
             top_k=top_k,
             corpus_batch_size=corpus_batch_size,
-            corpus_chunk_size=corpus_chunk_size,
+            max_scoring_batch_size=max_scoring_batch_size,
+            scoring_chunk_size=scoring_chunk_size,
             cache_dir=cache_dir,
-            preload_corpus_to_gpu=preload_corpus_to_gpu,
             max_input_tiles=max_input_tiles,
             use_thumbnail=use_thumbnail,
         )

--- a/retrieval-bench/src/retrieval_bench/singletons/colembed_retriever.py
+++ b/retrieval-bench/src/retrieval_bench/singletons/colembed_retriever.py
@@ -34,8 +34,6 @@ except ImportError as e:  # pragma: no cover
         "Please install at least: torch (and for actual retrieval: transformers, optionally flash-attn)."
     ) from e
 
-from retrieval_bench.singletons._shared import try_preload_corpus_to_gpu as _try_preload_corpus_to_gpu
-
 
 class _ColEmbedState:
     def __init__(
@@ -43,7 +41,7 @@ class _ColEmbedState:
         *,
         model_id: str,
         device: str,
-        corpus_chunk_size: int,
+        max_scoring_batch_size: int,
         batch_size: int,
         corpus_batch_size: int,
         top_k: int,
@@ -51,7 +49,7 @@ class _ColEmbedState:
     ) -> None:
         self.model_id = model_id
         self.device = device
-        self.corpus_chunk_size = corpus_chunk_size
+        self.max_scoring_batch_size = max_scoring_batch_size
         self.batch_size = batch_size
         self.corpus_batch_size = corpus_batch_size
         self.top_k = top_k
@@ -149,6 +147,8 @@ class _ColEmbedState:
                 return emb
             except Exception:
                 logger.debug("Cache load failed for %s, recomputing", cache_path, exc_info=True)
+                # fall through to recompute
+                pass
 
         t0 = time.time()
         emb = self._embed_corpus_batched(corpus)
@@ -160,58 +160,60 @@ class _ColEmbedState:
         return emb
 
     def _embed_query(self, query: str) -> torch.Tensor:
-        # Returns CPU tensor [seq_len, embed_dim]
         with torch.no_grad():
-            q_emb = self.model.forward_queries([query], batch_size=1).cpu()
-        return q_emb[0]  # [seq_len, dim]
+            q_emb = self.model.forward_queries([query], batch_size=1).detach()
+        return q_emb[0].to(self.device)  # [seq_len, dim] on GPU
 
-    def _score_query(self, query_embedding_cpu: torch.Tensor) -> torch.Tensor:
-        if self.corpus_embeddings_cpu is None:
-            raise RuntimeError("corpus_embeddings_cpu is not set; call init() first")
+    def _score_query(self, query_embedding: torch.Tensor) -> torch.Tensor:
+        emb_gpu = self.corpus_embeddings_gpu
+        emb_cpu = self.corpus_embeddings_cpu
+        if emb_gpu is None and emb_cpu is None:
+            raise RuntimeError("No corpus embeddings available.")
 
-        num_corpus = self.corpus_embeddings_cpu.shape[0]
-        scores_cpu = torch.empty(num_corpus, dtype=torch.float32, device="cpu")
-        chunk = self.corpus_chunk_size
+        num_corpus = (emb_gpu if emb_gpu is not None else emb_cpu).shape[0]
         device = self.device
+        scores = torch.empty(num_corpus, dtype=torch.float32, device=device)
+
+        chunk = max(1, int(self.max_scoring_batch_size))
 
         with torch.no_grad():
-            q_gpu = query_embedding_cpu.to(device, non_blocking=True)  # [q_seq, dim]
-            q_t = q_gpu.transpose(0, 1)  # [dim, q_seq]
+            q_t = query_embedding.transpose(0, 1)  # [dim, q_seq]
 
             for c_start in range(0, num_corpus, chunk):
                 c_end = min(c_start + chunk, num_corpus)
-
-                if self.corpus_embeddings_gpu is not None:
-                    c_gpu = self.corpus_embeddings_gpu[c_start:c_end]
-                else:
-                    c_gpu = self.corpus_embeddings_cpu[c_start:c_end].to(device, non_blocking=True)
-
-                token_sims = torch.matmul(c_gpu, q_t)  # [chunk, c_seq, q_seq]
+                c_chunk = emb_gpu[c_start:c_end] if emb_gpu is not None else emb_cpu[c_start:c_end].to(device)
+                token_sims = torch.matmul(c_chunk, q_t)  # [chunk, c_seq, q_seq]
                 chunk_scores = token_sims.max(dim=1).values.float().sum(dim=1)  # [chunk]
-                scores_cpu[c_start:c_end] = chunk_scores.cpu()
+                scores[c_start:c_end] = chunk_scores
 
-        return scores_cpu
+        return scores
 
     def retrieve_one(
         self, query: str, *, return_markdown: bool = False
     ) -> Union[Dict[str, float], Tuple[Dict[str, float], Dict[str, str]]]:
-        if self.corpus_ids is None or self.corpus_embeddings_cpu is None or self.corpus_markdown is None:
+        if (
+            self.corpus_ids is None
+            or (self.corpus_embeddings_gpu is None and self.corpus_embeddings_cpu is None)
+            or self.corpus_markdown is None
+        ):
             raise RuntimeError("Retriever not initialized. Call retriever.init(...) first.")
 
-        query_embedding_cpu = self._embed_query(query)
-        scores_cpu = self._score_query(query_embedding_cpu)
+        q_emb = self._embed_query(query)
+        scores = self._score_query(q_emb)
 
         k = min(self.top_k, len(self.corpus_ids))
-        topk_scores, topk_indices = torch.topk(scores_cpu, k)
+        topk_scores, topk_indices = torch.topk(scores, k)
 
         corpus_ids = self.corpus_ids
-        run = {corpus_ids[int(idx)]: float(score) for idx, score in zip(topk_indices.tolist(), topk_scores.tolist())}
+        topk_indices_cpu = topk_indices.cpu().tolist()
+        topk_scores_cpu = topk_scores.cpu().tolist()
+        run = {corpus_ids[int(idx)]: float(score) for idx, score in zip(topk_indices_cpu, topk_scores_cpu)}
 
         if not return_markdown:
             return run
 
         corpus_markdown = self.corpus_markdown
-        markdown_by_id = {corpus_ids[int(idx)]: corpus_markdown[int(idx)] for idx in topk_indices.tolist()}
+        markdown_by_id = {corpus_ids[int(idx)]: corpus_markdown[int(idx)] for idx in topk_indices_cpu}
         return run, markdown_by_id
 
 
@@ -238,9 +240,8 @@ class ColEmbedSingletonRetriever:
         top_k: int = 100,
         batch_size: int = 32,
         corpus_batch_size: int = 32,
-        corpus_chunk_size: int = 256,
+        max_scoring_batch_size: int = 256,
         cache_dir: str | Path = "cache",
-        preload_corpus_to_gpu: bool = True,
     ) -> None:
         """
         Initialize (or re-initialize) the singleton for a given dataset/corpus.
@@ -259,7 +260,7 @@ class ColEmbedSingletonRetriever:
                 self._state = _ColEmbedState(
                     model_id=model_id,
                     device=device,
-                    corpus_chunk_size=corpus_chunk_size,
+                    max_scoring_batch_size=max_scoring_batch_size,
                     batch_size=batch_size,
                     corpus_batch_size=corpus_batch_size,
                     top_k=top_k,
@@ -270,7 +271,7 @@ class ColEmbedSingletonRetriever:
                 self._state.top_k = top_k
                 self._state.batch_size = batch_size
                 self._state.corpus_batch_size = corpus_batch_size
-                self._state.corpus_chunk_size = corpus_chunk_size
+                self._state.max_scoring_batch_size = max_scoring_batch_size
                 self._state.cache_dir = cache_dir
 
             # If already initialized for the same dataset with same corpus_ids length, keep as-is.
@@ -294,12 +295,9 @@ class ColEmbedSingletonRetriever:
             self._state.corpus_markdown = corpus_markdown
             self._state.corpus_embeddings_cpu = corpus_embeddings_cpu
 
-            # Optional preload to GPU for faster repeated retrieval.
             self._state.corpus_embeddings_gpu = None
-            if preload_corpus_to_gpu:
-                self._state.corpus_embeddings_gpu = _try_preload_corpus_to_gpu(
-                    corpus_embeddings_cpu, self._state.device
-                )
+            if corpus_embeddings_cpu.shape[0] <= self._state.max_scoring_batch_size:
+                self._state.corpus_embeddings_gpu = corpus_embeddings_cpu.to(self._state.device)
 
     def retrieve(
         self, query: str, *, return_markdown: bool = False

--- a/retrieval-bench/src/retrieval_bench/singletons/hf_dense_retriever.py
+++ b/retrieval-bench/src/retrieval_bench/singletons/hf_dense_retriever.py
@@ -39,9 +39,18 @@ try:
 except ImportError as e:  # pragma: no cover
     raise ImportError("Required dependencies not installed for HF dense retriever. Install: torch") from e
 
-from retrieval_bench.singletons._shared import hash_corpus_ids10 as _hash_corpus_ids10
-from retrieval_bench.singletons._shared import slugify as _slugify
-from retrieval_bench.singletons._shared import try_preload_corpus_to_gpu as _try_preload_corpus_to_gpu
+
+def _hash_corpus_ids10(corpus_ids: Sequence[str]) -> str:
+    h = hashlib.sha256()
+    for cid in corpus_ids:
+        h.update(str(cid).encode("utf-8"))
+        h.update(b"\n")
+    return h.hexdigest()[:10]
+
+
+def _slugify(value: str) -> str:
+    v = (value or "").strip().replace("/", "__")
+    return v or "unnamed"
 
 
 def _last_token_pool(last_hidden_states: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
@@ -139,7 +148,7 @@ class _HfDenseState:
         score_scale: float,
         batch_size: int,
         corpus_batch_size: int,
-        scoring_batch_size: int,
+        max_scoring_batch_size: int,
         top_k: int,
         cache_dir: Path,
     ) -> None:
@@ -153,7 +162,7 @@ class _HfDenseState:
         self.score_scale = float(score_scale)
         self.batch_size = int(batch_size)
         self.corpus_batch_size = int(corpus_batch_size)
-        self.scoring_batch_size = int(scoring_batch_size)
+        self.max_scoring_batch_size = int(max_scoring_batch_size)
         self.top_k = int(top_k)
         self.cache_dir = cache_dir
 
@@ -322,6 +331,7 @@ class _HfDenseState:
                 return emb
             except Exception:
                 logger.debug("Cache load failed for %s, recomputing", emb_path, exc_info=True)
+                pass
 
         # Build from scratch.
         emb_path.parent.mkdir(parents=True, exist_ok=True)
@@ -345,36 +355,40 @@ class _HfDenseState:
             q = str(self.query_prefix) + str(query_text)
         else:
             q = _wrap_instruct(self.task_description, str(query_text))
-        emb = self._embed_texts_batched([q], batch_size=1)
-        if emb.ndim != 2 or emb.shape[0] != 1:
-            raise RuntimeError(f"Unexpected query embedding shape: {tuple(emb.shape)}")
-        return emb[0]  # [dim] on CPU
 
-    def score_query(self, query_embedding_cpu: torch.Tensor) -> torch.Tensor:
-        if self.corpus_embeddings_cpu is None:
-            raise RuntimeError("corpus_embeddings_cpu is not set; call init() first")
-        num_docs = self.corpus_embeddings_cpu.shape[0]
-        scores_cpu = torch.empty((num_docs,), dtype=torch.float32, device="cpu")
+        with torch.no_grad():
+            batch = self._tokenize([q])
+            outputs = self.model(**batch)
+            pooled = self._pool(outputs.last_hidden_state, batch["attention_mask"])
+            mode = str(self.pooling or "last_token").strip().lower()
+            if mode not in ("mean", "avg", "average"):
+                pooled = F.normalize(pooled, p=2, dim=1)
 
-        chunk = max(1, int(self.scoring_batch_size))
+        return pooled[0].detach()  # [dim], stays on GPU
+
+    def score_query(self, query_embedding: torch.Tensor) -> torch.Tensor:
+        emb_gpu = self.corpus_embeddings_gpu
+        emb_cpu = self.corpus_embeddings_cpu
+        if emb_gpu is None and emb_cpu is None:
+            raise RuntimeError("No corpus embeddings available.")
+
+        num_docs = (emb_gpu if emb_gpu is not None else emb_cpu).shape[0]
+        device = str(self.device)
+        scores = torch.empty((num_docs,), dtype=torch.float32, device=device)
+
+        chunk = max(1, int(self.max_scoring_batch_size))
         scale = float(self.score_scale)
 
         with torch.no_grad():
-            q_gpu = query_embedding_cpu.to(self.device, non_blocking=True)  # [dim]
-            q_gpu = q_gpu.unsqueeze(1)  # [dim, 1]
+            q_col = query_embedding.unsqueeze(1)  # [dim, 1]
 
             for c_start in range(0, num_docs, chunk):
                 c_end = min(c_start + chunk, num_docs)
-                if self.corpus_embeddings_gpu is not None:
-                    c_gpu = self.corpus_embeddings_gpu[c_start:c_end]
-                else:
-                    c_gpu = self.corpus_embeddings_cpu[c_start:c_end].to(self.device, non_blocking=True)
+                c_chunk = emb_gpu[c_start:c_end] if emb_gpu is not None else emb_cpu[c_start:c_end].to(device)
+                chunk_scores = torch.matmul(c_chunk, q_col).squeeze(1).float() * scale
+                scores[c_start:c_end] = chunk_scores
 
-                # [chunk, dim] @ [dim, 1] -> [chunk, 1]
-                chunk_scores = torch.matmul(c_gpu, q_gpu).squeeze(1).float() * scale
-                scores_cpu[c_start:c_end] = chunk_scores.to("cpu")
-
-        return scores_cpu
+        return scores
 
     def retrieve_one(
         self,
@@ -383,38 +397,40 @@ class _HfDenseState:
         return_markdown: bool = False,
         excluded_ids: Optional[Sequence[str]] = None,
     ) -> Union[Dict[str, float], Tuple[Dict[str, float], Dict[str, str]]]:
-        if self.corpus_ids is None or self.corpus_embeddings_cpu is None or self.corpus_markdown is None:
+        if (
+            self.corpus_ids is None
+            or (self.corpus_embeddings_gpu is None and self.corpus_embeddings_cpu is None)
+            or self.corpus_markdown is None
+        ):
             raise RuntimeError("Retriever not initialized. Call retriever.init(...) first.")
 
-        q_emb_cpu = self.embed_query(query)
-        scores_cpu = self.score_query(q_emb_cpu)
+        q_emb = self.embed_query(query)
+        scores = self.score_query(q_emb)
 
-        # Apply per-query excluded ids BEFORE top-k selection (BRIGHT semantics).
-        # This prevents excluded docs from "stealing" slots in top-k.
         if excluded_ids and self.corpus_id_to_idx:
+            excluded_indices = []
             for did in set(str(x) for x in excluded_ids):
                 if did == "N/A":
                     continue
                 idx = self.corpus_id_to_idx.get(did, None)
-                if idx is None:
-                    continue
-                try:
-                    scores_cpu[int(idx)] = float("-inf")
-                except Exception:
-                    # Ignore malformed indices; keep scoring robust.
-                    pass
+                if idx is not None:
+                    excluded_indices.append(int(idx))
+            if excluded_indices:
+                scores[torch.tensor(excluded_indices, device=scores.device)] = float("-inf")
 
         k = min(int(self.top_k), len(self.corpus_ids))
-        topk_scores, topk_indices = torch.topk(scores_cpu, k)
+        topk_scores, topk_indices = torch.topk(scores, k)
 
         ids = self.corpus_ids
-        run = {ids[int(idx)]: float(score) for idx, score in zip(topk_indices.tolist(), topk_scores.tolist())}
+        topk_indices_cpu = topk_indices.cpu().tolist()
+        topk_scores_cpu = topk_scores.cpu().tolist()
+        run = {ids[int(idx)]: float(score) for idx, score in zip(topk_indices_cpu, topk_scores_cpu)}
 
         if not return_markdown:
             return run
 
         md = self.corpus_markdown
-        markdown_by_id = {ids[int(idx)]: md[int(idx)] for idx in topk_indices.tolist()}
+        markdown_by_id = {ids[int(idx)]: md[int(idx)] for idx in topk_indices_cpu}
         return run, markdown_by_id
 
 
@@ -444,9 +460,8 @@ class HfDenseSingletonRetriever:
         score_scale: float = 100.0,
         batch_size: int = 1,
         corpus_batch_size: int = 1,
-        scoring_batch_size: int = 4096,
+        max_scoring_batch_size: int = 4096,
         cache_dir: str | Path = "cache/hf_dense",
-        preload_corpus_to_gpu: bool = False,
     ) -> None:
         """
         Initialize (or re-initialize) the singleton for a given dataset/corpus.
@@ -476,7 +491,7 @@ class HfDenseSingletonRetriever:
                     score_scale=float(score_scale),
                     batch_size=int(batch_size),
                     corpus_batch_size=int(corpus_batch_size),
-                    scoring_batch_size=int(scoring_batch_size),
+                    max_scoring_batch_size=int(max_scoring_batch_size),
                     top_k=int(top_k),
                     cache_dir=cache_dir,
                 )
@@ -485,7 +500,7 @@ class HfDenseSingletonRetriever:
                 self._state.top_k = int(top_k)
                 self._state.batch_size = int(batch_size)
                 self._state.corpus_batch_size = int(corpus_batch_size)
-                self._state.scoring_batch_size = int(scoring_batch_size)
+                self._state.max_scoring_batch_size = int(max_scoring_batch_size)
                 self._state.cache_dir = cache_dir
                 self._state.task_description = str(task_description)
                 self._state.query_prefix = str(query_prefix) if isinstance(query_prefix, str) else None
@@ -502,12 +517,10 @@ class HfDenseSingletonRetriever:
                 and _hash_corpus_ids10(self._state.corpus_ids) == corpus_ids_hash10
                 and self._state.corpus_embeddings_cpu is not None
             ):
-                # Already initialized for the same corpus; only (possibly) update GPU preload.
-                if preload_corpus_to_gpu and self._state.corpus_embeddings_gpu is None:
-                    self._state.corpus_embeddings_gpu = _try_preload_corpus_to_gpu(
-                        self._state.corpus_embeddings_cpu, self._state.device
-                    )
-                if (not preload_corpus_to_gpu) and self._state.corpus_embeddings_gpu is not None:
+                should_be_on_gpu = len(corpus_ids_list) <= self._state.max_scoring_batch_size
+                if should_be_on_gpu and self._state.corpus_embeddings_gpu is None:
+                    self._state.corpus_embeddings_gpu = self._state.corpus_embeddings_cpu.to(self._state.device)
+                if (not should_be_on_gpu) and self._state.corpus_embeddings_gpu is not None:
                     self._state.corpus_embeddings_gpu = None
                 return
 
@@ -524,8 +537,8 @@ class HfDenseSingletonRetriever:
             self._state.corpus_embeddings_cpu = emb_cpu
 
             self._state.corpus_embeddings_gpu = None
-            if preload_corpus_to_gpu:
-                self._state.corpus_embeddings_gpu = _try_preload_corpus_to_gpu(emb_cpu, self._state.device)
+            if emb_cpu.shape[0] <= self._state.max_scoring_batch_size:
+                self._state.corpus_embeddings_gpu = emb_cpu.to(self._state.device)
 
     def retrieve(
         self, query: str, *, return_markdown: bool = False, excluded_ids: Optional[Sequence[str]] = None

--- a/retrieval-bench/src/retrieval_bench/singletons/nemotron_colembed_vl_v2_retriever.py
+++ b/retrieval-bench/src/retrieval_bench/singletons/nemotron_colembed_vl_v2_retriever.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import math
 import os
 import time
 import threading
@@ -38,8 +39,6 @@ except ImportError as e:  # pragma: no cover
         "Required dependencies not installed for Nemotron ColEmbed-VL v2 retriever. "
         "Please install at least: torch (and for actual retrieval: transformers, optionally flash-attn)."
     ) from e
-
-from retrieval_bench.singletons._shared import try_preload_corpus_to_gpu as _try_preload_corpus_to_gpu
 
 
 def _set_tiling_knobs_if_present(model: Any, *, max_input_tiles: int, use_thumbnail: bool) -> None:
@@ -74,13 +73,21 @@ def _set_tiling_knobs_if_present(model: Any, *, max_input_tiles: int, use_thumbn
             pass
 
 
+def _balanced_chunk_size(num_items: int, max_chunk: int) -> int:
+    if num_items <= max_chunk:
+        return num_items
+    k = math.ceil(num_items / max_chunk)
+    return math.ceil(num_items / k)
+
+
 class _NemotronColEmbedVLV2State:
     def __init__(
         self,
         *,
         model_id: str,
         device: str,
-        corpus_chunk_size: int,
+        max_scoring_batch_size: int,
+        scoring_chunk_size: int,
         corpus_batch_size: int,
         top_k: int,
         cache_dir: Path,
@@ -89,7 +96,8 @@ class _NemotronColEmbedVLV2State:
     ) -> None:
         self.model_id = str(model_id)
         self.device = str(device)
-        self.corpus_chunk_size = int(corpus_chunk_size)
+        self.max_scoring_batch_size = int(max_scoring_batch_size)
+        self.scoring_chunk_size = int(scoring_chunk_size)
         self.corpus_batch_size = int(corpus_batch_size)
         self.top_k = int(top_k)
         self.cache_dir = cache_dir
@@ -156,11 +164,7 @@ class _NemotronColEmbedVLV2State:
     def _corpus_cache_path(self, dataset_name: str) -> Path:
         dataset_slug = str(dataset_name).replace("/", "__")
         model_slug = self.model_id.split("/")[-1].replace("/", "__")
-        key = (
-            f"{dataset_name}::{self.model_id}::images"
-            f"::max_input_tiles={int(self.max_input_tiles)}"
-            f"::use_thumbnail={bool(self.use_thumbnail)}"
-        )
+        key = f"{dataset_name}::{self.model_id}::images::max_input_tiles={int(self.max_input_tiles)}::use_thumbnail={bool(self.use_thumbnail)}"
         key_hash = hashlib.sha256(key.encode("utf-8")).hexdigest()[:10]
         filename = f"corpus_image_embeddings__{dataset_slug}__{model_slug}__{key_hash}.pt"
         return self.cache_dir / filename
@@ -242,54 +246,68 @@ class _NemotronColEmbedVLV2State:
         return emb, lengths
 
     def _embed_query(self, query: str) -> torch.Tensor:
-        # Returns CPU tensor [q_seq, dim]
         with torch.no_grad():
-            q_emb = self.model.forward_queries([str(query)], batch_size=1).detach().to("cpu")
+            q_emb = self.model.forward_queries([str(query)], batch_size=1).detach()
         if not isinstance(q_emb, torch.Tensor) or q_emb.ndim != 3 or q_emb.shape[0] != 1:
             raise RuntimeError(f"Unexpected query embedding shape: {getattr(q_emb, 'shape', None)}")
-        return q_emb[0]
+        return q_emb[0].to(self.device)
 
-    def _score_query(self, query_embedding_cpu: torch.Tensor) -> torch.Tensor:
-        if self.corpus_embeddings_cpu is None:
-            raise RuntimeError("corpus_embeddings_cpu is not set; call init() first")
-        if self.corpus_token_lengths_cpu is None:
-            raise RuntimeError("corpus_token_lengths_cpu is not set; call init() first")
+    def _score_maxsim_block(
+        self,
+        emb_block: torch.Tensor,
+        len_block: torch.Tensor,
+        q_t: torch.Tensor,
+        device: str,
+    ) -> torch.Tensor:
+        token_sims = torch.matmul(emb_block, q_t)  # [block, c_seq, q_seq]
+        c_seq = int(token_sims.shape[1])
+        pos = torch.arange(c_seq, device=device).unsqueeze(0)
+        valid = pos < len_block.unsqueeze(1)
+        token_sims = token_sims.masked_fill(~valid.unsqueeze(-1), float("-inf"))
+        return token_sims.max(dim=1).values.float().sum(dim=1)
 
-        num_corpus = self.corpus_embeddings_cpu.shape[0]
-        scores_cpu = torch.empty((num_corpus,), dtype=torch.float32, device="cpu")
+    def _score_query(self, query_embedding: torch.Tensor) -> torch.Tensor:
+        emb_gpu = self.corpus_embeddings_gpu
+        emb_cpu = self.corpus_embeddings_cpu
+        len_gpu = self.corpus_token_lengths_gpu
+        len_cpu = self.corpus_token_lengths_cpu
+        if emb_gpu is None and emb_cpu is None:
+            raise RuntimeError("No corpus embeddings available.")
+        if len_gpu is None and len_cpu is None:
+            raise RuntimeError("No corpus token lengths available.")
 
-        chunk = max(1, int(self.corpus_chunk_size))
+        source = emb_gpu if emb_gpu is not None else emb_cpu
+        num_corpus = source.shape[0]
         device = str(self.device)
+        scores = torch.empty((num_corpus,), dtype=torch.float32, device=device)
 
         with torch.no_grad():
-            q_gpu = query_embedding_cpu.to(device, non_blocking=True)  # [q_seq, dim]
-            q_t = q_gpu.transpose(0, 1)  # [dim, q_seq]
+            q_t = query_embedding.transpose(0, 1)  # [dim, q_seq]
 
-            for c_start in range(0, num_corpus, chunk):
-                c_end = min(c_start + chunk, num_corpus)
+            if emb_gpu is not None:
+                scores[:] = self._score_maxsim_block(emb_gpu, len_gpu, q_t, device)
+            else:
+                transfer_chunk = _balanced_chunk_size(num_corpus, max(1, int(self.max_scoring_batch_size)))
+                score_chunk = max(1, int(self.scoring_chunk_size))
 
-                if self.corpus_embeddings_gpu is not None:
-                    c_gpu = self.corpus_embeddings_gpu[c_start:c_end]
-                else:
-                    c_gpu = self.corpus_embeddings_cpu[c_start:c_end].to(device, non_blocking=True)
+                for t_start in range(0, num_corpus, transfer_chunk):
+                    t_end = min(t_start + transfer_chunk, num_corpus)
+                    t_emb = emb_cpu[t_start:t_end].to(device)
+                    t_len = len_cpu[t_start:t_end].to(device)
 
-                if self.corpus_token_lengths_gpu is not None:
-                    len_gpu = self.corpus_token_lengths_gpu[c_start:c_end]
-                else:
-                    len_gpu = self.corpus_token_lengths_cpu[c_start:c_end].to(device, non_blocking=True)
+                    for s_start in range(0, t_emb.shape[0], score_chunk):
+                        s_end = min(s_start + score_chunk, t_emb.shape[0])
+                        block_scores = self._score_maxsim_block(
+                            t_emb[s_start:s_end],
+                            t_len[s_start:s_end],
+                            q_t,
+                            device,
+                        )
+                        scores[t_start + s_start : t_start + s_end] = block_scores
 
-                # c_gpu: [chunk, c_seq, dim]
-                # q_t:   [dim, q_seq]
-                token_sims = torch.matmul(c_gpu, q_t)  # [chunk, c_seq, q_seq]
-                # Mask padded tokens so they can never win the max.
-                c_seq = int(token_sims.shape[1])
-                pos = torch.arange(c_seq, device=device).unsqueeze(0)  # [1, c_seq]
-                valid = pos < len_gpu.to(device=device).unsqueeze(1)  # [chunk, c_seq]
-                token_sims = token_sims.masked_fill(~valid.unsqueeze(-1), float("-inf"))
-                chunk_scores = token_sims.max(dim=1).values.float().sum(dim=1)  # [chunk]
-                scores_cpu[c_start:c_end] = chunk_scores.detach().to("cpu")
+                    del t_emb, t_len
 
-        return scores_cpu
+        return scores
 
     def retrieve_one(
         self,
@@ -298,35 +316,35 @@ class _NemotronColEmbedVLV2State:
         return_markdown: bool = False,
         excluded_ids: Optional[Sequence[str]] = None,
     ) -> Union[Dict[str, float], Tuple[Dict[str, float], Dict[str, str]]]:
-        if self.corpus_ids is None or self.corpus_embeddings_cpu is None:
+        if self.corpus_ids is None or (self.corpus_embeddings_gpu is None and self.corpus_embeddings_cpu is None):
             raise RuntimeError("Retriever not initialized. Call retriever.init(...) first.")
 
-        q_emb_cpu = self._embed_query(str(query))
-        scores_cpu = self._score_query(q_emb_cpu)
+        q_emb = self._embed_query(str(query))
+        scores = self._score_query(q_emb)
 
-        # Apply per-query excluded ids BEFORE top-k selection (BRIGHT semantics).
         if excluded_ids and self.corpus_id_to_idx:
+            excluded_indices = []
             for did in set(str(x) for x in excluded_ids):
                 if did == "N/A":
                     continue
                 idx = self.corpus_id_to_idx.get(did, None)
-                if idx is None:
-                    continue
-                try:
-                    scores_cpu[int(idx)] = float("-inf")
-                except Exception:
-                    pass
+                if idx is not None:
+                    excluded_indices.append(int(idx))
+            if excluded_indices:
+                scores[torch.tensor(excluded_indices, device=scores.device)] = float("-inf")
 
         k = min(int(self.top_k), len(self.corpus_ids))
-        topk_scores, topk_indices = torch.topk(scores_cpu, k)
+        topk_scores, topk_indices = torch.topk(scores, k)
         ids = self.corpus_ids
-        run = {ids[int(idx)]: float(score) for idx, score in zip(topk_indices.tolist(), topk_scores.tolist())}
+        topk_indices_cpu = topk_indices.cpu().tolist()
+        topk_scores_cpu = topk_scores.cpu().tolist()
+        run = {ids[int(idx)]: float(score) for idx, score in zip(topk_indices_cpu, topk_scores_cpu)}
 
         if not return_markdown:
             return run
 
         md = self.corpus_markdown or [""] * len(ids)
-        markdown_by_id = {ids[int(idx)]: str(md[int(idx)]) for idx in topk_indices.tolist()}
+        markdown_by_id = {ids[int(idx)]: str(md[int(idx)]) for idx in topk_indices_cpu}
         return run, markdown_by_id
 
 
@@ -348,10 +366,10 @@ class NemotronColEmbedVLV2SingletonRetriever:
         model_id: str = "nvidia/nemotron-colembed-vl-8b-v2",
         device: str = "cuda",
         top_k: int = 100,
-        corpus_batch_size: int = 8,
-        corpus_chunk_size: int = 256,
+        corpus_batch_size: int = 32,
+        max_scoring_batch_size: int = 3000,
+        scoring_chunk_size: int = 1311,
         cache_dir: str | Path = "cache/nemotron_colembed_vl_v2",
-        preload_corpus_to_gpu: bool = False,
         max_input_tiles: int = 8,
         use_thumbnail: bool = True,
     ) -> None:
@@ -366,7 +384,8 @@ class NemotronColEmbedVLV2SingletonRetriever:
                 self._state = _NemotronColEmbedVLV2State(
                     model_id=str(model_id),
                     device=str(device),
-                    corpus_chunk_size=int(corpus_chunk_size),
+                    max_scoring_batch_size=int(max_scoring_batch_size),
+                    scoring_chunk_size=int(scoring_chunk_size),
                     corpus_batch_size=int(corpus_batch_size),
                     top_k=int(top_k),
                     cache_dir=cache_dir_p,
@@ -377,7 +396,8 @@ class NemotronColEmbedVLV2SingletonRetriever:
                 # Update tunables.
                 self._state.top_k = int(top_k)
                 self._state.corpus_batch_size = int(corpus_batch_size)
-                self._state.corpus_chunk_size = int(corpus_chunk_size)
+                self._state.max_scoring_batch_size = int(max_scoring_batch_size)
+                self._state.scoring_chunk_size = int(scoring_chunk_size)
                 self._state.cache_dir = cache_dir_p
                 self._state.max_input_tiles = int(max_input_tiles)
                 self._state.use_thumbnail = bool(use_thumbnail)
@@ -390,18 +410,14 @@ class NemotronColEmbedVLV2SingletonRetriever:
                 and self._state.corpus_embeddings_cpu is not None
                 and self._state.corpus_token_lengths_cpu is not None
             ):
-                # Only adjust GPU preload.
-                if preload_corpus_to_gpu and self._state.corpus_embeddings_gpu is None:
-                    self._state.corpus_embeddings_gpu = _try_preload_corpus_to_gpu(
-                        self._state.corpus_embeddings_cpu, self._state.device
-                    )
-                if preload_corpus_to_gpu and self._state.corpus_token_lengths_gpu is None:
-                    self._state.corpus_token_lengths_gpu = self._state.corpus_token_lengths_cpu.to(
-                        self._state.device, non_blocking=True
-                    )
-                if (not preload_corpus_to_gpu) and self._state.corpus_embeddings_gpu is not None:
+                should_be_on_gpu = len(corpus_ids) <= self._state.max_scoring_batch_size
+                if should_be_on_gpu and self._state.corpus_embeddings_gpu is None:
+                    self._state.corpus_embeddings_gpu = self._state.corpus_embeddings_cpu.to(self._state.device)
+                if should_be_on_gpu and self._state.corpus_token_lengths_gpu is None:
+                    self._state.corpus_token_lengths_gpu = self._state.corpus_token_lengths_cpu.to(self._state.device)
+                if (not should_be_on_gpu) and self._state.corpus_embeddings_gpu is not None:
                     self._state.corpus_embeddings_gpu = None
-                if (not preload_corpus_to_gpu) and self._state.corpus_token_lengths_gpu is not None:
+                if (not should_be_on_gpu) and self._state.corpus_token_lengths_gpu is not None:
                     self._state.corpus_token_lengths_gpu = None
                 return
 
@@ -424,11 +440,9 @@ class NemotronColEmbedVLV2SingletonRetriever:
 
             self._state.corpus_embeddings_gpu = None
             self._state.corpus_token_lengths_gpu = None
-            if preload_corpus_to_gpu:
-                self._state.corpus_embeddings_gpu = _try_preload_corpus_to_gpu(emb_cpu, self._state.device)
-                self._state.corpus_token_lengths_gpu = self._state.corpus_token_lengths_cpu.to(
-                    self._state.device, non_blocking=True
-                )
+            if emb_cpu.shape[0] <= self._state.max_scoring_batch_size:
+                self._state.corpus_embeddings_gpu = emb_cpu.to(self._state.device)
+                self._state.corpus_token_lengths_gpu = lengths_cpu.to(self._state.device)
 
     def retrieve(
         self,

--- a/retrieval-bench/src/retrieval_bench/singletons/nemotron_embed_vl_dense_retriever.py
+++ b/retrieval-bench/src/retrieval_bench/singletons/nemotron_embed_vl_dense_retriever.py
@@ -38,7 +38,6 @@ except ImportError as e:  # pragma: no cover
 
 from retrieval_bench.singletons._shared import hash_corpus_ids10 as _hash_corpus_ids10
 from retrieval_bench.singletons._shared import slugify as _slugify
-from retrieval_bench.singletons._shared import try_preload_corpus_to_gpu as _try_preload_corpus_to_gpu
 
 
 def _l2_normalize_fp32(x: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
@@ -94,7 +93,7 @@ class _NemotronVLDenseState:
         doc_max_length: int,
         query_max_length: int,
         corpus_batch_size: int,
-        corpus_chunk_size: int,
+        max_scoring_batch_size: int,
         cache_dir: Path,
         max_input_tiles: int,
         use_thumbnail: bool,
@@ -106,7 +105,7 @@ class _NemotronVLDenseState:
         self.doc_max_length = int(doc_max_length)
         self.query_max_length = int(query_max_length)
         self.corpus_batch_size = int(corpus_batch_size)
-        self.corpus_chunk_size = int(corpus_chunk_size)
+        self.max_scoring_batch_size = int(max_scoring_batch_size)
         self.cache_dir = cache_dir
         self.max_input_tiles = int(max_input_tiles)
         self.use_thumbnail = bool(use_thumbnail)
@@ -156,11 +155,13 @@ class _NemotronVLDenseState:
                     **common_kwargs,
                 )
 
-        # Prefer FlashAttention2 when available; fall back to eager.
         try:
             model = _from_pretrained(attn_implementation="flash_attention_2")
-        except Exception:
-            model = _from_pretrained(attn_implementation="eager")
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to load {self.model_id} with flash_attention_2: {e}\n"
+                'Install a compatible flash-attn: pip install "flash-attn>=2.6.3,<2.8" --no-build-isolation'
+            ) from e
 
         model.to("cuda")
         model.eval()
@@ -288,33 +289,47 @@ class _NemotronVLDenseState:
         bs = max(1, int(self.corpus_batch_size))
         out: List[torch.Tensor] = []
         modality = str(self.doc_modality).strip().lower()
+        n_batches = (len(corpus) + bs - 1) // bs
+        total_preprocess_s = 0.0
+        total_forward_s = 0.0
 
-        # Set doc max length for document calls.
         self._set_processor_max_length_for_call(p_max_length=int(self.doc_max_length))
 
-        with torch.inference_mode():
+        with torch.no_grad():
             for i in range(0, len(corpus), bs):
                 batch = corpus[i : i + bs]
 
+                t0 = time.time()
                 if modality == "image":
                     images = [doc["image"].convert("RGB") for doc in batch]
-                    emb = self.model.encode_documents(images=images)
+                    examples = [{"image": img, "text": ""} for img in images]
                 elif modality == "text":
                     texts = [str(doc.get("markdown", "")) for doc in batch]
-                    emb = self.model.encode_documents(texts=texts)
+                    examples = [{"image": "", "text": t} for t in texts]
                 else:  # image_text
                     images = [doc["image"].convert("RGB") for doc in batch]
                     texts = [str(doc.get("markdown", "")) for doc in batch]
-                    emb = self.model.encode_documents(images=images, texts=texts)
+                    examples = [{"image": img, "text": t} for img, t in zip(images, texts)]
 
-                if not isinstance(emb, torch.Tensor):
-                    raise RuntimeError(f"encode_documents returned unexpected type: {type(emb)}")
-                if emb.ndim != 2:
-                    raise RuntimeError(f"Unexpected document embedding shape: {tuple(emb.shape)}")
+                docs_dict = self.model.processor.process_documents(examples)
+                t1 = time.time()
 
-                emb = _l2_normalize_fp32(emb).to(torch.float16).detach().to("cpu")
-                out.append(emb)
+                emb = self.model._embed_batch(docs_dict)
+                torch.cuda.synchronize()
+                t2 = time.time()
 
+                total_preprocess_s += t1 - t0
+                total_forward_s += t2 - t1
+
+                if not isinstance(emb, torch.Tensor) or emb.ndim != 2:
+                    raise RuntimeError(f"Unexpected embedding: type={type(emb)}, shape={getattr(emb, 'shape', None)}")
+
+                out.append(_l2_normalize_fp32(emb).to(torch.float16).detach().to("cpu"))
+
+        print(
+            f"[nemotron-vl-dense] corpus embedding: {n_batches} batches x {bs} docs, "
+            f"preprocess={total_preprocess_s:.1f}s, forward={total_forward_s:.1f}s"
+        )
         return torch.cat(out, dim=0) if out else torch.empty((0, 0), dtype=torch.float16, device="cpu")
 
     def _load_or_build_corpus_embeddings(
@@ -378,10 +393,9 @@ class _NemotronVLDenseState:
         return emb
 
     def embed_query(self, query_text: str) -> torch.Tensor:
-        # Set query max length for query call.
         self._set_processor_max_length_for_call(p_max_length=int(self.query_max_length))
 
-        with torch.inference_mode():
+        with torch.no_grad():
             emb = self.model.encode_queries([str(query_text)])
 
         if not isinstance(emb, torch.Tensor):
@@ -390,34 +404,32 @@ class _NemotronVLDenseState:
             raise RuntimeError(f"Unexpected query embedding shape: {tuple(emb.shape)}")
 
         emb1 = emb[0]
-        emb1 = _l2_normalize_fp32(emb1).to(torch.float16).detach().to("cpu")
-        return emb1  # [dim] on CPU
+        emb1 = _l2_normalize_fp32(emb1).to(torch.float16).detach()
+        return emb1  # [dim] on GPU
 
-    def score_query(self, query_embedding_cpu: torch.Tensor) -> torch.Tensor:
-        if self.corpus_embeddings_cpu is None:
-            raise RuntimeError("corpus_embeddings_cpu is not set; call init() first")
+    def score_query(self, query_embedding: torch.Tensor) -> torch.Tensor:
+        emb_gpu = self.corpus_embeddings_gpu
+        emb_cpu = self.corpus_embeddings_cpu
+        if emb_gpu is None and emb_cpu is None:
+            raise RuntimeError("No corpus embeddings available.")
 
-        num_docs = self.corpus_embeddings_cpu.shape[0]
-        scores_cpu = torch.empty((num_docs,), dtype=torch.float32, device="cpu")
+        with torch.no_grad():
+            q_col = query_embedding.unsqueeze(1)  # [dim, 1]
 
-        chunk = max(1, int(self.corpus_chunk_size))
-        device = str(self.device)
+            if emb_gpu is not None:
+                return torch.matmul(emb_gpu, q_col).squeeze(1).float()
 
-        with torch.inference_mode():
-            q_gpu = query_embedding_cpu.to(device, non_blocking=True)  # [dim]
-            q_gpu = q_gpu.unsqueeze(1)  # [dim, 1]
+            num_docs = emb_cpu.shape[0]
+            device = str(self.device)
+            scores = torch.empty((num_docs,), dtype=torch.float32, device=device)
+            chunk = max(1, int(self.max_scoring_batch_size))
 
             for c_start in range(0, num_docs, chunk):
                 c_end = min(c_start + chunk, num_docs)
-                if self.corpus_embeddings_gpu is not None:
-                    c_gpu = self.corpus_embeddings_gpu[c_start:c_end]
-                else:
-                    c_gpu = self.corpus_embeddings_cpu[c_start:c_end].to(device, non_blocking=True)
+                c_chunk = emb_cpu[c_start:c_end].to(device)
+                scores[c_start:c_end] = torch.matmul(c_chunk, q_col).squeeze(1).float()
 
-                chunk_scores = torch.matmul(c_gpu, q_gpu).squeeze(1).float()  # [chunk]
-                scores_cpu[c_start:c_end] = chunk_scores.to("cpu")
-
-        return scores_cpu
+        return scores
 
     def retrieve_one(
         self,
@@ -426,35 +438,35 @@ class _NemotronVLDenseState:
         return_markdown: bool = False,
         excluded_ids: Optional[Sequence[str]] = None,
     ) -> Union[Dict[str, float], Tuple[Dict[str, float], Dict[str, str]]]:
-        if self.corpus_ids is None or self.corpus_embeddings_cpu is None:
+        if self.corpus_ids is None or (self.corpus_embeddings_gpu is None and self.corpus_embeddings_cpu is None):
             raise RuntimeError("Retriever not initialized. Call retriever.init(...) first.")
 
-        q_emb_cpu = self.embed_query(str(query))
-        scores_cpu = self.score_query(q_emb_cpu)
+        q_emb = self.embed_query(str(query))
+        scores = self.score_query(q_emb)
 
-        # Apply per-query excluded ids BEFORE top-k selection (BRIGHT semantics).
         if excluded_ids and self.corpus_id_to_idx:
+            excluded_indices = []
             for did in set(str(x) for x in excluded_ids):
                 if did == "N/A":
                     continue
                 idx = self.corpus_id_to_idx.get(did, None)
-                if idx is None:
-                    continue
-                try:
-                    scores_cpu[int(idx)] = float("-inf")
-                except Exception:
-                    pass
+                if idx is not None:
+                    excluded_indices.append(int(idx))
+            if excluded_indices:
+                scores[torch.tensor(excluded_indices, device=scores.device)] = float("-inf")
 
         k = min(int(self.top_k), len(self.corpus_ids))
-        topk_scores, topk_indices = torch.topk(scores_cpu, k)
+        topk_scores, topk_indices = torch.topk(scores, k)
         ids = self.corpus_ids
-        run = {ids[int(idx)]: float(score) for idx, score in zip(topk_indices.tolist(), topk_scores.tolist())}
+        topk_indices_cpu = topk_indices.cpu().tolist()
+        topk_scores_cpu = topk_scores.cpu().tolist()
+        run = {ids[int(idx)]: float(score) for idx, score in zip(topk_indices_cpu, topk_scores_cpu)}
 
         if not return_markdown:
             return run
 
         md = self.corpus_markdown or [""] * len(ids)
-        markdown_by_id = {ids[int(idx)]: str(md[int(idx)]) for idx in topk_indices.tolist()}
+        markdown_by_id = {ids[int(idx)]: str(md[int(idx)]) for idx in topk_indices_cpu}
         return run, markdown_by_id
 
 
@@ -475,10 +487,9 @@ class NemotronEmbedVLDenseSingletonRetriever:
         doc_modality: str = "image_text",
         doc_max_length: Union[int, str] = "auto",
         query_max_length: int = 10240,
-        corpus_batch_size: int = 4,
-        corpus_chunk_size: int = 4096,
+        corpus_batch_size: int = 32,
+        max_scoring_batch_size: int = 4096,
         cache_dir: str | Path = "cache/nemotron_vl_dense",
-        preload_corpus_to_gpu: bool = False,
         max_input_tiles: int = 6,
         use_thumbnail: bool = True,
     ) -> None:
@@ -521,7 +532,7 @@ class NemotronEmbedVLDenseSingletonRetriever:
                     doc_max_length=int(doc_max_length_eff),
                     query_max_length=int(query_max_length),
                     corpus_batch_size=int(corpus_batch_size),
-                    corpus_chunk_size=int(corpus_chunk_size),
+                    max_scoring_batch_size=int(max_scoring_batch_size),
                     cache_dir=cache_dir_p,
                     max_input_tiles=int(max_input_tiles),
                     use_thumbnail=bool(use_thumbnail),
@@ -530,7 +541,7 @@ class NemotronEmbedVLDenseSingletonRetriever:
                 # Update tunables.
                 self._state.top_k = int(top_k)
                 self._state.corpus_batch_size = int(corpus_batch_size)
-                self._state.corpus_chunk_size = int(corpus_chunk_size)
+                self._state.max_scoring_batch_size = int(max_scoring_batch_size)
                 self._state.cache_dir = cache_dir_p
 
             corpus_ids_list = [str(x) for x in corpus_ids]
@@ -542,12 +553,10 @@ class NemotronEmbedVLDenseSingletonRetriever:
                 and _hash_corpus_ids10(self._state.corpus_ids) == corpus_ids_hash10
                 and self._state.corpus_embeddings_cpu is not None
             ):
-                # Already initialized for the same corpus; only adjust GPU preload.
-                if preload_corpus_to_gpu and self._state.corpus_embeddings_gpu is None:
-                    self._state.corpus_embeddings_gpu = _try_preload_corpus_to_gpu(
-                        self._state.corpus_embeddings_cpu, self._state.device
-                    )
-                if (not preload_corpus_to_gpu) and self._state.corpus_embeddings_gpu is not None:
+                should_be_on_gpu = len(corpus_ids_list) <= self._state.max_scoring_batch_size
+                if should_be_on_gpu and self._state.corpus_embeddings_gpu is None:
+                    self._state.corpus_embeddings_gpu = self._state.corpus_embeddings_cpu.to(self._state.device)
+                if (not should_be_on_gpu) and self._state.corpus_embeddings_gpu is not None:
                     self._state.corpus_embeddings_gpu = None
                 return
 
@@ -564,8 +573,8 @@ class NemotronEmbedVLDenseSingletonRetriever:
             self._state.corpus_embeddings_cpu = emb_cpu
 
             self._state.corpus_embeddings_gpu = None
-            if preload_corpus_to_gpu:
-                self._state.corpus_embeddings_gpu = _try_preload_corpus_to_gpu(emb_cpu, self._state.device)
+            if emb_cpu.shape[0] <= self._state.max_scoring_batch_size:
+                self._state.corpus_embeddings_gpu = emb_cpu.to(self._state.device)
 
     def retrieve(
         self,


### PR DESCRIPTION
## Description
Improve retrieval performance and multimodal robustness across dense and late-interaction backends.

Key changes:
- Standardize backend scoring knobs around `max_scoring_batch_size`
- Improve multimodal auto-detection by checking for non-null image entries
- Speed up Nemotron Embed VL corpus embedding with batched processor/forward flow and timing visibility
- Tighten FlashAttention load error handling for clearer setup guidance
- Use GPU-aware `no_grad` query/scoring paths and opportunistic GPU embedding preload when corpus size allows
- Update README examples to reflect the current scoring parameter name

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] ~~If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.~~ N/A
