### PR TITLE
(client) fix query_iterator hang by using close-on-empty pattern

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -130,13 +130,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     && ./ci/scripts/build_pip_packages.sh --type ${RELEASE_TYPE} --lib client \
     && ./ci/scripts/build_pip_packages.sh --type ${RELEASE_TYPE} --lib service
 
-# Pin milvus-lite<2.5: version 2.5+ leaks the parent LD_LIBRARY_PATH into its
-# subprocess, causing the milvus binary to load incompatible libs and hang.
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install ./src/dist/*.whl \
     && uv pip install ./api/dist/*.whl \
-    && uv pip install ./client/dist/*.whl \
-    && uv pip install 'milvus-lite>=2.4.0,<2.5'
+    && uv pip install ./client/dist/*.whl
 
 # Remove Ray's Java JAR (ray_dist.jar). It bundles shaded Jackson (e.g. jackson-core) and is only
 # needed for Ray's Java API / cross-language. This image runs Python-only; removing it drops

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
 milvus = [
     "pymilvus==2.5.10",
     "pymilvus[bulk_writer,model]",
-    "milvus-lite>=2.4.0,<2.5",
 ]
 minio = [
     "minio>=7.2.15",

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
     "uvicorn",
     "pip",
     "opencv-python",
-    "pymilvus>=2.5.10",
+    "pymilvus==2.5.10",
     "pymilvus[bulk_writer, model]",
     "tritonclient",
     "nvidia-riva-client==2.25.0",


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
