### PR TITLE
Aligns NeMo Retriever Library extraction docs with the current default pipeline by removing references to deprecated PDF extractors and obsolete OCR API usage left over from the NeMo Retriever Library transition.

### DIFF
--- a/docs/docs/extraction/cli-reference.md
+++ b/docs/docs/extraction/cli-reference.md
@@ -203,7 +203,7 @@ nemo-retriever \
 To submit a .pdf file with both a splitting task and an extraction task, run the following code.
 
 !!! note
-    Currently, `split` only works for pdfium, nemotron-parse, and Unstructured.io.
+    Currently, `split` only works for pdfium and nemotron-parse.
 
 ```bash
 nemo-retriever \

--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -87,7 +87,6 @@ Ingestor(client=client)
         extract_tables=True,
         extract_charts=True,
         extract_images=True,
-        paddle_output_format="markdown",
         extract_infographics=True,
         text_depth="page"
     )

--- a/docs/docs/extraction/nv-ingest_cli.md
+++ b/docs/docs/extraction/nv-ingest_cli.md
@@ -65,7 +65,7 @@ nv-ingest-cli \
 To submit a .pdf file with both a splitting task and an extraction task, run the following code.
 
 !!! note
-    Currently, `split` only works for pdfium, nemotron-parse, and Unstructured.io.
+    Currently, `split` only works for pdfium and nemotron-parse.
 
 ```bash
 nv-ingest-cli \

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -28,7 +28,7 @@ NeMo Retriever Library is a microservice service that does the following:
 
 - Accept a JSON job description, containing a document payload, and a set of ingestion tasks to perform on that payload.
 - Allow the results of a job to be retrieved. The result is a JSON dictionary that contains a list of metadata describing objects extracted from the base document, and processing annotations and timing/trace data.
-- Support multiple methods of extraction for each document type to balance trade-offs between throughput and accuracy. For example, for .pdf documents, extraction is performed by using pdfium, [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse), Unstructured.io, and Adobe Content Extraction Services.
+- Support multiple methods of extraction for each document type to balance trade-offs between throughput and accuracy. For example, for .pdf documents, extraction is performed by using pdfium and [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse).
 - Support various types of pre- and post- processing operations, including text splitting and chunking, transform and filtering, embedding generation, and image offloading to storage.
 
 NeMo Retriever Library supports the following file types:


### PR DESCRIPTION
# Summary
Aligns NeMo Retriever Library extraction docs with the current default pipeline by removing references to deprecated PDF extractors and obsolete OCR API usage left over from the NeMo Retriever Library transition.

## Changes
extraction/overview.md — Describes supported PDF extraction as pdfium and nemotron-parse only (no longer lists Unstructured.io or Adobe Content Extraction Services as current options).
extraction/cli-reference.md and extraction/nv-ingest_cli.md — Updates the split task note so it only mentions pdfium and nemotron-parse (drops Unstructured.io).
extraction/faq.md — Removes obsolete paddle_output_format from the Ingestor.extract(...) example (PaddleOCR replaced by nemotron-ocr; parameter no longer applies).
## Why
Reduces user confusion and failed configuration attempts when following docs that still described deprecated engines or old OCR parameters.