### PR TITLE
fix retriever cli examples

### DIFF
--- a/docs/docs/extraction/cli-reference.md
+++ b/docs/docs/extraction/cli-reference.md
@@ -1,21 +1,21 @@
 # CLI Reference
 
 After you install the Python dependencies, you can use the [NeMo Retriever Library](overview.md) command line interface (CLI).
-To use the CLI, use the `nemo-retriever` command.
+To use the CLI, use the `retriever` command.
 
 !!! note "Command name"
-    Depending on your installation (NeMo Retriever Library vs. nv-ingest-client), you invoke the CLI by using `nemo-retriever` or `nv-ingest-cli`. Both expose the same options and behavior. The following sections use `nemo-retriever` for consistency with the examples.
+    Depending on your installation (NeMo Retriever Library vs. nv-ingest-client), you invoke the CLI by using `retriever` or `nv-ingest-cli`. Both expose the same options and behavior. The following sections use `retriever` for consistency with the examples.
 
 To check the version of the CLI that you have installed, run the following command.
 
 ```bash
-nemo-retriever --version
+retriever --version
 ```
 
 To get a list of the current CLI commands and their options, run the following command.
 
 ```bash
-nemo-retriever --help
+retriever --help
 ```
 
 !!! tip
@@ -108,10 +108,10 @@ Running with `--fail_on_error` causes the process to exit on the first job failu
 
 ## Complete --help Output
 
-The following is the standard help output for the CLI (equivalent to `nemo-retriever --help` or `nv-ingest-cli --help`). Use it as a quick reference when you cannot run the command locally.
+The following is the standard help output for the CLI (equivalent to `retriever --help` or `nv-ingest-cli --help`). Use it as a quick reference when you cannot run the command locally.
 
 ```text
-Usage: nemo-retriever [OPTIONS]
+Usage: retriever [OPTIONS]
 
 Options:
   --batch_size INTEGER          Batch size (must be >= 1).  [default: 10]
@@ -164,8 +164,8 @@ Use the following code examples to submit a document to the `nemo-retriever-ms-r
 
 Each of the following commands can be run from the host machine, or from within the `nemo-retriever-ms-runtime` container.
 
-- Host: `nemo-retriever ...`
-- Container: `nemo-retriever ...`
+- Host: `retriever ...`
+- Container: `retriever ...`
 
 
 ### Example: Text File With No Splitting
@@ -177,7 +177,7 @@ To submit a text file with no splitting, run the following code.
     You receive a response that contains a single document, which is the entire text file. The data that is returned is wrapped in the appropriate [metadata structure](content-metadata.md).
 
 ```bash
-nemo-retriever \
+retriever \
   --doc ./data/test.pdf \
   --client_host=localhost \
   --client_port=7670
@@ -189,7 +189,7 @@ nemo-retriever \
 To submit a .pdf file with only a splitting task, run the following code.
 
 ```bash
-nemo-retriever \
+retriever \
   --doc ./data/test.pdf \
   --output_directory ./processed_docs \
   --task='split' \
@@ -206,7 +206,7 @@ To submit a .pdf file with both a splitting task and an extraction task, run the
     Currently, `split` only works for pdfium and nemotron-parse.
 
 ```bash
-nemo-retriever \
+retriever \
   --doc ./data/test.pdf \
   --output_directory ./processed_docs \
   --task='extract:{"document_type": "pdf", "extract_method": "pdfium"}' \
@@ -229,7 +229,7 @@ This allows you to control how many pages are included in each PDF chunk during 
     Smaller chunks provide more parallelism but increase overhead, while larger chunks reduce overhead but limit concurrency.
 
 ```bash
-nemo-retriever \
+retriever \
   --doc ./data/test.pdf \
   --output_directory ./processed_docs \
   --task='extract:{"document_type": "pdf", "extract_method": "pdfium", "extract_text": "true"}' \
@@ -244,7 +244,7 @@ nemo-retriever \
 To invoke image captioning and control reasoning:
 
 ```bash
-nemo-retriever \
+retriever \
   --doc ./data/test.pdf \
   --task='extract:{"document_type": "pdf", "extract_method": "pdfium", "extract_images": "true"}' \
   --task='caption:{"prompt": "Caption the content of this image:", "reasoning": true}' \
@@ -264,7 +264,7 @@ Alternatively, you can use an environment variable to set the API version:
 ```bash
 export NEMO_RETRIEVER_API_VERSION=v2
 
-nemo-retriever \
+retriever \
   --doc ./data/test.pdf \
   --output_directory ./processed_docs \
   --task='extract:{"document_type": "pdf", "extract_method": "pdfium", "extract_text": "true"}' \
@@ -280,7 +280,7 @@ To submit a dataset for processing, run the following code.
 To create a dataset, refer to [Command Line Dataset Creation with Enumeration and Sampling](#command-line-dataset-creation-with-enumeration-and-sampling).
 
 ```shell
-nemo-retriever \
+retriever \
   --dataset dataset.json \
   --output_directory ./processed_docs \
   --task='extract:{"document_type": "pdf", "extract_method": "pdfium"}' \
@@ -292,7 +292,7 @@ nemo-retriever \
 Submit a PDF file with extraction tasks and upload extracted images to MinIO.
 
 ```bash
-nemo-retriever \
+retriever \
   --doc ./data/test.pdf \
   --output_directory ./processed_docs \
   --task='extract:{"document_type": "pdf", "extract_method": "pdfium"}' \

--- a/docs/docs/extraction/cli-reference.md
+++ b/docs/docs/extraction/cli-reference.md
@@ -1,313 +1,256 @@
 # CLI Reference
 
-After you install the Python dependencies, you can use the [NeMo Retriever Library](overview.md) command line interface (CLI).
-To use the CLI, use the `retriever` command.
+After you install the Python dependencies, you can run the graph pipeline example script at `src/nemo_retriever/examples/graph_pipeline.py`.
 
-!!! note "Command name"
-    Depending on your installation (NeMo Retriever Library vs. nv-ingest-client), you invoke the CLI by using `retriever` or `nv-ingest-cli`. Both expose the same options and behavior. The following sections use `retriever` for consistency with the examples.
-
-To check the version of the CLI that you have installed, run the following command.
+The recommended invocation is:
 
 ```bash
-retriever --version
+python3 -m nemo_retriever.examples.graph_pipeline <input-path> [OPTIONS]
 ```
 
-To get a list of the current CLI commands and their options, run the following command.
+!!! note "What this page covers"
+    This page documents the `graph_pipeline.py` example script. It does not use the older `retriever --task ...` interface, so options such as `--dataset`, `--task`, `--output_directory`, and `--pdf_split_page_count` are not described here.
+
+To list the available options in an environment with the project dependencies installed, run:
 
 ```bash
-retriever --help
+python3 -m nemo_retriever.examples.graph_pipeline --help
 ```
-
-!!! tip
-
-    There is a Jupyter notebook available to help you get started with the CLI. For more information, refer to [CLI Client Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/cli_client_usage.ipynb).
 
 
 ## Parameter Reference
 
-The following table lists all CLI options.
+The script requires a positional `input_path`, which can be either a single file or a directory containing files of the selected `--input-type`.
+The table below focuses on the flags used most often with `graph_pipeline.py`.
 
-\* At least one of `--doc` or `--dataset` must be provided; otherwise there are no files to process.
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `<input_path>` | path | required | File or directory to ingest. |
+| `--run-mode` | string | `batch` | Execution mode: `batch` (Ray Data) or `inprocess` (single-process pandas). |
+| `--input-type` | string | `pdf` | Input type: `pdf`, `doc`, `txt`, `html`, `image`, or `audio`. |
+| `--method` | string | `pdfium` | Extraction method used for PDF and document ingestion. |
+| `--dpi` | int | `300` | Render DPI for PDF page images. |
+| `--extract-text / --no-extract-text` | bool | `True` | Enable or disable text extraction. |
+| `--extract-tables / --no-extract-tables` | bool | `True` | Enable or disable table extraction. |
+| `--extract-charts / --no-extract-charts` | bool | `True` | Enable or disable chart extraction. |
+| `--extract-infographics / --no-extract-infographics` | bool | `False` | Enable or disable infographic extraction. |
+| `--extract-page-as-image / --no-extract-page-as-image` | bool | `True` | Preserve rendered page images during extraction. |
+| `--use-graphic-elements` | flag | `False` | Enable graphic-element processing when the configured pipeline supports it. |
+| `--use-table-structure` | flag | `False` | Enable table-structure processing when the configured pipeline supports it. |
+| `--table-output-format` | string | none | Optional output format for table-structure extraction. |
+| `--api-key` | string | none | API key for remote NIM endpoints. If omitted, the script also checks `NVIDIA_API_KEY` and `NGC_API_KEY`. |
+| `--page-elements-invoke-url` | URL | none | Remote page-elements endpoint. |
+| `--ocr-invoke-url` | URL | none | Remote OCR endpoint. |
+| `--graphic-elements-invoke-url` | URL | none | Remote graphic-elements endpoint. |
+| `--table-structure-invoke-url` | URL | none | Remote table-structure endpoint. |
+| `--embed-invoke-url` | URL | none | Remote embedding endpoint. |
+| `--embed-model-name` | string | `nvidia/llama-nemotron-embed-1b-v2` | Embedding model name. |
+| `--embed-modality` | string | `text` | Embedding modality, for example `text` or `text_image`. |
+| `--embed-granularity` | string | `element` | Embedding granularity. |
+| `--text-elements-modality` | string | none | Override modality for text elements. |
+| `--structured-elements-modality` | string | none | Override modality for structured elements. |
+| `--text-chunk` | flag | `False` | Add a text-splitting stage after extraction. |
+| `--text-chunk-max-tokens` | int | none | Maximum tokens per chunk. |
+| `--text-chunk-overlap-tokens` | int | none | Token overlap between adjacent chunks. |
+| `--dedup / --no-dedup` | bool | auto | Explicitly enable or disable deduplication. If captioning is enabled, dedup is enabled automatically unless `--no-dedup` is passed. |
+| `--dedup-iou-threshold` | float | `0.45` | IOU threshold used by deduplication. |
+| `--caption / --no-caption` | bool | `False` | Add an image-captioning stage. |
+| `--caption-invoke-url` | URL | none | Remote caption endpoint. |
+| `--caption-model-name` | string | `nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16` | Caption model name. |
+| `--caption-device` | string | none | Device override for local captioning. |
+| `--caption-context-text-max-chars` | int | `0` | Max surrounding text characters supplied to the captioner. |
+| `--caption-gpu-memory-utilization` | float | `0.5` | Fraction of GPU memory reserved for captioning. |
+| `--store-images-uri` | URI | none | Persist extracted images to external storage. |
+| `--store-text / --no-store-text` | bool | `False` | Store extracted text alongside images when `--store-images-uri` is set. |
+| `--strip-base64 / --no-strip-base64` | bool | `True` | Remove inline base64 payloads after storing artifacts. |
+| `--ray-address` | string | none | Ray cluster address for batch execution. |
+| `--ray-log-to-driver / --no-ray-log-to-driver` | bool | `True` | Control Ray worker log forwarding in batch mode. |
+| `--lancedb-uri` | path | `lancedb` | LanceDB directory used for the output table. |
+| `--hybrid / --no-hybrid` | bool | `False` | Enable hybrid retrieval for evaluation. |
+| `--query-csv` | path | `./data/bo767_query_gt.csv` | Query CSV used for recall evaluation. If the file does not exist, evaluation is skipped. |
+| `--evaluation-mode` | string | `recall` | Evaluation mode: `recall` or `beir`. |
+| `--recall-match-mode` | string | `pdf_page` | Recall matching mode: `pdf_page`, `pdf_only`, or `audio_segment`. |
+| `--audio-match-tolerance-secs` | float | `2.0` | Audio matching tolerance used with `audio_segment` recall. |
+| `--segment-audio / --no-segment-audio` | bool | `False` | Enable audio segmentation before transcription. |
+| `--audio-split-type` | string | `size` | Audio split mode: `size`, `time`, or `frame`. |
+| `--audio-split-interval` | int | `500000` | Split interval used by the selected audio split mode. |
+| `--runtime-metrics-dir` | path | none | Directory for runtime summary JSON output. |
+| `--runtime-metrics-prefix` | string | none | Prefix for the runtime summary file name. |
+| `--detection-summary-file` | path | none | Write a detection summary JSON file after ingestion. |
+| `--log-file` | path | none | Tee stdout, stderr, and logs into a single file. |
 
-| Flag | Aliases | Type | Default | Required | Description |
-|------|---------|------|---------|----------|-------------|
-| `--doc` | — | path (multiple) | none | No | Path to a document to process. Can be specified multiple times. Files must exist. Supports glob-style patterns. |
-| `--dataset` | — | path | none | No | Path to a dataset definition file (JSON with `sampled_files` list). |
-| `--output_directory` | — | path | none | No | Directory where result metadata and optional media are written. If omitted, results are not saved to disk. |
-| `--task` | — | string (multiple) | none | No | Task definition in `task_id:{"key":"value"}` format. Repeat for multiple tasks (e.g. extract, split, caption). |
-| `--client_host` | — | string | `localhost` | No | Hostname or IP of the ingest service. |
-| `--client_port` | — | int | `7670` | No | Port of the ingest service. |
-| `--api_version` | — | enum | `v2` | No | API version: `v1` or `v2`. Required for `--pdf_split_page_count`. |
-| `--pdf_split_page_count` | — | int | none | No | Pages per PDF chunk when splitting (V2 API). Typically 1–128; server default if unset. |
-| `--client_type` | — | enum | `rest` | No | Client transport: `rest` or `simple`. |
-| `--client_kwargs` | — | string (JSON) | `{}` | No | Extra JSON object passed to the client. |
-| `--batch_size` | — | int | `10` | No | The number of in-flight jobs. This value must be greater than or equal to 1. |
-| `--concurrency_n` | — | int | `10` | No | Number of concurrent jobs to maintain. |
-| `--log_level` | — | enum | `INFO` | No | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. |
-| `--dry_run` | — | flag | false | No | Do not run the pipeline; only validate and log what would be done. |
-| `--fail_on_error` | — | flag | false | No | Stop on first job error instead of continuing. |
-| `--save_images_separately` | — | flag | false | No | Write extracted images to disk under `output_directory` and set `content_url` in metadata. |
-| `--shuffle_dataset` | — | flag | true | No | Shuffle file list from `--dataset` before processing. |
-| `--collect_profiling_traces` | — | flag | false | No | After the run, fetch Zipkin traces for submitted jobs and write them under `output_directory`. |
-| `--zipkin_host` | — | string | `localhost` | No | Host for Zipkin API (used when `--collect_profiling_traces` is set). |
-| `--zipkin_port` | — | int | `9411` | No | Port for Zipkin API. |
-| `--version` | — | flag | — | No | Print nv-ingest and nv-ingest-cli versions and exit. |
 
+## Output and Artifacts
 
+The graph pipeline script does not write per-document JSON files to an `output_directory`.
 
+Instead, the main outputs are:
 
-## Output Format and Output_Directory Layout
-
-### Output Format
-
-- **Metadata**: When `--output_directory` is set, the CLI writes JSON files. Each result is a JSON structure that follows the [content metadata schema](content-metadata.md): `content`, `content_url`, `source_metadata`, `content_metadata`, and type-specific blocks (`text_metadata`, `image_metadata`, `table_metadata`, etc.).
-- **Streaming / stdout**: Progress and telemetry are written to stderr (e.g. progress bar, timing). No structured result stream is written to stdout unless you use a different mode (e.g. streaming APIs) not covered by this CLI.
-
-### Output_Directory Structure
-
-When `--output_directory DIR` is used, the CLI creates:
-
-- **`DIR/<content_type>/<source_basename>.metadata.json`**  
-  One JSON file per source document, grouped by content type (`text`, `image`, `structured`, etc.). Each file contains an array of document objects (one per extracted chunk/element) with the full metadata structure.
-
-- **`DIR/<content_type>/media/`** (optional)  
-  If `--save_images_separately` is set, extracted images are saved here as files (e.g. `<source_basename>_0.png`). Metadata JSON then references them via `content_url` instead of inline base64.
-
-- **`DIR/zipkin_profiles/`** (optional)  
-  If `--collect_profiling_traces` is used, Zipkin trace JSON files are written here for profiling analysis.
-
-### Parsing Results Programmatically
-
-- Read each `*.metadata.json` file under `DIR` and parse as JSON. Each file is an array of objects; each object has a `metadata` key with the schema described in [Content Metadata](content-metadata.md).
-- To iterate over all extracted items for a single run, walk the subdirectories of `output_directory` and load every `*.metadata.json`; then iterate over the array elements in each file.
+- **LanceDB table**: The script writes the ingested rows to the `nv-ingest` table under `--lancedb-uri`. Each run overwrites that table.
+- **Runtime summary JSON**: If `--runtime-metrics-dir` or `--runtime-metrics-prefix` is provided, the script writes `<prefix>.runtime.summary.json`.
+- **Detection summary JSON**: If `--detection-summary-file` is set, the script writes a detection summary for the processed results.
+- **Stored media artifacts**: If `--store-images-uri` is set, extracted images are written to the configured storage URI. `--store-text` and `--strip-base64/--no-strip-base64` control the stored payload.
 
 
 ## Errors and Exit Codes
 
-The CLI does not define custom exit codes for every case. In general:
+The script does not define a custom exit-code table, but the following behaviors are enforced directly by `graph_pipeline.py`:
 
-- **Exit 0**: All requested files were processed successfully (or `--dry_run` completed).
-- **Non-zero**: Validation failed, a runtime error occurred, or the process was interrupted.
-
-Common errors and how they appear:
-
-| Condition | Message / behavior | Exit |
-|-----------|---------------------|------|
-| **Connection refused** | Client cannot reach `--client_host`:`--client_port`. Log message like `Error: ...` or connection-related exception. | Non-zero |
-| **Missing input** | Neither `--doc` nor `--dataset` provided, or no files matched. | Non-zero |
-| **File does not exist** | `--doc` or `--dataset` path missing. | Non-zero (Click: "File does not exist: &lt;path&gt;") |
-| **Invalid task format** | `--task` value not in `task_id:{"options"}` form or invalid JSON. | Non-zero (Click: "Invalid JSON format for task '...' ..." or "Unsupported task type: ...") |
-| **Unsupported document type** | Task expects a document type not supported by the server or extractor. | Non-zero (server/validation error) |
-| **Batch size &lt; 1** | `--batch_size` &lt; 1. | Non-zero (Click: "Batch size must be >= 1.") |
-| **Invalid boolean in extract task** | e.g. `extract_text` not true/false, 1/0, yes/no. | Non-zero (ValueError: "Invalid boolean value for ...") |
-| **UDF validation** | Missing `target_stage` or `phase`, or both specified. | Non-zero (ValueError from task validation) |
-| **Timeout** | Job did not complete within the client’s timeout; may be retried internally. | Depends on retries / `--fail_on_error` |
-
-Running with `--fail_on_error` causes the process to exit on the first job failure; otherwise the CLI may continue and report failures at the end.
-
-
-## Complete --help Output
-
-The following is the standard help output for the CLI (equivalent to `retriever --help` or `nv-ingest-cli --help`). Use it as a quick reference when you cannot run the command locally.
-
-```text
-Usage: retriever [OPTIONS]
-
-Options:
-  --batch_size INTEGER          Batch size (must be >= 1).  [default: 10]
-  --doc PATH                     Add a new document to be processed
-                                 (supports multiple).  [default: (none)]
-  --dataset PATH                 Path to a dataset definition file.
-                                 [default: (none)]
-  --client_host TEXT             DNS name or URL for the endpoint.
-                                 [default: localhost]
-  --client_port INTEGER           Port for the client endpoint.  [default: 7670]
-  --client_kwargs TEXT           Additional arguments to pass to the client.
-                                 [default: {}]
-  --api_version [v1|v2]          API version to use (v1 or v2). V2 required
-                                 for PDF split page count feature.
-                                 [default: v2]
-  --client_type [rest|simple]    Client type used to connect to the ingest
-                                 service.  [default: rest]
-  --concurrency_n INTEGER        Number of inflight jobs to maintain at one
-                                 time.  [default: 10]
-  --dry_run                      Perform a dry run without executing actions.
-  --fail_on_error                Fail on error.
-  --output_directory PATH        Output directory for results.
-                                 [default: (none)]
-  --log_level [DEBUG|INFO|WARNING|ERROR|CRITICAL]
-                                  Log level.  [default: INFO]
-  --save_images_separately       Save images separately from returned
-                                 metadata.
-  --shuffle_dataset / --no-shuffle_dataset
-                                  Shuffle the dataset before processing.
-                                 [default: True]
-  --task TEXT                    Task definition in
-                                 '[task_id]:{json_options}' format (repeatable).
-  --collect_profiling_traces     Collect Zipkin traces for submitted jobs
-                                 into output_directory.
-  --zipkin_host TEXT             DNS name or Zipkin API.  [default: localhost]
-  --zipkin_port INTEGER          Port for the Zipkin trace API.
-                                 [default: 9411]
-  --pdf_split_page_count INTEGER Number of pages per PDF chunk for splitting
-                                 (v2 api).  [default: (none)]
-  --version                      Show version.
-  --help                         Show this message and exit.
-```
-
-For detailed **task** syntax (`extract`, `split`, `caption`, `embed`, `udf`, etc.), refer to the `--task` option in the parameter table and the examples below.
+| Condition | Behavior | Exit |
+|-----------|----------|------|
+| Input path does not exist | Raises `BadParameter` for the positional input path. | Non-zero |
+| No matching files for `--input-type` | Raises `BadParameter` after scanning the input directory. | Non-zero |
+| Unsupported `--input-type` | Raises `BadParameter`. | Non-zero |
+| Unsupported `--run-mode` | Raises `ValueError`. | Non-zero |
+| Unsupported `--recall-match-mode` | Raises `ValueError`. | Non-zero |
+| Unsupported `--audio-split-type` | Raises `ValueError`. | Non-zero |
+| Unsupported `--evaluation-mode` | Raises `ValueError`. | Non-zero |
+| `--evaluation-mode beir` without BEIR inputs | Raises `ValueError` unless both `--beir-loader` and `--beir-dataset-name` are provided. | Non-zero |
+| Missing `--query-csv` for recall mode | Logs a warning and skips recall evaluation. | Zero |
 
 
 ## Examples
 
-Use the following code examples to submit a document to the `nemo-retriever-ms-runtime` service.
-
-Each of the following commands can be run from the host machine, or from within the `nemo-retriever-ms-runtime` container.
-
-- Host: `retriever ...`
-- Container: `retriever ...`
+Run the following commands from the source tree after activating the environment that has the NeMo Retriever dependencies installed.
 
 
-### Example: Text File With No Splitting
+### Example: PDF ingestion in batch mode
 
-To submit a text file with no splitting, run the following code.
-
-!!! note
-
-    You receive a response that contains a single document, which is the entire text file. The data that is returned is wrapped in the appropriate [metadata structure](content-metadata.md).
+This example ingests a PDF, uses a remote embedding endpoint, and writes the resulting vectors to LanceDB.
 
 ```bash
-retriever \
-  --doc ./data/test.pdf \
-  --client_host=localhost \
-  --client_port=7670
+python3 -m nemo_retriever.examples.graph_pipeline ./data/test.pdf \
+  --run-mode batch \
+  --input-type pdf \
+  --method pdfium \
+  --embed-invoke-url http://localhost:8000/v1 \
+  --lancedb-uri ./artifacts/lancedb
 ```
 
 
-### Example: PDF File With Splitting Only
+### Example: In-process PDF run for local testing
 
-To submit a .pdf file with only a splitting task, run the following code.
+Use `inprocess` mode when you want a simpler local run without Ray.
 
 ```bash
-retriever \
-  --doc ./data/test.pdf \
-  --output_directory ./processed_docs \
-  --task='split' \
-  --client_host=localhost \
-  --client_port=7670
+python3 -m nemo_retriever.examples.graph_pipeline ./data/test.pdf \
+  --run-mode inprocess \
+  --input-type pdf \
+  --method pdfium \
+  --ocr-invoke-url http://localhost:9000/v1 \
+  --embed-invoke-url http://localhost:8000/v1 \
+  --lancedb-uri ./artifacts/lancedb
 ```
 
 
-### Example: PDF File With Splitting and Extraction
+### Example: PDF extraction with chunking
 
-To submit a .pdf file with both a splitting task and an extraction task, run the following code.
-
-!!! note
-    Currently, `split` only works for pdfium and nemotron-parse.
+The graph pipeline does not expose the old `split` task or `--pdf_split_page_count`. To add a post-extraction text-splitting stage, use the text chunking flags instead.
 
 ```bash
-retriever \
-  --doc ./data/test.pdf \
-  --output_directory ./processed_docs \
-  --task='extract:{"document_type": "pdf", "extract_method": "pdfium"}' \
-  --task='extract:{"document_type": "docx", "extract_method": "python_docx"}' \
-  --task='split' \
-  --client_host=localhost \
-  --client_port=7670
-
+python3 -m nemo_retriever.examples.graph_pipeline ./data/test.pdf \
+  --input-type pdf \
+  --method pdfium \
+  --text-chunk \
+  --text-chunk-max-tokens 512 \
+  --text-chunk-overlap-tokens 100 \
+  --embed-invoke-url http://localhost:8000/v1 \
+  --lancedb-uri ./artifacts/lancedb
 ```
 
 
-### Example: PDF File With Custom Split Page Count
+### Example: Caption extracted page imagery
 
-To submit a PDF file with a custom split page count, use the `--pdf_split_page_count` option.
-This allows you to control how many pages are included in each PDF chunk during processing.
-
-!!! note
-    The `--pdf_split_page_count` option requires using the V2 API (set via `--api_version v2` or environment variable `NEMO_RETRIEVER_API_VERSION=v2`).
-    It accepts values between 1 and 128 pages per chunk (default is server default, typically 32).
-    Smaller chunks provide more parallelism but increase overhead, while larger chunks reduce overhead but limit concurrency.
+This script supports captioning, but it does not expose the old caption `reasoning` option. Use the caption flags that `graph_pipeline.py` actually provides.
 
 ```bash
-retriever \
-  --doc ./data/test.pdf \
-  --output_directory ./processed_docs \
-  --task='extract:{"document_type": "pdf", "extract_method": "pdfium", "extract_text": "true"}' \
-  --pdf_split_page_count 64 \
-  --api_version v2 \
-  --client_host=localhost \
-  --client_port=7670
+python3 -m nemo_retriever.examples.graph_pipeline ./data/test.pdf \
+  --input-type pdf \
+  --extract-page-as-image \
+  --caption \
+  --caption-invoke-url http://localhost:8010/v1 \
+  --caption-context-text-max-chars 500 \
+  --embed-invoke-url http://localhost:8000/v1 \
+  --lancedb-uri ./artifacts/lancedb
 ```
 
-### Example: Caption images with reasoning control
 
-To invoke image captioning and control reasoning:
+### Example: Store extracted images to object storage
+
+Use `--store-images-uri` to persist extracted image artifacts outside the LanceDB table.
 
 ```bash
-retriever \
-  --doc ./data/test.pdf \
-  --task='extract:{"document_type": "pdf", "extract_method": "pdfium", "extract_images": "true"}' \
-  --task='caption:{"prompt": "Caption the content of this image:", "reasoning": true}' \
-  --client_host=localhost \
-  --client_port=7670
+python3 -m nemo_retriever.examples.graph_pipeline ./data/test.pdf \
+  --input-type pdf \
+  --store-images-uri s3://my-bucket/nemo-retriever/images \
+  --store-text \
+  --no-strip-base64 \
+  --embed-invoke-url http://localhost:8000/v1 \
+  --lancedb-uri ./artifacts/lancedb
 ```
 
-- `reasoning` (boolean): Set to `true` to enable reasoning, `false` to disable it. Defaults to service default (typically disabled).
-- Ensure the VLM caption profile/service is running or pointing to the public build endpoint; otherwise the caption task will be skipped.
 
-!!! tip
+### Example: Process plain-text files
 
-  The caption service uses a default VLM which you can override by selecting other vision-language models to better match your image captioning needs. For more information, refer to [Extract Captions from Images](python-api-reference.md#extract-captions-from-images).
-
-Alternatively, you can use an environment variable to set the API version:
+For text inputs, switch the input type to `txt` and point the script at either a single file or a directory of `.txt` files.
 
 ```bash
-export NEMO_RETRIEVER_API_VERSION=v2
-
-retriever \
-  --doc ./data/test.pdf \
-  --output_directory ./processed_docs \
-  --task='extract:{"document_type": "pdf", "extract_method": "pdfium", "extract_text": "true"}' \
-  --pdf_split_page_count 64 \
-  --client_host=localhost \
-  --client_port=7670
+python3 -m nemo_retriever.examples.graph_pipeline ./data/text_docs \
+  --input-type txt \
+  --embed-invoke-url http://localhost:8000/v1 \
+  --lancedb-uri ./artifacts/lancedb
 ```
 
 
-### Example: Process a Dataset
-
-To submit a dataset for processing, run the following code.
-To create a dataset, refer to [Command Line Dataset Creation with Enumeration and Sampling](#command-line-dataset-creation-with-enumeration-and-sampling).
-
-```shell
-retriever \
-  --dataset dataset.json \
-  --output_directory ./processed_docs \
-  --task='extract:{"document_type": "pdf", "extract_method": "pdfium"}' \
-  --client_host=localhost \
-  --client_port=7670
-
-```
-
-Submit a PDF file with extraction tasks and upload extracted images to MinIO.
+### Example: Process HTML files
 
 ```bash
-retriever \
-  --doc ./data/test.pdf \
-  --output_directory ./processed_docs \
-  --task='extract:{"document_type": "pdf", "extract_method": "pdfium"}' \
-  --client_host=localhost \
-  --client_port=7670
-
+python3 -m nemo_retriever.examples.graph_pipeline ./data/html_docs \
+  --input-type html \
+  --embed-invoke-url http://localhost:8000/v1 \
+  --lancedb-uri ./artifacts/lancedb
 ```
 
 
-## Command Line Dataset Creation with Enumeration and Sampling
+### Example: Process image files with multimodal embeddings
 
-The `gen_dataset.py` script samples files from a specified source directory according to defined proportions and a total size target.
-It offers options for caching the file list, outputting a sampled file list, and validating the output.
+```bash
+python3 -m nemo_retriever.examples.graph_pipeline ./data/images \
+  --input-type image \
+  --embed-modality text_image \
+  --embed-granularity page \
+  --caption \
+  --caption-invoke-url http://localhost:8010/v1 \
+  --embed-invoke-url http://localhost:8000/v1 \
+  --lancedb-uri ./artifacts/lancedb
+```
 
-```shell
-python ./src/util/gen_dataset.py --source_directory=./data --size=1GB --sample pdf=60 --sample txt=40 --output_file \
-  dataset.json --validate-output
+
+### Example: Process audio files
+
+Use the audio-specific flags when ingesting `.mp3`, `.wav`, or `.m4a` inputs.
+
+```bash
+python3 -m nemo_retriever.examples.graph_pipeline ./data/audio \
+  --input-type audio \
+  --segment-audio \
+  --audio-split-type time \
+  --audio-split-interval 45 \
+  --recall-match-mode audio_segment \
+  --embed-invoke-url http://localhost:8000/v1 \
+  --lancedb-uri ./artifacts/lancedb
+```
+
+
+### Example: Write runtime and detection summaries
+
+```bash
+python3 -m nemo_retriever.examples.graph_pipeline ./data/test.pdf \
+  --input-type pdf \
+  --embed-invoke-url http://localhost:8000/v1 \
+  --lancedb-uri ./artifacts/lancedb \
+  --runtime-metrics-dir ./artifacts/runtime \
+  --runtime-metrics-prefix sample-run \
+  --detection-summary-file ./artifacts/detection_summary.json \
+  --log-file ./artifacts/graph_pipeline.log
 ```


### PR DESCRIPTION
## Description
Fixes to cli examples in the cli-reference.md file.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
