### PR TITLE
Add --reranker-invoke-url to graph_pipeline.py for remote reranking e…

### DIFF
--- a/nemo_retriever/src/nemo_retriever/examples/graph_pipeline.py
+++ b/nemo_retriever/src/nemo_retriever/examples/graph_pipeline.py
@@ -299,6 +299,7 @@ def main(
     evaluation_mode: str = typer.Option("recall", "--evaluation-mode"),
     reranker: Optional[bool] = typer.Option(False, "--reranker/--no-reranker"),
     reranker_model_name: str = typer.Option(VL_RERANK_MODEL, "--reranker-model-name"),
+    reranker_invoke_url: Optional[str] = typer.Option(None, "--reranker-invoke-url"),
     beir_loader: Optional[str] = typer.Option(None, "--beir-loader"),
     beir_dataset_name: Optional[str] = typer.Option(None, "--beir-dataset-name"),
     beir_split: str = typer.Option("test", "--beir-split"),
@@ -333,6 +334,7 @@ def main(
         extract_remote_api_key = remote_api_key
         embed_remote_api_key = remote_api_key
         caption_remote_api_key = remote_api_key
+        reranker_remote_api_key = remote_api_key
 
         # Warn if remote URLs configured without an API key
         if (
@@ -343,6 +345,7 @@ def main(
                     graphic_elements_invoke_url,
                     table_structure_invoke_url,
                     embed_invoke_url,
+                    reranker_invoke_url,
                 )
             )
             and remote_api_key is None
@@ -656,6 +659,8 @@ def main(
                 hybrid=hybrid,
                 reranker=bool(reranker),
                 reranker_model_name=str(reranker_model_name),
+                reranker_endpoint=reranker_invoke_url,
+                reranker_api_key=reranker_remote_api_key or "",
             )
             evaluation_start = time.perf_counter()
             beir_dataset, _raw_hits, _run, evaluation_metrics = evaluate_lancedb_beir(cfg)
@@ -705,6 +710,8 @@ def main(
                 match_mode=recall_match_mode,
                 audio_match_tolerance_secs=float(audio_match_tolerance_secs),
                 reranker=reranker_model_name if reranker else None,
+                reranker_endpoint=reranker_invoke_url,
+                reranker_api_key=reranker_remote_api_key or "",
                 embed_modality=embed_modality,
             )
             evaluation_start = time.perf_counter()

--- a/nemo_retriever/src/nemo_retriever/examples/graph_pipeline.py
+++ b/nemo_retriever/src/nemo_retriever/examples/graph_pipeline.py
@@ -352,6 +352,10 @@ def main(
         ):
             logger.warning("Remote endpoint URL(s) were configured without an API key.")
 
+        if reranker_invoke_url and not reranker:
+            logger.info("Enabling --reranker because --reranker-invoke-url was provided.")
+            reranker = True
+
         # Zero out GPU fractions when a remote URL replaces the local model
         if page_elements_invoke_url and float(page_elements_gpus_per_actor or 0.0) != 0.0:
             logger.warning("Forcing page-elements GPUs to 0.0 because --page-elements-invoke-url is set.")


### PR DESCRIPTION
…ndpoints

## Description
```
uv run nemo_retriever/src/nemo_retriever/examples/graph_pipeline.py \
  /home/edwardk/data/jp20 \
  --query-csv /home/edwardk/data/jp20_query_gt.csv \
  --run-mode batch \
  --reranker \
  --reranker-invoke-url https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-vl-1b-v2/reranking \
  --api-key nvapi-..... \
  --no-recall-details
```
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
