### PR TITLE
End-to-end air-gapped deployment guide for NeMo Retriever Library

### DIFF
--- a/docs/docs/extraction/air-gapped-deployment.md
+++ b/docs/docs/extraction/air-gapped-deployment.md
@@ -62,7 +62,7 @@ Again, take the exact repository and tag from your pinned `values.yaml` for 26.3
 
 ## Helm charts and packaging artifacts
 
-From a connected environment, download and version-control the chart archive you install, for example (see [NV-Ingest Helm README](https://github.com/NVIDIA/nv-ingest/blob/release/26.3.0/helm/README.md)):
+From a connected environment, download and version-control the chart archive you install, for example (see [NV-Ingest Helm README](https://github.com/NVIDIA/NeMo-Retriever/blob/release/26.3.0/helm/README.md)):
 
 - `nv-ingest-26.3.0.tgz` from NGC Helm (`helm pull` with NGC credentials)
 

--- a/docs/docs/extraction/air-gapped-deployment.md
+++ b/docs/docs/extraction/air-gapped-deployment.md
@@ -7,7 +7,7 @@ This guide consolidates what you need to run NeMo Retriever Library in a secured
     Image repositories and default tags change between releases. Always verify pins against the `release/26.3.0` (or your exact stack) branches of:
 
     - [NeMo Retriever `docker-compose.yaml`](https://github.com/NVIDIA/NeMo-Retriever/blob/release/26.3.0/docker-compose.yaml) for self-hosted Compose (check out the **Git tag or branch that matches 26.3.0** in your environment; `main` moves forward)
-    - [`helm/values.yaml`](https://github.com/NVIDIA/nv-ingest/blob/release/26.3.0/helm/values.yaml) and [`helm/README.md`](https://github.com/NVIDIA/nv-ingest/blob/release/26.3.0/helm/README.md) for Kubernetes / Helm
+    - [`helm/values.yaml`](https://github.com/NVIDIA/NeMo-Retriever/blob/release/26.3.0/helm/values.yaml) and [`helm/README.md`](https://github.com/NVIDIA/NeMo-Retriever/blob/release/26.3.0/helm/README.md) for Kubernetes / Helm
 
 ## End-to-end workflow
 

--- a/docs/docs/extraction/air-gapped-deployment.md
+++ b/docs/docs/extraction/air-gapped-deployment.md
@@ -1,0 +1,137 @@
+# Air-Gapped Deployment (End-to-End)
+
+This guide consolidates what you need to run NeMo Retriever Library in a secured, network-isolated environment (for example 26.3.0 on Kubernetes or Docker Compose). It focuses on NeMo Retriever–specific images, Helm assets, and configuration so you can plug them into your broader air-gapped platform (private container registry, model artifact storage, [NVIDIA GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/), and [NIM Operator](https://docs.nvidia.com/nim-operator/latest/install.html)).
+
+!!! note "Source of truth for versions"
+
+    Image repositories and default tags change between releases. Always verify pins against the `release/26.3.0` (or your exact stack) branches of:
+
+    - [NeMo Retriever `docker-compose.yaml`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docker-compose.yaml) for self-hosted Compose (check out the **Git tag or branch that matches 26.3.0** in your environment; `main` moves forward)
+    - [`helm/values.yaml`](https://github.com/NVIDIA/nv-ingest/blob/release/26.3.0/helm/values.yaml) and [`helm/README.md`](https://github.com/NVIDIA/nv-ingest/blob/release/26.3.0/helm/README.md) for Kubernetes / Helm
+
+## End-to-end workflow
+
+Use a staging machine (or bastion) that can reach the public internet and NGC, then promote artifacts into the disconnected site.
+
+1. **Inventory** — Decide deployment mode (Compose vs Helm), optional profiles / NIMs (audio, Nemotron Parse, VLM, Milvus retrieval, reranker), and list every image and chart you must mirror (sections below).
+2. **Mirror container images** — Pull from upstream registries, retag to your private registry (optional but recommended), record digests for reproducibility, and push to the registry reachable from the air-gapped environment.
+3. **Stage non-image assets** — Helm chart `.tgz` packages from NGC (or vendor them internally), Python wheels for clients (`nv-ingest-client`), and any operator bundles your cluster policy requires.
+4. **Configure pulls and runtime** — Point all `image.repository` values (and Compose image env vars) at the private registry; use `imagePullSecrets`; set `imagePullPolicy: IfNotPresent` (or `Never` only if every node is preloaded). Ensure **no** workload still references `integrate.api.nvidia.com`, `ai.api.nvidia.com`, or other hosted NVIDIA APIs unless you intentionally proxy them.
+5. **NIM models and caches** — For Kubernetes, follow [NIM Operator: Air-gapped environments](https://docs.nvidia.com/nim-operator/latest/air-gap.html) to preload models into NIMCache / private artifact storage so NIM pods never need outbound registry access at runtime.
+6. **Validate** — From a jump host inside the enclave, run image pull tests, `helm template` with offline values, then smoke-test ingest health (`/v1/health/ready`) and a minimal extract job.
+
+## What NeMo Retriever / NV-Ingest needs (container images)
+
+### Core pipeline (typical default)
+
+These services are commonly enabled for document extraction with self-hosted NIMs (names match Docker Compose services where applicable).
+
+| Role | Default image (verify tag in repo) | Notes |
+|------|--------------------------------------|--------|
+| Ingest runtime | `nvcr.io/nvidia/nemo-microservices/nv-ingest:26.3.0` | Main API / Ray service |
+| Page elements NIM | `nvcr.io/nim/nvidia/nemotron-page-elements-v3` | Default tag in Compose: `1.8.0` |
+| Graphic elements NIM | `nvcr.io/nim/nvidia/nemotron-graphic-elements-v1` | Default tag: `1.8.0` |
+| Table structure NIM | `nvcr.io/nim/nvidia/nemotron-table-structure-v1` | Default tag: `1.8.0` |
+| OCR NIM | `nvcr.io/nim/nvidia/nemotron-ocr-v1` | Default tag: `1.3.0` |
+| Embedding NIM | `nvcr.io/nim/nvidia/llama-nemotron-embed-1b-v2` | Default tag: `1.13.0` |
+| Redis | `redis/redis-stack` | Message broker / stack |
+| OpenTelemetry Collector | `otel/opentelemetry-collector-contrib` | e.g. `0.140.0` in Helm values |
+| Zipkin | `openzipkin/zipkin` | e.g. `3.5.0` in Helm values |
+
+### Optional profiles / features
+
+Add these images only if you enable the matching Compose profiles or Helm NIM toggles.
+
+| Feature | Image | When needed |
+|---------|--------|-------------|
+| Nemotron Parse | `nvcr.io/nim/nvidia/nemotron-parse` | Advanced PDF parsing profile |
+| VLM captioning | `nvcr.io/nim/nvidia/nemotron-nano-12b-v2-vl` | `vlm` profile / `nemotron_nano_12b_v2_vl` in Helm |
+| Audio (ASR) | `nvcr.io/nim/nvidia/parakeet-1-1b-ctc-en-us` | `audio` profile |
+| Reranking NIM | `nvcr.io/nim/nvidia/llama-nemotron-rerank-1b-v2` | Reranker profile / `rerankqa` in Helm |
+| Retrieval stack (Milvus path) | `milvusdb/milvus`, `minio/minio`, `quay.io/coreos/etcd`, `zilliz/attu` | Compose `retrieval` profile; Helm deploys Milvus/MinIO via subchart defaults |
+| Observability extras | `prom/prometheus`, `grafana/grafana` | Only if you enable monitoring containers in Compose |
+
+### Kubernetes-only dependencies (Helm chart defaults)
+
+When you install from the nv-ingest Helm chart, also plan to mirror subchart images your values enable, for example:
+
+- Milvus (`milvusdb/milvus` and bundled etcd/minio images from chart values)
+- Redis (`redis` with chart tag, for example `8.2.3` in default `values.yaml`)
+
+Again, take the exact repository and tag from your pinned `values.yaml` for 26.3.0.
+
+## Helm charts and packaging artifacts
+
+From a connected environment, download and version-control the chart archive you install, for example (see [NV-Ingest Helm README](https://github.com/NVIDIA/nv-ingest/blob/release/26.3.0/helm/README.md)):
+
+- `nv-ingest-26.3.0.tgz` from NGC Helm (`helm pull` with NGC credentials)
+
+If your process forbids live `helm install` from URLs, use `helm pull` on the staging host, copy the `.tgz` and any dependent charts into the enclave, then `helm upgrade --install` using the local file path.
+
+## Pinning versions and digests
+
+- Tags — Align Compose `*_TAG` / Helm `image.tag` fields with the same release line you qualified (for example `26.3.0` for the ingest image, NIM tags from `docker-compose.yaml` / `nimOperator` in `values.yaml`).
+- Digests — After `docker pull nvcr.io/...:tag`, run `docker inspect --format='{{index .RepoDigests 0}}' image:tag` (or use crane / skopeo; see tooling below) and record `repository@sha256:...`. Prefer deploying with digests in highly regulated environments; keep a mapping table from digest → human-readable tag for operations.
+
+## Mirroring images into a private registry
+
+Typical pattern on the staging host:
+
+1. `docker login nvcr.io` (NGC key as password, username `$oauthtoken`) and log in to other upstream registries you use (`docker.io`, `quay.io`, etc.).
+2. For each image: `docker pull upstream/image:tag`
+3. `docker tag upstream/image:tag <PRIVATE_REGISTRY>/nv-ingest-mirror/upstream-image:tag`
+4. `docker push <PRIVATE_REGISTRY>/nv-ingest-mirror/upstream-image:tag`
+
+For large fleets, prefer [skopeo](https://github.com/containers/skopeo) or [crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) for copy/sync between registries without loading into a local Docker daemon.
+
+Transfer tarballs instead when the enclave has no registry yet: `docker save -o nv-ingest-bundle.tar` multiple images, move media, then `docker load` / `ctr -n k8s.io images import` on nodes (cluster-specific).
+
+## Pointing deployments at the private registry (avoid runtime pulls)
+
+### Docker Compose
+
+- Override each `*_IMAGE` / `*_TAG` environment variable (see [`docker-compose.yaml`](https://github.com/NVIDIA/NeMo-Retriever/blob/release/26.3.0/docker-compose.yaml)) so every `image:` resolves to your mirror.
+- Keep hosted API endpoints disabled: use in-stack URLs for NIMs (defaults in the compose file already prefer `http://…` service names over `https://integrate.api.nvidia.com`).
+- Provide `.env` or config alongside the compose file in the enclave; never rely on pulling new images at `up` time without registry access.
+
+For a short Compose-oriented procedure, see [Air-Gapped Deployment (Docker Compose)](quickstart-guide.md#air-gapped-deployment-docker-compose) in the self-hosted quickstart; this page is the complete checklist.
+
+### Helm (Kubernetes)
+
+1. Set the main ingest image, for example:
+
+   ```text
+   image.repository=<PRIVATE_REGISTRY>/nvidia/nemo-microservices/nv-ingest
+   image.tag=26.3.0
+   ```
+
+2. Under `nimOperator` in `values.yaml`, override `image.repository` / `image.tag` for each enabled NIM (page elements, graphic elements, table structure, OCR, embed, optional parse/VLM/audio/rerank) to your mirrored paths.
+
+3. Configure `imagePullSecrets` so kubelet can authenticate to your private registry (the chart defaults assume NGC-style secrets; replace with secrets that reference your mirror’s credentials).
+
+4. Set `imagePullPolicy: IfNotPresent` (default in many paths) once images are pre-pulled or pulled through the mirror; use `Never` only if you fully preload images on every node and understand scheduling failure modes.
+
+5. Review `envVars` for any URL that still points to the public internet (for example hosted VLM or Parse endpoints). For fully offline captioning, deploy the Nemotron Nano VL NIM in-cluster and set `VLM_CAPTION_ENDPOINT` to the in-cluster HTTP/gRPC endpoint (see comments in `values.yaml` for the expected pattern).
+
+6. Install [GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/) and [NIM Operator](https://docs.nvidia.com/nim-operator/latest/), configured for offline registries and cached models ([NIM Operator air-gap guide](https://docs.nvidia.com/nim-operator/latest/air-gap.html)).
+
+## Recommended tooling references
+
+| Tool | Use case |
+|------|-----------|
+| [skopeo](https://github.com/containers/skopeo) | Copy/sign/inspect images between registries without Docker |
+| [crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) | Bulk copy, tag, digest resolution |
+| [Helm](https://helm.sh/docs/) | Package, template, and install charts from local `.tgz` |
+| [Harbor](https://goharbor.io/) or [Docker Registry](https://distribution.github.io/distribution/) | Private registry to host mirrored images |
+| [NIM Operator — Air-gapped environments](https://docs.nvidia.com/nim-operator/latest/air-gap.html) | NIM-specific mirroring, secrets, and model cache behavior |
+
+## Related documentation
+
+- [Deploy With Helm for NeMo Retriever Library](helm.md)
+- [Deploy (Self-Hosted) Quickstart](quickstart-guide.md) — includes Compose air-gap summary
+- [Environment Variables](environment-config.md) — runtime tuning and endpoints
+- [Generate Your NGC Keys](ngc-api-key.md) — staging-time pulls from `nvcr.io`
+
+## Broader dependencies (outside this doc’s scope)
+
+Plan separately for GPU drivers / GPU Operator, ingress / TLS, storage classes for Milvus and NIM PVCs, enterprise image scanning, and internal PyPI / wheel mirrors for Python clients. NeMo Retriever’s ingest container is built so common tokenizer assets are present at build time; if you enable features that need extra Hugging Face access, you must **pre-stage** those artifacts per your security policy (see [Environment Variables](environment-config.md) for tokens such as `HF_ACCESS_TOKEN`).

--- a/docs/docs/extraction/air-gapped-deployment.md
+++ b/docs/docs/extraction/air-gapped-deployment.md
@@ -6,7 +6,7 @@ This guide consolidates what you need to run NeMo Retriever Library in a secured
 
     Image repositories and default tags change between releases. Always verify pins against the `release/26.3.0` (or your exact stack) branches of:
 
-    - [NeMo Retriever `docker-compose.yaml`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docker-compose.yaml) for self-hosted Compose (check out the **Git tag or branch that matches 26.3.0** in your environment; `main` moves forward)
+    - [NeMo Retriever `docker-compose.yaml`](https://github.com/NVIDIA/NeMo-Retriever/blob/release/26.3.0/docker-compose.yaml) for self-hosted Compose (check out the **Git tag or branch that matches 26.3.0** in your environment; `main` moves forward)
     - [`helm/values.yaml`](https://github.com/NVIDIA/nv-ingest/blob/release/26.3.0/helm/values.yaml) and [`helm/README.md`](https://github.com/NVIDIA/nv-ingest/blob/release/26.3.0/helm/README.md) for Kubernetes / Helm
 
 ## End-to-end workflow

--- a/docs/docs/extraction/helm.md
+++ b/docs/docs/extraction/helm.md
@@ -5,5 +5,7 @@
 To deploy [NeMo Retriever Library](overview.md) by using Helm, refer to [NV-Ingest Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/helm/README.md).
 
 !!! note "Air-gapped environments"
-   
-    For deploying in an air-gapped environment, refer to the [NVIDIA NIM Operator documentation on Air-Gapped Environments](https://docs.nvidia.com/nim-operator/latest/air-gap.html), which explains how to deploy NIMs when your cluster has no internet or NGC registry access.
+
+    For an end-to-end checklist (images to mirror, Helm assets, registry overrides, and tooling), start with [Air-Gapped Deployment (End-to-End)](air-gapped-deployment.md).
+
+    For NIM Operator specifics (model caches, operator configuration in disconnected clusters), refer to [NVIDIA NIM Operator: Air-Gapped Environments](https://docs.nvidia.com/nim-operator/latest/air-gap.html).

--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -410,6 +410,8 @@ docker compose \
 
 ## Air-Gapped Deployment (Docker Compose)
 
+For a complete NeMo Retriever Library air-gapped checklist (Compose and Kubernetes, image inventory, digest pinning, Helm charts, and registry configuration), see [Air-Gapped Deployment (End-to-End)](air-gapped-deployment.md).
+
 When deploying in an air-gapped environment (no internet or NGC registry access), you must pre-stage container images on a machine with network access, then transfer and load them in the isolated environment.
 
 1. On a machine with network access: Clone the repo, authenticate with NGC (`docker login nvcr.io`), and pull all images used by your chosen profile (for example, `docker compose --profile retrieval pull`).

--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -89,11 +89,11 @@ h. Run the command `docker ps`. You should see output similar to the following. 
     1b885f37c991  nvcr.io/nvidia/nemo-microservices/nv-ingest:...  "/usr/bin/tini -- /w…"  7 minutes ago   Up 7 minutes (healthy)  0.0.0.0:7670...  nv-ingest-nv-ingest-ms-runtime-1
     14ef31ed7f49  milvusdb/milvus:v2.5.3-gpu                       "/tini -- bash -c 's…"  7 minutes ago   Up 7 minutes (healthy)  0.0.0.0:9091...  milvus-standalone
     dceaf36cc5df  otel/opentelemetry-collector-contrib:...         "/otelcol-contrib --…"  7 minutes ago   Up 7 minutes            0.0.0.0:4317...  nv-ingest-otel-collector-1
-    5bd0b48eb71b  nvcr.io/nim/nvidia/nemoretriever-graphic-ele...  "/opt/nvidia/nvidia_…"  7 minutes ago   Up 7 minutes            0.0.0.0:8003...  nv-ingest-graphic-elements-1
-    daf878669036  nvcr.io/nim/nvidia/nemoretriever-ocr-v1:1.2.1    "/opt/nvidia/nvidia_…"  7 minutes ago   Up 7 minutes            0.0.0.0:8009...  nv-ingest-ocr-1
-    216bdf11c566  nvcr.io/nim/nvidia/nemoretriever-page-elements-v3:1.7.0  "/opt/nvidia/nvidia_…"  7 minutes ago   Up 7 minutes            0.0.0.0:8000...  nv-ingest-page-elements-1
-    aee9580b0b9a  nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2:1.10.0  "/opt/nvidia/nvidia_…"  7 minutes ago   Up 7 minutes            0.0.0.0:8012...  nv-ingest-embedding-1
-    178a92bf6f7f  nvcr.io/nim/nvidia/nemoretriever-table-struc...  "/opt/nvidia/nvidia_…"  7 minutes ago   Up 7 minutes            0.0.0.0:8006...  nv-ingest-table-structure-1
+    5bd0b48eb71b  nvcr.io/nim/nvidia/nemotron-graphic-ele...  "/opt/nvidia/nvidia_…"  7 minutes ago   Up 7 minutes            0.0.0.0:8003...  nv-ingest-graphic-elements-1
+    daf878669036  nvcr.io/nim/nvidia/nemotron-ocr-v1:1.2.1    "/opt/nvidia/nvidia_…"  7 minutes ago   Up 7 minutes            0.0.0.0:8009...  nv-ingest-ocr-1
+    216bdf11c566  nvcr.io/nim/nvidia/nemotron-page-elements-v3:1.7.0  "/opt/nvidia/nvidia_…"  7 minutes ago   Up 7 minutes            0.0.0.0:8000...  nv-ingest-page-elements-1
+    aee9580b0b9a  nvcr.io/nim/nvidia/llama-nemotron-embed-1b-v2:1.13.0  "/opt/nvidia/nvidia_…"  7 minutes ago   Up 7 minutes            0.0.0.0:8012...  nv-ingest-embedding-1
+    178a92bf6f7f  nvcr.io/nim/nvidia/nemotron-table-structure-v1:.....  "/opt/nvidia/nvidia_…"  7 minutes ago   Up 7 minutes            0.0.0.0:8006...  nv-ingest-table-structure-1
     7ddbf7690036  openzipkin/zipkin                                "start-zipkin"          7 minutes ago   Up 7 minutes (healthy)  9410/tcp...      nv-ingest-zipkin-1
     b73bbe0c202d  minio/minio:RELEASE.2023-03-20T20-16-18Z         "/usr/bin/docker-ent…"  7 minutes ago   Up 7 minutes (healthy)  0.0.0.0:9000...  minio
     97fa798dbe4f  prom/prometheus:latest                           "/bin/prometheus --w…"  7 minutes ago   Up 7 minutes            0.0.0.0:9090...  nv-ingest-prometheus-1

--- a/docs/docs/extraction/releasenotes-nv-ingest.md
+++ b/docs/docs/extraction/releasenotes-nv-ingest.md
@@ -19,7 +19,7 @@ Highlights for the 26.03 release include:
 - NeMo Retriever Library now supports two deployment options:  
   - A new no-container, pip-installable in-process library for development (available on PyPI)  
   - Existing production-ready Helm chart with NIMs  
-- Added documentation notes on Air-gapped deployment support  
+- Added an end-to-end [Air-Gapped Deployment](air-gapped-deployment.md) guide (image inventory, mirroring, Helm packaging, and registry overrides) alongside existing Compose notes  
 - Added documentation notes on OpenShift support  
 - Added support for RTX4500 Pro Blackwell SKU  
 - Added support for llama-nemotron-embed-vl-v2 in text and text+image modes  

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
         - Deploy (Library Mode): extraction/quickstart-library-mode.md
         - Deploy (Self-Hosted): extraction/quickstart-guide.md
         - Deploy (Helm Chart): extraction/helm.md
+        - Air-Gapped Deployment: extraction/air-gapped-deployment.md
       - Developer Guide:
         - Notebooks: extraction/notebooks.md
         - Use the CLI: extraction/cli-reference.md


### PR DESCRIPTION
# Summary
Adds consolidated documentation for customers who deploy NeMo Retriever / NV-Ingest in air-gapped environments (e.g. 26.3.0), addressing RFE 6096584 (Teradata): one place that explains what to mirror, how to pin versions/digests, Helm chart staging, private registry overrides, and links to mirroring tooling, while pointing to NIM Operator air-gap docs for operator-specific behavior.

## Motivation
Guidance was split across Compose notes, Helm pointers, and NIM Operator docs. This change gives a repeatable, NeMo Retriever–centric checklist that fits into the broader offline story (GPU Operator, private registry, NIM caches).

## Changes
New: docs/docs/extraction/air-gapped-deployment.md — workflow, image inventory (core + optional profiles + Helm subchart reminders), digest pinning, Compose vs Helm registry configuration, avoiding runtime pulls to public APIs, tooling links (skopeo, crane, Helm, Harbor/distribution), and related internal doc links.
docs/mkdocs.yml — nav entry under Get Started: Air-Gapped Deployment.
docs/docs/extraction/helm.md — air-gap note leads with the new guide, then NIM Operator air-gap.
docs/docs/extraction/quickstart-guide.md — Compose air-gap section links to the full guide.
docs/docs/extraction/releasenotes-nv-ingest.md — 26.03 highlights updated to reference the new guide.
