### PR TITLE
update support matrix to add footnotes

### DIFF
--- a/docs/docs/extraction/support-matrix.md
+++ b/docs/docs/extraction/support-matrix.md
@@ -64,6 +64,12 @@ The following are the hardware requirements to run NeMo Retriever Library.
 | Reranker       | With Core Pipeline        | Yes           | Yes           | Yes           | Yes         | Yes         | No*           | No*           | No*    | No*                    |
 | Reranker       | Standalone (recall only)  | Yes           | Yes           | Yes           | Yes         | Yes         | Yes           | Yes           | Yes    | Yes                    |
 
+¹ Audio runs but requires runtime engine build — no pre-defined model profile.
+
+² Nemotron Parse fails to start on 32GB, pending engineering investigation.
+
+³ VLM fails to load on 32GB, 32GB is below the minimum threshold.
+
 \* GPUs with less than 80GB VRAM cannot run the reranker concurrently with the core pipeline. 
 To perform recall testing with the reranker on these GPUs, shut down the core pipeline NIM microservices 
 and run only the embedder, reranker, and your vector database.


### PR DESCRIPTION
On branch kheiss/5961722a, the support matrix work is already in place and committed (4744677a — “update support matrix to add footnotes”). The working tree is clean.

That commit includes:

RTX PRO 4500 Blackwell in the GPU list and Hardware Requirements column (memory 32GB GDDR7 (GB203) and the ¹/²/³ cells).
Footnote text for ¹, ², and ³ directly under the table, before the Reranker \* note.