### PR TITLE
Remove get_hf_revision from files outside nemo_retriever/

### DIFF
--- a/api/src/nv_ingest_api/internal/transform/split_text.py
+++ b/api/src/nv_ingest_api/internal/transform/split_text.py
@@ -56,14 +56,8 @@ def _get_tokenizer(
         if cache_key in _tokenizer_cache:
             return _tokenizer_cache[cache_key]
 
-        from nemo_retriever.utils.hf_model_registry import get_hf_revision
-
         logger.info("Loading and caching tokenizer: %s", tokenizer_identifier)
-        tokenizer = AutoTokenizer.from_pretrained(
-            tokenizer_identifier,
-            revision=get_hf_revision(tokenizer_identifier),
-            token=token,
-        )
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_identifier, token=token)
         _tokenizer_cache[cache_key] = tokenizer
         return tokenizer
 

--- a/docker/scripts/post_build_triggers.py
+++ b/docker/scripts/post_build_triggers.py
@@ -4,30 +4,6 @@ import time
 
 from transformers import AutoTokenizer
 
-try:
-    from nemo_retriever.utils.hf_model_registry import get_hf_revision
-except ModuleNotFoundError:
-    # Fallback for Docker build stages where nemo_retriever isn't installed yet.
-    _REVISIONS = {
-        "meta-llama/Llama-3.2-1B": "4e20de362430cd3b72f300e6b0f18e50e7166e08",
-        "intfloat/e5-large-unsupervised": "15af9288f69a6291f37bfb89b47e71abc747b206",
-    }
-
-    def get_hf_revision(model_id, *, strict=True):  # type: ignore[misc]
-        revision = _REVISIONS.get(model_id)
-        if revision is not None:
-            return revision
-        msg = (
-            f"No pinned HuggingFace revision for model '{model_id}'. "
-            "Add an entry to _REVISIONS in post_build_triggers.py (and "
-            "HF_MODEL_REVISIONS in hf_model_registry.py) to pin it."
-        )
-        if strict:
-            raise ValueError(msg)
-        print(f"WARNING: {msg} Falling back to the default (main) branch.")
-        return None
-
-
 MAX_RETRIES = 5
 
 
@@ -36,7 +12,7 @@ def download_tokenizer(model_name, save_path, token=None):
 
     for attempt in range(MAX_RETRIES):
         try:
-            tokenizer = AutoTokenizer.from_pretrained(model_name, revision=get_hf_revision(model_name), token=token)
+            tokenizer = AutoTokenizer.from_pretrained(model_name, token=token)
             tokenizer.save_pretrained(save_path)
             return
         except Exception as e:


### PR DESCRIPTION
## Summary
- Removes `get_hf_revision` references that were mistakenly added to files outside the `nemo_retriever/` directory in PR #1499
- Reverts `docker/scripts/post_build_triggers.py` to use `AutoTokenizer.from_pretrained` without the `revision=` parameter and removes the `get_hf_revision` import/fallback block
- Reverts `api/src/nv_ingest_api/internal/transform/split_text.py` to use `AutoTokenizer.from_pretrained` without the `revision=` parameter and removes the `nemo_retriever` import

## Test plan
- [ ] Verify Docker build still downloads tokenizers correctly
- [ ] Verify text splitting pipeline works without revision pinning in the API layer

Made with [Cursor](https://cursor.com)