### PR TITLE
fix: pin liteLLM upper bound to 1.82.6 to mitigate supply chain attack

### DIFF
--- a/retrieval-bench/pyproject.toml
+++ b/retrieval-bench/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "bm25s",
     "datasets>=4.5.0",
     "jinja2",
-    "litellm",
+    "litellm<=1.82.6",
     "Pillow",
     "pydantic>=2.0.0,<3.0.0",
     "pytrec_eval",


### PR DESCRIPTION
## Summary

liteLLM versions **1.82.7** and **1.82.8** were compromised via a **supply chain attack through Trivy** by the **TeamPCP** hacking group. These malicious versions:

- **Steal credentials**: SSH keys, AWS credentials, GCP credentials, Kubernetes secrets, crypto wallets, and CI/CD tokens
- **Version 1.82.8** additionally installs a **`.pth` persistence mechanism** that survives package upgrades, allowing the malicious code to persist even after updating to a clean version

The current `litellm` dependency in `retrieval-bench/pyproject.toml` has **no version pinning at all**, meaning any `pip install` will pull the latest (compromised) version.

## Fix

Pin `litellm<=1.82.6` — the **last known safe version** before the compromise.

```diff
-    "litellm",
+    "litellm<=1.82.6",
```

Once BerriAI publishes a verified clean release, the upper bound can be raised accordingly.

## References

- [BerriAI/litellm#24512](https://github.com/BerriAI/litellm/issues/24512) — Incident report
- [Endor Labs advisory](https://www.endorlabs.com/) — Supply chain attack analysis