### PR TITLE
(retriever) ASR refactor

### DIFF
--- a/nemo_retriever/src/nemo_retriever/audio/__init__.py
+++ b/nemo_retriever/src/nemo_retriever/audio/__init__.py
@@ -12,6 +12,7 @@ batch, inprocess, fused, and online run modes.
 from __future__ import annotations
 
 from nemo_retriever.audio.asr_actor import ASRActor
+from nemo_retriever.audio.asr_actor import asr_chunks_to_text
 from nemo_retriever.audio.asr_actor import asr_params_from_env
 from nemo_retriever.audio.chunk_actor import MediaChunkActor
 from nemo_retriever.audio.media_interface import MediaInterface
@@ -24,6 +25,7 @@ __all__ = [
     "ASRActor",
     "ASRParams",
     "app",
+    "asr_chunks_to_text",
     "asr_params_from_env",
     "AudioChunkParams",
     "MediaChunkActor",

--- a/nemo_retriever/src/nemo_retriever/audio/asr_actor.py
+++ b/nemo_retriever/src/nemo_retriever/audio/asr_actor.py
@@ -8,6 +8,10 @@ ASRActor: Ray Data map_batches callable for speech-to-text.
 Supports remote (Parakeet/Riva gRPC) or local (HuggingFace nvidia/parakeet-ctc-1.1b).
 When audio_endpoints are both null/empty, uses local model; otherwise uses remote client.
 
+Core batch function: asr_chunks_to_text(batch_df, model=..., client=..., asr_params=...).
+Model injection happens there; inprocess and GPU pool pass a ParakeetCTC1B1ASR instance.
+ASRActor is a thin wrapper that holds _model/_client and delegates to asr_chunks_to_text.
+
 Consumes chunk rows (path, bytes, source_path, duration, chunk_index, metadata)
 and produces rows with text (transcript) for downstream embed/VDB. For now,
 ``segment_audio=True`` only fans out rows when using a hosted/remote Parakeet
@@ -120,60 +124,127 @@ def _get_client(params: ASRParams):  # noqa: ANN201
     )
 
 
-class ASRActor:
-    """
-    Ray Data map_batches callable: chunk rows (path/bytes) -> rows with text (transcript).
+def _infer_remote(client: Any, raw: bytes, path: Optional[str]) -> Optional[tuple[List[Dict[str, Any]], str]]:
+    """Use remote Parakeet client to transcribe audio bytes; return (segments, transcript)."""
+    audio_b64 = base64.b64encode(raw).decode("ascii")
+    try:
+        segments, transcript = client.infer(
+            audio_b64,
+            model_name="parakeet",
+        )
+        safe_segments = segments if isinstance(segments, list) else []
+        safe_transcript = transcript if isinstance(transcript, str) else ""
+        return safe_segments, safe_transcript
+    except Exception as e:
+        logger.warning("Parakeet infer failed for path=%s: %s", path, e)
+        return None
 
-    When audio_endpoints are set, uses Parakeet (Riva ASR) via gRPC. When both are
-    null/empty, uses local HuggingFace/NeMo Parakeet (nvidia/parakeet-ctc-1.1b).
-    Output rows have path, text, page_number, metadata for downstream embed. When
-    ``params.segment_audio`` is enabled for remote Parakeet, punctuation-delimited
+
+def _asr_out_columns() -> List[str]:
+    return [
+        "path",
+        "source_path",
+        "duration",
+        "chunk_index",
+        "metadata",
+        "page_number",
+        "text",
+    ]
+
+
+def _build_output_rows(
+    row: pd.Series,
+    transcript: str,
+    *,
+    segment_audio: bool,
+    segments: Optional[List[Dict[str, Any]]] = None,
+) -> List[Dict[str, Any]]:
+    """Build one or more output rows for a chunk, optionally exploding remote punctuation segments."""
+    path = row.get("path")
+    source_path = row.get("source_path", path)
+    duration = row.get("duration")
+    chunk_index = row.get("chunk_index", 0)
+    metadata = row.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {"source_path": source_path, "chunk_index": chunk_index, "duration": duration}
+    else:
+        metadata = copy.deepcopy(metadata)
+    metadata.setdefault("source_path", source_path)
+    metadata.setdefault("chunk_index", chunk_index)
+    metadata.setdefault("duration", duration)
+    page_number = row.get("page_number", chunk_index)
+
+    if segment_audio and segments:
+        out_rows: List[Dict[str, Any]] = []
+        segment_count = len(segments)
+        for segment_index, segment in enumerate(segments):
+            if not isinstance(segment, dict):
+                continue
+            segment_text = str(segment.get("text") or "").strip()
+            if not segment_text:
+                continue
+            segment_metadata = copy.deepcopy(metadata)
+            segment_metadata["segment_index"] = segment_index
+            segment_metadata["segment_count"] = segment_count
+            if segment.get("start") is not None:
+                segment_metadata["segment_start"] = segment.get("start")
+            if segment.get("end") is not None:
+                segment_metadata["segment_end"] = segment.get("end")
+            out_rows.append(
+                {
+                    "path": path,
+                    "source_path": source_path,
+                    "duration": duration,
+                    "chunk_index": chunk_index,
+                    "metadata": segment_metadata,
+                    "page_number": page_number,
+                    "text": segment_text,
+                }
+            )
+        if out_rows:
+            return out_rows
+
+    return [
+        {
+            "path": path,
+            "source_path": source_path,
+            "duration": duration,
+            "chunk_index": chunk_index,
+            "metadata": metadata,
+            "page_number": page_number,
+            "text": transcript,
+        }
+    ]
+
+
+def asr_chunks_to_text(
+    batch_df: pd.DataFrame,
+    *,
+    model: Any = None,
+    client: Any = None,
+    asr_params: Optional[dict] = None,
+    **kwargs: Any,
+) -> pd.DataFrame:
+    """
+    Core batch function: turn chunk rows (path/bytes) into rows with text (transcript).
+
+    model: ParakeetCTC1B1ASR instance for local ASR (or None).
+    client: Remote gRPC client for remote ASR (or None).
+    asr_params: ASRParams or dict for options / creating backend when none injected.
+
+    If both model and client are None, builds ASRActor(asr_params) and delegates
+    with model=actor._model, client=actor._client.
+
+    When ``params.segment_audio`` is enabled for remote Parakeet, punctuation-delimited
     segments are emitted as multiple rows per chunk.
     """
+    if not isinstance(batch_df, pd.DataFrame) or batch_df.empty:
+        return pd.DataFrame(columns=_asr_out_columns())
 
-    def __init__(self, params: ASRParams | None = None) -> None:
-        self._params = params or ASRParams()
-        if _use_remote(self._params):
-            self._client = _get_client(self._params)
-            self._model = None
-        else:
-            self._client = None
-            from nemo_retriever.model.local import ParakeetCTC1B1ASR
+    params = ASRParams(**(asr_params or {}))
 
-            self._model = ParakeetCTC1B1ASR()
-
-    def __call__(self, batch_df: pd.DataFrame) -> pd.DataFrame:
-        if not isinstance(batch_df, pd.DataFrame) or batch_df.empty:
-            return pd.DataFrame(
-                columns=["path", "source_path", "duration", "chunk_index", "metadata", "page_number", "text"]
-            )
-
-        if self._client is not None:
-            return self._call_remote_batch(batch_df)
-        return self._call_local_batch(batch_df)
-
-    def _call_remote_batch(self, batch_df: pd.DataFrame) -> pd.DataFrame:
-        """Remote ASR: one infer call per row (no batching on server side)."""
-        out_rows: List[Dict[str, Any]] = []
-        for _, row in batch_df.iterrows():
-            try:
-                out_rows.extend(self._transcribe_one(row))
-            except Exception as e:
-                logger.exception("ASR failed for row path=%s: %s", row.get("path"), e)
-                continue
-
-        if not out_rows:
-            return pd.DataFrame(
-                columns=["path", "source_path", "duration", "chunk_index", "metadata", "page_number", "text"]
-            )
-        return pd.DataFrame(out_rows)
-
-    def _call_local_batch(self, batch_df: pd.DataFrame) -> pd.DataFrame:
-        """Local ASR: one batched transcribe call for the whole batch."""
-        if self._model is None:
-            return pd.DataFrame(
-                columns=["path", "source_path", "duration", "chunk_index", "metadata", "page_number", "text"]
-            )
+    # Local path: model has transcribe(paths)
+    if model is not None and hasattr(model, "transcribe"):
         temp_paths: List[Optional[str]] = []
         paths_for_model: List[str] = []
         rows_list: List[pd.Series] = []
@@ -219,7 +290,7 @@ class ASRActor:
             temp_paths.append(temp_created)
 
         try:
-            transcripts = self._model.transcribe(paths_for_model) if paths_for_model else []
+            transcripts = model.transcribe(paths_for_model) if paths_for_model else []
         finally:
             for p in temp_paths:
                 if p:
@@ -227,149 +298,86 @@ class ASRActor:
 
         out_rows: List[Dict[str, Any]] = []
         for row, transcript in zip(rows_list, transcripts):
-            out_rows.extend(self._build_output_rows(row, transcript or ""))
-
-        if not out_rows:
-            return pd.DataFrame(
-                columns=["path", "source_path", "duration", "chunk_index", "metadata", "page_number", "text"]
+            out_rows.extend(
+                _build_output_rows(
+                    row,
+                    transcript or "",
+                    segment_audio=params.segment_audio,
+                    segments=None,
+                )
             )
+        if not out_rows:
+            return pd.DataFrame(columns=_asr_out_columns())
         return pd.DataFrame(out_rows)
 
-    def _transcribe_remote(self, raw: bytes, path: Optional[str]) -> Optional[tuple[List[Dict[str, Any]], str]]:
-        """Use remote Parakeet client to transcribe audio bytes and return segments + transcript."""
-        audio_b64 = base64.b64encode(raw).decode("ascii")
-        try:
-            segments, transcript = self._client.infer(
-                audio_b64,
-                model_name="parakeet",
-            )
-            safe_segments = segments if isinstance(segments, list) else []
-            safe_transcript = transcript if isinstance(transcript, str) else ""
-            return safe_segments, safe_transcript
-        except Exception as e:
-            logger.warning("Parakeet infer failed for path=%s: %s", path, e)
-            return None
-
-    def _transcribe_local(self, raw: bytes, path: Optional[str]) -> Optional[str]:
-        """Use local Parakeet model to transcribe; path or temp file with raw bytes."""
-        if self._model is None:
-            return None
-        path_to_use = path
-        if not path_to_use or not Path(path_to_use).exists():
-            # Raw bytes: write to temp file (format detected by loader/ffmpeg)
-            with tempfile.NamedTemporaryFile(suffix=".audio", delete=False) as f:
-                f.write(raw)
-                path_to_use = f.name
-            try:
-                transcripts = self._model.transcribe([path_to_use])
-                return transcripts[0] if transcripts else ""
-            finally:
-                Path(path_to_use).unlink(missing_ok=True)
-        else:
-            transcripts = self._model.transcribe([path_to_use])
-            return transcripts[0] if transcripts else ""
-
-    def _build_output_rows(
-        self,
-        row: pd.Series,
-        transcript: str,
-        *,
-        segments: Optional[List[Dict[str, Any]]] = None,
-    ) -> List[Dict[str, Any]]:
-        """Build one or more output rows for a chunk, optionally exploding remote punctuation segments."""
-        path = row.get("path")
-        source_path = row.get("source_path", path)
-        duration = row.get("duration")
-        chunk_index = row.get("chunk_index", 0)
-        metadata = row.get("metadata")
-        if not isinstance(metadata, dict):
-            metadata = {"source_path": source_path, "chunk_index": chunk_index, "duration": duration}
-        else:
-            metadata = copy.deepcopy(metadata)
-        metadata.setdefault("source_path", source_path)
-        metadata.setdefault("chunk_index", chunk_index)
-        metadata.setdefault("duration", duration)
-        page_number = row.get("page_number", chunk_index)
-
-        if self._params.segment_audio and segments:
-            out_rows: List[Dict[str, Any]] = []
-            segment_count = len(segments)
-            for segment_index, segment in enumerate(segments):
-                if not isinstance(segment, dict):
+    # Remote path: client is set
+    if client is not None:
+        out_rows: List[Dict[str, Any]] = []
+        for _, row in batch_df.iterrows():
+            raw = row.get("bytes")
+            path = row.get("path")
+            if raw is None and path:
+                try:
+                    with open(path, "rb") as f:
+                        raw = f.read()
+                except Exception as e:
+                    logger.warning("Could not read %s: %s", path, e)
                     continue
-                segment_text = str(segment.get("text") or "").strip()
-                if not segment_text:
-                    continue
-                segment_metadata = copy.deepcopy(metadata)
-                segment_metadata["segment_index"] = segment_index
-                segment_metadata["segment_count"] = segment_count
-                if segment.get("start") is not None:
-                    segment_metadata["segment_start"] = segment.get("start")
-                if segment.get("end") is not None:
-                    segment_metadata["segment_end"] = segment.get("end")
-                out_rows.append(
-                    {
-                        "path": path,
-                        "source_path": source_path,
-                        "duration": duration,
-                        "chunk_index": chunk_index,
-                        "metadata": segment_metadata,
-                        "page_number": page_number,
-                        "text": segment_text,
-                    }
-                )
-            if out_rows:
-                return out_rows
-
-        return [
-            {
-                "path": path,
-                "source_path": source_path,
-                "duration": duration,
-                "chunk_index": chunk_index,
-                "metadata": metadata,
-                "page_number": page_number,
-                "text": transcript,
-            }
-        ]
-
-    def _transcribe_one(self, row: pd.Series) -> List[Dict[str, Any]]:
-        raw = row.get("bytes")
-        path = row.get("path")
-        if raw is None and path:
-            try:
-                with open(path, "rb") as f:
-                    raw = f.read()
-            except Exception as e:
-                logger.warning("Could not read %s: %s", path, e)
-                return []
-        if raw is None:
-            return []
-
-        if self._client is not None:
-            remote_result = self._transcribe_remote(raw, path)
+            if raw is None:
+                continue
+            remote_result = _infer_remote(client, raw, path)
             if remote_result is None:
-                return []
+                continue
             segments, transcript = remote_result
-            return self._build_output_rows(row, transcript, segments=segments)
-        else:
-            transcript = self._transcribe_local(raw, path)
-            if transcript is None:
-                return []
-            return self._build_output_rows(row, transcript)
+            out_rows.extend(
+                _build_output_rows(
+                    row,
+                    transcript,
+                    segment_audio=params.segment_audio,
+                    segments=segments,
+                )
+            )
+        if not out_rows:
+            return pd.DataFrame(columns=_asr_out_columns())
+        return pd.DataFrame(out_rows)
 
-
-def apply_asr_to_df(
-    batch_df: pd.DataFrame,
-    asr_params: Optional[dict] = None,
-    **kwargs: Any,
-) -> pd.DataFrame:
-    """
-    Inprocess helper: apply ASR to a DataFrame of chunk rows; returns DataFrame with text column set.
-
-    Used by InProcessIngestor when _pipeline_type == "audio". asr_params can be a dict
-    to construct ASRParams (e.g. from model_dump()).
-    """
-    params = ASRParams(**(asr_params or {}))
+    # Backward compat: no model/client injected, create actor and delegate
     actor = ASRActor(params=params)
-    return actor(batch_df)
+    return asr_chunks_to_text(
+        batch_df,
+        model=actor._model,
+        client=actor._client,
+        asr_params=params.model_dump(mode="python"),
+        **kwargs,
+    )
+
+
+class ASRActor:
+    """
+    Ray Data map_batches callable: chunk rows (path/bytes) -> rows with text (transcript).
+
+    When audio_endpoints are set, uses Parakeet (Riva ASR) via gRPC. When both are
+    null/empty, uses local HuggingFace/NeMo Parakeet (nvidia/parakeet-ctc-1.1b).
+    Output rows have path, text, page_number, metadata for downstream embed. When
+    ``params.segment_audio`` is enabled for remote Parakeet, punctuation-delimited
+    segments are emitted as multiple rows per chunk.
+    """
+
+    def __init__(self, params: ASRParams | None = None) -> None:
+        self._params = params or ASRParams()
+        if _use_remote(self._params):
+            self._client = _get_client(self._params)
+            self._model = None
+        else:
+            self._client = None
+            from nemo_retriever.model.local import ParakeetCTC1B1ASR
+
+            self._model = ParakeetCTC1B1ASR()
+
+    def __call__(self, batch_df: pd.DataFrame) -> pd.DataFrame:
+        return asr_chunks_to_text(
+            batch_df,
+            model=self._model,
+            client=self._client,
+            asr_params=self._params.model_dump(mode="python"),
+        )

--- a/nemo_retriever/src/nemo_retriever/audio/media_interface.py
+++ b/nemo_retriever/src/nemo_retriever/audio/media_interface.py
@@ -125,14 +125,38 @@ class MediaInterface(_LoaderInterface):
                 probe = _probe(str(path_file), format=path_file.suffix)
             if probe["streams"][0]["codec_type"] == "video":
                 sample_rate = float(probe["streams"][0]["avg_frame_rate"].split("/")[0])
-                duration = float(probe["format"]["duration"])
+                duration_raw = probe["format"].get("duration")
+                if duration_raw is not None and str(duration_raw).strip():
+                    duration = float(duration_raw)
+                else:
+                    logger.warning(
+                        "Missing duration for video file %s (format keys: %s); ffprobe may have reported invalid data.",
+                        path_file,
+                        list(probe["format"].keys()),
+                    )
+                    duration = None
             elif probe["streams"][0]["codec_type"] == "audio":
                 sample_rate = float(probe["streams"][0]["sample_rate"])
-                bitrate = probe["format"]["bit_rate"]
-                duration = (file_size * 8) / float(bitrate)
+                bitrate = probe["format"].get("bit_rate")
+                if bitrate is not None and str(bitrate).strip():
+                    duration = (file_size * 8) / float(bitrate)
+                else:
+                    # VBR or invalid/corrupt chunk often has no bit_rate; use format duration if present
+                    duration_raw = probe["format"].get("duration")
+                    if duration_raw is not None and str(duration_raw).strip():
+                        duration = float(duration_raw)
+                    else:
+                        logger.warning(
+                            "Missing bit_rate and duration for audio file %s (format keys: %s); "
+                            "ffprobe may have reported invalid data.",
+                            path_file,
+                            list(probe["format"].keys()),
+                        )
+                        duration = None
             else:
                 raise ValueError(f"Unknown codec_type: {probe['streams'][0]}")
-            num_splits = self.find_num_splits(file_size, sample_rate, duration, split_interval, split_type)
+            if duration is not None:
+                num_splits = self.find_num_splits(file_size, sample_rate, duration, split_interval, split_type)
         except ffmpeg.Error as e:
             logger.error("FFmpeg error for file %s: %s", path_file, e.stderr.decode())
         except ValueError as e:

--- a/nemo_retriever/src/nemo_retriever/audio/stage.py
+++ b/nemo_retriever/src/nemo_retriever/audio/stage.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Optional
 import pandas as pd
 import typer
 
-from nemo_retriever.audio.asr_actor import apply_asr_to_df
+from nemo_retriever.audio.asr_actor import asr_chunks_to_text
 from nemo_retriever.audio.asr_actor import asr_params_from_env
 from nemo_retriever.audio.chunk_actor import audio_path_to_chunks_df
 from nemo_retriever.audio.media_interface import is_media_available
@@ -124,7 +124,7 @@ def _run_extract_one(
     if chunk_df.empty:
         return chunk_df
     asr_kw = asr_params.model_dump(mode="python")
-    return apply_asr_to_df(chunk_df, asr_params=asr_kw)
+    return asr_chunks_to_text(chunk_df, asr_params=asr_kw)
 
 
 @app.command("extract")

--- a/nemo_retriever/src/nemo_retriever/ingest_modes/inprocess.py
+++ b/nemo_retriever/src/nemo_retriever/ingest_modes/inprocess.py
@@ -1322,14 +1322,19 @@ class InProcessIngestor(Ingestor):
         Use with .files("mp3/*.mp3").extract_audio(...).embed().vdb_upload().ingest().
         Do not call .extract() when using .extract_audio(). ASR requires a remote Parakeet/Riva endpoint.
         """
-        from nemo_retriever.audio.asr_actor import apply_asr_to_df
+        from nemo_retriever.audio.asr_actor import asr_chunks_to_text, _use_remote
+        from nemo_retriever.model.local import ParakeetCTC1B1ASR
 
         self._pipeline_type = "audio"
         chunk_resolved = _coerce_params(params, AudioChunkParams, kwargs)
         asr_resolved = _coerce_params(asr_params, ASRParams, kwargs)
         self._extract_audio_chunk_kwargs = chunk_resolved.model_dump(mode="python")
         self._extract_audio_asr_kwargs = asr_resolved.model_dump(mode="python")
-        self._tasks.append((apply_asr_to_df, {"asr_params": self._extract_audio_asr_kwargs}))
+        if _use_remote(asr_resolved):
+            self._tasks.append((asr_chunks_to_text, {"model": None, "asr_params": self._extract_audio_asr_kwargs}))
+        else:
+            model = ParakeetCTC1B1ASR()
+            self._tasks.append((asr_chunks_to_text, {"model": model, "asr_params": self._extract_audio_asr_kwargs}))
         return self
 
     def embed(self, params: EmbedParams | None = None, **kwargs: Any) -> "InProcessIngestor":
@@ -1476,6 +1481,41 @@ class InProcessIngestor(Ingestor):
         post_tasks = [(f, k) for f, k in self._tasks if f in self._POST_TASKS]
         return per_doc_tasks, post_tasks
 
+    def _load_doc_to_df(self, doc_path: str) -> pd.DataFrame:
+        """Load a single document into a DataFrame of chunks/pages based on _pipeline_type."""
+        if self._pipeline_type == "pdf":
+            abs_path = os.path.abspath(doc_path)
+            ext = os.path.splitext(abs_path)[1].lower()
+            if ext in SUPPORTED_EXTENSIONS and ext != ".pdf":
+                try:
+                    with open(abs_path, "rb") as f:
+                        file_bytes = f.read()
+                    pdf_bytes = convert_to_pdf_bytes(file_bytes, ext)
+                    pages = _split_pdf_to_single_page_bytes(pdf_bytes)
+                    out_rows = [{"bytes": b, "path": abs_path, "page_number": i + 1} for i, b in enumerate(pages)]
+                    return pd.DataFrame(out_rows)
+                except BaseException as e:
+                    return pd.DataFrame([{"bytes": b"", "path": abs_path, "page_number": 0, "error": str(e)}])
+            return pdf_path_to_pages_df(doc_path)
+        if self._pipeline_type == "html":
+            return html_file_to_chunks_df(doc_path, params=HtmlChunkParams(**self._extract_html_kwargs))
+        if self._pipeline_type == "image":
+            from nemo_retriever.image.load import image_file_to_pages_df
+
+            return image_file_to_pages_df(doc_path)
+        if self._pipeline_type == "audio":
+            from nemo_retriever.audio.chunk_actor import audio_path_to_chunks_df
+
+            return audio_path_to_chunks_df(doc_path, params=AudioChunkParams(**self._extract_audio_chunk_kwargs))
+        return txt_file_to_chunks_df(doc_path, params=TextChunkParams(**self._extract_txt_kwargs))
+
+    def _iter_doc_chunks(self, doc_path: str, page_chunk_size: int) -> Iterator[pd.DataFrame]:
+        """Yield chunk DataFrames for one document. PDF: multiple page chunks; else: one loader result."""
+        if self._pipeline_type == "pdf":
+            yield from _iter_page_chunks(doc_path, page_chunk_size)
+        else:
+            yield self._load_doc_to_df(doc_path)
+
     def ingest(self, params: IngestExecuteParams | None = None, **kwargs: Any) -> list[Any]:
         run_params = _coerce_params(params, IngestExecuteParams, kwargs)
         show_progress = run_params.show_progress
@@ -1512,8 +1552,13 @@ class InProcessIngestor(Ingestor):
                     chunks: list[pd.DataFrame] = []
                     chunk_to_doc: list[str] = []
                     doc_chunk_total: dict[str, int] = defaultdict(int)
-                    for doc in docs:
-                        for chunk_df in _iter_page_chunks(doc, page_chunk_size):
+                    doc_iter = (
+                        tqdm(docs, desc="Chunking documents", unit="doc")
+                        if (show_progress and tqdm is not None)
+                        else docs
+                    )
+                    for doc in doc_iter:
+                        for chunk_df in self._iter_doc_chunks(doc, page_chunk_size):
                             chunk_to_doc.append(doc)
                             doc_chunk_total[doc] += 1
                             chunks.append(chunk_df)
@@ -1591,8 +1636,11 @@ class InProcessIngestor(Ingestor):
                 chunks: list[pd.DataFrame] = []
                 chunk_to_doc: list[str] = []
                 doc_chunk_total: dict[str, int] = defaultdict(int)
-                for doc in docs:
-                    for chunk_df in _iter_page_chunks(doc, page_chunk_size):
+                doc_iter = (
+                    tqdm(docs, desc="Chunking documents", unit="doc") if (show_progress and tqdm is not None) else docs
+                )
+                for doc in doc_iter:
+                    for chunk_df in self._iter_doc_chunks(doc, page_chunk_size):
                         chunk_to_doc.append(doc)
                         doc_chunk_total[doc] += 1
                         chunks.append(chunk_df)
@@ -1668,8 +1716,11 @@ class InProcessIngestor(Ingestor):
                 doc_chunk_total: dict[str, int] = defaultdict(int)
                 doc_done: dict[str, int] = defaultdict(int)
 
-                for doc_path in docs:
-                    for chunk_df in _iter_page_chunks(doc_path, page_chunk_size):
+                doc_iter = (
+                    tqdm(docs, desc="Chunking documents", unit="doc") if (show_progress and tqdm is not None) else docs
+                )
+                for doc_path in doc_iter:
+                    for chunk_df in self._iter_doc_chunks(doc_path, page_chunk_size):
                         doc_chunk_total[doc_path] += 1
                         current: Any = chunk_df
                         for func, kwargs in cpu_and_extract:
@@ -1726,50 +1777,7 @@ class InProcessIngestor(Ingestor):
         if show_progress and tqdm is not None:
             doc_iter = tqdm(docs, desc="Processing documents", unit="doc")
 
-        if self._pipeline_type == "pdf":
-
-            def _loader(p: str) -> pd.DataFrame:
-                """
-                Load a document as a per-page DataFrame. For .pdf use pdf_path_to_pages_df.
-                For .docx/.pptx convert to PDF via LibreOffice then split (same schema).
-                """
-                abs_path = os.path.abspath(p)
-                ext = os.path.splitext(abs_path)[1].lower()
-                if ext in SUPPORTED_EXTENSIONS and ext != ".pdf":
-                    try:
-                        with open(abs_path, "rb") as f:
-                            file_bytes = f.read()
-                        pdf_bytes = convert_to_pdf_bytes(file_bytes, ext)
-                        pages = _split_pdf_to_single_page_bytes(pdf_bytes)
-                        out_rows = [{"bytes": b, "path": abs_path, "page_number": i + 1} for i, b in enumerate(pages)]
-                        return pd.DataFrame(out_rows)
-                    except BaseException as e:
-                        return pd.DataFrame([{"bytes": b"", "path": abs_path, "page_number": 0, "error": str(e)}])
-                return pdf_path_to_pages_df(p)
-
-        elif self._pipeline_type == "html":
-
-            def _loader(p: str) -> pd.DataFrame:
-                return html_file_to_chunks_df(p, params=HtmlChunkParams(**self._extract_html_kwargs))
-
-        elif self._pipeline_type == "image":
-
-            def _loader(p: str) -> pd.DataFrame:
-                from nemo_retriever.image.load import image_file_to_pages_df
-
-                return image_file_to_pages_df(p)
-
-        elif self._pipeline_type == "audio":
-
-            def _loader(p: str) -> pd.DataFrame:
-                from nemo_retriever.audio.chunk_actor import audio_path_to_chunks_df
-
-                return audio_path_to_chunks_df(p, params=AudioChunkParams(**self._extract_audio_chunk_kwargs))
-
-        else:
-
-            def _loader(p: str) -> pd.DataFrame:
-                return txt_file_to_chunks_df(p, params=TextChunkParams(**self._extract_txt_kwargs))
+        _loader = self._load_doc_to_df
 
         for doc_path in doc_iter:
             initial_df = _loader(doc_path)

--- a/nemo_retriever/src/nemo_retriever/model/local/parakeet_ctc_1_1b_asr.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/parakeet_ctc_1_1b_asr.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import tempfile
+from collections import defaultdict
 from pathlib import Path
 from typing import List, Optional
 
@@ -26,6 +27,8 @@ logger = logging.getLogger(__name__)
 
 MODEL_ID = "nvidia/parakeet-ctc-1.1b"
 SAMPLING_RATE = 16000
+# Model has max_position_embeddings=5000; long audio exceeds it. Cap segment duration (seconds).
+MAX_AUDIO_DURATION_SEC = 25.0
 
 
 def _strip_pad_from_transcript(text: str) -> str:
@@ -179,7 +182,37 @@ class ParakeetCTC1B1ASR:
         return result
 
     def _transcribe_audio_batch(self, audios: List[np.ndarray]) -> List[str]:
-        """Single forward pass for a list of audio arrays; returns one string per array."""
+        """Forward pass for a list of audio arrays. Long clips are split to avoid max_position_embeddings."""
+        if self._model is None or self._processor is None or not audios:
+            return [""] * len(audios)
+        max_samples = int(MAX_AUDIO_DURATION_SEC * SAMPLING_RATE)
+        segments: List[np.ndarray] = []
+        segment_to_orig: List[int] = []  # original index for each segment
+        for i, audio in enumerate(audios):
+            n = len(audio)
+            if n <= max_samples:
+                segments.append(audio)
+                segment_to_orig.append(i)
+            else:
+                for start in range(0, n, max_samples):
+                    end = min(start + max_samples, n)
+                    segments.append(audio[start:end].copy())
+                    segment_to_orig.append(i)
+        if not segments:
+            return [""] * len(audios)
+        try:
+            segment_transcripts = self._transcribe_audio_batch_impl(segments)
+        except Exception as e:
+            logger.warning("ASR (transformers) batch failed: %s", e)
+            return [""] * len(audios)
+        # Reassemble: concatenate transcripts for segments belonging to the same original audio
+        orig_to_texts: dict[int, List[str]] = defaultdict(list)
+        for seg_idx, orig_idx in enumerate(segment_to_orig):
+            orig_to_texts[orig_idx].append(_strip_pad_from_transcript((segment_transcripts[seg_idx] or "").strip()))
+        return [" ".join(filter(None, orig_to_texts[i])).strip() for i in range(len(audios))]
+
+    def _transcribe_audio_batch_impl(self, audios: List[np.ndarray]) -> List[str]:
+        """Single forward pass for a list of audio arrays (each assumed within length limit)."""
         if self._model is None or self._processor is None or not audios:
             return [""] * len(audios)
         try:

--- a/nemo_retriever/tests/test_asr_actor.py
+++ b/nemo_retriever/tests/test_asr_actor.py
@@ -18,7 +18,7 @@ from unittest.mock import patch
 import pandas as pd
 
 from nemo_retriever.audio.asr_actor import ASRActor
-from nemo_retriever.audio.asr_actor import apply_asr_to_df
+from nemo_retriever.audio.asr_actor import asr_chunks_to_text
 from nemo_retriever.params import ASRParams
 
 
@@ -90,7 +90,8 @@ def test_asr_actor_mock_transcribe():
         assert call_arg == base64.b64encode(raw).decode("ascii")
 
 
-def test_apply_asr_to_df():
+def test_asr_chunks_to_text_remote():
+    """asr_chunks_to_text with remote endpoints uses client (no model)."""
     with patch("nemo_retriever.audio.asr_actor._get_client") as mock_get:
         mock_client = MagicMock()
         mock_client.infer.return_value = ([], "applied transcript")
@@ -109,7 +110,7 @@ def test_apply_asr_to_df():
                 }
             ]
         )
-        out = apply_asr_to_df(batch, asr_params={"audio_endpoints": ("localhost:50051", None)})
+        out = asr_chunks_to_text(batch, asr_params={"audio_endpoints": ("localhost:50051", None)})
         assert isinstance(out, pd.DataFrame)
         assert len(out) == 1
         assert out["text"].iloc[0] == "applied transcript"
@@ -157,7 +158,7 @@ def test_asr_actor_remote_segment_audio():
         assert out["metadata"].iloc[1]["segment_end"] == 2.5
 
 
-def test_apply_asr_to_df_segment_audio():
+def test_asr_chunks_to_text_remote_segment_audio():
     with patch("nemo_retriever.audio.asr_actor._get_client") as mock_get:
         mock_client = MagicMock()
         mock_client.infer.return_value = (
@@ -182,7 +183,7 @@ def test_apply_asr_to_df_segment_audio():
                 }
             ]
         )
-        out = apply_asr_to_df(
+        out = asr_chunks_to_text(
             batch,
             asr_params={"audio_endpoints": ("localhost:50051", None), "segment_audio": True},
         )
@@ -239,8 +240,8 @@ def test_local_asr_does_not_call_get_client():
             sys.modules["nemo_retriever.model.local"] = prev_local
 
 
-def test_local_asr_apply_asr_to_df():
-    """apply_asr_to_df with audio_endpoints=(None, None) uses local model when mocked."""
+def test_asr_chunks_to_text_local_backward_compat():
+    """asr_chunks_to_text with audio_endpoints=(None, None) and no model uses local model when mocked."""
     mock_model = MagicMock()
     mock_model.transcribe.return_value = ["apply local text"]
     mock_class = MagicMock(return_value=mock_model)
@@ -263,7 +264,7 @@ def test_local_asr_apply_asr_to_df():
                     }
                 ]
             )
-            out = apply_asr_to_df(batch, asr_params={"audio_endpoints": (None, None)})
+            out = asr_chunks_to_text(batch, asr_params={"audio_endpoints": (None, None)})
 
             mock_get.assert_not_called()
             assert len(out) == 1
@@ -273,3 +274,26 @@ def test_local_asr_apply_asr_to_df():
             sys.modules.pop("nemo_retriever.model.local", None)
         else:
             sys.modules["nemo_retriever.model.local"] = prev_local
+
+
+def test_asr_chunks_to_text_reuses_injected_model():
+    """asr_chunks_to_text(batch_df, model=parakeet) uses the given model without creating ASRActor."""
+    mock_model = MagicMock()
+    mock_model.transcribe.return_value = ["injected model transcript"]
+    batch = pd.DataFrame(
+        [
+            {
+                "path": "/p",
+                "bytes": b"x",
+                "source_path": "/s",
+                "duration": 0.5,
+                "chunk_index": 0,
+                "metadata": {},
+                "page_number": 0,
+            }
+        ]
+    )
+    out = asr_chunks_to_text(batch, model=mock_model, asr_params={"audio_endpoints": (None, None)})
+    assert len(out) == 1
+    assert out["text"].iloc[0] == "injected model transcript"
+    mock_model.transcribe.assert_called_once()


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Refactors ASR so all “chunk rows → transcript rows” logic goes through **`asr_chunks_to_text`**, with **`ASRActor`** as a thin wrapper.

### What changed

- **`asr_chunks_to_text(batch_df, model=..., client=..., asr_params=...)`**  
  Single batch entry point for ASR. **`ASRActor`** only constructs `model`/`client` from **`ASRParams`** and delegates here.

- **Injectable `model` / `client`**  
  Inprocess and the GPU pool can pass a **`ParakeetCTC1B1ASR`** (or remote client) so the same code path runs inside and outside Ray **`map_batches`**.

- **Long audio (local Parakeet)**  
  **`ParakeetCTC1B1ASR`** splits inputs that exceed the model length budget and concatenates transcripts.

- **Media probing**  
  **`media_interface`**: more robust ffprobe handling when **`duration`** or **`bit_rate`** is missing (e.g. VBR / bad probes).

- **Inprocess**  
  **`_load_doc_to_df` / `_iter_doc_chunks`** unify loading for **pdf / html / image / audio / txt** in the ingest loop.

- **API**  
  Removed **`apply_asr_to_df`**; use **`asr_chunks_to_text`** directly (tests updated).

### Why

- One implementation for Ray batch, inprocess, and audio CLI—easier to fix and extend.
- Injected **`model`** supports GPU pool / avoids duplicate model setup where the caller already holds the model.
- Preserves **`main`** behavior for remote **`segment_audio`** while keeping the refactored structure.

### Testing

- `pytest nemo_retriever/tests/test_asr_actor.py`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
