### PR TITLE
update files per 5966321

### DIFF
--- a/docs/docs/extraction/chunking.md
+++ b/docs/docs/extraction/chunking.md
@@ -108,4 +108,4 @@ If you are building the container yourself and want to pre-download this model, 
 
 - [Use the Python API](nv-ingest-python-api.md)
 - [NeMo Retriever Library V2 API Guide](v2-api-guide.md)
-- [Environment Variables](environment-variables.md)
+- [Environment Variables](environment-config.md)

--- a/docs/docs/extraction/content-metadata.md
+++ b/docs/docs/extraction/content-metadata.md
@@ -374,4 +374,4 @@ For the full file, refer to the [data folder](https://github.com/NVIDIA/nv-inges
 
 ## Related Topics
 
-- [Environment Variables](environment-variables.md)
+- [Environment Variables](environment-config.md)

--- a/docs/docs/extraction/scaling-modes.md
+++ b/docs/docs/extraction/scaling-modes.md
@@ -102,4 +102,4 @@ Open `docker-compose.yaml` and locate:
 
 - [Prerequisites](prerequisites.md)
 - [Support Matrix](support-matrix.md)
-- [Troubleshooting](troubleshooting.md)
+- [Troubleshooting](troubleshoot.md)

--- a/docs/docs/extraction/user-defined-functions.md
+++ b/docs/docs/extraction/user-defined-functions.md
@@ -264,7 +264,7 @@ def enhance_metadata(control_message: IngestControlMessage) -> IngestControlMess
     return control_message
 ```
 
-> **📖 For detailed metadata schema documentation, see:** [metadata_documentation.md](metadata_documentation.md)
+> **📖 For detailed metadata schema documentation, see:** [Content metadata](content-metadata.md)
 
 ### UDF Targeting
 
@@ -537,7 +537,7 @@ For detailed guidance on creating custom NIM integrations, including:
 - Error handling and debugging
 - Performance best practices
 
-See the comprehensive [**NimClient Usage Guide**](nimclient_usage.md).
+See the comprehensive [**NimClient Usage Guide**](nimclient.md).
 
 ### Error Handling
 


### PR DESCRIPTION
 # Fix broken internal links in extraction guides

## Description
Several pages under docs/docs/extraction/ still pointed at old filenames from before the NeMo Retriever / nv-ingest doc refresh. Those targets were removed or renamed, so the links returned 404s in published docs.

This change updates only the link targets (and one link label) so navigation stays correct:

Environment configuration — environment-variables.md → environment-config.md in chunking.md and content-metadata.md.
Troubleshooting — troubleshooting.md → troubleshoot.md in scaling-modes.md.
Metadata — metadata_documentation.md → content-metadata.md in user-defined-functions.md, with link text set to “Content metadata” instead of a filename.
NimClient — nimclient_usage.md → nimclient.md in user-defined-functions.md.
No content or behavior outside these markdown links was changed.