### PR TITLE
(retriever) fix lancedb deprecation warnings

### DIFF
--- a/nemo_retriever/src/nemo_retriever/retriever.py
+++ b/nemo_retriever/src/nemo_retriever/retriever.py
@@ -161,16 +161,18 @@ class Retriever:
             if effective_nprobes <= 0:
                 effective_nprobes = 16
 
-        _KEEP_KEYS = {
-            "text",
-            "metadata",
-            "source",
-            "page_number",
-            "pdf_page",
-            "pdf_basename",
-            "source_id",
-            "path",
-        }
+_KEEP_KEYS: frozenset[str] = frozenset(
+    {
+        "text",
+        "metadata",
+        "source",
+        "page_number",
+        "pdf_page",
+        "pdf_basename",
+        "source_id",
+        "path",
+    }
+)
 
         results: list[list[dict[str, Any]]] = []
         for i, vector in enumerate(query_vectors):

--- a/nemo_retriever/src/nemo_retriever/retriever.py
+++ b/nemo_retriever/src/nemo_retriever/retriever.py
@@ -161,6 +161,17 @@ class Retriever:
             if effective_nprobes <= 0:
                 effective_nprobes = 16
 
+        _KEEP_KEYS = {
+            "text",
+            "metadata",
+            "source",
+            "page_number",
+            "pdf_page",
+            "pdf_basename",
+            "source_id",
+            "path",
+        }
+
         results: list[list[dict[str, Any]]] = []
         for i, vector in enumerate(query_vectors):
             q = np.asarray(vector, dtype="float32")
@@ -175,9 +186,6 @@ class Retriever:
                     .text(query_texts[i])
                     .nprobes(effective_nprobes)
                     .refine_factor(int(self.refine_factor))
-                    .select(
-                        ["text", "metadata", "source", "page_number", "pdf_page", "pdf_basename", "source_id", "path"]
-                    )
                     .limit(int(top_k))
                     .rerank(RRFReranker())
                     .to_list()
@@ -203,7 +211,7 @@ class Retriever:
                     .limit(int(top_k))
                     .to_list()
                 )
-            results.append(hits)
+            results.append([{k: v for k, v in h.items() if k in _KEEP_KEYS} for h in hits])
         return results
 
     # ------------------------------------------------------------------

--- a/nemo_retriever/src/nemo_retriever/retriever.py
+++ b/nemo_retriever/src/nemo_retriever/retriever.py
@@ -9,6 +9,19 @@ from pathlib import Path
 from typing import Any, Optional, Sequence
 from tqdm import tqdm
 
+_KEEP_KEYS = frozenset(
+    {
+        "text",
+        "metadata",
+        "source",
+        "page_number",
+        "pdf_page",
+        "pdf_basename",
+        "source_id",
+        "path",
+    }
+)
+
 
 @dataclass
 class Retriever:
@@ -160,19 +173,6 @@ class Retriever:
                 pass
             if effective_nprobes <= 0:
                 effective_nprobes = 16
-
-_KEEP_KEYS: frozenset[str] = frozenset(
-    {
-        "text",
-        "metadata",
-        "source",
-        "page_number",
-        "pdf_page",
-        "pdf_basename",
-        "source_id",
-        "path",
-    }
-)
 
         results: list[list[dict[str, Any]]] = []
         for i, vector in enumerate(query_vectors):

--- a/nemo_retriever/tests/test_retriever_queries.py
+++ b/nemo_retriever/tests/test_retriever_queries.py
@@ -370,3 +370,111 @@ class TestRetrieverDefaults:
         from nemo_retriever.retriever import retriever, Retriever
 
         assert retriever is Retriever
+
+
+# ---------------------------------------------------------------------------
+# Retriever._search_lancedb — post-filter strips unwanted columns
+# ---------------------------------------------------------------------------
+
+
+class TestSearchLancedbKeepKeys:
+    """Verify that _search_lancedb strips columns not in _KEEP_KEYS."""
+
+    def _fake_table(self, raw_hits: list[dict]):
+        """Return a mock LanceDB table whose search chains return *raw_hits*."""
+        chain = MagicMock()
+        chain.nprobes.return_value = chain
+        chain.refine_factor.return_value = chain
+        chain.select.return_value = chain
+        chain.limit.return_value = chain
+        chain.to_list.return_value = raw_hits
+        chain.list_indices.return_value = []
+
+        table = MagicMock()
+        table.search.return_value = chain
+        table.list_indices.return_value = []
+        return table
+
+    def test_extra_keys_stripped_from_dense_results(self):
+        from nemo_retriever.retriever import _KEEP_KEYS
+
+        raw = [
+            {
+                "text": "hello",
+                "metadata": "{}",
+                "source": "{}",
+                "page_number": 0,
+                "pdf_page": "doc_0",
+                "pdf_basename": "doc",
+                "source_id": "doc.pdf",
+                "path": "/doc.pdf",
+                # These should be stripped:
+                "vector": [0.1, 0.2, 0.3],
+                "_distance": 0.42,
+                "_rowid": 7,
+            }
+        ]
+        r = _make_retriever(hybrid=False)
+        mock_db = MagicMock()
+        mock_db.open_table.return_value = self._fake_table(raw)
+
+        with patch("lancedb.connect", return_value=mock_db):
+            results = r._search_lancedb(
+                lancedb_uri="fake",
+                lancedb_table="t",
+                query_vectors=[_DUMMY_VECTOR],
+                query_texts=["q"],
+            )
+
+        hit = results[0][0]
+        assert set(hit.keys()) <= _KEEP_KEYS
+        assert "vector" not in hit
+        assert "_distance" not in hit
+        assert "_rowid" not in hit
+        assert hit["text"] == "hello"
+
+    def test_extra_keys_stripped_from_hybrid_results(self):
+        from nemo_retriever.retriever import _KEEP_KEYS
+
+        raw = [
+            {
+                "text": "hello",
+                "metadata": "{}",
+                "source": "{}",
+                "page_number": 0,
+                "pdf_page": "doc_0",
+                "pdf_basename": "doc",
+                "source_id": "doc.pdf",
+                "path": "/doc.pdf",
+                # These should be stripped:
+                "vector": [0.1, 0.2, 0.3],
+                "_score": 1.5,
+                "_relevance_score": 0.9,
+            }
+        ]
+        r = _make_retriever(hybrid=True)
+        mock_db = MagicMock()
+        fake_table = self._fake_table(raw)
+        # Hybrid chain also needs .vector(), .text(), .rerank()
+        chain = fake_table.search.return_value
+        chain.vector.return_value = chain
+        chain.text.return_value = chain
+        chain.rerank.return_value = chain
+        mock_db.open_table.return_value = fake_table
+
+        with (
+            patch("lancedb.connect", return_value=mock_db),
+            patch("lancedb.rerankers.RRFReranker"),
+        ):
+            results = r._search_lancedb(
+                lancedb_uri="fake",
+                lancedb_table="t",
+                query_vectors=[_DUMMY_VECTOR],
+                query_texts=["q"],
+            )
+
+        hit = results[0][0]
+        assert set(hit.keys()) <= _KEEP_KEYS
+        assert "vector" not in hit
+        assert "_score" not in hit
+        assert "_relevance_score" not in hit


### PR DESCRIPTION
## Description
This PR avoids the folowing warning:
```
[2026-04-08T20:05:16Z WARN  lance::dataset::scanner] Deprecation warning, this behavior will change in the future. This search specified output columns but did not include `_score`.  Currently the `_score` column will be included.  In the future it will not.  Call `disable_scoring_autoprojection` to adopt the future behavior and avoid this warning
[2026-04-08T20:05:16Z WARN  lance::dataset::scanner] Deprecation warning, this behavior will change in the future. This search specified output columns but did not include `_distance`.  Currently the `_distance` column will be included.  In the future it will not.  Call `disable_scoring_autoprojection` to adopt the future behavior and avoid this warning
[2026-04-08T20:05:16Z WARN  lance::dataset::scanner] Deprecation warning, this behavior will change in the future. This search specified output columns but did not include `_score`.  Currently the `_score` column will be included.  In the future it will not.  Call `disable_scoring_autoprojection` to adopt the future behavior and avoid this warning
[2026-04-08T20:05:16Z WARN  lance::dataset::scanner] Deprecation warning, this behavior will change in the future. This search specified output columns but did not include `_distance`.  Currently the `_distance` column will be included.  In the future it will not.  Call `disable_scoring_autoprojection` to adopt the future behavior and avoid this warning
[2026-04-08T20:05:16Z WARN  lance::dataset::scanner] Deprecation warning, this behavior will change in the future. This search specified output columns but did not include `_score`.  Currently the `_score` column will be included.  In the future it will not.  Call `disable_scoring_autoprojection` to adopt the future behavior and avoid this warning
[2026-04-08T20:05:16Z WARN  lance::dataset::scanner] Deprecation warning, this behavior will change in the future. This search specified output columns but did not include `_distance`.  Currently the `_distance` column will be included.  In the future it will not.  Call `disable_scoring_autoprojection` to adopt the future behavior and avoid this warning
```
by removing `.select()` from hybrid search paths and post-filters the result dicts to the original column set.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
