### PR TITLE
Document RTX PRO 4500 Blackwell (GB203) in hardware support matrix 5961722

### DIFF
--- a/docs/docs/extraction/support-matrix.md
+++ b/docs/docs/extraction/support-matrix.md
@@ -64,17 +64,9 @@ The following are the hardware requirements to run NeMo Retriever Library.
 | Reranker       | With Core Pipeline        | Yes           | Yes           | Yes           | Yes         | Yes         | No*           | No*           | No*    | No*                    |
 | Reranker       | Standalone (recall only)  | Yes           | Yes           | Yes           | Yes         | Yes         | Yes           | Yes           | Yes    | Yes                    |
 
-¹ Audio (Parakeet) runs but requires runtime engine build — no pre-defined model profile for this GPU. Dev team to confirm official support status.
-
-² Nemotron Parse fails to start on 32GB despite being supported on A10G (24GB). Pending engineering investigation — may be Blackwell architecture compatibility issue (see related bug).
-
-³ VLM (nemotron-nano-12b-v2-vl) fails to load on 32GB, consistent with "Not supported" on A100-40GB (40GB). 32GB is below the threshold.
-
 \* GPUs with less than 80GB VRAM cannot run the reranker concurrently with the core pipeline. 
 To perform recall testing with the reranker on these GPUs, shut down the core pipeline NIM microservices 
 and run only the embedder, reranker, and your vector database.
-
-
 
 ## Related Topics
 


### PR DESCRIPTION
# Document RTX PRO 4500 Blackwell (GB203) in hardware support matrix (5961722)

## Summary

The NeMo Retriever Library hardware support matrix listed eight GPU options and had no entry for the NVIDIA RTX PRO 4500 Blackwell (GB203, 32GB GDDR7). This change adds that GPU to the supported list and extends the requirements table with a dedicated column so behavior for core pipeline, audio, nemotron-parse, VLM, and reranker is explicit, including known limitations called out by engineering.

Changes

docs/docs/extraction/support-matrix.md
Add a bullet with product link: [RTX PRO 4500 Blackwell](https://www.nvidia.com/en-us/products/workstations/professional-desktop-gpus/rtx-pro-4500/).
Add table column RTX PRO 4500 Blackwell with memory 32GB GDDR7 (GB203).
Align core pipeline rows with other single-GPU entries (~150GB disk, one GPU).
Document Audio (Parakeet) with footnote ¹: runs with a runtime engine build; no pre-defined model profile; official support to be confirmed.
Document nemotron-parse as not supported on this column with footnote ²: failure on 32GB vs A10G (24GB); possible Blackwell-related issue; tracks related bug.
Document VLM as not supported with footnote ³: consistent with sub-40GB class constraints for nemotron-nano-12b-v2-vl.
Align reranker rows with other <80GB GPUs (No* with core pipeline, Yes standalone).
Footnotes ¹–³ are used so they do not conflict with the existing reranker * note.