### PR TITLE
Fixed bug 5966370

### DIFF
--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -476,11 +476,11 @@ docker compose \
 
 ## Specify MIG slices for NIM models
 
-When you deploy the pipeline with NIM models on MIG‑enabled GPUs, MIG device slices are requested and scheduled through the `values.yaml` file for the corresponding NIM microservice. For IBM Content-Aware Storage (CAS) deployments, this allows NIM pods to land only on nodes that expose the desired MIG profiles [raw.githubusercontent](https://raw.githubusercontent.com/NVIDIA/nv-ingest/main/helm/README.md%E2%80%8B).​
+When you deploy the pipeline with NIM models on MIG‑enabled GPUs, MIG device slices are requested and scheduled through the `values.yaml` file for the corresponding NIM microservice. For IBM Content-Aware Storage (CAS) deployments, this allows NIM pods to land only on nodes that expose the desired MIG profiles [raw.githubusercontent](https://raw.githubusercontent.com/NVIDIA/nv-ingest/main/helm/README.md).
 
 To target a specific MIG profile—for example, a 3g.20gb slice on an A100, which is a hardware-partitioned virtual GPU instance that gives your workload a fixed mid-sized share of the A100’s compute plus 20 GB of dedicated GPU memory and behaves like a smaller independent GPU—for a given NIM, configure the `resources` and `nodeSelector` under that NIM’s values path in `values.yaml`.
 
-The following example shows the pattern. Paths vary by NIM, such as `nvingest.nvidiaNim.nemoretrieverPageElements` instead of the generic `nvingest.nim` placeholder. For details refer to [catalog.ngc.nvidia](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/nemo-microservices/helm-charts/nv-ingest)​.
+The following example shows the pattern. Paths vary by NIM, such as `nvingest.nvidiaNim.nemoretrieverPageElements` instead of the generic `nvingest.nim` placeholder. For details refer to [catalog.ngc.nvidia](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/nemo-microservices/helm-charts/nv-ingest).
 Set `resources.requests` and `resources.limits` to the name of the MIG resource that you want (for example, `nvidia.com/mig-3g.20gb`).
 ```shell
 nvingest:


### PR DESCRIPTION
# Fix broken Helm README and NGC links in Docker Compose quickstart (bug 5966370)

## Summary
Removes corrupted characters from two markdown links in the Deploy with Docker Compose quickstart so links resolve correctly instead of returning 404 or odd behavior.

## Problem
The raw.githubusercontent link under Specify MIG slices for NIM models included the literal sequence %E2%80%8B (the UTF-8 encoding of U+200B) at the end of the URL, so GitHub treated it as a different path and returned 404.
A zero-width space (U+200B) also appeared after the Helm README link and after the catalog.ngc.nvidia link, which is unnecessary and easy to reintroduce via copy-paste.

##Changes

- docs/docs/extraction/quickstart-guide.md
- Normalize the Helm README URL to
- https://raw.githubusercontent.com/NVIDIA/nv-ingest/main/helm/README.md (no %E2%80%8B).
- Strip the trailing zero-width space after the NGC Helm chart link.