### PR TITLE
Kheiss/5965601a

### DIFF
--- a/docs/docs/extraction/prerequisites.md
+++ b/docs/docs/extraction/prerequisites.md
@@ -38,7 +38,7 @@ For additional hardware details, refer to [Support Matrix](support-matrix.md).
 
 - **System Memory**: At least 256 GB RAM
 - **CPU Cores**: At least 32 CPU cores
-- **GPU**: NVIDIA GPU with at least 24 GB VRAM (e.g., A100, H100, L40S, or equivalent)
+- **GPU**: NVIDIA GPU with at least 24 GB VRAM. Use a model [listed in the Support Matrix](support-matrix.md); examples include A10G, A100, H100, L40S, and H200 NVL.
 
 !!! note
 


### PR DESCRIPTION
# Align GPU prerequisites with support matrix

## Summary
Updates the Recommended Production Deployment Specifications GPU line in docs/docs/extraction/prerequisites.md so hardware guidance matches the [Support Matrix](vscode-file://vscode-app/c:/Users/kheiss/AppData/Local/Programs/cursor/resources/app/out/vs/code/electron-sandbox/workbench/docs/docs/extraction/support-matrix.md). Examples now refer only to validated models, and readers are directed to the matrix for the full list.

## Problem
The previous wording used “or equivalent,” which could encourage GPUs (for example V100) that are not listed as supported. V100 also ships in 16 GB SKUs, which do not meet the stated ≥ 24 GB VRAM requirement when users follow the example line alone.

## What changed
Replaced the generic “(e.g., … or equivalent)” pattern with an explicit requirement to use a GPU listed in the Support Matrix, with a link to that page.
Listed example SKUs that appear in the matrix: A10G, A100, H100, L40S, H200 NVL (other validated models remain covered by the matrix link).
