### PR TITLE
(retriever) cache local embedder across repeated query() calls

### DIFF
--- a/nemo_retriever/src/nemo_retriever/retriever.py
+++ b/nemo_retriever/src/nemo_retriever/retriever.py
@@ -70,6 +70,8 @@ class Retriever:
     Set to 1 to rerank only the top_k results."""
     # Internal cache for the local rerank model (not part of the public API).
     _reranker_model: Any = field(default=None, init=False, repr=False, compare=False)
+    # Internal cache for local HF embedders, keyed by model name.
+    _embedder_cache: dict = field(default_factory=dict, init=False, repr=False, compare=False)
 
     def _resolve_embedding_endpoint(self) -> Optional[str]:
         http_ep = self.embedding_http_endpoint.strip() if isinstance(self.embedding_http_endpoint, str) else None
@@ -108,11 +110,23 @@ class Retriever:
                 out.append(list(embedding))
         return out
 
-    def _embed_queries_local_hf(self, query_texts: list[str], *, model_name: str) -> list[list[float]]:
-        from nemo_retriever.model import create_local_embedder, is_vl_embed_model
+    def _get_local_embedder(self, model_name: str) -> Any:
+        """Lazily load and cache the local HF embedder for *model_name*."""
+        if model_name not in self._embedder_cache:
+            from nemo_retriever.model import create_local_embedder
 
-        cache_dir = str(self.local_hf_cache_dir) if self.local_hf_cache_dir else None
-        embedder = create_local_embedder(model_name, device=self.local_hf_device, hf_cache_dir=cache_dir)
+            cache_dir = str(self.local_hf_cache_dir) if self.local_hf_cache_dir else None
+            self._embedder_cache[model_name] = create_local_embedder(
+                model_name,
+                device=self.local_hf_device,
+                hf_cache_dir=cache_dir,
+            )
+        return self._embedder_cache[model_name]
+
+    def _embed_queries_local_hf(self, query_texts: list[str], *, model_name: str) -> list[list[float]]:
+        from nemo_retriever.model import is_vl_embed_model
+
+        embedder = self._get_local_embedder(model_name)
 
         if is_vl_embed_model(model_name):
             vectors = embedder.embed_queries(query_texts, batch_size=int(self.local_hf_batch_size))


### PR DESCRIPTION
## Description
Fixes https://github.com/NVIDIA/NeMo-Retriever/issues/1631

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
