### PR TITLE
align 26.03 support matrix, release notes, and library quickstart with LanceDB default

### DIFF
--- a/docs/docs/extraction/quickstart-library-mode.md
+++ b/docs/docs/extraction/quickstart-library-mode.md
@@ -115,9 +115,15 @@ This chart shows some gadgets, and some very fictitious costs.
 ... document extract continues ...
 ```
 
-## Step 3: Query ingested content (Milvus)
+## Query ingested content
 
-The following example uses **`nvingest_retrieval`** against a **Milvus** collection (for example data you uploaded with `milvus_uri`, including milvus-lite). If you ingested with **LanceDB** as in the previous example, use the LanceDB APIs, environment variables (`VDB_BACKEND`, `HYBRID`), and hybrid retrieval patterns described in [Data Upload](data-store.md) instead of this Milvus-specific helper.
+### LanceDB (default path)
+
+If you ingested with LanceDB as in the `run_pipeline` example, query with **`lancedb_retrieval`** or the `LanceDB` operator’s **`retrieval`** method using the same `uri` and `table_name` you passed to **`vdb_upload`**. See [Data Upload — Upload to LanceDB (default)](data-store.md#upload-to-lancedb-default) for a minimal example, hybrid search, and related configuration.
+
+### Milvus (optional)
+
+The following example uses **`nvingest_retrieval`** against a **Milvus** collection (for example data you uploaded with `milvus_uri`, including milvus-lite). Skip this subsection if you used LanceDB above.
 
 To query for relevant snippets of Milvus-ingested content, and use them with an LLM to generate answers, use the following code.
 

--- a/docs/docs/extraction/quickstart-library-mode.md
+++ b/docs/docs/extraction/quickstart-library-mode.md
@@ -115,9 +115,11 @@ This chart shows some gadgets, and some very fictitious costs.
 ... document extract continues ...
 ```
 
-## Step 3: Query ingested content (Milvus)
+## Query ingested content (Milvus)
 
-The following example uses **`nvingest_retrieval`** against a **Milvus** collection (for example data you uploaded with `milvus_uri`, including milvus-lite). If you ingested with **LanceDB** as in the previous example, use the LanceDB APIs, environment variables (`VDB_BACKEND`, `HYBRID`), and hybrid retrieval patterns described in [Data Upload](data-store.md) instead of this Milvus-specific helper.
+This step is optional and shows how to query your ingested content from Milvus. If you are using the default LanceDB path, see `data-store.md` for LanceDB query examples.
+
+The following example uses `nvingest_retrieval` against a Milvus collection (for example data you uploaded with `milvus_uri`, including milvus-lite). If you ingested with **LanceDB** as in the previous example, use the LanceDB APIs, environment variables (`VDB_BACKEND`, `HYBRID`), and hybrid retrieval patterns described in [Data Upload](data-store.md) instead of this Milvus-specific helper.
 
 To query for relevant snippets of Milvus-ingested content, and use them with an LLM to generate answers, use the following code.
 

--- a/docs/docs/extraction/quickstart-library-mode.md
+++ b/docs/docs/extraction/quickstart-library-mode.md
@@ -6,6 +6,8 @@
 
 Use the [Quick Start for NeMo Retriever Library](https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/nemo_retriever/README.md) to set up and run the NeMo Retriever Library locally, so you can build a GPU‑accelerated, multimodal RAG ingestion pipeline that parses PDFs, HTML, text, audio, and video into LanceDB vector embeddings, integrates with Nemotron RAG models (locally or via NIM endpoints), which includes Ray‑based scaling with built‑in recall evaluation. Python 3.12 or later is required (see [Prerequisites](prerequisites.md)).
 
+By default, library mode stores vectors in LanceDB (embedded; data under `./lancedb` unless you set `uri`). You do not need `milvus-lite` or a running Milvus server for that path. To use Milvus instead (for example [milvus-lite](https://milvus.io/docs/milvus_lite.md) with a local `milvus.db` file), call `.vdb_upload` with `milvus_uri` and without selecting the LanceDB operator—for example `.vdb_upload(collection_name=..., milvus_uri="milvus.db", ...)` as shown in [Data Upload](data-store.md#upload-to-milvus).
+
 ## `run_pipeline`
 
 The primary Python entry point for launching the Ray-based ingestion pipeline in library mode is `run_pipeline` in `nv_ingest.framework.orchestration.ray.util.pipeline.pipeline_runners`.
@@ -29,11 +31,9 @@ def main():
         message_client_hostname="localhost",
     )
 
-    # gpu_cagra accelerated indexing is not available in milvus-lite
-    # Provide a filename for milvus_uri to use milvus-lite
-    milvus_uri = "milvus.db"
-    collection_name = "test"
-    sparse = False
+    # LanceDB (default): embedded vector store; set uri/table_name as needed.
+    # For Milvus instead, use .vdb_upload(collection_name=..., milvus_uri="milvus.db", sparse=False, dense_dim=2048).
+    table_name = "test"
 
     # do content extraction from files
     ingestor = (
@@ -51,11 +51,10 @@ def main():
         )
         .embed()
         .vdb_upload(
-            collection_name=collection_name,
-            milvus_uri=milvus_uri,
-            sparse=sparse,
-            # for llama-3.2 embedder, use 1024 for e5-v5
-            dense_dim=2048,
+            vdb_op="lancedb",
+            uri="lancedb",
+            table_name=table_name,
+            hybrid=False,
         )
     )
 
@@ -116,9 +115,11 @@ This chart shows some gadgets, and some very fictitious costs.
 ... document extract continues ...
 ```
 
-## Step 3: Query Ingested Content
+## Step 3: Query ingested content (Milvus)
 
-To query for relevant snippets of the ingested content, and use them with an LLM to generate answers, use the following code.
+The following example uses **`nvingest_retrieval`** against a **Milvus** collection (for example data you uploaded with `milvus_uri`, including milvus-lite). If you ingested with **LanceDB** as in the previous example, use the LanceDB APIs, environment variables (`VDB_BACKEND`, `HYBRID`), and hybrid retrieval patterns described in [Data Upload](data-store.md) instead of this Milvus-specific helper.
+
+To query for relevant snippets of Milvus-ingested content, and use them with an LLM to generate answers, use the following code.
 
 ```python
 import os

--- a/docs/docs/extraction/quickstart-library-mode.md
+++ b/docs/docs/extraction/quickstart-library-mode.md
@@ -6,7 +6,11 @@
 
 Use the [Quick Start for NeMo Retriever Library](https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/nemo_retriever/README.md) to set up and run the NeMo Retriever Library locally, so you can build a GPU‑accelerated, multimodal RAG ingestion pipeline that parses PDFs, HTML, text, audio, and video into LanceDB vector embeddings, integrates with Nemotron RAG models (locally or via NIM endpoints), which includes Ray‑based scaling with built‑in recall evaluation. Python 3.12 or later is required (see [Prerequisites](prerequisites.md)).
 
-By default, library mode stores vectors in LanceDB (embedded; data under `./lancedb` unless you set `uri`). You do not need `milvus-lite` or a running Milvus server for that path. To use Milvus instead (for example [milvus-lite](https://milvus.io/docs/milvus_lite.md) with a local `milvus.db` file), call `.vdb_upload` with `milvus_uri` and without selecting the LanceDB operator—for example `.vdb_upload(collection_name=..., milvus_uri="milvus.db", ...)` as shown in [Data Upload](data-store.md#upload-to-milvus).
+By default, library mode stores vectors in LanceDB (embedded; data under `./lancedb` unless you set `uri`). You do not need to pass `uri` for the default setup.
+
+```python
+store = ExtractorStore.from_default()
+```
 
 ## `run_pipeline`
 

--- a/docs/docs/extraction/quickstart-library-mode.md
+++ b/docs/docs/extraction/quickstart-library-mode.md
@@ -6,11 +6,7 @@
 
 Use the [Quick Start for NeMo Retriever Library](https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/nemo_retriever/README.md) to set up and run the NeMo Retriever Library locally, so you can build a GPU‑accelerated, multimodal RAG ingestion pipeline that parses PDFs, HTML, text, audio, and video into LanceDB vector embeddings, integrates with Nemotron RAG models (locally or via NIM endpoints), which includes Ray‑based scaling with built‑in recall evaluation. Python 3.12 or later is required (see [Prerequisites](prerequisites.md)).
 
-By default, library mode stores vectors in LanceDB (embedded; data under `./lancedb` unless you set `uri`). You do not need to pass `uri` for the default setup.
-
-```python
-store = ExtractorStore.from_default()
-```
+By default, library mode stores vectors in LanceDB under `./lancedb` in the current working directory; `uri="lancedb"` in the example below is that same default path, not an extra requirement.
 
 ## `run_pipeline`
 

--- a/docs/docs/extraction/releasenotes-nv-ingest.md
+++ b/docs/docs/extraction/releasenotes-nv-ingest.md
@@ -27,7 +27,8 @@ Highlights for the 26.03 release include:
 - VLM-based image caption enhancements:  
   - Infographics can be captioned  
   - Reasoning mode is configurable  
-- Enabled hybrid search with Lancedb  
+- **LanceDB is now the default vector database backend** for extraction and indexing; Milvus remains fully supported. For upload, hybrid search, and infrastructure options, see [Data Upload](data-store.md).  
+- Enabled hybrid search with LanceDB (BM25 full-text search combined with dense vectors and reciprocal rank fusion).  
 - Added retrieval_bench subfolder with generalizable agentic retrieval pipeline  
 - The project now uses UV as the primary environment and package manager instead of Conda, resulting in faster installs and simpler dependency handling  
 - Default Redis TTL increased from 1–2 hours to 48 hours so long-running jobs (e.g., VLM captioning) don’t expire before completion  

--- a/docs/docs/extraction/support-matrix.md
+++ b/docs/docs/extraction/support-matrix.md
@@ -22,7 +22,7 @@ The core pipeline features include the following:
 - nemotron-table-structure-v1 — Detects rows, columns, and cells within a table to preserve table structure and convert to Markdown format. 
 - nemotron-graphic-elements-v1 — Detects graphic elements within chart images such as titles, legends, axes, and numerical values. 
 - nemotron-ocr-v1 — Image OCR model to detect and extract text from images.
-- retrieval — Enables embedding and indexing into Milvus.
+- retrieval — Enables embedding and indexing into [LanceDB](https://lancedb.com/) (default) or [Milvus](https://milvus.io/). For configuration and alternatives, refer to [Data Upload](data-store.md).
 
 Advanced features require additional GPU support and disk space. 
 This includes the following:


### PR DESCRIPTION
## Summary

Closes gaps where extraction docs still read as Milvus-only or inconsistent with **LanceDB as the default vector database** (Milvus remains fully documented as an alternative).

## Changes

- **`docs/docs/extraction/support-matrix.md`** — Retrieval bullet now states embedding/indexing target **LanceDB (default) or Milvus**, with a link to [Data Upload](docs/docs/extraction/data-store.md).
- **`docs/docs/extraction/releasenotes-nv-ingest.md`** — Adds a 26.03 highlight that **LanceDB is the default** backend (Milvus still supported) and links to Data Upload; clarifies hybrid search for LanceDB; fixes **“Lancedb”** → **LanceDB**.
- **`docs/docs/extraction/quickstart-library-mode.md`** — States default library path is **LanceDB** (no `milvus-lite` required); describes optional Milvus; main example uses **`vdb_op="lancedb"`**; **Step 3** is labeled **Milvus** retrieval (`nvingest_retrieval`) with a pointer to Data Upload for **LanceDB** retrieval/hybrid.

## Notes

- Aligns with existing extraction pages (`data-store.md`, Compose quickstart, FAQ, Python API) that already describe LanceDB-first behavior.