### PR TITLE
Fix nemotron_parse tuning param types

### DIFF
--- a/nemo_retriever/src/nemo_retriever/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/params/models.py
@@ -154,9 +154,9 @@ class BatchTuningParams(_ParamsModel):
     gpu_page_elements: Optional[float] = None
     gpu_ocr: Optional[float] = None
     gpu_embed: Optional[float] = None
-    nemotron_parse_workers: float = 0.0
-    gpu_nemotron_parse: float = 0.0
-    nemotron_parse_batch_size: float = 0.0
+    nemotron_parse_workers: int = 0
+    gpu_nemotron_parse: Optional[float] = None
+    nemotron_parse_batch_size: int = 0
     inference_batch_size: int = 8
 
 

--- a/nemo_retriever/src/nemo_retriever/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/params/models.py
@@ -154,9 +154,9 @@ class BatchTuningParams(_ParamsModel):
     gpu_page_elements: Optional[float] = None
     gpu_ocr: Optional[float] = None
     gpu_embed: Optional[float] = None
-    nemotron_parse_workers: int = 0
+    nemotron_parse_workers: Optional[int] = None
     gpu_nemotron_parse: Optional[float] = None
-    nemotron_parse_batch_size: int = 0
+    nemotron_parse_batch_size: Optional[int] = None
     inference_batch_size: int = 8
 
 


### PR DESCRIPTION
## Description

The three nemotron-parse fields in `BatchTuningParams` were introduced with the wrong types in #1442 (commit 368f4149). They diverge from the surrounding conventions.

The `gpu_nemotron_parse = 0.0` is particularly problematic because `batch_tuning_to_node_overrides._set_gpu` treats 0.0 as an explicit override (it intentionally accepts 0.0 as "pin to CPU"), so the default overrides the `VLLM_GPUS_PER_ACTOR = 1.0` fallback. Ray ends up scheduling `NemotronParseGPUActor` with `num_gpus=0`, which means `ray.get_gpu_ids()` returns `[]`, `CUDA_VISIBLE_DEVICES` is empty, and vllm's EngineCore subprocess dies at `torch._C._cuda_init() with RuntimeError: No CUDA GPUs are available`. The actor swallows the exception and emits error payloads, so the pipeline appears to progress while producing garbage.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
