### PR TITLE
Enable nemo-retriever install and CLI on non-Linux platforms

### DIFF
--- a/api/src/nv_ingest_api/internal/primitives/nim/model_interface/decorators.py
+++ b/api/src/nv_ingest_api/internal/primitives/nim/model_interface/decorators.py
@@ -9,10 +9,18 @@ from multiprocessing import Manager
 
 logger = logging.getLogger(__name__)
 
-# Create a shared manager and lock for thread-safe access
-manager = Manager()
-global_cache = manager.dict()
+# Lazily initialized on first use so that importing this module does not
+# spawn a subprocess at import time (which breaks Windows multiprocessing).
+_manager = None
+global_cache = None
 lock = Lock()
+
+
+def _ensure_manager():
+    global _manager, global_cache
+    if _manager is None:
+        _manager = Manager()
+        global_cache = _manager.dict()
 
 
 def multiprocessing_cache(max_calls):
@@ -28,10 +36,14 @@ def multiprocessing_cache(max_calls):
     """
 
     def decorator(func):
-        call_count = manager.Value("i", 0)  # Shared integer for call counting
+        call_count = None  # Initialized lazily alongside the manager
 
         @wraps(func)
         def wrapper(*args, **kwargs):
+            nonlocal call_count
+            _ensure_manager()
+            if call_count is None:
+                call_count = _manager.Value("i", 0)
             key = (func.__name__, args, frozenset(kwargs.items()))
 
             with lock:

--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
   "nemotron-page-elements-v3>=0.dev0",
   "nemotron-graphic-elements-v1>=0.dev0",
   "nemotron-table-structure-v1>=0.dev0",
-  "nemotron-ocr>=0.dev0",
+  "nemotron-ocr>=0.dev0; sys_platform == 'linux'",
   "markitdown",
   "timm==1.0.22",
   "tqdm",
@@ -76,7 +76,7 @@ dependencies = [
   "soundfile>=0.12.0",
   "scipy>=1.11.0",
   "nvidia-ml-py",
-  "vllm==0.16.0",
+  "vllm==0.16.0; sys_platform == 'linux'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description

Two targeted fixes that unblock installation and basic CLI usage of `nemo-retriever` on Windows
and other non-Linux platforms without changing the default Linux experience.

**`nemo_retriever/pyproject.toml`** — add `sys_platform == 'linux'` markers to `vllm` and `nemotron-ocr`:

- `vllm` has no `win_amd64` wheels and its PyPI transitive deps (`flashinfer-python` →
  `nvidia-cutlass-dsl`) also lack Windows wheels, causing the resolver to fail on non-Linux.
- `nemotron-ocr` ships only as an sdist that compiles a CUDA extension at build time, requiring
  `CUDA_HOME` — this fails on any machine without a CUDA toolchain. The existing
  `no-build-package = ["nemotron-ocr"]` guard is not respected by `uv pip install`, only by
  `uv sync`.
- The three other nemotron packages (`page-elements-v3`, `graphic-elements-v1`,
  `table-structure-v1`) are pure Python and install cleanly on all platforms — no markers needed.
- Linux users see no change: both packages install as before with a plain
  `uv pip install -e ./nemo_retriever/`.

**`api/src/nv_ingest_api/internal/primitives/nim/model_interface/decorators.py`** — lazy-initialize `Manager()`:

- `Manager()` was called at module level, which immediately spawns a subprocess. On Linux this is
  invisible (fork), but on Windows Python uses the `spawn` start method, which re-imports the main
  module in the child process to bootstrap — hitting `Manager()` again before bootstrapping is
  complete and raising `RuntimeError`. This caused any CLI invocation (including `--help`) to crash
  on Windows.
- Defers `Manager()` and `global_cache` initialization to first actual call of the
  `multiprocessing_cache` decorator. No behaviour change on Linux.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
