### PR TITLE
Update the documents per 6000508 - point GitHub links to NVIDIA/nv-ingest 

### DIFF
--- a/docs/docs/extraction/cli-reference.md
+++ b/docs/docs/extraction/cli-reference.md
@@ -20,7 +20,7 @@ nemo-retriever --help
 
 !!! tip
 
-    There is a Jupyter notebook available to help you get started with the CLI. For more information, refer to [CLI Client Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/cli_client_usage.ipynb).
+    There is a Jupyter notebook available to help you get started with the CLI. For more information, refer to [CLI Client Quick Start Guide](https://github.com/NVIDIA/nv-ingest/blob/main/client/client_examples/examples/cli_client_usage.ipynb).
 
 
 ## Parameter Reference

--- a/docs/docs/extraction/helm.md
+++ b/docs/docs/extraction/helm.md
@@ -2,7 +2,7 @@
 
 # Deploy With Helm for NeMo Retriever Library
 
-To deploy [NeMo Retriever Library](overview.md) by using Helm, refer to [NV-Ingest Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/helm/README.md).
+To deploy [NeMo Retriever Library](overview.md) by using Helm, refer to [NV-Ingest Helm Charts](https://github.com/NVIDIA/nv-ingest/blob/26.03/helm/README.md).
 
 !!! note "Air-gapped environments"
    

--- a/docs/docs/extraction/python-api-reference.md
+++ b/docs/docs/extraction/python-api-reference.md
@@ -8,7 +8,7 @@ The [NeMo Retriever Library](overview.md) Python API provides a simple and flexi
 
 !!! tip
 
-    There is a Jupyter notebook available to help you get started with the Python API. For more information, refer to [Python Client Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/python_client_usage.ipynb).
+    There is a Jupyter notebook available to help you get started with the Python API. For more information, refer to [Python Client Quick Start Guide](https://github.com/NVIDIA/nv-ingest/blob/main/client/client_examples/examples/python_client_usage.ipynb).
 
 
 ## Summary of Key Methods

--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -410,7 +410,7 @@ docker compose \
 When deploying in an air-gapped environment (no internet or NGC registry access), you must pre-stage container images on a machine with network access, then transfer and load them in the isolated environment.
 
 1. On a machine with network access: Clone the repo, authenticate with NGC (`docker login nvcr.io`), and pull all images used by your chosen profile (for example, `docker compose --profile retrieval pull`).
-2. Save images: Export the images to archives (for example, using `docker save` for each image or a script that saves all images referenced by your [docker-compose.yaml](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docker-compose.yaml)).
+2. Save images: Export the images to archives (for example, using `docker save` for each image or a script that saves all images referenced by your [docker-compose.yaml](https://github.com/NVIDIA/nv-ingest/blob/main/docker-compose.yaml)).
 3. Transfer the image archives and your `docker-compose.yaml` (and `.env` if used) to the air-gapped system.
 4. On the air-gapped machine: Load the images (`docker load -i <archive>`) and start the stack with the same profile (for example, `docker compose --profile retrieval up`).
 

--- a/docs/docs/extraction/quickstart-library-mode.md
+++ b/docs/docs/extraction/quickstart-library-mode.md
@@ -4,4 +4,4 @@
 
     NVIDIA Ingest (nv-ingest) has been renamed NeMo Retriever Library.
 
-Use the [Quick Start for NeMo Retriever Library](https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/nemo_retriever/README.md) to set up and run the NeMo Retriever Library locally, so you can build a GPU‑accelerated, multimodal RAG ingestion pipeline that parses PDFs, HTML, text, audio, and video into LanceDB vector embeddings, integrates with Nemotron RAG models (locally or via NIM endpoints), which includes Ray‑based scaling with built‑in recall evaluation.
+Use the [Quick Start for NeMo Retriever Library](https://github.com/NVIDIA/nv-ingest/blob/26.03/nemo_retriever/README.md) to set up and run the NeMo Retriever Library locally, so you can build a GPU‑accelerated, multimodal RAG ingestion pipeline that parses PDFs, HTML, text, audio, and video into LanceDB vector embeddings, integrates with Nemotron RAG models (locally or via NIM endpoints), which includes Ray‑based scaling with built‑in recall evaluation.

--- a/docs/docs/extraction/releasenotes-nv-ingest.md
+++ b/docs/docs/extraction/releasenotes-nv-ingest.md
@@ -10,11 +10,11 @@ This documentation contains the release notes for [NeMo Retriever Library](overv
 
 NVIDIA® NeMo Retriever Library version 26.03 adds broader hardware and software support along with many pipeline, evaluation, and deployment enhancements.
 
-To upgrade the Helm charts for this release, refer to the [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/release/26.3.0/helm/README.md).
+To upgrade the Helm charts for this release, refer to the [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/nv-ingest/blob/release/26.3.0/helm/README.md).
 
 Highlights for the 26.03 release include:
 
-- NV-Ingest GitHub repo renamed to NeMo-Retriever  
+- Source code and documentation links use the [NVIDIA/nv-ingest](https://github.com/NVIDIA/nv-ingest) GitHub repository (product name: NeMo Retriever Library)  
 - NeMo Retriever Extraction pipeline renamed to NeMo Retriever Library  
 - NeMo Retriever Library now supports two deployment options:  
   - A new no-container, pip-installable in-process library for development (available on PyPI)  


### PR DESCRIPTION
# point GitHub links to NVIDIA/nv-ingest 

## Description
Several docs and the root README linked to github.com/NVIDIA/NeMo-Retriever, which does not exist, so users hit GitHub 404s (including Jupyter notebook links on the CLI and Python API reference pages). All such URLs are updated to the correct repo: github.com/NVIDIA/nv-ingest, with the same paths under that repo (for example client/client_examples/examples/*.ipynb, helm/README.md, docker-compose.yaml, nemo_retriever/README.md).

Release notes: The 26.03 highlight line that said the repo was renamed to NeMo-Retriever was replaced with wording that matches the repo name and links to NVIDIA/nv-ingest so the notes stay accurate with the fixed links.

## Files changed

- CLI / Python API reference	docs/docs/extraction/cli-reference.md, docs/docs/extraction/python-api-reference.md
- Deploy / quickstart	docs/docs/extraction/helm.md, docs/docs/extraction/quickstart-guide.md, docs/docs/extraction/quickstart-library-mode.md
- Release notes	docs/docs/extraction/releasenotes-nv-ingest.md
- README	README.md