### PR TITLE
(retriever) resolve relative storage_uri to absolute path

### DIFF
--- a/nemo_retriever/src/nemo_retriever/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/params/models.py
@@ -4,12 +4,13 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, Literal, Optional, Sequence, Tuple
 from urllib.parse import urlparse
 
 import warnings
 
+
+from upath import UPath
 
 from nemo_retriever.tabular_data.sql_database import SQLDatabase
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -292,7 +293,7 @@ class StoreParams(_ParamsModel):
     def _resolve_local_storage_uri(self) -> "StoreParams":
         """Resolve relative local paths to absolute so they survive Ray serialization."""
         if not urlparse(self.storage_uri).scheme:
-            self.storage_uri = str(Path(self.storage_uri).resolve())
+            self.storage_uri = str(UPath(self.storage_uri).resolve())
         return self
 
 

--- a/nemo_retriever/src/nemo_retriever/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/params/models.py
@@ -4,7 +4,9 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Literal, Optional, Sequence, Tuple
+from urllib.parse import urlparse
 
 import warnings
 
@@ -289,11 +291,7 @@ class StoreParams(_ParamsModel):
     @model_validator(mode="after")
     def _resolve_local_storage_uri(self) -> "StoreParams":
         """Resolve relative local paths to absolute so they survive Ray serialization."""
-        from urllib.parse import urlparse
-
         if not urlparse(self.storage_uri).scheme:
-            from pathlib import Path
-
             self.storage_uri = str(Path(self.storage_uri).resolve())
         return self
 

--- a/nemo_retriever/src/nemo_retriever/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/params/models.py
@@ -286,6 +286,17 @@ class StoreParams(_ParamsModel):
     image_format: str = "png"
     strip_base64: bool = True
 
+    @model_validator(mode="after")
+    def _resolve_local_storage_uri(self) -> "StoreParams":
+        """Resolve relative local paths to absolute so they survive Ray serialization."""
+        from urllib.parse import urlparse
+
+        if not urlparse(self.storage_uri).scheme:
+            from pathlib import Path
+
+            self.storage_uri = str(Path(self.storage_uri).resolve())
+        return self
+
 
 class PageElementsParams(_ParamsModel):
     remote: RemoteInvokeParams = Field(default_factory=RemoteInvokeParams)

--- a/nemo_retriever/tests/test_io_image_store.py
+++ b/nemo_retriever/tests/test_io_image_store.py
@@ -608,7 +608,8 @@ class TestStoreText:
 class TestStoreParams:
     def test_defaults(self):
         p = StoreParams()
-        assert p.storage_uri == "stored_images"
+        assert p.storage_uri.endswith("/stored_images")
+        assert Path(p.storage_uri).is_absolute()
         assert p.store_page_images is True
         assert p.store_tables is True
         assert p.image_format == "png"


### PR DESCRIPTION
## Description
When `StoreParams` receives a relative `storage_uri` like `./stored_images`, the path is passed as-is to Ray workers during batch execution. Ray workers run in their own working directory, so the relative path resolves to a location inside Ray's temp directory rather than the user's project directory. The stored images end up written to an unexpected location and appear missing from the expected path.

This PR adds a model validator to `StoreParams` that resolves local relative paths to absolute at construction time, before the params are serialized and sent to Ray. URIs with a scheme (e.g. s3://) are left unchanged.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
