### PR TITLE
Docs: default Llama tokenizer for token-based splitting (chunking + Python API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ dict_keys([1, 2, 3])
 dict_keys(['multimodal_test.pdf'])
 ```
 
-### Step 3: Query Ingested Content
+### Query Ingested Content
 
 To query for relevant snippets of the ingested content, and use them with an LLM to generate answers, use the following code.
 

--- a/docs/docs/extraction/chunking.md
+++ b/docs/docs/extraction/chunking.md
@@ -45,15 +45,13 @@ However, in some cases, such as with `.txt` documents, there aren't any page bre
 
 If you want chunks smaller than `page`, use token-based splitting as described in the following section.
 
-
-
 ## Token-Based Splitting
 
 The `split` task uses a tokenizer to count the number of tokens in the document, 
-and splits the document based on the desired maximum chunk size and chunk overlap. 
-We recommend that you use the `meta-llama/Llama-3.2-1B` tokenizer, 
-because it's the same tokenizer as the llama-3.2 embedding model that we use for embedding.
-However, you can use any tokenizer from any HuggingFace model that includes a tokenizer file.
+and splits the document based on the desired maximum chunk size and chunk overlap.
+
+We recommend the default tokenizer for token-based splitting. For more information, refer to [Llama tokenizer (default)](#llama-tokenizer-default).
+You can also use any tokenizer from any HuggingFace model that includes a tokenizer file.
 
 Use the `split` method to chunk large documents as shown in the following code.
 
@@ -81,6 +79,23 @@ ingestor = ingestor.split(
 )
 ```
 
+### Llama tokenizer
+
+The default tokenizer for token-based splitting is **`meta-llama/Llama-3.2-1B`**. It matches the tokenizer used by the Llama 3.2 embedding model, which helps keep chunk boundaries aligned with the embedding model.
+
+!!! note
+
+    This tokenizer is gated on Hugging Face and requires an access token. For more information, refer to [User access tokens](https://huggingface.co/docs/hub/en/security-tokens). You must set `hf_access_token` in your `split` params (for example, `"hf_***"`) to authenticate.
+
+By default, the NV Ingest container includes this tokenizer pre-downloaded at build time, so it does not need to be fetched at runtime. If you build the container yourself and want to pre-download it, do the following:
+
+- Review the [license agreement](https://huggingface.co/meta-llama/Llama-3.2-1B).
+- [Request access](https://huggingface.co/meta-llama/Llama-3.2-1B).
+- Set the `DOWNLOAD_LLAMA_TOKENIZER` environment variable to `True`.
+- Set the `HF_ACCESS_TOKEN` environment variable to your HuggingFace access token.
+
+For details on how to set environment variables, refer to [Environment Variables](environment-config.md).
+
 ### Split Parameters
 
 The following table contains the `split` parameters.
@@ -93,21 +108,6 @@ The following table contains the `split` parameters.
 | `params` | A sub-dictionary that can contain `split_source_types` and `hf_access_token` | `{}` |
 | `hf_access_token` | Your Hugging Face access token. | — |
 | `split_source_types` | The source types to split on (only splits on text by default). | — |
-
-
-
-### Pre-download the Tokenizer
-
-By default, the NV Ingest container comes with the `meta-llama/Llama-3.2-1B` tokenizer pre-downloaded 
-so that it doesn't have to download a tokenizer at runtime.
-If you are building the container yourself and want to pre-download this model, do the following:
-
-- Review the [license agreement](https://huggingface.co/meta-llama/Llama-3.2-1B).
-- [Request access](https://huggingface.co/meta-llama/Llama-3.2-1B).
-- Set the `DOWNLOAD_LLAMA_TOKENIZER` environment variable to `True`
-- Set the `HF_ACCESS_TOKEN` environment variable to your HuggingFace access token.
-
-
 
 ## Related Topics
 

--- a/docs/docs/extraction/nv-ingest-python-api.md
+++ b/docs/docs/extraction/nv-ingest-python-api.md
@@ -542,6 +542,8 @@ For more information on environment variables, refer to [Environment Variables](
 
 Use the following code to extract mp3 audio content.
 
+The example uses the default tokenizer for token-based splitting; see [Llama tokenizer (default)](chunking.md#llama-tokenizer-default).
+
 ```python
 from nv_ingest_client.client import Ingestor
 


### PR DESCRIPTION
## Summary
Clarifies **token-based splitting** in the extraction docs by documenting the **default tokenizer** (`meta-llama/Llama-3.2-1B`), how it relates to the embedding tokenizer, and how to satisfy **Hugging Face gated access** (`hf_access_token`). Consolidates **pre-download / Docker build** instructions (`DOWNLOAD_LLAMA_TOKENIZER`, `HF_ACCESS_TOKEN`, license and access links) into a dedicated subsection. Adds a **cross-link** from the Python API audio example to that tokenizer section. Minor README tweak: renames a heading from **“Step 3: Query Ingested Content”** to **“Query Ingested Content”** for clearer structure.
## Changes
| Area | Change |
|------|--------|
| `docs/docs/extraction/chunking.md` | Default tokenizer recommendation, new **Llama tokenizer** subsection (gated model note, `hf_access_token`, container pre-download vs custom build, env vars → link to `environment-config.md`); removes duplicate **Pre-download the Tokenizer** block in favor of the consolidated section |
| `docs/docs/extraction/nv-ingest-python-api.md` | Note before audio extract example pointing readers to the tokenizer section in `chunking.md` |
| `README.md` | Heading text only (“Step 3” removed from query section title) |
## Testing
- [ ] `mkdocs serve` / doc build (if applicable) — confirm internal anchor `chunking.md#llama-tokenizer-default` resolves as expected in your MkDocs theme (heading is `### Llama tokenizer`; add an explicit `{#...}` if the anchor does not match).
## Scope
Documentation-only; no runtime or API behavior changes in this branch.
