### PR TITLE
docs: add notebook-local client setup guidance

### DIFF
--- a/client/client_examples/examples/cli_client_usage.ipynb
+++ b/client/client_examples/examples/cli_client_usage.ipynb
@@ -17,6 +17,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "70343d26-9f65-4fdb-9f49-6fb0546d8080",
+   "metadata": {},
+   "source": [
+    "## Container setup before you run this notebook\n",
+    "\n",
+    "If you opened this notebook directly from the quickstart docs, make sure the NV-Ingest client container is running first. From `client/client_examples/`, build and start it with the commands shown in `client/client_examples/README.md`.\n",
+    "\n",
+    "The container clones this repository into `/workspace/nv-ingest` and copies the example notebooks into `/workspace/client_examples/examples`.\n",
+    "\n",
+    "- The default sample files below come from `/workspace/nv-ingest/data` inside the container.\n",
+    "- If you mounted your own dataset with `-v ${DATASET_ROOT}:/workspace/client_examples/data`, override `SAMPLE_PDF0` and `SAMPLE_PDF1` before running the next cell.\n",
+    "- Set `REDIS_HOST`, `REDIS_PORT`, and `TASK_QUEUE` if your NV-Ingest services are not reachable at the defaults.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6e0a6279-e78f-412a-94e7-a64ce5c0e4df",
    "metadata": {},
    "source": [
@@ -33,17 +49,20 @@
     "import os\n",
     "\n",
     "# sample input file and output directories\n",
-    "SAMPLE_PDF0 = \"/workspace/nv-ingest/data/multimodal_test.pdf\"\n",
+    "SAMPLE_PDF0 = os.environ.get(\"SAMPLE_PDF0\", \"/workspace/nv-ingest/data/multimodal_test.pdf\")\n",
     "os.environ[\"SAMPLE_PDF0\"] = SAMPLE_PDF0\n",
-    "SAMPLE_PDF1 = \"/workspace/nv-ingest/data/functional_validation.pdf\"\n",
-    "BATCH_FILE = \"/workspace/client_examples/examples/dataset.json\"\n",
+    "SAMPLE_PDF1 = os.environ.get(\"SAMPLE_PDF1\", \"/workspace/nv-ingest/data/functional_validation.pdf\")\n",
+    "os.environ[\"SAMPLE_PDF1\"] = SAMPLE_PDF1\n",
+    "BATCH_FILE = os.environ.get(\"BATCH_FILE\", \"/workspace/client_examples/examples/dataset.json\")\n",
     "os.environ[\"BATCH_FILE\"] = BATCH_FILE\n",
-    "OUTPUT_DIRECTORY_SINGLE = \"/workspace/client_examples/examples/processed_docs_single\"\n",
-    "OUTPUT_DIRECTORY_BATCH = \"/workspace/client_examples/examples/processed_docs_batch\"\n",
+    "OUTPUT_DIRECTORY_SINGLE = os.environ.get(\"OUTPUT_DIRECTORY_SINGLE\", \"/workspace/client_examples/examples/processed_docs_single\")\n",
+    "OUTPUT_DIRECTORY_BATCH = os.environ.get(\"OUTPUT_DIRECTORY_BATCH\", \"/workspace/client_examples/examples/processed_docs_batch\")\n",
     "os.environ[\"OUTPUT_DIRECTORY_SINGLE\"] = OUTPUT_DIRECTORY_SINGLE\n",
     "os.environ[\"OUTPUT_DIRECTORY_BATCH\"] = OUTPUT_DIRECTORY_BATCH\n",
-    "REDIS_HOST = \"localhost\"\n",
-    "REDIS_PORT = \"7670\""
+    "TASK_QUEUE = os.environ.get(\"TASK_QUEUE\", \"ingest_task_queue\")\n",
+    "os.environ[\"TASK_QUEUE\"] = TASK_QUEUE\n",
+    "REDIS_HOST = os.environ.get(\"REDIS_HOST\", \"localhost\")\n",
+    "REDIS_PORT = os.environ.get(\"REDIS_PORT\", \"7670\")"
    ]
   },
   {

--- a/client/client_examples/examples/python_client_usage.ipynb
+++ b/client/client_examples/examples/python_client_usage.ipynb
@@ -16,6 +16,23 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0e63106b",
+   "metadata": {},
+   "source": [
+    "## Container setup before you run this notebook\n",
+    "\n",
+    "If you opened this notebook directly from the quickstart docs, make sure the NV-Ingest client container is running first. From `client/client_examples/`, build and start it with the commands shown in `client/client_examples/README.md`.\n",
+    "\n",
+    "The container clones this repository into `/workspace/nv-ingest` and copies the example notebooks into `/workspace/client_examples/examples`.\n",
+    "\n",
+    "- If you want to use the repository sample PDFs, keep the default `SAMPLE_PDF` path below.\n",
+    "- If you mounted your own dataset with `-v ${DATASET_ROOT}:/workspace/client_examples/data`, set `SAMPLE_PDF` to a file under `/workspace/client_examples/data` before running the next cell.\n",
+    "- Set `HTTP_HOST`, `HTTP_PORT`, and `TASK_QUEUE` if your NV-Ingest services are not reachable at the defaults.\n",
+    "- Set `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` only if your workflow needs object storage access.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c14fe242",
    "metadata": {},
    "source": [
@@ -44,7 +61,7 @@
     "DEFAULT_JOB_TIMEOUT = 90\n",
     "\n",
     "# sample input file and output directory\n",
-    "SAMPLE_PDF = \"/workspace/data/multimodal_test.pdf\""
+    "SAMPLE_PDF = os.environ.get('SAMPLE_PDF', \"/workspace/nv-ingest/data/multimodal_test.pdf\")"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- add notebook-local container setup instructions to the Python and CLI client example notebooks
- make the notebook defaults overrideable via environment variables
- align the Python notebook sample PDF default with the client container layout

Fixes #120.

## Verification
- validated both edited notebooks with `jq empty`
- attempted `python3 -m pytest client/client_tests -q`, but collection fails in this local environment because the repo's multi-package Python modules are not installed
- attempted `python3 -m build client`, but the local environment does not have the `build` module installed