### PR TITLE
vdb: Add legacy ADT backend path

### DIFF
--- a/nemo_retriever/src/nemo_retriever/examples/graph_pipeline.py
+++ b/nemo_retriever/src/nemo_retriever/examples/graph_pipeline.py
@@ -35,12 +35,13 @@ Examples::
 
 from __future__ import annotations
 
+import importlib
 import json
 import logging
 import os
 import time
 from pathlib import Path
-from typing import Optional, TextIO
+from typing import Any, Optional, TextIO
 
 import typer
 
@@ -141,6 +142,108 @@ def _ensure_lancedb_table(uri: str, table_name: str) -> None:
     schema = lancedb_schema()
     empty = pa.table({f.name: [] for f in schema}, schema=schema)
     db.create_table(table_name, data=empty, schema=schema, mode="create")
+
+
+def _load_json_object(raw: Optional[str], path: Optional[Path], *, label: str) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    if path is not None:
+        try:
+            parsed = json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+        except Exception as exc:
+            raise typer.BadParameter(f"Unable to read {label} file {path}: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise typer.BadParameter(f"{label} file must contain a JSON object.")
+        payload.update(parsed)
+
+    if raw:
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise typer.BadParameter(f"{label} must be a JSON object: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise typer.BadParameter(f"{label} must be a JSON object.")
+        payload.update(parsed)
+
+    return payload
+
+
+def _import_object(import_path: str) -> Any:
+    normalized = str(import_path or "").strip()
+    module_name, sep, attr_name = normalized.partition(":")
+    if not sep:
+        module_name, _, attr_name = normalized.rpartition(".")
+    if not module_name or not attr_name:
+        raise typer.BadParameter(
+            "--vdb-op must be an import path like 'package.module:ClassName' or 'package.module.ClassName'."
+        )
+    try:
+        module = importlib.import_module(module_name)
+    except Exception as exc:
+        raise typer.BadParameter(f"Unable to import module {module_name!r}: {exc}") from exc
+    try:
+        return getattr(module, attr_name)
+    except AttributeError as exc:
+        raise typer.BadParameter(f"Module {module_name!r} has no attribute {attr_name!r}.") from exc
+
+
+def _load_legacy_vdb_op(
+    import_path: Optional[str],
+    kwargs_json: Optional[str],
+    kwargs_file: Optional[Path],
+) -> Any | None:
+    if not import_path:
+        if kwargs_json or kwargs_file is not None:
+            raise typer.BadParameter("--vdb-op-kwargs and --vdb-op-kwargs-file require --vdb-op.")
+        return None
+
+    factory = _import_object(import_path)
+    kwargs = _load_json_object(kwargs_json, kwargs_file, label="--vdb-op-kwargs")
+    try:
+        op = factory(**kwargs)
+    except Exception as exc:
+        raise typer.BadParameter(f"Unable to construct VDB operator {import_path!r}: {exc}") from exc
+    if not callable(getattr(op, "run", None)):
+        raise typer.BadParameter(f"VDB operator {import_path!r} must provide a callable run(records) method.")
+    return op
+
+
+def _describe_vdb_op(vdb_op: Any) -> str:
+    op_type = type(vdb_op)
+    return f"{op_type.__module__}:{op_type.__qualname__}"
+
+
+def _vdb_target_name(vdb_op: Any) -> str:
+    for attr_name in ("collection_name", "index_name", "table_name"):
+        value = getattr(vdb_op, attr_name, None)
+        if value:
+            return str(value)
+    return ""
+
+
+def _write_legacy_vdb(
+    result_df,
+    *,
+    vdb_op: Any,
+    embedding_column: str,
+    text_column: str,
+) -> dict[str, object]:
+    from nemo_retriever.vector_store.legacy_vdb_adapter import dataframe_to_legacy_vdb_records
+
+    records = dataframe_to_legacy_vdb_records(
+        result_df,
+        embedding_column=embedding_column,
+        embedding_key="embedding",
+        text_column=text_column,
+    )
+    record_count = len(records[0]) if records else 0
+    result = vdb_op.run(records)
+    return {
+        "backend": "legacy_vdb",
+        "operator": _describe_vdb_op(vdb_op),
+        "target": _vdb_target_name(vdb_op),
+        "records": record_count,
+        "result_type": type(result).__name__,
+    }
 
 
 def _write_runtime_summary(
@@ -281,6 +384,26 @@ def main(
     nemotron_parse_batch_size: Optional[int] = typer.Option(0, "--nemotron-parse-batch-size"),
     # LanceDB / evaluation
     lancedb_uri: str = typer.Option(LANCEDB_URI, "--lancedb-uri"),
+    vdb_op: Optional[str] = typer.Option(
+        None,
+        "--vdb-op",
+        help=(
+            "Optional import path for a legacy nv_ingest_client VDB ADT operator. "
+            "Omit to use the native LanceDB writer."
+        ),
+    ),
+    vdb_op_kwargs: Optional[str] = typer.Option(
+        None,
+        "--vdb-op-kwargs",
+        help="JSON object passed to the --vdb-op constructor.",
+    ),
+    vdb_op_kwargs_file: Optional[Path] = typer.Option(
+        None,
+        "--vdb-op-kwargs-file",
+        help="Path to a JSON object passed to the --vdb-op constructor.",
+        path_type=Path,
+        dir_okay=False,
+    ),
     save_intermediate: Optional[Path] = typer.Option(
         None,
         "--save-intermediate",
@@ -323,12 +446,16 @@ def main(
             raise ValueError(f"Unsupported --audio-split-type: {audio_split_type!r}")
         if evaluation_mode not in {"recall", "beir"}:
             raise ValueError(f"Unsupported --evaluation-mode: {evaluation_mode!r}")
+        legacy_vdb_op = _load_legacy_vdb_op(vdb_op, vdb_op_kwargs, vdb_op_kwargs_file)
 
         if run_mode == "batch":
             os.environ["RAY_LOG_TO_DRIVER"] = "1" if ray_log_to_driver else "0"
 
         lancedb_uri = str(Path(lancedb_uri).expanduser().resolve())
-        _ensure_lancedb_table(lancedb_uri, LANCEDB_TABLE)
+        if legacy_vdb_op is None:
+            _ensure_lancedb_table(lancedb_uri, LANCEDB_TABLE)
+        else:
+            logger.info("Using legacy VDB operator %s.", _describe_vdb_op(legacy_vdb_op))
 
         remote_api_key = resolve_remote_api_key(api_key)
         extract_remote_api_key = remote_api_key
@@ -588,6 +715,84 @@ def main(
                 Path(detection_summary_file),
                 collect_detection_summary_from_df(result_df),
             )
+
+        if legacy_vdb_op is not None:
+            from nemo_retriever.utils.detection_summary import print_run_summary
+
+            logger.info(
+                "Writing graph results to legacy VDB operator %s via VDB.run(records).",
+                _describe_vdb_op(legacy_vdb_op),
+            )
+            vdb_write_start = time.perf_counter()
+            vdb_summary = _write_legacy_vdb(
+                result_df,
+                vdb_op=legacy_vdb_op,
+                embedding_column=str(embed_params.output_column),
+                text_column=str(embed_params.text_column),
+            )
+            vdb_write_time = time.perf_counter() - vdb_write_start
+            total_time = time.perf_counter() - ingest_start
+            vdb_operator = str(vdb_summary["operator"])
+            vdb_target = str(vdb_summary.get("target") or "")
+
+            logger.info(
+                "Legacy VDB upload complete: operator=%s target=%s records=%s",
+                vdb_operator,
+                vdb_target or "<unspecified>",
+                vdb_summary.get("records"),
+            )
+            logger.warning(
+                "Skipping LanceDB recall/BEIR evaluation because --vdb-op selected a legacy VDB ADT operator. "
+                "Backend-neutral evaluation needs a retrieval result contract for custom VDB operators."
+            )
+
+            _write_runtime_summary(
+                runtime_metrics_dir,
+                runtime_metrics_prefix,
+                {
+                    "run_mode": run_mode,
+                    "input_path": str(Path(input_path).resolve()),
+                    "input_pages": int(num_rows),
+                    "num_pages": int(num_rows),
+                    "num_rows": int(len(result_df.index)),
+                    "ingestion_only_secs": float(ingestion_only_total_time),
+                    "ray_download_secs": float(ray_download_time),
+                    "lancedb_write_secs": float(vdb_write_time),
+                    "vdb_write_secs": float(vdb_write_time),
+                    "evaluation_secs": 0.0,
+                    "total_secs": float(total_time),
+                    "evaluation_mode": "skipped",
+                    "evaluation_metrics": {},
+                    "recall_details": bool(recall_details),
+                    "vdb_backend": "legacy_vdb",
+                    "vdb_operator": vdb_operator,
+                    "vdb_target": vdb_target,
+                    "vdb_records": int(vdb_summary.get("records") or 0),
+                },
+            )
+
+            if run_mode == "batch":
+                ray.shutdown()
+
+            print_run_summary(
+                num_rows,
+                Path(input_path),
+                hybrid,
+                vdb_operator,
+                vdb_target,
+                total_time,
+                ingestion_only_total_time,
+                ray_download_time,
+                vdb_write_time,
+                0.0,
+                {},
+                evaluation_label="Evaluation",
+                evaluation_count=None,
+                vdb_backend="legacy_vdb",
+                vdb_uri=vdb_operator,
+                vdb_table_name=vdb_target,
+            )
+            return
 
         # ------------------------------------------------------------------
         # Write to LanceDB

--- a/nemo_retriever/src/nemo_retriever/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/graph_ingestor.py
@@ -45,8 +45,10 @@ from nemo_retriever.params import (
     HtmlChunkParams,
     StoreParams,
     TextChunkParams,
+    VdbUploadParams,
 )
 from nemo_retriever.utils.remote_auth import resolve_remote_api_key
+from nemo_retriever.vector_store.legacy_vdb_adapter import execution_result_to_legacy_vdb_records
 
 
 def _resolve_api_key(params: Any) -> Any:
@@ -148,6 +150,10 @@ class GraphIngestor(ingestor):
         self._caption_params: Any = None
         self._dedup_params: Any = None
         self._store_params: Any = None
+        self._vdb_upload_params: Any = None
+        self._vdb_op: Any = None
+        self._vdb_upload_uses_native_lancedb: bool = False
+        self._vdb_upload_result: Any = None
         # Ordered list of stage names; "extract" is tracked but excluded from
         # the post-extraction stage_order passed to graph builders.
         self._stage_order: List[str] = []
@@ -239,6 +245,25 @@ class GraphIngestor(ingestor):
         """Record an embedding stage."""
         self._embed_params = _resolve_api_key(_coerce(params, kwargs, default_factory=EmbedParams))
         self._record_stage("embed")
+        return self
+
+    def vdb_upload(
+        self,
+        params: Optional[VdbUploadParams] = None,
+        *,
+        vdb_op: Any = None,
+        **kwargs: Any,
+    ) -> "GraphIngestor":
+        """Configure a VDB upload after graph execution."""
+        self._vdb_upload_params = _coerce(params, kwargs, default_factory=VdbUploadParams)
+        if vdb_op is None:
+            self._vdb_op = None
+            self._vdb_upload_uses_native_lancedb = True
+            return self
+        if not callable(getattr(vdb_op, "run", None)):
+            raise ValueError(f"vdb_op must provide a callable run(records) method, got {type(vdb_op).__name__}.")
+        self._vdb_op = vdb_op
+        self._vdb_upload_uses_native_lancedb = False
         return self
 
     # ------------------------------------------------------------------
@@ -334,6 +359,7 @@ class GraphIngestor(ingestor):
             )
             result = executor.ingest(self._documents)
             self._rd_dataset = result
+            self._run_vdb_upload(result)
             return result
         else:
             graph = build_graph(
@@ -352,11 +378,66 @@ class GraphIngestor(ingestor):
             )
             executor = InprocessExecutor(graph, show_progress=self._show_progress)
             self._rd_dataset = None
-            return executor.ingest(self._documents)
+            result = executor.ingest(self._documents)
+            self._run_vdb_upload(result)
+            return result
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _run_vdb_upload(self, result: Any) -> None:
+        if self._vdb_upload_uses_native_lancedb:
+            self._vdb_upload_result = self._run_native_lancedb_upload(result)
+            return
+        if self._vdb_op is None:
+            return
+        lancedb_params = getattr(self._vdb_upload_params, "lancedb", None)
+        records = execution_result_to_legacy_vdb_records(
+            result,
+            embedding_column=getattr(self._embed_params, "output_column", None)
+            or getattr(lancedb_params, "embedding_column", "text_embeddings_1b_v2"),
+            embedding_key=getattr(lancedb_params, "embedding_key", "embedding"),
+            text_column=getattr(self._embed_params, "text_column", None)
+            or getattr(lancedb_params, "text_column", "text"),
+        )
+        self._vdb_upload_result = self._vdb_op.run(records)
+
+    def _run_native_lancedb_upload(self, result: Any) -> dict[str, Any]:
+        """Write default LanceDB uploads using the Retriever-native LanceDB schema."""
+        from nemo_retriever.vector_store.lancedb_store import handle_lancedb
+
+        lancedb = self._vdb_upload_params.lancedb
+
+        if hasattr(result, "to_dict") and hasattr(result, "columns"):
+            df = result
+            rows = df.to_dict(orient="records")
+        else:
+            rows: list[dict[str, Any]] = []
+            iter_batches = getattr(result, "iter_batches", None)
+            if callable(iter_batches):
+                for batch_df in iter_batches(batch_format="pandas"):
+                    rows.extend(batch_df.to_dict(orient="records"))
+            else:
+                to_pandas = getattr(result, "to_pandas", None)
+                if not callable(to_pandas):
+                    raise TypeError(f"Cannot convert {type(result).__name__} to a pandas DataFrame for LanceDB upload.")
+                df = to_pandas()
+                rows = df.to_dict(orient="records")
+
+        handle_lancedb(
+            rows,
+            lancedb.lancedb_uri,
+            lancedb.table_name,
+            hybrid=lancedb.hybrid,
+            mode="overwrite",
+        )
+        return {
+            "backend": "lancedb",
+            "uri": lancedb.lancedb_uri,
+            "table_name": lancedb.table_name,
+            "rows": len(rows),
+        }
 
     @staticmethod
     def _has_error(v: Any) -> bool:

--- a/nemo_retriever/src/nemo_retriever/utils/detection_summary.py
+++ b/nemo_retriever/src/nemo_retriever/utils/detection_summary.py
@@ -235,6 +235,9 @@ def print_run_summary(
     processed_files: Optional[int] = None,
     evaluation_label: str = "Recall",
     evaluation_count: Optional[int] = None,
+    vdb_backend: str = "lancedb",
+    vdb_uri: Optional[str] = None,
+    vdb_table_name: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Print a human-readable run summary and return all metrics as a dict.
 
@@ -247,6 +250,8 @@ def print_run_summary(
     if evaluation_metrics is None:
         evaluation_metrics = {}
     pages = processed_pages if processed_pages is not None else 0
+    backend = (vdb_backend or "lancedb").strip() or "lancedb"
+    backend_label = "LanceDB" if backend.lower() == "lancedb" else backend.replace("_", " ").title()
 
     ingest_only_pps = pages / ingest_only_total_time if ingest_only_total_time > 0 else 0
     ingest_write_denom = ingest_only_total_time + lancedb_write_total_time
@@ -259,8 +264,13 @@ def print_run_summary(
     print("Run Configuration:")
     print(f"\tInput path: {input_path}")
     print(f"\tHybrid: {hybrid}")
-    print(f"\tLancedb URI: {lancedb_uri}")
-    print(f"\tLancedb Table: {lancedb_table_name}")
+    if backend.lower() == "lancedb":
+        print(f"\tLancedb URI: {lancedb_uri}")
+        print(f"\tLancedb Table: {lancedb_table_name}")
+    else:
+        print(f"\tVector DB Backend: {backend_label}")
+        print(f"\t{backend_label} URI: {vdb_uri or lancedb_uri}")
+        print(f"\t{backend_label} Collection: {vdb_table_name or lancedb_table_name}")
 
     print("Runtimes:")
     if processed_files is not None:
@@ -268,7 +278,10 @@ def print_run_summary(
     print(f"\tTotal pages processed: {pages} from {input_path}")
     print(f"\tIngestion only time: {_fmt_time(ingest_only_total_time)}")
     print(f"\tRay dataset download time: {_fmt_time(ray_dataset_download_total_time)}")
-    print(f"\tLanceDB Write Time: {_fmt_time(lancedb_write_total_time)}")
+    if backend.lower() == "lancedb":
+        print(f"\tLanceDB Write Time: {_fmt_time(lancedb_write_total_time)}")
+    else:
+        print(f"\t{backend_label} Write Time: {_fmt_time(lancedb_write_total_time)}")
     if recall_total_time > 0:
         print(f"\tRecall time: {_fmt_time(recall_total_time)}")
     if evaluation_total_time > 0:
@@ -276,7 +289,10 @@ def print_run_summary(
 
     print("PPS:")
     print(f"\tIngestion only PPS: {ingest_only_pps:.2f}")
-    print(f"\tIngestion + LanceDB Write PPS: {ingest_and_lancedb_write_pps:.2f}")
+    if backend.lower() == "lancedb":
+        print(f"\tIngestion + LanceDB Write PPS: {ingest_and_lancedb_write_pps:.2f}")
+    else:
+        print(f"\tIngestion + {backend_label} Write PPS: {ingest_and_lancedb_write_pps:.2f}")
     if recall_total_time > 0:
         print(f"\tRecall QPS: {recall_qps:.2f}")
     print(f"\tTotal - Processed: {pages} pages in {_fmt_time(total_time)} @ {total_pps:.2f} PPS")
@@ -302,6 +318,10 @@ def print_run_summary(
         "total_pps": round(total_pps, 4),
         "ray_dataset_download_secs": round(ray_dataset_download_total_time, 4),
         "lancedb_write_secs": round(lancedb_write_total_time, 4),
+        "vdb_backend": backend,
+        "vdb_uri": vdb_uri or lancedb_uri,
+        "vdb_table": vdb_table_name or lancedb_table_name,
+        "vdb_write_secs": round(lancedb_write_total_time, 4),
         "recall_time_secs": round(recall_total_time, 4),
         "evaluation_time_secs": round(evaluation_total_time, 4),
         "evaluation_label": evaluation_label,

--- a/nemo_retriever/src/nemo_retriever/vector_store/legacy_vdb_adapter.py
+++ b/nemo_retriever/src/nemo_retriever/vector_store/legacy_vdb_adapter.py
@@ -2,7 +2,25 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Adapters for invoking legacy NV-Ingest VDB operators from Retriever rows."""
+"""Compatibility conversion for legacy NV-Ingest VDB operators.
+
+This module is intentionally not a new vector-store abstraction.  The legacy
+``nv_ingest_client.util.vdb`` operators already expose the ADT boundary this PR
+needs to support: ``VDB.run(records)``.  The missing piece is that Retriever's
+graph pipeline produces row-oriented dataframes/Ray datasets, while those legacy
+operators expect NV-Ingest records shaped like::
+
+    [{"document_type": "text", "metadata": {...}}]
+
+where ``metadata`` contains ``content``, ``embedding``, ``content_metadata``,
+and ``source_metadata``.  Structured, image, and audio rows additionally need
+their legacy metadata blocks because the old VDB cleanup code reads text from
+``table_metadata``, ``image_metadata``, or ``audio_metadata`` based on
+``document_type``.
+
+Keep this file as a boundary adapter between Retriever rows and the legacy ADT
+record dialect.  New backend APIs should not grow here.
+"""
 
 from __future__ import annotations
 

--- a/nemo_retriever/src/nemo_retriever/vector_store/legacy_vdb_adapter.py
+++ b/nemo_retriever/src/nemo_retriever/vector_store/legacy_vdb_adapter.py
@@ -1,0 +1,305 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Adapters for invoking legacy NV-Ingest VDB operators from Retriever rows."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping
+from typing import Any, List
+
+
+_MISSING = object()
+_STRUCTURED_CONTENT_TYPES = {"chart", "infographic", "table"}
+
+
+def _is_missing(value: Any) -> bool:
+    if value is None:
+        return True
+    if value is _MISSING:
+        return True
+    if type(value).__name__ in {"NAType", "NaTType"}:
+        return True
+    return isinstance(value, float) and math.isnan(value)
+
+
+def _maybe_parse_json(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    if not stripped:
+        return _MISSING
+    if stripped[0] not in "[{":
+        return value
+    try:
+        return json.loads(stripped)
+    except Exception:
+        return value
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    parsed = _maybe_parse_json(value)
+    if isinstance(parsed, Mapping):
+        return dict(parsed)
+    return {}
+
+
+def _as_list(value: Any) -> list[Any] | None:
+    parsed = _maybe_parse_json(value)
+    if isinstance(parsed, list):
+        return parsed if parsed else None
+    if isinstance(parsed, tuple):
+        return list(parsed) if parsed else None
+    if isinstance(parsed, (str, bytes, bytearray, Mapping)) or _is_missing(parsed):
+        return None
+    tolist = getattr(parsed, "tolist", None)
+    if callable(tolist):
+        converted = tolist()
+        if isinstance(converted, list) and converted:
+            return converted
+    return None
+
+
+def _row_get(row: Mapping[str, Any], key: str, default: Any = None) -> Any:
+    value = row.get(key, _MISSING)
+    if _is_missing(value):
+        return default
+    return value
+
+
+def _safe_int(value: Any) -> int | None:
+    if _is_missing(value):
+        return None
+    try:
+        return int(value)
+    except Exception:
+        return None
+
+
+def _content_type_base(value: Any) -> str | None:
+    if _is_missing(value):
+        return None
+    normalized = str(value).strip().lower()
+    if not normalized:
+        return None
+    if normalized.endswith("_caption"):
+        normalized = normalized[: -len("_caption")]
+    return normalized or None
+
+
+def _merge_dicts(*values: Any) -> dict[str, Any]:
+    merged: dict[str, Any] = {}
+    for value in values:
+        merged.update(_as_dict(value))
+    return merged
+
+
+def _extract_embedding(row: Mapping[str, Any], metadata: Mapping[str, Any], embedding_column: str, embedding_key: str):
+    embedding = _as_list(metadata.get("embedding"))
+    if embedding is not None:
+        return embedding
+
+    payload = _maybe_parse_json(_row_get(row, embedding_column))
+    if isinstance(payload, Mapping):
+        return _as_list(payload.get(embedding_key))
+    return _as_list(payload)
+
+
+def _extract_content(row: Mapping[str, Any], metadata: Mapping[str, Any], text_column: str) -> str:
+    content = _row_get(row, text_column)
+    if _is_missing(content):
+        content = metadata.get("content")
+    if _is_missing(content):
+        content = _row_get(row, "content", "")
+    return "" if _is_missing(content) else str(content)
+
+
+def _build_content_metadata(row: Mapping[str, Any], metadata: Mapping[str, Any]) -> dict[str, Any]:
+    content_metadata = _merge_dicts(_row_get(row, "content_metadata"), metadata.get("content_metadata"))
+
+    page_number = _safe_int(_row_get(row, "page_number"))
+    if page_number is not None:
+        content_metadata.setdefault("page_number", page_number)
+
+    content_type = _content_type_base(
+        _row_get(row, "_content_type")
+        or metadata.get("_content_type")
+        or metadata.get("content_type")
+        or content_metadata.get("subtype")
+        or content_metadata.get("type")
+    )
+    if content_type:
+        content_metadata.setdefault("type", content_type)
+        if content_type in _STRUCTURED_CONTENT_TYPES or content_type in {"image", "page_image", "audio"}:
+            content_metadata.setdefault("subtype", content_type)
+
+    bbox = _row_get(row, "_bbox_xyxy_norm")
+    if bbox is not None:
+        content_metadata.setdefault("location", bbox)
+    return content_metadata
+
+
+def _build_source_metadata(row: Mapping[str, Any], metadata: Mapping[str, Any]) -> dict[str, Any]:
+    source_metadata = _merge_dicts(_row_get(row, "source_metadata"), metadata.get("source_metadata"))
+    source_path = (
+        _row_get(row, "path")
+        or _row_get(row, "source_path")
+        or metadata.get("source_path")
+        or source_metadata.get("source_id")
+        or source_metadata.get("source_name")
+    )
+    if source_path:
+        source_value = str(source_path)
+        source_metadata.setdefault("source_id", source_value)
+        source_metadata.setdefault("source_name", source_value)
+    else:
+        source_metadata.setdefault("source_name", "unknown")
+        source_metadata.setdefault("source_id", source_metadata["source_name"])
+    return source_metadata
+
+
+def _infer_document_type(
+    row: Mapping[str, Any],
+    metadata: Mapping[str, Any],
+    content_metadata: Mapping[str, Any],
+) -> str:
+    explicit = _row_get(row, "document_type") or metadata.get("document_type")
+    if explicit:
+        return str(explicit)
+
+    content_type = _content_type_base(
+        _row_get(row, "_content_type")
+        or metadata.get("_content_type")
+        or metadata.get("content_type")
+        or content_metadata.get("subtype")
+        or content_metadata.get("type")
+    )
+    if content_type in _STRUCTURED_CONTENT_TYPES:
+        return "structured"
+    if content_type in {"image", "page_image"}:
+        return "image"
+    if content_type == "audio":
+        return "audio"
+    return "text"
+
+
+def _build_legacy_record(
+    row: Mapping[str, Any],
+    *,
+    embedding_column: str,
+    embedding_key: str,
+    text_column: str,
+) -> dict[str, Any] | None:
+    metadata = _as_dict(_row_get(row, "metadata"))
+    embedding = _extract_embedding(row, metadata, embedding_column, embedding_key)
+    if embedding is None:
+        return None
+
+    content = _extract_content(row, metadata, text_column)
+    content_metadata = _build_content_metadata(row, metadata)
+    source_metadata = _build_source_metadata(row, metadata)
+    document_type = _infer_document_type(row, metadata, content_metadata)
+
+    record_metadata = dict(metadata)
+    record_metadata["content"] = content
+    record_metadata["embedding"] = embedding
+    record_metadata["content_metadata"] = content_metadata
+    record_metadata["source_metadata"] = source_metadata
+
+    if document_type == "structured":
+        table_metadata = _as_dict(record_metadata.get("table_metadata"))
+        table_metadata.setdefault("table_content", content)
+        table_metadata.setdefault("table_location", content_metadata.get("location"))
+        table_metadata.setdefault("table_location_max_dimensions", content_metadata.get("max_dimensions"))
+        record_metadata["table_metadata"] = table_metadata
+    elif document_type == "image":
+        image_metadata = _as_dict(record_metadata.get("image_metadata"))
+        image_metadata.setdefault("caption", content)
+        image_metadata.setdefault("text", content)
+        image_metadata.setdefault("image_location", content_metadata.get("location"))
+        image_metadata.setdefault("image_location_max_dimensions", content_metadata.get("max_dimensions"))
+        record_metadata["image_metadata"] = image_metadata
+    elif document_type == "audio":
+        audio_metadata = _as_dict(record_metadata.get("audio_metadata"))
+        audio_metadata.setdefault("audio_transcript", content)
+        record_metadata["audio_metadata"] = audio_metadata
+
+    return {"document_type": document_type, "metadata": record_metadata}
+
+
+def dataframe_to_legacy_vdb_records(
+    df: Any,
+    *,
+    embedding_column: str = "text_embeddings_1b_v2",
+    embedding_key: str = "embedding",
+    text_column: str = "text",
+) -> list[list[dict[str, Any]]]:
+    """Convert a Retriever pandas DataFrame into legacy NV-Ingest VDB records."""
+    if df is None:
+        return [[]]
+
+    if hasattr(df, "to_dict") and hasattr(df, "columns"):
+        rows = df.to_dict(orient="records")
+    elif isinstance(df, list):
+        rows = df
+    else:
+        raise TypeError(f"Expected a pandas DataFrame or list of dict rows, got {type(df).__name__}.")
+
+    records: List[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        record = _build_legacy_record(
+            row,
+            embedding_column=embedding_column,
+            embedding_key=embedding_key,
+            text_column=text_column,
+        )
+        if record is not None:
+            records.append(record)
+    return [records]
+
+
+def execution_result_to_legacy_vdb_records(
+    result: Any,
+    *,
+    embedding_column: str = "text_embeddings_1b_v2",
+    embedding_key: str = "embedding",
+    text_column: str = "text",
+) -> list[list[dict[str, Any]]]:
+    """Convert a GraphIngestor execution result into one legacy VDB record batch."""
+    if hasattr(result, "to_dict") and hasattr(result, "columns"):
+        return dataframe_to_legacy_vdb_records(
+            result,
+            embedding_column=embedding_column,
+            embedding_key=embedding_key,
+            text_column=text_column,
+        )
+
+    records: List[dict[str, Any]] = []
+    iter_batches = getattr(result, "iter_batches", None)
+    if callable(iter_batches):
+        for batch_df in iter_batches(batch_format="pandas"):
+            records.extend(
+                dataframe_to_legacy_vdb_records(
+                    batch_df,
+                    embedding_column=embedding_column,
+                    embedding_key=embedding_key,
+                    text_column=text_column,
+                )[0]
+            )
+        return [records]
+
+    to_pandas = getattr(result, "to_pandas", None)
+    if callable(to_pandas):
+        return dataframe_to_legacy_vdb_records(
+            to_pandas(),
+            embedding_column=embedding_column,
+            embedding_key=embedding_key,
+            text_column=text_column,
+        )
+
+    raise TypeError(f"Cannot convert {type(result).__name__} to legacy VDB records.")

--- a/nemo_retriever/tests/test_batch_pipeline.py
+++ b/nemo_retriever/tests/test_batch_pipeline.py
@@ -1,6 +1,6 @@
 import sys
 import json
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 from typer.testing import CliRunner
 
@@ -32,6 +32,17 @@ class _FakeDataset:
                 return _FakeCounted()
 
         return _FakeGrouped()
+
+
+class _FakeRowsDataset:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def materialize(self):
+        return self
+
+    def take_all(self):
+        return list(self._rows)
 
 
 class _FakeErrorRows:
@@ -85,6 +96,19 @@ class _FakeIngestor:
 
     def get_error_rows(self, dataset=None):
         return _FakeErrorRows()
+
+
+class _FakeLegacyVDB:
+    instances = []
+
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.records = None
+        self.__class__.instances.append(self)
+
+    def run(self, records):
+        self.records = records
+        return {"ok": True}
 
 
 def test_resolve_input_file_patterns_recurses_for_directory_inputs(tmp_path) -> None:
@@ -267,6 +291,73 @@ def test_batch_pipeline_routes_beir_mode_to_evaluator(tmp_path, monkeypatch) -> 
     assert captured["cfg"].loader == "vidore_hf"
     assert captured["cfg"].dataset_name == "vidore_v3_computer_science"
     assert tuple(captured["cfg"].ks) == (5, 10)
+
+
+def test_graph_pipeline_routes_custom_vdb_op_through_legacy_adt(tmp_path, monkeypatch) -> None:
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    (dataset_dir / "sample.pdf").write_text("placeholder", encoding="utf-8")
+    runtime_dir = tmp_path / "runtime_metrics"
+
+    rows = [
+        {
+            "text": "alpha",
+            "text_embeddings_1b_v2": {"embedding": [0.1, 0.2]},
+            "source_path": str(dataset_dir / "sample.pdf"),
+            "page_number": 1,
+            "_content_type": "text",
+        }
+    ]
+
+    class _FakeRowsIngestor(_FakeIngestor):
+        def ingest(self, params=None):
+            return _FakeRowsDataset(rows)
+
+    fake_ingestor = _FakeRowsIngestor()
+    monkeypatch.setattr(batch_pipeline, "GraphIngestor", lambda *args, **kwargs: fake_ingestor)
+    monkeypatch.setattr(
+        batch_pipeline,
+        "_ensure_lancedb_table",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("LanceDB table should not be initialized")),
+    )
+    monkeypatch.setattr(
+        batch_pipeline,
+        "handle_lancedb",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("LanceDB writer should not run")),
+    )
+    monkeypatch.setitem(sys.modules, "ray", SimpleNamespace(shutdown=lambda: None))
+
+    _FakeLegacyVDB.instances.clear()
+    fake_module = ModuleType("fake_legacy_vdb_module")
+    fake_module.FakeLegacyVDB = _FakeLegacyVDB
+    monkeypatch.setitem(sys.modules, "fake_legacy_vdb_module", fake_module)
+
+    result = RUNNER.invoke(
+        batch_pipeline.app,
+        [
+            str(dataset_dir),
+            "--vdb-op",
+            "fake_legacy_vdb_module:FakeLegacyVDB",
+            "--vdb-op-kwargs",
+            '{"collection_name":"custom"}',
+            "--runtime-metrics-dir",
+            str(runtime_dir),
+            "--runtime-metrics-prefix",
+            "custom-vdb",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    vdb = _FakeLegacyVDB.instances[-1]
+    assert vdb.kwargs == {"collection_name": "custom"}
+    assert len(vdb.records) == 1
+    assert len(vdb.records[0]) == 1
+    assert vdb.records[0][0]["metadata"]["content"] == "alpha"
+
+    payload = json.loads((runtime_dir / "custom-vdb.runtime.summary.json").read_text(encoding="utf-8"))
+    assert payload["vdb_backend"] == "legacy_vdb"
+    assert payload["vdb_records"] == 1
+    assert payload["evaluation_mode"] == "skipped"
 
 
 def test_batch_pipeline_accepts_harness_runtime_metric_flags(tmp_path, monkeypatch) -> None:

--- a/nemo_retriever/tests/test_legacy_vdb_adapter.py
+++ b/nemo_retriever/tests/test_legacy_vdb_adapter.py
@@ -1,0 +1,269 @@
+import json
+
+import pandas as pd
+
+from nemo_retriever.graph_ingestor import GraphIngestor
+from nemo_retriever.params import EmbedParams, LanceDbParams, VdbUploadParams
+from nemo_retriever.vector_store.legacy_vdb_adapter import (
+    dataframe_to_legacy_vdb_records,
+    execution_result_to_legacy_vdb_records,
+)
+
+
+class FakeVDB:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def run(self, records):
+        self.calls.append(records)
+        return {"records": len(records[0])}
+
+
+def test_dataframe_to_legacy_vdb_records_builds_required_shape_and_skips_missing_embeddings() -> None:
+    df = pd.DataFrame(
+        [
+            {
+                "text": "alpha",
+                "path": "/tmp/a.pdf",
+                "page_number": 3,
+                "metadata": {
+                    "content_metadata": {"section": "intro"},
+                    "source_metadata": {"source_name": "a.pdf"},
+                },
+                "text_embeddings_1b_v2": {"embedding": [0.1, 0.2]},
+            },
+            {
+                "text": "skip",
+                "metadata": {"content_metadata": {}, "source_metadata": {}},
+                "text_embeddings_1b_v2": {"embedding": []},
+            },
+            {
+                "text": "also skip",
+                "metadata": {"content_metadata": {}, "source_metadata": {}},
+            },
+        ]
+    )
+
+    records = dataframe_to_legacy_vdb_records(df)
+
+    assert len(records) == 1
+    assert len(records[0]) == 1
+    record = records[0][0]
+    assert record["document_type"] == "text"
+    assert record["metadata"]["content"] == "alpha"
+    assert record["metadata"]["embedding"] == [0.1, 0.2]
+    assert record["metadata"]["content_metadata"]["section"] == "intro"
+    assert record["metadata"]["content_metadata"]["page_number"] == 3
+    assert record["metadata"]["source_metadata"]["source_name"] == "a.pdf"
+    assert record["metadata"]["source_metadata"]["source_id"] == "/tmp/a.pdf"
+
+
+def test_dataframe_to_legacy_vdb_records_accepts_json_metadata_and_embedding_payloads() -> None:
+    df = pd.DataFrame(
+        [
+            {
+                "text": "table text",
+                "page_number": "7",
+                "_content_type": "table_caption",
+                "_bbox_xyxy_norm": [0.1, 0.2, 0.3, 0.4],
+                "metadata": json.dumps(
+                    {
+                        "content_metadata": {"custom": "value"},
+                        "source_metadata": {"source_name": "doc.pdf"},
+                    }
+                ),
+                "text_embeddings_1b_v2": json.dumps({"embedding": [1.0, 2.0, 3.0]}),
+            }
+        ]
+    )
+
+    records = dataframe_to_legacy_vdb_records(df)
+
+    record = records[0][0]
+    assert record["document_type"] == "structured"
+    assert record["metadata"]["content"] == "table text"
+    assert record["metadata"]["embedding"] == [1.0, 2.0, 3.0]
+    assert record["metadata"]["content_metadata"]["page_number"] == 7
+    assert record["metadata"]["content_metadata"]["subtype"] == "table"
+    assert record["metadata"]["table_metadata"]["table_content"] == "table text"
+    assert record["metadata"]["table_metadata"]["table_location"] == [0.1, 0.2, 0.3, 0.4]
+    assert record["metadata"]["source_metadata"]["source_name"] == "doc.pdf"
+
+
+def test_execution_result_to_legacy_vdb_records_aggregates_ray_style_batches() -> None:
+    class FakeDataset:
+        def iter_batches(self, *, batch_format):
+            assert batch_format == "pandas"
+            yield pd.DataFrame(
+                [
+                    {
+                        "text": "one",
+                        "metadata": {"embedding": [1.0], "content_metadata": {}, "source_metadata": {}},
+                    }
+                ]
+            )
+            yield pd.DataFrame(
+                [
+                    {
+                        "text": "two",
+                        "metadata": {"embedding": [2.0], "content_metadata": {}, "source_metadata": {}},
+                    }
+                ]
+            )
+
+    records = execution_result_to_legacy_vdb_records(FakeDataset())
+
+    assert [record["metadata"]["content"] for record in records[0]] == ["one", "two"]
+
+
+def test_graph_ingestor_vdb_upload_invokes_legacy_vdb_op(monkeypatch) -> None:
+    result_df = pd.DataFrame(
+        [
+            {
+                "text": "embedded text",
+                "metadata": {
+                    "content_metadata": {"type": "text"},
+                    "source_metadata": {"source_name": "doc.pdf"},
+                },
+                "custom_embeddings": {"embedding": [0.5, 0.25]},
+            }
+        ]
+    )
+
+    class FakeExecutor:
+        def __init__(self, graph, **kwargs):
+            self.graph = graph
+
+        def ingest(self, data):
+            return result_df
+
+    monkeypatch.setattr("nemo_retriever.graph_ingestor.build_graph", lambda **kwargs: object())
+    monkeypatch.setattr("nemo_retriever.graph_ingestor.InprocessExecutor", FakeExecutor)
+
+    fake_vdb = FakeVDB()
+    ingestor = GraphIngestor(run_mode="inprocess", documents=["/tmp/input.pdf"])
+    result = (
+        ingestor.embed(EmbedParams(output_column="custom_embeddings"))
+        .vdb_upload(vdb_op=fake_vdb)
+        .ingest()
+    )
+
+    assert result is result_df
+    assert ingestor._vdb_op is fake_vdb
+    assert len(fake_vdb.calls) == 1
+    record = fake_vdb.calls[0][0][0]
+    assert record["document_type"] == "text"
+    assert record["metadata"]["content"] == "embedded text"
+    assert record["metadata"]["embedding"] == [0.5, 0.25]
+    assert record["metadata"]["content_metadata"] == {"type": "text"}
+    assert record["metadata"]["source_metadata"] == {"source_name": "doc.pdf", "source_id": "doc.pdf"}
+
+
+def test_graph_ingestor_default_vdb_upload_uses_native_lancedb_writer(monkeypatch) -> None:
+    result_df = pd.DataFrame(
+        [
+            {
+                "text": "retriever native text",
+                "path": "/tmp/native.pdf",
+                "page_number": 4,
+                "metadata": {
+                    "embedding": [0.1, 0.2],
+                    "content_metadata": {"type": "text"},
+                    "source_metadata": {"source_name": "native.pdf"},
+                },
+            }
+        ]
+    )
+
+    class FakeExecutor:
+        def __init__(self, graph, **kwargs):
+            self.graph = graph
+
+        def ingest(self, data):
+            return result_df
+
+    calls = []
+
+    def fake_handle_lancedb(rows, uri, table_name, *, hybrid=False, mode="overwrite"):
+        calls.append((rows, uri, table_name, hybrid, mode))
+
+    monkeypatch.setattr("nemo_retriever.graph_ingestor.build_graph", lambda **kwargs: object())
+    monkeypatch.setattr("nemo_retriever.graph_ingestor.InprocessExecutor", FakeExecutor)
+    monkeypatch.setattr(
+        "nemo_retriever.vector_store.lancedb_store.handle_lancedb",
+        fake_handle_lancedb,
+    )
+
+    params = VdbUploadParams(
+        lancedb=LanceDbParams(
+            lancedb_uri="/tmp/native-lancedb",
+            table_name="native_table",
+            overwrite=False,
+            create_index=False,
+            hybrid=True,
+        )
+    )
+    ingestor = GraphIngestor(run_mode="inprocess", documents=["/tmp/input.pdf"])
+    result = ingestor.embed().vdb_upload(params).ingest()
+
+    assert result is result_df
+    assert ingestor._vdb_op is None
+    assert len(calls) == 1
+    rows, uri, table_name, hybrid, mode = calls[0]
+    assert rows == result_df.to_dict(orient="records")
+    assert uri == "/tmp/native-lancedb"
+    assert table_name == "native_table"
+    assert hybrid is True
+    assert mode == "overwrite"
+    assert ingestor._vdb_upload_result == {
+        "backend": "lancedb",
+        "uri": "/tmp/native-lancedb",
+        "table_name": "native_table",
+        "rows": 1,
+    }
+
+
+def test_graph_ingestor_default_batch_mode_vdb_upload_invokes_legacy_vdb_op(monkeypatch) -> None:
+    result_df = pd.DataFrame(
+        [
+            {
+                "text": "batch text",
+                "metadata": {
+                    "content_metadata": {"type": "text"},
+                    "source_metadata": {"source_name": "batch.pdf"},
+                },
+                "custom_embeddings": {"embedding": [0.75, 0.125]},
+            }
+        ]
+    )
+
+    class FakeCluster:
+        def available_gpu_count(self):
+            return 0
+
+    class FakeExecutor:
+        def __init__(self, graph, **kwargs):
+            self.graph = graph
+
+        def ingest(self, data):
+            return result_df
+
+    monkeypatch.setattr("nemo_retriever.graph_ingestor.build_graph", lambda **kwargs: object())
+    monkeypatch.setattr("nemo_retriever.graph_ingestor.gather_cluster_resources", lambda ray: FakeCluster())
+    monkeypatch.setattr("nemo_retriever.graph_ingestor.batch_tuning_to_node_overrides", lambda *args, **kwargs: {})
+    monkeypatch.setattr("nemo_retriever.graph_ingestor.RayDataExecutor", FakeExecutor)
+    monkeypatch.setattr("ray.is_initialized", lambda: True)
+
+    fake_vdb = FakeVDB()
+    result = (
+        GraphIngestor(documents=["/tmp/input.pdf"])
+        .embed(EmbedParams(output_column="custom_embeddings"))
+        .vdb_upload(vdb_op=fake_vdb)
+        .ingest()
+    )
+
+    assert result is result_df
+    assert len(fake_vdb.calls) == 1
+    record = fake_vdb.calls[0][0][0]
+    assert record["metadata"]["content"] == "batch text"
+    assert record["metadata"]["embedding"] == [0.75, 0.125]

--- a/nemo_retriever/tests/test_milvus_vdb_contract.py
+++ b/nemo_retriever/tests/test_milvus_vdb_contract.py
@@ -1,0 +1,83 @@
+import os
+import uuid
+
+import pandas as pd
+import pytest
+from pymilvus import MilvusClient
+
+from nemo_retriever.graph_ingestor import GraphIngestor
+from nemo_retriever.params import EmbedParams
+from nv_ingest_client.util.vdb.milvus import Milvus
+
+
+@pytest.mark.integration
+def test_graph_ingestor_legacy_milvus_vdb_op_writes_records(monkeypatch) -> None:
+    milvus_uri = os.environ.get("NEMO_RETRIEVER_MILVUS_URI")
+    if not milvus_uri:
+        pytest.skip("Set NEMO_RETRIEVER_MILVUS_URI to run live Milvus VDB contract test.")
+
+    collection_name = f"codex_vdb_contract_{uuid.uuid4().hex[:12]}"
+    text = f"milvus contract smoke {uuid.uuid4().hex}"
+    result_df = pd.DataFrame(
+        [
+            {
+                "text": text,
+                "path": "/tmp/contract.pdf",
+                "page_number": 1,
+                "metadata": {
+                    "content_metadata": {"type": "text"},
+                    "source_metadata": {"source_name": "contract.pdf"},
+                },
+                "contract_embeddings": {"embedding": [0.125, 0.875]},
+            }
+        ]
+    )
+
+    class FakeExecutor:
+        def __init__(self, graph, **kwargs):
+            self.graph = graph
+
+        def ingest(self, data):
+            return result_df
+
+    monkeypatch.setattr("nemo_retriever.graph_ingestor.build_graph", lambda **kwargs: object())
+    monkeypatch.setattr("nemo_retriever.graph_ingestor.InprocessExecutor", FakeExecutor)
+
+    client = MilvusClient(uri=milvus_uri)
+    try:
+        vdb = Milvus(
+            collection_name=collection_name,
+            milvus_uri=milvus_uri,
+            sparse=False,
+            recreate=True,
+            gpu_index=False,
+            gpu_search=False,
+            dense_dim=2,
+            stream=True,
+            threshold=10,
+            no_wait_index=True,
+        )
+
+        (
+            GraphIngestor(run_mode="inprocess", documents=["/tmp/contract.pdf"])
+            .embed(EmbedParams(output_column="contract_embeddings"))
+            .vdb_upload(vdb_op=vdb)
+            .ingest()
+        )
+
+        client.flush(collection_name)
+        client.load_collection(collection_name)
+        rows = client.query(
+            collection_name=collection_name,
+            filter=f'text == "{text}"',
+            output_fields=["text", "source", "content_metadata"],
+        )
+
+        assert len(rows) == 1
+        assert rows[0]["text"] == text
+        assert rows[0]["source"]["source_name"] == "contract.pdf"
+        assert rows[0]["content_metadata"]["page_number"] == 1
+        assert rows[0]["content_metadata"]["type"] == "text"
+    finally:
+        if client.has_collection(collection_name):
+            client.drop_collection(collection_name)


### PR DESCRIPTION
Adds a generic graph ingestion path for legacy NV-Ingest VDB ADT operators while keeping native LanceDB as the default. Milvus is used as an external backend example rather than a core Retriever dependency.

- Adds a legacy VDB adapter that converts Retriever rows into the legacy list-of-records contract and routes explicit `--vdb-op` operators through `VDB.run(records)`.
- Extends `graph_pipeline` with generic VDB operator loading/kwargs and backend-aware run summaries while preserving default LanceDB recall behavior.
- Adds unit coverage for the adapter, graph pipeline routing, and a Milvus contract integration test.