### PR TITLE
 Align production GPU examples with support matrix (NVBug 5965601)

### DIFF
--- a/docs/docs/extraction/prerequisites.md
+++ b/docs/docs/extraction/prerequisites.md
@@ -38,7 +38,7 @@ For additional hardware details, refer to [Support Matrix](support-matrix.md).
 
 - **System Memory**: At least 256 GB RAM
 - **CPU Cores**: At least 32 CPU cores
-- **GPU**: NVIDIA GPU with at least 24 GB VRAM (e.g., A100, V100, or equivalent)
+- **GPU**: NVIDIA GPU with at least 24 GB VRAM (e.g., A100, H100, L40S, or equivalent)
 
 !!! note
 


### PR DESCRIPTION
# Align production GPU examples with support matrix (NVBug 5965601)

## Summary
Updates the Recommended Production Deployment GPU line in docs/docs/extraction/prerequisites.md so example hardware matches the [Support Matrix](vscode-file://vscode-app/c:/Users/kheiss/AppData/Local/Programs/cursor/resources/app/out/vs/code/electron-sandbox/workbench/docs/docs/extraction/support-matrix.md) instead of citing V100.

Why: V100 is not listed on the support matrix, and 16 GB V100 SKUs do not meet the same line’s at least 24 GB VRAM requirement, which could mislead users who plan or buy hardware from the prerequisites page alone.

Change: Replace the examples A100, V100 with A100, H100, L40S, which are consistent with validated hardware and satisfy the stated VRAM bar.