### PR TITLE
remove duplicate caption() section with wrong parameters (NVBug 6000620)

### DIFF
--- a/docs/docs/extraction/nv-ingest-python-api.md
+++ b/docs/docs/extraction/nv-ingest-python-api.md
@@ -424,31 +424,6 @@ results = ingestor.ingest()
 
     For more information about working with infographics and multimodal content, refer to [Use Multimodal Embedding](vlm-embed.md).
 
-### Caption Images and Control Reasoning
-
-The caption task can call a VLM with optional prompt and system prompt overrides:
-
-- `caption_prompt` (user prompt): defaults to `"Caption the content of this image:"`.
-- `caption_system_prompt` (system prompt): defaults to `"/no_think"` (reasoning off). Set to `"/think"` to enable reasoning per the Nemotron Nano 12B v2 VL model card.
-
-Example:
-```python
-from nv_ingest_client.client.interface import Ingestor
-
-ingestor = (
-    Ingestor()
-    .files("path/to/doc-with-images.pdf")
-    .extract(extract_images=True)
-    .caption(
-        prompt="Caption the content of this image:",
-        system_prompt="/think",  # or "/no_think"
-    )
-    .ingest()
-)
-```
-
-
-
 ## Extract Embeddings
 
 The `embed` method in the library generates text embeddings for document content.

--- a/docs/docs/extraction/python-api-reference.md
+++ b/docs/docs/extraction/python-api-reference.md
@@ -516,33 +516,6 @@ results = ingestor.ingest()
 
     For more information about working with infographics and multimodal content, refer to [Use Multimodal Embedding](vlm-embed.md).
 
-### Caption Images and Control Reasoning
-
-The caption task can call a VLM with optional prompt and system prompt overrides:
-
-- `caption_prompt` (user prompt): defaults to `"Caption the content of this image:"`.
-- `caption_system_prompt` (system prompt): defaults to `"/no_think"` (reasoning off). Set to `"/think"` to enable reasoning per the Nemotron Nano 12B v2 VL model card.
-- `context_text_max_chars` (int, optional): Maximum characters of page text to include as context for the VLM.
-- `temperature` (float, optional): Sampling temperature for the VLM.
-
-Example:
-```python
-from nemo_retriever.client.interface import Ingestor
-
-ingestor = (
-    Ingestor()
-    .files("path/to/doc-with-images.pdf")
-    .extract(extract_images=True)
-    .caption(
-        prompt="Caption the content of this image:",
-        system_prompt="/think",  # or "/no_think"
-    )
-    .ingest()
-)
-```
-
-
-
 ## Extract Embeddings
 
 The `embed` method in the NeMo Retriever Library generates text embeddings for document content.


### PR DESCRIPTION
Docs: remove duplicate caption() section with wrong parameters (NVBug 6000620)

Summary
The Python API guides had two sections that both described VLM reasoning for .caption(). The second section used incorrect parameter names (caption_prompt, caption_system_prompt) and an example with system_prompt="/think", which the client explicitly rejects (ValueError: use reasoning (bool) instead). That duplicated and contradicted the correct section earlier in the same pages, which documents prompt and reasoning and matches the CLI.

Changes
docs/docs/extraction/nv-ingest-python-api.md — Removed the duplicate “Caption Images and Control Reasoning” subsection after the infographics tip. The surviving “Caption images and control reasoning” section and the infographic example (already using reasoning=True) remain the single source of truth.
docs/docs/extraction/python-api-reference.md — Same removal for consistency with the NeMo Retriever–branded guide.