### PR TITLE
(retriever) downgrade transformers pin from >=5 to >=4.57.6,<5

### DIFF
--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -50,10 +50,8 @@ dependencies = [
   "urllib3==2.6.3",
   "debugpy>=1.8.0",
   "python-multipart>=0.0.9",
-  # transformers>=5 enables loading nvidia/parakeet-ctc-1.1b via pipeline (see
-  # parakeet-ctc-1.1b README). If using llama_nemotron_embed_1b_v2, verify
-  # compatibility with transformers 5 (it previously relied on HybridCache).
-  "transformers>=5.0.0",
+  # transformers>=4.57 includes native nvidia/parakeet-ctc-1.1b support.
+  "transformers>=4.57.6,<5",
   "tokenizers>=0.20.3",
   "accelerate>=1.1.0",
   "torch~=2.9.1",

--- a/nemo_retriever/src/nemo_retriever/model/local/parakeet_ctc_1_1b_asr.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/parakeet_ctc_1_1b_asr.py
@@ -7,7 +7,7 @@ Local ASR using nvidia/parakeet-ctc-1.1b via Hugging Face Transformers.
 
 Uses AutoModelForCTC + AutoProcessor with batch_decode(skip_special_tokens=True)
 to avoid <pad> tokens in output; falls back to post-processing to strip any remaining.
-Requires transformers>=5. Model expects 16 kHz mono input.
+Requires transformers>=4.57. Model expects 16 kHz mono input.
 """
 
 from __future__ import annotations
@@ -111,7 +111,7 @@ class ParakeetCTC1B1ASR:
     Local ASR using nvidia/parakeet-ctc-1.1b via Hugging Face Transformers.
 
     Uses AutoModelForCTC + AutoProcessor with batch_decode(skip_special_tokens=True)
-    and post-processes to remove any remaining <pad> tokens. Requires transformers>=5.
+    and post-processes to remove any remaining <pad> tokens. Requires transformers>=4.57.
     """
 
     def __init__(


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
