### PR TITLE
Release prep: update version references to 26.3.0

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -262,7 +262,7 @@ services:
       - audio
 
   nv-ingest-ms-runtime:
-    image: nvcr.io/nvidia/nemo-microservices/nv-ingest:26.3.0-RC4
+    image: nvcr.io/nvidia/nemo-microservices/nv-ingest:26.3.0
     shm_size: 40gb # Should be at minimum 30% of assigned memory per Ray documentation
     build:
       context: ${NV_INGEST_ROOT:-.}

--- a/docs/docs/extraction/helm.md
+++ b/docs/docs/extraction/helm.md
@@ -3,7 +3,7 @@
 <!-- Use this documentation to deploy [NeMo Retriever Library](overview.md) by using Helm. -->
 
 To deploy [NeMo Retriever Library](overview.md) by using Helm, 
-refer to [NeMo Retriever Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/release/26.3.0-RC4/helm/README.md).
+refer to [NeMo Retriever Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/release/26.3.0/helm/README.md).
 
 !!! note "Air-gapped environments"
    

--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -84,7 +84,7 @@ h. Run the command `docker ps`. You should see output similar to the following. 
     CONTAINER ID  IMAGE                                            COMMAND                 CREATED         STATUS                  PORTS            NAMES
 uv venv --python 3.12 nv-ingest-dev
 source nv-ingest-dev/bin/activate
-uv pip install nv-ingest==26.3.0-RC4 nv-ingest-api==26.3.0-RC4 nv-ingest-client==26.3.0-RC4
+uv pip install nv-ingest==26.3.0 nv-ingest-api==26.3.0 nv-ingest-client==26.3.0
 ```
 
 !!! tip

--- a/docs/docs/extraction/quickstart-library-mode.md
+++ b/docs/docs/extraction/quickstart-library-mode.md
@@ -34,7 +34,7 @@ Use the following procedure to prepare your environment.
     ```
        uv venv --python 3.12 nvingest && \
          source nvingest/bin/activate && \
-         uv pip install nemo-retriever==26.3.0-RC4 milvus-lite==2.4.12
+         uv pip install nemo-retriever==26.3.0 milvus-lite==2.4.12
     ```
 
     !!! tip

--- a/docs/docs/extraction/releasenotes-nv-ingest.md
+++ b/docs/docs/extraction/releasenotes-nv-ingest.md
@@ -12,7 +12,7 @@ This documentation contains the release notes for [NeMo Retriever Library](overv
 
 The NeMo Retriever Library 26.03 release adds new hardware and software support, and other improvements.
 
-To upgrade the Helm Charts for this version, refer to [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/release/26.3.0-RC1/helm/README.md).
+To upgrade the Helm Charts for this version, refer to [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/release/26.3.0/helm/README.md).
 
 Updates and enhancements in the 26.03 release include the following:
 

--- a/docs/docs/extraction/user-defined-functions.md
+++ b/docs/docs/extraction/user-defined-functions.md
@@ -941,6 +941,6 @@ def debug_udf(control_message: IngestControlMessage) -> IngestControlMessage:
 
 ## Related Topics
 
-- [NeMo Retriever Library UDF Examples](https://github.com/NVIDIA/NeMo-Retriever/blob/release/26.3.0-RC1/examples/udfs/README.md)
+- [NeMo Retriever Library UDF Examples](https://github.com/NVIDIA/NeMo-Retriever/blob/release/26.3.0/examples/udfs/README.md)
 - [User-Defined Stages for NeMo Retriever Library](user-defined-stages.md)
 - [NimClient Usage](nimclient.md)

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nv-ingest
 description: NV-Ingest Microservice
 type: application
-version: 26.3.0-RC4
+version: 26.3.0
 maintainers:
   - name: NVIDIA Corporation
     url: https://www.nvidia.com/

--- a/helm/README.md
+++ b/helm/README.md
@@ -45,7 +45,7 @@ To install or upgrade the Helm chart, run the following code.
 helm upgrade \
     --install \
     nv-ingest \
-    https://helm.ngc.nvidia.com/nvidia/nemo-microservices/charts/nv-ingest-26.3.0-RC4.tgz \
+    https://helm.ngc.nvidia.com/nvidia/nemo-microservices/charts/nv-ingest-26.3.0.tgz \
     -n ${NAMESPACE} \
     --username '$oauthtoken' \
     --password "${NGC_API_KEY}" \
@@ -54,7 +54,7 @@ helm upgrade \
     --set ngcApiSecret.create=true \
     --set ngcApiSecret.password="${NGC_API_KEY}" \
     --set image.repository="nvcr.io/nvidia/nemo-microservices/nv-ingest" \
-    --set image.tag="26.3.0-RC4"
+    --set image.tag="26.3.0"
 ```
 
 Optionally you can create your own versions of the `Secrets` if you do not want to use the creation via the helm chart.
@@ -105,7 +105,7 @@ For more information, refer to [NV-Ingest-Client](https://github.com/NVIDIA/nv-i
 # Just to be cautious we remove any existing installation
 pip uninstall nv-ingest-client
 
-pip install nv-ingest-client==26.3.0-RC4
+pip install nv-ingest-client==26.3.0
 ```
 
 #### Rest Endpoint Ingress
@@ -347,7 +347,7 @@ You can also use NV-Ingest's Python client API to interact with the service runn
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"nvcr.io/nvidia/nemo-microservices/nv-ingest"` |  |
-| image.tag | string | `"26.3.0-RC4"` |  |
+| image.tag | string | `"26.3.0"` |  |
 | imagePullSecrets[0].name | string | `"ngc-api"` |  |
 | imagePullSecrets[1].name | string | `"ngc-secret"` |  |
 | ingress.annotations | object | `{}` |  |

--- a/helm/README.md.gotmpl
+++ b/helm/README.md.gotmpl
@@ -46,7 +46,7 @@ To install or upgrade the Helm chart, run the following code.
 helm upgrade \
     --install \
     nv-ingest \
-    https://helm.ngc.nvidia.com/nvidia/nemo-microservices/charts/nv-ingest-26.3.0-RC4.tgz \
+    https://helm.ngc.nvidia.com/nvidia/nemo-microservices/charts/nv-ingest-26.3.0.tgz \
     -n ${NAMESPACE} \
     --username '$oauthtoken' \
     --password "${NGC_API_KEY}" \
@@ -55,7 +55,7 @@ helm upgrade \
     --set ngcApiSecret.create=true \
     --set ngcApiSecret.password="${NGC_API_KEY}" \
     --set image.repository="nvcr.io/nvidia/nemo-microservices/nv-ingest" \
-    --set image.tag="26.3.0-RC4"
+    --set image.tag="26.3.0"
 ```
 
 Optionally you can create your own versions of the `Secrets` if you do not want to use the creation via the helm chart.
@@ -107,7 +107,7 @@ For more information, refer to [NV-Ingest-Client](https://github.com/NVIDIA/nv-i
 # Just to be cautious we remove any existing installation
 pip uninstall nv-ingest-client
 
-pip install nv-ingest-client==26.3.0-RC4
+pip install nv-ingest-client==26.3.0
 ```
 
 #### Rest Endpoint Ingress

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -28,7 +28,7 @@ nameOverride: ""
 image:
   pullPolicy: IfNotPresent
   repository: "nvcr.io/nvidia/nemo-microservices/nv-ingest"
-  tag: "26.3.0-RC4"
+  tag: "26.3.0"
 
 ## @section Pod Configuration
 ## @param podAnnotations [object] Sets additional annotations on the main deployment pods

--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -30,9 +30,9 @@ dependencies = [
   "typer>=0.12.0",
   "pyyaml>=6.0",
   "lancedb",
-  "nv-ingest==26.3.0rc4",
-  "nv-ingest-api==26.3.0rc4",
-  "nv-ingest-client==26.3.0rc4",
+  "nv-ingest==26.3.0",
+  "nv-ingest-api==26.3.0",
+  "nv-ingest-client==26.3.0",
   "fastapi>=0.114.0",
   "uvicorn[standard]>=0.30.0",
   "httpx>=0.27.0",
@@ -90,9 +90,9 @@ retriever = "nemo_retriever.__main__:main"
 version = {attr = "nemo_retriever.version.get_build_version"}
 
 [tool.uv.sources]
-nv-ingest = { path = "../src/", editable = true }
-nv-ingest-api = { path = "../api/", editable = true }
-nv-ingest-client = { path = "../client/", editable = true }
+#nv-ingest = { path = "../src/", editable = true }
+#nv-ingest-api = { path = "../api/", editable = true }
+#nv-ingest-client = { path = "../client/", editable = true }
 #nemotron-page-elements-v3 = { index = "test-pypi" }
 #nemotron-graphic-elements-v1 = { index = "test-pypi" }
 #nemotron-table-structure-v1 = { index = "test-pypi" }

--- a/src/nv_ingest/api/main.py
+++ b/src/nv_ingest/api/main.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 app = FastAPI(
     title="NV-Ingest Microservice",
     description="Service for ingesting heterogenous datatypes",
-    version="26.3.0-RC4",
+    version="26.3.0",
     contact={
         "name": "NVIDIA Corporation",
         "url": "https://nvidia.com",

--- a/tools/harness/pyproject.toml
+++ b/tools/harness/pyproject.toml
@@ -10,9 +10,9 @@ dependencies = [
     "pyyaml>=6.0",
     "requests>=2.32.5",
     "pynvml>=11.5.0",
-    "nv-ingest==26.3.0rc4",
-    "nv-ingest-api==26.3.0rc4",
-    "nv-ingest-client==26.3.0rc4",
+    "nv-ingest==26.3.0",
+    "nv-ingest-api==26.3.0",
+    "nv-ingest-client==26.3.0",
     "milvus-lite==2.4.12",
     "pypdfium2>=4.30.0,<5.0.0",
     "nemotron-page-elements-v3==3.0.1",
@@ -33,9 +33,9 @@ nv-ingest-harness-stats = "nv_ingest_harness.cli.stats:main"
 package = true
 
 [tool.uv.sources]
-nv-ingest = { path = "../../src", editable = true }
-nv-ingest-api = { path = "../../api/", editable = true }
-nv-ingest-client = { path = "../../client/", editable = true }
+#nv-ingest = { path = "../../src", editable = true }
+#nv-ingest-api = { path = "../../api/", editable = true }
+#nv-ingest-client = { path = "../../client/", editable = true }
 nemotron-page-elements-v3 = { index = "test-pypi" }
 nemotron-graphic-elements-v1 = { index = "test-pypi" }
 nemotron-table-structure-v1 = { index = "test-pypi" }

--- a/tools/harness/test_configs.yaml
+++ b/tools/harness/test_configs.yaml
@@ -28,7 +28,7 @@ active:
     kubectl_bin: microk8s kubectl  # kubectl binary command (e.g., "kubectl", "microk8s kubectl")
     kubectl_sudo: null  # Prepend sudo to kubectl commands (null = same as helm_sudo)
     chart: nemo-microservices/nv-ingest  # Remote chart reference (set to null to use local chart from ./helm)
-    chart_version: 26.3.0-RC4  # Chart version (required for remote charts)
+    chart_version: 26.3.0  # Chart version (required for remote charts)
     release: nv-ingest
     namespace: nv-ingest
     values_file: .helm-env  # Optional: path to values file


### PR DESCRIPTION
## Summary
- Update all version references from 26.3.0-RC4 to 26.3.0 for release
- Update nv-ingest, nv-ingest-api, nv-ingest-client dependency versions in pyproject.toml files
- Update Helm chart version, image tags, and regenerate Helm README.md
- Update docker-compose image tag and FastAPI version string
- Update documentation references (quickstart, library mode, helm, UDFs, release notes)
- Comment out local editable uv sources for release packaging

## Test plan
- [ ] Verify Helm chart installs correctly with new version
- [ ] Verify pip install resolves correct package versions
- [ ] Verify documentation links point to correct release branch

Made with [Cursor](https://cursor.com)