### PR TITLE
Join table-structure detections with OCR to restore markdown cell con…

### DIFF
--- a/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
+++ b/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
@@ -539,13 +539,14 @@ def build_graph(
             ocr_kwargs: dict[str, Any] = {}
             if extract_params.method in ("pdfium_hybrid", "ocr") and extract_params.extract_text:
                 ocr_kwargs["extract_text"] = True
-            if extract_params.extract_tables and not extract_params.use_table_structure:
+            if extract_params.extract_tables:
                 ocr_kwargs["extract_tables"] = True
             if extract_params.extract_charts and not extract_params.use_graphic_elements:
                 ocr_kwargs["extract_charts"] = True
             if extract_params.extract_infographics:
                 ocr_kwargs["extract_infographics"] = True
             ocr_kwargs["use_graphic_elements"] = extract_params.use_graphic_elements
+            ocr_kwargs["use_table_structure"] = extract_params.use_table_structure
             if extract_params.ocr_invoke_url:
                 ocr_kwargs["ocr_invoke_url"] = extract_params.ocr_invoke_url
             if extract_params.api_key:

--- a/nemo_retriever/src/nemo_retriever/graph/multi_type_extract_operator.py
+++ b/nemo_retriever/src/nemo_retriever/graph/multi_type_extract_operator.py
@@ -68,7 +68,10 @@ def _parse_mode_enabled(extract_params: ExtractParams) -> bool:
 def _ocr_stage_needed(extract_params: ExtractParams) -> bool:
     if extract_params.method in ("pdfium_hybrid", "ocr") and extract_params.extract_text:
         return True
-    if extract_params.extract_tables and not extract_params.use_table_structure:
+    if extract_params.extract_tables:
+        # OCR is always needed for table crops: either to produce pseudo-markdown
+        # (when use_table_structure=False) or to join against the
+        # table_structure_v1 detections published by TableStructureActor.
         return True
     if extract_params.extract_charts and not extract_params.use_graphic_elements:
         return True
@@ -304,10 +307,13 @@ class _MultiTypeExtractBase(AbstractOperator):
                 graphic_kwargs["api_key"] = extract_params.api_key
             batch_df = self._instantiate_resolved(GraphicElementsActor, **graphic_kwargs).run(batch_df)
 
-        ocr_kwargs: dict[str, Any] = {"use_graphic_elements": extract_params.use_graphic_elements}
+        ocr_kwargs: dict[str, Any] = {
+            "use_graphic_elements": extract_params.use_graphic_elements,
+            "use_table_structure": extract_params.use_table_structure,
+        }
         if extract_params.method in ("pdfium_hybrid", "ocr") and extract_params.extract_text:
             ocr_kwargs["extract_text"] = True
-        if extract_params.extract_tables and not extract_params.use_table_structure:
+        if extract_params.extract_tables:
             ocr_kwargs["extract_tables"] = True
         if extract_params.extract_charts and not extract_params.use_graphic_elements:
             ocr_kwargs["extract_charts"] = True

--- a/nemo_retriever/src/nemo_retriever/ocr/cpu_ocr.py
+++ b/nemo_retriever/src/nemo_retriever/ocr/cpu_ocr.py
@@ -34,6 +34,7 @@ class OCRCPUActor(AbstractOperator, CPUOperator):
         self.ocr_kwargs["extract_charts"] = bool(self.ocr_kwargs.get("extract_charts", False))
         self.ocr_kwargs["extract_infographics"] = bool(self.ocr_kwargs.get("extract_infographics", False))
         self.ocr_kwargs["use_graphic_elements"] = bool(self.ocr_kwargs.get("use_graphic_elements", False))
+        self.ocr_kwargs["use_table_structure"] = bool(self.ocr_kwargs.get("use_table_structure", False))
         self.ocr_kwargs["request_timeout_s"] = float(self.ocr_kwargs.get("request_timeout_s", 120.0))
         self.ocr_kwargs["inference_batch_size"] = int(self.ocr_kwargs.get("inference_batch_size", 8))
 

--- a/nemo_retriever/src/nemo_retriever/ocr/gpu_ocr.py
+++ b/nemo_retriever/src/nemo_retriever/ocr/gpu_ocr.py
@@ -34,6 +34,7 @@ class OCRActor(AbstractOperator, GPUOperator):
         self.ocr_kwargs["extract_charts"] = bool(self.ocr_kwargs.get("extract_charts", False))
         self.ocr_kwargs["extract_infographics"] = bool(self.ocr_kwargs.get("extract_infographics", False))
         self.ocr_kwargs["use_graphic_elements"] = bool(self.ocr_kwargs.get("use_graphic_elements", False))
+        self.ocr_kwargs["use_table_structure"] = bool(self.ocr_kwargs.get("use_table_structure", False))
         self.ocr_kwargs["request_timeout_s"] = float(self.ocr_kwargs.get("request_timeout_s", 120.0))
         self.ocr_kwargs["inference_batch_size"] = int(self.ocr_kwargs.get("inference_batch_size", 8))
 

--- a/nemo_retriever/src/nemo_retriever/ocr/shared.py
+++ b/nemo_retriever/src/nemo_retriever/ocr/shared.py
@@ -23,7 +23,10 @@ import numpy as np
 import pandas as pd
 from nemo_retriever.params import RemoteRetryParams
 from nemo_retriever.nim.nim import invoke_image_inference_batches
-from nemo_retriever.utils.table_and_chart import join_graphic_elements_and_ocr_output
+from nemo_retriever.utils.table_and_chart import (
+    join_graphic_elements_and_ocr_output,
+    join_table_structure_and_ocr_output,
+)
 
 try:
     from PIL import Image
@@ -441,6 +444,46 @@ def _find_ge_detections_for_bbox(
     return None
 
 
+def _find_ts_detections_for_bbox(
+    row: Any,
+    table_bbox: Sequence[float],
+) -> Optional[Tuple[List[Dict[str, Any]], Optional[Tuple[int, int]]]]:
+    """Find table-structure detections + crop size for a table bbox.
+
+    Reads the ``table_structure_v1`` column from *row* and returns the
+    ``(detections, (H, W))`` tuple for the region whose ``bbox_xyxy_norm``
+    matches *table_bbox*. Returns ``None`` if the column is missing, no
+    region matches, or the matching region has no detections.
+    """
+    ts_col = getattr(row, "table_structure_v1", None)
+    if not isinstance(ts_col, dict):
+        return None
+    regions = ts_col.get("regions")
+    if not isinstance(regions, list):
+        return None
+
+    for region in regions:
+        if not isinstance(region, dict):
+            continue
+        region_bbox = region.get("bbox_xyxy_norm")
+        if not isinstance(region_bbox, (list, tuple)) or len(region_bbox) != 4:
+            continue
+        if not _bboxes_close(table_bbox, region_bbox):
+            continue
+        dets = region.get("detections")
+        if not isinstance(dets, list) or not dets:
+            return None
+        hw = region.get("orig_shape_hw")
+        hw_t: Optional[Tuple[int, int]] = None
+        if isinstance(hw, (list, tuple)) and len(hw) == 2:
+            try:
+                hw_t = (int(hw[0]), int(hw[1]))
+            except (TypeError, ValueError):
+                hw_t = None
+        return (dets, hw_t)
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Core function
 # ---------------------------------------------------------------------------
@@ -458,6 +501,7 @@ def ocr_page_elements(
     extract_charts: bool = False,
     extract_infographics: bool = False,
     use_graphic_elements: bool = False,
+    use_table_structure: bool = False,
     inference_batch_size: int = 8,
     remote_retry: RemoteRetryParams | None = None,
     **kwargs: Any,
@@ -605,7 +649,16 @@ def ocr_page_elements(
                                     crop_hw_table = (_ch, _cw)
                             except Exception:
                                 pass
-                            text = _blocks_to_pseudo_markdown(blocks, crop_hw=crop_hw_table) or _blocks_to_text(blocks)
+                            text = ""
+                            if use_table_structure:
+                                ts_match = _find_ts_detections_for_bbox(row, bbox)
+                                if ts_match is not None:
+                                    ts_dets, ts_hw = ts_match
+                                    text = join_table_structure_and_ocr_output(ts_dets, preds, ts_hw or crop_hw_table)
+                            if not text:
+                                text = _blocks_to_pseudo_markdown(blocks, crop_hw=crop_hw_table) or _blocks_to_text(
+                                    blocks
+                                )
                         else:
                             text = _blocks_to_text(blocks)
                         entry = {"bbox_xyxy_norm": bbox, "text": text}
@@ -646,7 +699,14 @@ def ocr_page_elements(
                                 return
                     blocks = _parse_ocr_result(preds)
                     if label_name == "table":
-                        text = _blocks_to_pseudo_markdown(blocks, crop_hw=crop_hw)
+                        text = ""
+                        if use_table_structure:
+                            ts_match = _find_ts_detections_for_bbox(row, bbox)
+                            if ts_match is not None:
+                                ts_dets, ts_hw = ts_match
+                                text = join_table_structure_and_ocr_output(ts_dets, preds, ts_hw or crop_hw)
+                        if not text:
+                            text = _blocks_to_pseudo_markdown(blocks, crop_hw=crop_hw)
                         if not text:
                             text = _blocks_to_text(blocks)
                     else:

--- a/nemo_retriever/src/nemo_retriever/table/config.py
+++ b/nemo_retriever/src/nemo_retriever/table/config.py
@@ -34,7 +34,6 @@ class TableExtractionStageConfig:
 @dataclass(frozen=True)
 class TableStructureOCRStageConfig:
     table_structure_invoke_url: str = ""
-    ocr_invoke_url: str = ""
     api_key: str = ""
     request_timeout_s: float = 60.0
 
@@ -43,7 +42,6 @@ def load_table_structure_ocr_config_from_dict(cfg: Dict[str, Any]) -> TableStruc
     cfg = dict(cfg or {})
     return TableStructureOCRStageConfig(
         table_structure_invoke_url=str(cfg.get("table_structure_invoke_url") or ""),
-        ocr_invoke_url=str(cfg.get("ocr_invoke_url") or ""),
         api_key=str(cfg.get("api_key") or ""),
         request_timeout_s=float(cfg.get("request_timeout_s", 60.0)),
     )

--- a/nemo_retriever/src/nemo_retriever/table/cpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/table/cpu_actor.py
@@ -28,7 +28,6 @@ class TableStructureCPUActor(AbstractOperator, CPUOperator):
         *,
         table_structure_invoke_url: Optional[str] = None,
         invoke_url: Optional[str] = None,
-        ocr_invoke_url: Optional[str] = None,
         api_key: Optional[str] = None,
         table_output_format: Optional[str] = None,
         request_timeout_s: float = 120.0,
@@ -37,14 +36,6 @@ class TableStructureCPUActor(AbstractOperator, CPUOperator):
         remote_max_429_retries: int = 5,
     ) -> None:
         super().__init__()
-        if ocr_invoke_url:
-            import warnings
-
-            warnings.warn(
-                "ocr_invoke_url is ignored by TableStructureCPUActor; configure OCR on OCRActor instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         self._table_structure_invoke_url = (
             table_structure_invoke_url or invoke_url or self.DEFAULT_TABLE_STRUCTURE_INVOKE_URL
         ).strip()

--- a/nemo_retriever/src/nemo_retriever/table/cpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/table/cpu_actor.py
@@ -37,6 +37,14 @@ class TableStructureCPUActor(AbstractOperator, CPUOperator):
         remote_max_429_retries: int = 5,
     ) -> None:
         super().__init__()
+        if ocr_invoke_url:
+            import warnings
+
+            warnings.warn(
+                "ocr_invoke_url is ignored by TableStructureCPUActor; configure OCR on OCRActor instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._table_structure_invoke_url = (
             table_structure_invoke_url or invoke_url or self.DEFAULT_TABLE_STRUCTURE_INVOKE_URL
         ).strip()

--- a/nemo_retriever/src/nemo_retriever/table/gpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/table/gpu_actor.py
@@ -34,6 +34,14 @@ class TableStructureActor(AbstractOperator, GPUOperator):
         remote_max_429_retries: int = 5,
     ) -> None:
         super().__init__()
+        if ocr_invoke_url:
+            import warnings
+
+            warnings.warn(
+                "ocr_invoke_url is ignored by TableStructureActor; configure OCR on OCRActor instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._table_structure_invoke_url = (table_structure_invoke_url or invoke_url or "").strip()
         self._api_key = api_key
         self._request_timeout_s = float(request_timeout_s)

--- a/nemo_retriever/src/nemo_retriever/table/gpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/table/gpu_actor.py
@@ -25,7 +25,6 @@ class TableStructureActor(AbstractOperator, GPUOperator):
         *,
         table_structure_invoke_url: Optional[str] = None,
         invoke_url: Optional[str] = None,
-        ocr_invoke_url: Optional[str] = None,
         api_key: Optional[str] = None,
         table_output_format: Optional[str] = None,
         request_timeout_s: float = 120.0,
@@ -34,14 +33,6 @@ class TableStructureActor(AbstractOperator, GPUOperator):
         remote_max_429_retries: int = 5,
     ) -> None:
         super().__init__()
-        if ocr_invoke_url:
-            import warnings
-
-            warnings.warn(
-                "ocr_invoke_url is ignored by TableStructureActor; configure OCR on OCRActor instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         self._table_structure_invoke_url = (table_structure_invoke_url or invoke_url or "").strip()
         self._api_key = api_key
         self._request_timeout_s = float(request_timeout_s)

--- a/nemo_retriever/src/nemo_retriever/table/shared.py
+++ b/nemo_retriever/src/nemo_retriever/table/shared.py
@@ -282,7 +282,13 @@ def table_structure_ocr_page_elements(
     Returns
     -------
     pandas.DataFrame
-        Original columns plus ``table`` and ``table_structure_ocr_v1``.
+        Original columns plus:
+
+        - ``table``: list of per-crop dicts with structure-only ``text`` fallback
+          (overwritten by the OCR stage when it runs with ``use_table_structure=True``).
+        - ``table_structure_v1``: page-level ``{regions, timing, error}`` payload
+          consumed by the OCR stage to join OCR text with structure detections.
+        - ``table_structure_ocr_v1``: per-row timing/error metadata.
     """
     from nemo_retriever.nim.nim import invoke_image_inference_batches
     from nemo_retriever.ocr.ocr import _crop_all_from_page, _np_rgb_to_b64_png
@@ -310,12 +316,14 @@ def table_structure_ocr_page_elements(
 
     # Per-row accumulators.
     all_table: List[List[Dict[str, Any]]] = []
+    all_ts_payloads: List[Dict[str, Any]] = []
     all_meta: List[Dict[str, Any]] = []
 
     t0_total = time.perf_counter()
 
     for row in batch_df.itertuples(index=False):
         table_items: List[Dict[str, Any]] = []
+        ts_regions: List[Dict[str, Any]] = []
         row_error: Any = None
 
         try:
@@ -333,6 +341,7 @@ def table_structure_ocr_page_elements(
 
             if not isinstance(page_image_b64, str) or not page_image_b64:
                 all_table.append(table_items)
+                all_ts_payloads.append({"regions": ts_regions, "timing": None, "error": None})
                 all_meta.append({"timing": None, "error": None})
                 continue
 
@@ -341,6 +350,7 @@ def table_structure_ocr_page_elements(
 
             if not crops:
                 all_table.append(table_items)
+                all_ts_payloads.append({"regions": ts_regions, "timing": None, "error": None})
                 all_meta.append({"timing": None, "error": None})
                 continue
 
@@ -386,8 +396,10 @@ def table_structure_ocr_page_elements(
                     structure_results.append([d for d in dets if (d.get("score") or 0.0) >= YOLOX_TABLE_MIN_SCORE])
 
             # --- Pass 3: Build structure-only output per crop ---
-            for crop_i, (_, bbox, _) in enumerate(crops):
+            for crop_i, (_, bbox, crop_array) in enumerate(crops):
                 structure_dets = structure_results[crop_i]
+                crop_hw = (int(crop_array.shape[0]), int(crop_array.shape[1]))
+                counts = _count_structure_labels(structure_dets)
                 table_items.append(
                     {
                         "bbox_xyxy_norm": bbox,
@@ -396,7 +408,16 @@ def table_structure_ocr_page_elements(
                             table_output_format=table_output_format,
                         ),
                         "structure_detections": structure_dets,
-                        "structure_counts": _count_structure_labels(structure_dets),
+                        "structure_counts": counts,
+                    }
+                )
+                ts_regions.append(
+                    {
+                        "bbox_xyxy_norm": [float(x) for x in bbox],
+                        "label_name": "table",
+                        "detections": structure_dets,
+                        "orig_shape_hw": [crop_hw[0], crop_hw[1]],
+                        "structure_counts": counts,
                     }
                 )
 
@@ -410,14 +431,18 @@ def table_structure_ocr_page_elements(
             }
 
         all_table.append(table_items)
+        all_ts_payloads.append({"regions": ts_regions, "timing": None, "error": row_error})
         all_meta.append({"timing": None, "error": row_error})
 
     elapsed = time.perf_counter() - t0_total
     for meta in all_meta:
         meta["timing"] = {"seconds": float(elapsed)}
+    for payload in all_ts_payloads:
+        payload["timing"] = {"seconds": float(elapsed)}
 
     out = batch_df.copy()
     out["table"] = all_table
+    out["table_structure_v1"] = all_ts_payloads
     out["table_structure_ocr_v1"] = all_meta
     return out
 

--- a/nemo_retriever/src/nemo_retriever/utils/table_and_chart.py
+++ b/nemo_retriever/src/nemo_retriever/utils/table_and_chart.py
@@ -251,7 +251,6 @@ def _join_yolox_table_structure_and_ocr_output(
     df_table = df_assign[df_assign["is_table"]].reset_index(drop=True)
     if len(df_table):
         mat = build_markdown(df_table)
-        mat = _trim_non_table_edge_rows(mat)
         markdown_table = display_markdown(mat, use_header=True)
 
         all_boxes = np.stack(df_table.ocr_box.values)
@@ -361,43 +360,6 @@ def remove_empty_row(mat: list) -> list:
         if max([len(c) for c in row]):
             mat_filter.append(row)
     return mat_filter
-
-
-def _trim_non_table_edge_rows(mat: list) -> list:
-    """Remove leading/trailing rows that look like non-table content.
-
-    Heuristics applied only to edge rows:
-    - All non-empty cells contain identical text (duplicated caption).
-    - Less than half the cells are filled (stray text from surrounding content).
-    """
-    if len(mat) <= 1:
-        return mat
-
-    n_cols = max(len(row) for row in mat) if mat else 0
-    if n_cols < 2:
-        return mat
-
-    def _is_noise_row(row: list) -> bool:
-        non_empty = [c for c in row if c.strip()]
-        if not non_empty:
-            return True
-        # All non-empty cells identical (repeated caption text).
-        if len(non_empty) > 1 and len(set(non_empty)) == 1:
-            return True
-        # Half or fewer cells filled.
-        if len(non_empty) <= n_cols / 2:
-            return True
-        return False
-
-    # Trim leading noise rows.
-    while len(mat) > 1 and _is_noise_row(mat[0]):
-        mat = mat[1:]
-
-    # Trim trailing noise rows.
-    while len(mat) > 1 and _is_noise_row(mat[-1]):
-        mat = mat[:-1]
-
-    return mat
 
 
 def reorder_boxes(

--- a/nemo_retriever/tests/test_table_structure.py
+++ b/nemo_retriever/tests/test_table_structure.py
@@ -169,7 +169,9 @@ class TestTableStructureOCRPageElements:
         )
         assert "table" in result.columns
         assert "table_structure_ocr_v1" in result.columns
+        assert "table_structure_v1" in result.columns
         assert result.iloc[0]["table"] == []
+        assert result.iloc[0]["table_structure_v1"]["regions"] == []
         # No model calls should have been made.
         mock_ts_model.invoke.assert_not_called()
 
@@ -228,6 +230,19 @@ class TestTableStructureOCRPageElements:
         assert "|" in table_entries[0]["text"]
         assert table_entries[0]["bbox_xyxy_norm"] == [0.0, 0.0, 1.0, 1.0]
         assert table_entries[0]["structure_counts"] == {"cell": 1, "row": 1, "column": 1}
+
+        # table_structure_v1 page-level column populated with region payload.
+        assert "table_structure_v1" in result.columns
+        ts_payload = result.iloc[0]["table_structure_v1"]
+        assert set(ts_payload.keys()) >= {"regions", "timing", "error"}
+        regions = ts_payload["regions"]
+        assert len(regions) == 1
+        region = regions[0]
+        assert region["label_name"] == "table"
+        assert region["bbox_xyxy_norm"] == [0.0, 0.0, 1.0, 1.0]
+        assert len(region["detections"]) == 3
+        assert len(region["orig_shape_hw"]) == 2
+        assert region["structure_counts"] == {"cell": 1, "row": 1, "column": 1}
 
     def test_with_no_cells_produces_structure_summary(self) -> None:
         """When table-structure returns no cells, it should still produce structure-only output."""
@@ -318,6 +333,160 @@ class TestTableStructureActor:
             assert "table_structure_ocr_v1" in result.columns
             meta = result.iloc[0]["table_structure_ocr_v1"]
             assert meta["error"] is not None
+
+    def test_ocr_invoke_url_on_gpu_actor_emits_deprecation_warning(self) -> None:
+        """Legacy ``ocr_invoke_url`` kwarg should warn but not fail."""
+        import warnings
+
+        from nemo_retriever.table.gpu_actor import TableStructureActor
+
+        with patch("nemo_retriever.model.local.NemotronTableStructureV1", return_value=MagicMock()):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                TableStructureActor(
+                    table_structure_invoke_url="http://ts",
+                    ocr_invoke_url="http://legacy-ocr",
+                )
+            dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+            assert dep, "expected DeprecationWarning for ocr_invoke_url"
+            assert "ocr_invoke_url" in str(dep[0].message)
+
+    def test_ocr_invoke_url_on_cpu_actor_emits_deprecation_warning(self) -> None:
+        import warnings
+
+        from nemo_retriever.table.cpu_actor import TableStructureCPUActor
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            TableStructureCPUActor(
+                table_structure_invoke_url="http://ts",
+                ocr_invoke_url="http://legacy-ocr",
+            )
+        dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert dep, "expected DeprecationWarning for ocr_invoke_url"
+        assert "ocr_invoke_url" in str(dep[0].message)
+
+
+# ---------------------------------------------------------------------------
+# OCR stage joining against table_structure_v1
+# ---------------------------------------------------------------------------
+
+
+def _make_page_df_with_ts_regions(
+    *,
+    ocr_bbox: list[float],
+    ts_regions: list[dict],
+    width: int = 200,
+    height: int = 100,
+) -> pd.DataFrame:
+    image_b64 = _make_b64_png(width, height)
+    return pd.DataFrame(
+        [
+            {
+                "page_image": {"image_b64": image_b64},
+                "page_elements_v3": {
+                    "detections": [
+                        {
+                            "label_name": "table",
+                            "bbox_xyxy_norm": ocr_bbox,
+                            "score": 0.95,
+                        }
+                    ]
+                },
+                "page_elements_v3_counts_by_label": {"table": 1},
+                "table_structure_v1": {
+                    "regions": ts_regions,
+                    "timing": {"seconds": 0.0},
+                    "error": None,
+                },
+            }
+        ]
+    )
+
+
+@_needs_pil
+@_needs_requests
+@_needs_torch
+class TestOCRJoinsTableStructure:
+    """When use_table_structure=True, OCR stage should join structure + OCR."""
+
+    def _structure_2x2(self) -> list[dict]:
+        return [
+            {"bbox_xyxy_norm": [0.0, 0.0, 1.0, 0.5], "label_name": "row", "score": 0.9},
+            {"bbox_xyxy_norm": [0.0, 0.5, 1.0, 1.0], "label_name": "row", "score": 0.9},
+            {"bbox_xyxy_norm": [0.0, 0.0, 0.5, 1.0], "label_name": "column", "score": 0.9},
+            {"bbox_xyxy_norm": [0.5, 0.0, 1.0, 1.0], "label_name": "column", "score": 0.9},
+            {"bbox_xyxy_norm": [0.0, 0.0, 0.5, 0.5], "label_name": "cell", "score": 0.9},
+            {"bbox_xyxy_norm": [0.5, 0.0, 1.0, 0.5], "label_name": "cell", "score": 0.9},
+            {"bbox_xyxy_norm": [0.0, 0.5, 0.5, 1.0], "label_name": "cell", "score": 0.9},
+            {"bbox_xyxy_norm": [0.5, 0.5, 1.0, 1.0], "label_name": "cell", "score": 0.9},
+        ]
+
+    def _ocr_preds_abcd(self) -> list[dict]:
+        return [
+            {"left": 0.05, "right": 0.45, "upper": 0.05, "lower": 0.45, "text": "A"},
+            {"left": 0.55, "right": 0.95, "upper": 0.05, "lower": 0.45, "text": "B"},
+            {"left": 0.05, "right": 0.45, "upper": 0.55, "lower": 0.95, "text": "C"},
+            {"left": 0.55, "right": 0.95, "upper": 0.55, "lower": 0.95, "text": "D"},
+        ]
+
+    def test_local_path_joins_structure_and_ocr(self) -> None:
+        """Local OCR path should join structure + OCR into markdown when use_table_structure=True."""
+        from nemo_retriever.ocr.shared import ocr_page_elements
+
+        bbox = [0.0, 0.0, 1.0, 1.0]
+        ts_regions = [
+            {
+                "bbox_xyxy_norm": bbox,
+                "label_name": "table",
+                "detections": self._structure_2x2(),
+                "orig_shape_hw": [100, 200],
+                "structure_counts": {"cell": 4, "row": 2, "column": 2},
+            }
+        ]
+        df = _make_page_df_with_ts_regions(ocr_bbox=bbox, ts_regions=ts_regions)
+
+        ocr_model = MagicMock()
+        ocr_model.invoke.return_value = self._ocr_preds_abcd()
+
+        result = ocr_page_elements(
+            df,
+            model=ocr_model,
+            extract_tables=True,
+            use_table_structure=True,
+        )
+
+        entries = result.iloc[0]["table"]
+        assert len(entries) == 1
+        text = entries[0]["text"]
+        for cell in ("A", "B", "C", "D"):
+            assert cell in text, f"missing cell '{cell}' in joined markdown: {text!r}"
+        assert "|" in text
+
+    def test_local_path_falls_back_when_no_structure_match(self) -> None:
+        """No matching structure region -> OCR pseudo-markdown fallback; no raise."""
+        from nemo_retriever.ocr.shared import ocr_page_elements
+
+        # TS regions is empty so there's no match for the table crop bbox.
+        df = _make_page_df_with_ts_regions(ocr_bbox=[0.0, 0.0, 1.0, 1.0], ts_regions=[])
+
+        ocr_model = MagicMock()
+        ocr_model.invoke.return_value = self._ocr_preds_abcd()
+
+        result = ocr_page_elements(
+            df,
+            model=ocr_model,
+            extract_tables=True,
+            use_table_structure=True,
+        )
+
+        entries = result.iloc[0]["table"]
+        assert len(entries) == 1
+        # Pseudo-markdown fallback still produces text with the OCR cell content.
+        text = entries[0]["text"]
+        assert text  # non-empty
+        for cell in ("A", "B", "C", "D"):
+            assert cell in text
 
 
 # ---------------------------------------------------------------------------

--- a/nemo_retriever/tests/test_table_structure.py
+++ b/nemo_retriever/tests/test_table_structure.py
@@ -334,38 +334,6 @@ class TestTableStructureActor:
             meta = result.iloc[0]["table_structure_ocr_v1"]
             assert meta["error"] is not None
 
-    def test_ocr_invoke_url_on_gpu_actor_emits_deprecation_warning(self) -> None:
-        """Legacy ``ocr_invoke_url`` kwarg should warn but not fail."""
-        import warnings
-
-        from nemo_retriever.table.gpu_actor import TableStructureActor
-
-        with patch("nemo_retriever.model.local.NemotronTableStructureV1", return_value=MagicMock()):
-            with warnings.catch_warnings(record=True) as caught:
-                warnings.simplefilter("always")
-                TableStructureActor(
-                    table_structure_invoke_url="http://ts",
-                    ocr_invoke_url="http://legacy-ocr",
-                )
-            dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-            assert dep, "expected DeprecationWarning for ocr_invoke_url"
-            assert "ocr_invoke_url" in str(dep[0].message)
-
-    def test_ocr_invoke_url_on_cpu_actor_emits_deprecation_warning(self) -> None:
-        import warnings
-
-        from nemo_retriever.table.cpu_actor import TableStructureCPUActor
-
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            TableStructureCPUActor(
-                table_structure_invoke_url="http://ts",
-                ocr_invoke_url="http://legacy-ocr",
-            )
-        dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-        assert dep, "expected DeprecationWarning for ocr_invoke_url"
-        assert "ocr_invoke_url" in str(dep[0].message)
-
 
 # ---------------------------------------------------------------------------
 # OCR stage joining against table_structure_v1

--- a/nemo_retriever/tests/test_table_structure.py
+++ b/nemo_retriever/tests/test_table_structure.py
@@ -429,7 +429,8 @@ class TestOCRJoinsTableStructure:
         text = entries[0]["text"]
         for cell in ("A", "B", "C", "D"):
             assert cell in text, f"missing cell '{cell}' in joined markdown: {text!r}"
-        assert "|" in text
+        # Structure-aware markdown includes a header separator; pseudo-markdown does not.
+        assert "---" in text, f"expected structure-aware markdown, got: {text!r}"
 
     def test_local_path_falls_back_when_no_structure_match(self) -> None:
         """No matching structure region -> OCR pseudo-markdown fallback; no raise."""
@@ -450,11 +451,52 @@ class TestOCRJoinsTableStructure:
 
         entries = result.iloc[0]["table"]
         assert len(entries) == 1
-        # Pseudo-markdown fallback still produces text with the OCR cell content.
+        # Pseudo-markdown fallback still produces text with the OCR cell content,
+        # but does not include the structure-aware markdown header separator.
         text = entries[0]["text"]
         assert text  # non-empty
         for cell in ("A", "B", "C", "D"):
             assert cell in text
+        assert "---" not in text, f"expected pseudo-markdown fallback, got: {text!r}"
+
+    def test_remote_path_joins_structure_and_ocr(self) -> None:
+        """Remote OCR path should join structure + OCR the same way as the local path."""
+        from nemo_retriever.ocr.shared import ocr_page_elements
+
+        bbox = [0.0, 0.0, 1.0, 1.0]
+        ts_regions = [
+            {
+                "bbox_xyxy_norm": bbox,
+                "label_name": "table",
+                "detections": self._structure_2x2(),
+                "orig_shape_hw": [100, 200],
+                "structure_counts": {"cell": 4, "row": 2, "column": 2},
+            }
+        ]
+        df = _make_page_df_with_ts_regions(ocr_bbox=bbox, ts_regions=ts_regions)
+
+        # The remote path calls invoke_image_inference_batches once per crop;
+        # each response element is passed through _extract_remote_ocr_item,
+        # which returns it as-is when it isn't a dict. So a length-1 list whose
+        # sole element is the list of OCR predictions simulates one table crop.
+        with patch(
+            "nemo_retriever.ocr.shared.invoke_image_inference_batches",
+            return_value=[self._ocr_preds_abcd()],
+        ):
+            result = ocr_page_elements(
+                df,
+                invoke_url="http://fake-ocr",
+                extract_tables=True,
+                use_table_structure=True,
+            )
+
+        entries = result.iloc[0]["table"]
+        assert len(entries) == 1
+        text = entries[0]["text"]
+        for cell in ("A", "B", "C", "D"):
+            assert cell in text, f"missing cell '{cell}' in joined markdown: {text!r}"
+        # Structure-aware markdown includes a header separator; pseudo-markdown does not.
+        assert "---" in text, f"expected structure-aware markdown, got: {text!r}"
 
 
 # ---------------------------------------------------------------------------

--- a/nemo_retriever/tests/test_table_structure.py
+++ b/nemo_retriever/tests/test_table_structure.py
@@ -468,7 +468,6 @@ class TestTableStructureOCRConfig:
 
         cfg = load_table_structure_ocr_config_from_dict({})
         assert cfg.table_structure_invoke_url == ""
-        assert cfg.ocr_invoke_url == ""
         assert cfg.api_key == ""
         assert cfg.request_timeout_s == 60.0
 
@@ -478,13 +477,11 @@ class TestTableStructureOCRConfig:
         cfg = load_table_structure_ocr_config_from_dict(
             {
                 "table_structure_invoke_url": "http://ts:8000",
-                "ocr_invoke_url": "http://ocr:8000",
                 "api_key": "secret",
                 "request_timeout_s": 60.0,
             }
         )
         assert cfg.table_structure_invoke_url == "http://ts:8000"
-        assert cfg.ocr_invoke_url == "http://ocr:8000"
         assert cfg.api_key == "secret"
         assert cfg.request_timeout_s == 60.0
 


### PR DESCRIPTION
…tent

## Description

A previous commit correctly removed OCR from the table-structure stage to avoid running it twice, but left `use_table_structure=True` pipelines producing empty markdown skeletons. The separate OCR stage was also gated off for tables in that config, so no stage produced the per-crop word boxes the existing `join_table_structure_and_ocr_output` helper needs, and the helper had no caller.

This PR reconnects them so the OCR stage now always runs on table crops. When `use_table_structure=True` it matches each crop's bbox against the page's regions and calls the existing join helper, falling back to pseudo-markdown on no match.

Before
```
===== table: src=/home/edwardk/git/nv-ingest/data/multimodal_test.pdf_1 page=1 idx=0 =====
|  |  |  |
| --- | --- | --- |
|  |  |  |
|  |  |  |
|  |  |  |
|  |  |  |
|  |  |  |
|  |  |  |
============================================================

===== table: src=/home/edwardk/git/nv-ingest/data/multimodal_test.pdf_2 page=2 idx=0 =====
|  |  |  |  |
| --- | --- | --- | --- |
|  |  |  |  |
|  |  |  |  |
|  |  |  |  |
|  |  |  |  |
|  |  |  |  |
|  |  |  |  |
|  |  |  |  |
============================================================
```
After
```
===== table: src=/home/edwardk/git/nv-ingest/data/multimodal_test.pdf_1 page=1 idx=0 =====
| Animal | Activity | Place |
| --- | --- | --- |
| Giraffe | Driving a car | At the beach |
| Lion | Putting on sunscreen | At the park |
| Cat | Jumping onto a laptop | In a home office |
| Dog | Chasing a squirrel | In the front yard |
============================================================

===== table: src=/home/edwardk/git/nv-ingest/data/multimodal_test.pdf_2 page=2 idx=0 =====
smoke test to ensure extraction is working as intended. This will be used in Cl time that changes make the library do negatively impact on to ensure we to not
| Car | Color1 | Color2 | Color3 |
| --- | --- | --- | --- |
| Coupe | White | Silver | Flat Gray |
| Sedan | White | Metallic Gray | Matte Gray |
| Minivan | Gray | Beige | Black |
| Truck | Dark Gray | Titanium Gray | Charcoal |
| Convertible | Light Gray | Graphite | Slate Gray |
============================================================
```
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
