### PR TITLE
(retriever) fix content transform to reload images from disk

### DIFF
--- a/nemo_retriever/src/nemo_retriever/graph/content_transforms.py
+++ b/nemo_retriever/src/nemo_retriever/graph/content_transforms.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Sequence
 
 import pandas as pd
 
+from nemo_retriever.io.image_store import load_image_b64_from_uri
 from nemo_retriever.ocr.ocr import _crop_b64_image_by_norm_bbox
 from nemo_retriever.params.models import IMAGE_MODALITIES
 
@@ -49,6 +50,17 @@ def _deep_copy_row(row_dict: Dict[str, Any]) -> Dict[str, Any]:
     return out
 
 
+def _resolve_image_b64(container: dict) -> Optional[str]:
+    """Return image_b64, reloading from stored_image_uri if stripped."""
+    b64 = container.get("image_b64")
+    if b64 is not None:
+        return b64
+    uri = container.get("stored_image_uri")
+    if uri:
+        return load_image_b64_from_uri(uri)
+    return None
+
+
 def explode_content_to_rows(
     batch_df: Any,
     *,
@@ -71,7 +83,7 @@ def explode_content_to_rows(
         batch_df = batch_df.copy()
         if text_mod in IMAGE_MODALITIES and "page_image" in batch_df.columns:
             batch_df["_image_b64"] = batch_df["page_image"].apply(
-                lambda page_image: page_image.get("image_b64") if isinstance(page_image, dict) else None
+                lambda page_image: _resolve_image_b64(page_image) if isinstance(page_image, dict) else None
             )
         batch_df["_embed_modality"] = text_mod
         return batch_df
@@ -84,7 +96,7 @@ def explode_content_to_rows(
         page_image = row_dict.get("page_image")
         page_image_b64: Optional[str] = None
         if any_images and isinstance(page_image, dict):
-            page_image_b64 = page_image.get("image_b64")
+            page_image_b64 = _resolve_image_b64(page_image)
 
         page_text = row_dict.get(text_column)
         if isinstance(page_text, str) and page_text.strip():
@@ -112,15 +124,19 @@ def explode_content_to_rows(
                     content_row[text_column] = value.strip()
                     content_row["_embed_modality"] = struct_mod
                     content_row["_content_type"] = content_type
-                    if struct_mod in IMAGE_MODALITIES and page_image_b64:
-                        bbox = item.get("bbox_xyxy_norm")
-                        if bbox and len(bbox) == 4:
-                            cropped_b64, _ = _crop_b64_image_by_norm_bbox(page_image_b64, bbox_xyxy_norm=bbox)
-                            content_row["_image_b64"] = cropped_b64
+                    if struct_mod in IMAGE_MODALITIES:
+                        item_b64 = _resolve_image_b64(item)
+                        if item_b64:
+                            content_row["_image_b64"] = item_b64
+                        elif page_image_b64:
+                            bbox = item.get("bbox_xyxy_norm")
+                            if bbox and len(bbox) == 4:
+                                cropped_b64, _ = _crop_b64_image_by_norm_bbox(page_image_b64, bbox_xyxy_norm=bbox)
+                                content_row["_image_b64"] = cropped_b64
+                            else:
+                                content_row["_image_b64"] = page_image_b64
                         else:
-                            content_row["_image_b64"] = page_image_b64
-                    elif struct_mod in IMAGE_MODALITIES:
-                        content_row["_image_b64"] = None
+                            content_row["_image_b64"] = None
                     new_rows.append(content_row)
                     exploded_any = True
 
@@ -155,7 +171,7 @@ def collapse_content_to_page_rows(
     if modality in IMAGE_MODALITIES:
         if "page_image" in batch_df.columns:
             batch_df["_image_b64"] = batch_df["page_image"].apply(
-                lambda page_image: page_image.get("image_b64") if isinstance(page_image, dict) else None
+                lambda page_image: _resolve_image_b64(page_image) if isinstance(page_image, dict) else None
             )
         else:
             batch_df["_image_b64"] = None

--- a/nemo_retriever/src/nemo_retriever/graph/content_transforms.py
+++ b/nemo_retriever/src/nemo_retriever/graph/content_transforms.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional, Sequence
 
 import pandas as pd
 
-from nemo_retriever.io.image_store import load_image_b64_from_uri
+from nemo_retriever.io.image_store import resolve_image_b64
 from nemo_retriever.ocr.ocr import _crop_b64_image_by_norm_bbox
 from nemo_retriever.params.models import IMAGE_MODALITIES
 
@@ -50,17 +50,6 @@ def _deep_copy_row(row_dict: Dict[str, Any]) -> Dict[str, Any]:
     return out
 
 
-def _resolve_image_b64(container: dict) -> Optional[str]:
-    """Return image_b64, reloading from stored_image_uri if stripped."""
-    b64 = container.get("image_b64")
-    if b64 is not None:
-        return b64
-    uri = container.get("stored_image_uri")
-    if uri:
-        return load_image_b64_from_uri(uri)
-    return None
-
-
 def explode_content_to_rows(
     batch_df: Any,
     *,
@@ -83,7 +72,7 @@ def explode_content_to_rows(
         batch_df = batch_df.copy()
         if text_mod in IMAGE_MODALITIES and "page_image" in batch_df.columns:
             batch_df["_image_b64"] = batch_df["page_image"].apply(
-                lambda page_image: _resolve_image_b64(page_image) if isinstance(page_image, dict) else None
+                lambda page_image: resolve_image_b64(page_image) if isinstance(page_image, dict) else None
             )
         batch_df["_embed_modality"] = text_mod
         return batch_df
@@ -96,7 +85,7 @@ def explode_content_to_rows(
         page_image = row_dict.get("page_image")
         page_image_b64: Optional[str] = None
         if any_images and isinstance(page_image, dict):
-            page_image_b64 = _resolve_image_b64(page_image)
+            page_image_b64 = resolve_image_b64(page_image)
 
         page_text = row_dict.get(text_column)
         if isinstance(page_text, str) and page_text.strip():
@@ -115,6 +104,7 @@ def explode_content_to_rows(
             for item in content_list:
                 if not isinstance(item, dict):
                     continue
+                item_b64 = resolve_image_b64(item) if struct_mod in IMAGE_MODALITIES else None
                 # Emit rows for text and (optionally) caption fields.
                 for field, content_type in [("text", column), ("caption", f"{column}_caption")]:
                     value = item.get(field, "")
@@ -125,7 +115,6 @@ def explode_content_to_rows(
                     content_row["_embed_modality"] = struct_mod
                     content_row["_content_type"] = content_type
                     if struct_mod in IMAGE_MODALITIES:
-                        item_b64 = _resolve_image_b64(item)
                         if item_b64:
                             content_row["_image_b64"] = item_b64
                         elif page_image_b64:
@@ -171,7 +160,7 @@ def collapse_content_to_page_rows(
     if modality in IMAGE_MODALITIES:
         if "page_image" in batch_df.columns:
             batch_df["_image_b64"] = batch_df["page_image"].apply(
-                lambda page_image: _resolve_image_b64(page_image) if isinstance(page_image, dict) else None
+                lambda page_image: resolve_image_b64(page_image) if isinstance(page_image, dict) else None
             )
         else:
             batch_df["_image_b64"] = None

--- a/nemo_retriever/src/nemo_retriever/io/image_store.py
+++ b/nemo_retriever/src/nemo_retriever/io/image_store.py
@@ -170,6 +170,17 @@ def load_image_b64_from_uri(uri: str) -> Optional[str]:
         return None
 
 
+def resolve_image_b64(container: dict) -> Optional[str]:
+    """Return image_b64, reloading from stored_image_uri if stripped."""
+    b64 = container.get("image_b64")
+    if b64 is not None:
+        return b64
+    uri = container.get("stored_image_uri")
+    if uri:
+        return load_image_b64_from_uri(uri)
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Per-row context and helpers for store_extracted
 # ---------------------------------------------------------------------------

--- a/nemo_retriever/src/nemo_retriever/utils/pipeline/content.py
+++ b/nemo_retriever/src/nemo_retriever/utils/pipeline/content.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Sequence
 
 import pandas as pd
 
+from nemo_retriever.io.image_store import load_image_b64_from_uri
 from nemo_retriever.ocr.ocr import _crop_b64_image_by_norm_bbox
 from nemo_retriever.params.models import IMAGE_MODALITIES
 
@@ -47,6 +48,17 @@ def _deep_copy_row(row_dict: Dict[str, Any]) -> Dict[str, Any]:
     return out
 
 
+def _resolve_image_b64(container: dict) -> Optional[str]:
+    """Return image_b64, reloading from stored_image_uri if stripped."""
+    b64 = container.get("image_b64")
+    if b64 is not None:
+        return b64
+    uri = container.get("stored_image_uri")
+    if uri:
+        return load_image_b64_from_uri(uri)
+    return None
+
+
 def explode_content_to_rows(
     batch_df: Any,
     *,
@@ -69,7 +81,7 @@ def explode_content_to_rows(
         batch_df = batch_df.copy()
         if text_mod in IMAGE_MODALITIES and "page_image" in batch_df.columns:
             batch_df["_image_b64"] = batch_df["page_image"].apply(
-                lambda page_image: page_image.get("image_b64") if isinstance(page_image, dict) else None
+                lambda page_image: _resolve_image_b64(page_image) if isinstance(page_image, dict) else None
             )
         batch_df["_embed_modality"] = text_mod
         return batch_df
@@ -82,7 +94,7 @@ def explode_content_to_rows(
         page_image = row_dict.get("page_image")
         page_image_b64: Optional[str] = None
         if any_images and isinstance(page_image, dict):
-            page_image_b64 = page_image.get("image_b64")
+            page_image_b64 = _resolve_image_b64(page_image)
 
         page_text = row_dict.get(text_column)
         if isinstance(page_text, str) and page_text.strip():
@@ -109,15 +121,19 @@ def explode_content_to_rows(
                     content_row[text_column] = value.strip()
                     content_row["_embed_modality"] = struct_mod
                     content_row["_content_type"] = content_type
-                    if struct_mod in IMAGE_MODALITIES and page_image_b64:
-                        bbox = item.get("bbox_xyxy_norm")
-                        if bbox and len(bbox) == 4:
-                            cropped_b64, _ = _crop_b64_image_by_norm_bbox(page_image_b64, bbox_xyxy_norm=bbox)
-                            content_row["_image_b64"] = cropped_b64
+                    if struct_mod in IMAGE_MODALITIES:
+                        item_b64 = _resolve_image_b64(item)
+                        if item_b64:
+                            content_row["_image_b64"] = item_b64
+                        elif page_image_b64:
+                            bbox = item.get("bbox_xyxy_norm")
+                            if bbox and len(bbox) == 4:
+                                cropped_b64, _ = _crop_b64_image_by_norm_bbox(page_image_b64, bbox_xyxy_norm=bbox)
+                                content_row["_image_b64"] = cropped_b64
+                            else:
+                                content_row["_image_b64"] = page_image_b64
                         else:
-                            content_row["_image_b64"] = page_image_b64
-                    elif struct_mod in IMAGE_MODALITIES:
-                        content_row["_image_b64"] = None
+                            content_row["_image_b64"] = None
                     new_rows.append(content_row)
                     exploded_any = True
 
@@ -152,7 +168,7 @@ def collapse_content_to_page_rows(
     if modality in IMAGE_MODALITIES:
         if "page_image" in batch_df.columns:
             batch_df["_image_b64"] = batch_df["page_image"].apply(
-                lambda page_image: page_image.get("image_b64") if isinstance(page_image, dict) else None
+                lambda page_image: _resolve_image_b64(page_image) if isinstance(page_image, dict) else None
             )
         else:
             batch_df["_image_b64"] = None

--- a/nemo_retriever/src/nemo_retriever/utils/pipeline/content.py
+++ b/nemo_retriever/src/nemo_retriever/utils/pipeline/content.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional, Sequence
 
 import pandas as pd
 
-from nemo_retriever.io.image_store import load_image_b64_from_uri
+from nemo_retriever.io.image_store import resolve_image_b64
 from nemo_retriever.ocr.ocr import _crop_b64_image_by_norm_bbox
 from nemo_retriever.params.models import IMAGE_MODALITIES
 
@@ -48,17 +48,6 @@ def _deep_copy_row(row_dict: Dict[str, Any]) -> Dict[str, Any]:
     return out
 
 
-def _resolve_image_b64(container: dict) -> Optional[str]:
-    """Return image_b64, reloading from stored_image_uri if stripped."""
-    b64 = container.get("image_b64")
-    if b64 is not None:
-        return b64
-    uri = container.get("stored_image_uri")
-    if uri:
-        return load_image_b64_from_uri(uri)
-    return None
-
-
 def explode_content_to_rows(
     batch_df: Any,
     *,
@@ -81,7 +70,7 @@ def explode_content_to_rows(
         batch_df = batch_df.copy()
         if text_mod in IMAGE_MODALITIES and "page_image" in batch_df.columns:
             batch_df["_image_b64"] = batch_df["page_image"].apply(
-                lambda page_image: _resolve_image_b64(page_image) if isinstance(page_image, dict) else None
+                lambda page_image: resolve_image_b64(page_image) if isinstance(page_image, dict) else None
             )
         batch_df["_embed_modality"] = text_mod
         return batch_df
@@ -94,7 +83,7 @@ def explode_content_to_rows(
         page_image = row_dict.get("page_image")
         page_image_b64: Optional[str] = None
         if any_images and isinstance(page_image, dict):
-            page_image_b64 = _resolve_image_b64(page_image)
+            page_image_b64 = resolve_image_b64(page_image)
 
         page_text = row_dict.get(text_column)
         if isinstance(page_text, str) and page_text.strip():
@@ -113,6 +102,7 @@ def explode_content_to_rows(
             for item in content_list:
                 if not isinstance(item, dict):
                     continue
+                item_b64 = resolve_image_b64(item) if struct_mod in IMAGE_MODALITIES else None
                 for field, content_type in [("text", column), ("caption", f"{column}_caption")]:
                     value = item.get(field, "")
                     if not isinstance(value, str) or not value.strip():
@@ -122,7 +112,6 @@ def explode_content_to_rows(
                     content_row["_embed_modality"] = struct_mod
                     content_row["_content_type"] = content_type
                     if struct_mod in IMAGE_MODALITIES:
-                        item_b64 = _resolve_image_b64(item)
                         if item_b64:
                             content_row["_image_b64"] = item_b64
                         elif page_image_b64:
@@ -168,7 +157,7 @@ def collapse_content_to_page_rows(
     if modality in IMAGE_MODALITIES:
         if "page_image" in batch_df.columns:
             batch_df["_image_b64"] = batch_df["page_image"].apply(
-                lambda page_image: _resolve_image_b64(page_image) if isinstance(page_image, dict) else None
+                lambda page_image: resolve_image_b64(page_image) if isinstance(page_image, dict) else None
             )
         else:
             batch_df["_image_b64"] = None

--- a/nemo_retriever/tests/test_io_image_store.py
+++ b/nemo_retriever/tests/test_io_image_store.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from nemo_retriever.io.image_store import _safe_stem, load_image_b64_from_uri, store_extracted
+from nemo_retriever.io.image_store import _safe_stem, load_image_b64_from_uri, resolve_image_b64, store_extracted
 from nemo_retriever.params import StoreParams
 
 
@@ -509,6 +509,32 @@ class TestLoadImageB64FromUri:
 
     def test_missing_file_returns_none(self):
         result = load_image_b64_from_uri("file:///nonexistent/path/image.png")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_image_b64
+# ---------------------------------------------------------------------------
+
+
+class TestResolveImageB64:
+    def test_returns_b64_when_present(self):
+        assert resolve_image_b64({"image_b64": "AAAA"}) == "AAAA"
+
+    def test_reloads_from_stored_uri(self, tmp_path: Path):
+        from PIL import Image
+
+        dest = tmp_path / "img.png"
+        Image.new("RGB", (2, 2), (0, 0, 0)).save(dest, format="PNG")
+        result = resolve_image_b64({"image_b64": None, "stored_image_uri": dest.as_uri()})
+        assert result is not None
+        assert base64.b64decode(result).startswith(b"\x89PNG")
+
+    def test_returns_none_when_both_absent(self):
+        assert resolve_image_b64({}) is None
+
+    def test_propagates_none_on_load_failure(self):
+        result = resolve_image_b64({"image_b64": None, "stored_image_uri": "file:///no/such/file.png"})
         assert result is None
 
 


### PR DESCRIPTION
## Description
When the `.store()` operator runs before the embed stage with `strip_base64=True` (the default), it writes images to disk and clears `image_b64` to free memory. The embed stage's content transforms then read None where they expect base64 image data, causing the VL multimodal embedder (e.g. `nvidia/llama-nemotron-embed-vl-1b-v2`) to silently fall back to text-only embedding. Text-only workflows are unaffected.

This PR adds a small fallback in the content transforms: when `image_b64` is missing but a `stored_image_uri` exists, the image is reloaded from disk using the existing `load_image_b64_from_uri` utility. The same fix is applied to structured content items (tables, charts, infographics), which prefer their own stored crop before falling back to re-cropping from the page image.


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
