### PR TITLE
Fix NRL GitHub Pages build and TOC; stop legacy Docker workflow from overwriting Pages

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,23 +1,20 @@
-name: Build NV-Ingest Documentation
+# Legacy full-site Docker documentation build (nv-ingest HTML + bundled MkDocs).
+#
+# Public GitHub Pages at https://nvidia.github.io/NeMo-Retriever/ must be published ONLY by
+# nrl-docs-github-pages.yml (mkdocs.nrl-github-pages.yml — 13-section NRL TOC). This workflow
+# must not call deploy-pages or it will overwrite that site with the old navigation.
+#
+# For the same Docker pipeline on every push to main (CI only), see docs-deploy.yml.
+name: Build NV-Ingest Documentation (legacy Docker site, artifact only)
 
-# Trigger for pull requests and pushing to main
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
+  group: docs-legacy-docker-artifact
   cancel-in-progress: false
 
 jobs:
@@ -27,14 +24,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      # Set up Docker Buildx, useful for building multi-platform images
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Build the Docker image using the Dockerfile
       - name: Build Docker image
         run: |
           docker build --target docs --build-arg GIT_COMMIT=${GITHUB_SHA} -t nv-ingest-docs:latest .
@@ -59,19 +51,8 @@ jobs:
       - name: Stop and remove the container
         run: docker rm $CONTAINER_ID
 
-      - name: Upload Site Artifacts
-        uses: actions/upload-pages-artifact@v3
+      - name: Upload legacy Docker site (not deployed to Pages)
+        uses: actions/upload-artifact@v4
         with:
+          name: nv-ingest-docs-docker-site
           path: ./generated-site
-
-  deploy:
-    needs:
-      - build
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -51,7 +51,7 @@ Use the following procedure to run the NIM locally.
     Password: <your-ngc-key>
     ```
 
-2. For convenience and security, store [your NGC key](ngc-api-key.md) in an environment variable file (`.env`). This enables services to access it without needing to enter the key manually each time. Create a .env file in your working directory and add the following line. Replace `<your-ngc-key>` with your actual NGC key.
+2. For convenience and security, store [your NGC key](api-keys.md) in an environment variable file (`.env`). This enables services to access it without needing to enter the key manually each time. Create a .env file in your working directory and add the following line. Replace `<your-ngc-key>` with your actual NGC key.
 
     ```ini
     NGC_API_KEY=<your-ngc-key>

--- a/docs/docs/extraction/choose-your-path.md
+++ b/docs/docs/extraction/choose-your-path.md
@@ -21,7 +21,7 @@ Use this page to pick documentation and deployment options that match your goal.
 
 ## I need API details and keys
 
-1. [Get your API key](ngc-api-key.md)
+1. [Get your API key](api-keys.md)
 2. [API reference](nemo-retriever-api-reference.md) and [V2 API guide](v2-api-guide.md) if applicable
 
 ## I am tuning performance or cost

--- a/docs/docs/extraction/chunking.md
+++ b/docs/docs/extraction/chunking.md
@@ -40,12 +40,12 @@ However, in some cases, such as with `.txt` documents, there aren't any page bre
 
 If you want chunks smaller than `page`, use token-based splitting as described in the following section.
 
-## Token-Based Splitting
+## Token-Based Splitting {: #token-based-splitting }
 
 The `split` task uses a tokenizer to count the number of tokens in the document, 
 and splits the document based on the desired maximum chunk size and chunk overlap.
 
-We recommend the default tokenizer for token-based splitting. For more information, refer to [Llama tokenizer (default)](#llama-tokenizer-default).
+We recommend the default tokenizer for token-based splitting. For more information, refer to [Llama tokenizer (default)](#llama-tokenizer).
 You can also use any tokenizer from any HuggingFace model that includes a tokenizer file.
 
 Use the `split` method to chunk large documents as shown in the following code.

--- a/docs/docs/extraction/custom-metadata.md
+++ b/docs/docs/extraction/custom-metadata.md
@@ -57,7 +57,7 @@ meta_df.to_csv(file_path)
 
 The following example adds custom metadata during ingestion. 
 For more information about the `Ingestor` class, refer to [Use the Python API](python-api-reference.md).
-For more information about the `vdb_upload` method, refer to [Upload Data](data-store.md).
+For more information about the `vdb_upload` method, refer to [Upload Data](vdbs.md).
 
 ```python
 from nv_ingest_client.client import Ingestor

--- a/docs/docs/extraction/embedding-nims-models.md
+++ b/docs/docs/extraction/embedding-nims-models.md
@@ -2,6 +2,6 @@
 
 Embeddings turn extracted text and multimodal content into vectors for semantic search. NeMo Retriever Library integrates with NVIDIA NIM microservices for embedding. Model names and compatibility vary by release; refer to the [Support matrix](support-matrix.md) and the [NVIDIA NIM catalog](https://build.nvidia.com/).
 
-For multimodal or VLM embeddings, refer to [Multimodal embeddings (VLM)](vlm-embed.md).
+For multimodal or VLM embeddings, refer to [Multimodal embeddings (VLM)](embedding.md).
 
-After embedding, content is stored in a vector database; refer to [Vector databases](data-store.md). RAG-style collections are created and populated through your pipeline configuration and harness runs. For details, refer to [Benchmarking](benchmarking.md) and the [data store](data-store.md) documentation for your backend.
+After embedding, content is stored in a vector database; refer to [Vector databases](vdbs.md). RAG-style collections are created and populated through your pipeline configuration and harness runs. For details, refer to [Benchmarking](benchmarking.md) and the [data store](vdbs.md) documentation for your backend.

--- a/docs/docs/extraction/extraction-charts-infographics.md
+++ b/docs/docs/extraction/extraction-charts-infographics.md
@@ -6,4 +6,4 @@ Charts and infographic regions are classified as graphic elements and processed 
 
 - [What is NeMo Retriever Library?](overview.md)
 - [Support matrix](support-matrix.md)
-- [Multimodal embeddings (VLM)](vlm-embed.md) when you treat graphics as images for embedding
+- [Multimodal embeddings (VLM)](embedding.md) when you treat graphics as images for embedding

--- a/docs/docs/extraction/extraction-ocr-scanned.md
+++ b/docs/docs/extraction/extraction-ocr-scanned.md
@@ -5,5 +5,5 @@ Scanned PDFs and image-only pages rely on OCR and hybrid paths that combine nati
 **Related**
 
 - [Text and layout extraction](text-layout-extraction.md)
-- [Nemotron Parse](nemoretriever-parse.md)
+- [Nemotron Parse](nemotron-parse.md)
 - [Throughput is dataset-dependent](throughput-is-dataset-dependent.md)

--- a/docs/docs/extraction/extraction-tables.md
+++ b/docs/docs/extraction/extraction-tables.md
@@ -5,5 +5,5 @@ NeMo Retriever Library detects tables as structured page elements, processes the
 **Related**
 
 - [What is NeMo Retriever Library?](overview.md) for artifact classification
-- [Nemotron Parse](nemoretriever-parse.md) for advanced visual parsing
+- [Nemotron Parse](nemotron-parse.md) for advanced visual parsing
 - [Metadata reference](content-metadata.md)

--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -17,7 +17,7 @@ NeMo Retriever Library supports extracting text representations of various forms
 and ingesting to a vector database. **[LanceDB](https://lancedb.com/) is the default**; [Milvus](https://milvus.io/) is also fully supported.
 NeMo Retriever Library does not store data on disk except through the vector database (LanceDB uses local Lance files; Milvus uses its server and MinIO).
 You can ingest to other data stores; however, you must configure other data stores yourself.
-For more information, refer to [Data Upload](data-store.md).
+For more information, refer to [Data Upload](vdbs.md).
 
 
 
@@ -35,7 +35,7 @@ For more information, refer to [Extract Captions from Images](python-api-referen
 For scanned documents, or documents with complex layouts, 
 we recommend that you use [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse). 
 Nemotron parse provides higher-accuracy text extraction. 
-For more information, refer to [Advanced Visual Parsing](nemoretriever-parse.md).
+For more information, refer to [Advanced Visual Parsing](nemotron-parse.md).
 
 
 
@@ -44,7 +44,7 @@ For more information, refer to [Advanced Visual Parsing](nemoretriever-parse.md)
 ### Self-Hosted Deployments
 
 For [self-hosted deployments](quickstart-guide.md), you should set the environment variables `NGC_API_KEY` and `NIM_NGC_API_KEY`.
-For more information, refer to [Generate Your NGC Keys](ngc-api-key.md).
+For more information, refer to [Generate Your NGC Keys](api-keys.md).
 
 For advanced scenarios, you might want to set `docker-compose` environment variables for NIM container paths, tags, and batch sizes. 
 You can set those directly in `docker-compose.yaml`, or in an [environment variable file](environment-config.md) that docker compose uses.

--- a/docs/docs/extraction/getting-started-about.md
+++ b/docs/docs/extraction/getting-started-about.md
@@ -4,7 +4,7 @@ This section walks you from **access and prerequisites** through **first deploym
 
 Typical order:
 
-1. [Get your API key](ngc-api-key.md) (NGC / API access as required by your workflow).
+1. [Get your API key](api-keys.md) (NGC / API access as required by your workflow).
 2. Confirm [Prerequisites](prerequisites.md) and the [Support matrix](support-matrix.md) for your OS, GPU, and software stack.
 3. Deploy using one of:
     - [Library mode](quickstart-library-mode.md) (without full stack containers where appropriate)

--- a/docs/docs/extraction/hosted-nims-when-to-use.md
+++ b/docs/docs/extraction/hosted-nims-when-to-use.md
@@ -1,6 +1,6 @@
 # When to use NVIDIA-hosted NIMs
 
-[NVIDIA-hosted NIMs](https://build.nvidia.com/) run inference on NVIDIA-managed infrastructure. You call models with API keys (refer to [Get your API key](ngc-api-key.md)) without operating GPU nodes yourself.
+[NVIDIA-hosted NIMs](https://build.nvidia.com/) run inference on NVIDIA-managed infrastructure. You call models with API keys (refer to [Get your API key](api-keys.md)) without operating GPU nodes yourself.
 
 Consider hosted NIMs when:
 

--- a/docs/docs/extraction/image-captioning.md
+++ b/docs/docs/extraction/image-captioning.md
@@ -4,6 +4,6 @@ Image captioning generates natural-language descriptions for unstructured image 
 
 **Related**
 
-- [Multimodal embeddings (VLM)](vlm-embed.md)
+- [Multimodal embeddings (VLM)](embedding.md)
 - [Metadata reference](content-metadata.md)
 - [What is NeMo Retriever Library?](overview.md)

--- a/docs/docs/extraction/integrations-langchain-llamaindex-haystack.md
+++ b/docs/docs/extraction/integrations-langchain-llamaindex-haystack.md
@@ -19,4 +19,4 @@ Haystack-related extraction modes may appear in API tables as **deprecated** in 
 
 - [Use the Python API](python-api-reference.md)
 - [Use the CLI](cli-reference.md)
-- [Split documents](chunking.md), [Upload data](data-store.md), [Filter search](custom-metadata.md)
+- [Split documents](chunking.md), [Upload data](vdbs.md), [Filter search](custom-metadata.md)

--- a/docs/docs/extraction/nv-ingest-python-api.md
+++ b/docs/docs/extraction/nv-ingest-python-api.md
@@ -27,7 +27,7 @@ The following table describes methods of the `Ingestor` class.
 | `save_to_disk` | Save ingestion results to disk instead of memory. |
 | `store`        | Persist extracted images/structured renderings to an fsspec-compatible backend. |
 | `split`        | Split documents into smaller sections for processing. For more information, refer to [Split Documents](chunking.md). |
-| `vdb_upload`   | Push extraction results to the vector database (LanceDB by default, or Milvus). For more information, refer to [Data Upload](data-store.md). |
+| `vdb_upload`   | Push extraction results to the vector database (LanceDB by default, or Milvus). For more information, refer to [Data Upload](vdbs.md). |
 
 
 ### Extract Method Options
@@ -418,7 +418,7 @@ results = ingestor.ingest()
 
 !!! tip
 
-    For more information about working with infographics and multimodal content, refer to [Use Multimodal Embedding](vlm-embed.md).
+    For more information about working with infographics and multimodal content, refer to [Use Multimodal Embedding](embedding.md).
 
 ## Extract Embeddings
 
@@ -569,6 +569,6 @@ Set extract_audio_params={"segment_audio": True} to output sentence-like audio s
 
 - [Split Documents](chunking.md)
 - [Troubleshoot Nemo Retriever Extraction](troubleshoot.md)
-- [Advanced Visual Parsing](nemoretriever-parse.md)
-- [Use NeMo Retriever Library with the Parakeet ASR NIM for Audio Processing](audio.md)
-- [Use Multimodal Embedding](vlm-embed.md)
+- [Advanced Visual Parsing](nemotron-parse.md)
+- [Use NeMo Retriever Library with the Parakeet ASR NIM for Audio Processing](audio-video.md)
+- [Use Multimodal Embedding](embedding.md)

--- a/docs/docs/extraction/production-checklist.md
+++ b/docs/docs/extraction/production-checklist.md
@@ -4,7 +4,7 @@ Use this checklist before you run NeMo Retriever Library in production. Pair it 
 
 **Security and access**
 
-- [ ] API keys and secrets follow least privilege ([Get your API key](ngc-api-key.md), [Environment variables](environment-config.md)).
+- [ ] API keys and secrets follow least privilege ([Get your API key](api-keys.md), [Environment variables](environment-config.md)).
 - [ ] Network policies match hosted versus self-hosted NIM choices ([When to use NVIDIA-hosted NIMs](hosted-nims-when-to-use.md), [When to self-host NIMs](self-host-nims-when-to-use.md)).
 
 **Operations**

--- a/docs/docs/extraction/python-api-reference.md
+++ b/docs/docs/extraction/python-api-reference.md
@@ -40,7 +40,7 @@ The following table describes methods of the `Ingestor` class.
 | `store_embed`      | Add a store-embed task.                                                      |
 | `split`            | Split documents into smaller sections. Refer to [Split Documents](chunking.md).  |
 | `udf`              | Add a user-defined function (UDF) task.                                      |
-| `vdb_upload`       | Push extraction results to Milvus vector database. Refer to [Data Upload](data-store.md). |
+| `vdb_upload`       | Push extraction results to Milvus vector database. Refer to [Data Upload](vdbs.md). |
 
 
 ### Extract Method Options
@@ -510,7 +510,7 @@ results = ingestor.ingest()
 
 !!! tip
 
-    For more information about working with infographics and multimodal content, refer to [Use Multimodal Embedding](vlm-embed.md).
+    For more information about working with infographics and multimodal content, refer to [Use Multimodal Embedding](embedding.md).
 
 ## Extract Embeddings
 
@@ -666,6 +666,6 @@ Face Parakeet model.
 
 - [Split Documents](chunking.md)
 - [Troubleshoot NeMo Retriever Library](troubleshoot.md)
-- [Advanced Visual Parsing](nemoretriever-parse.md)
-- [Use the NeMo Retriever Library with the Parakeet ASR NIM for Audio Processing](audio.md)
-- [Use Multimodal Embedding](vlm-embed.md)
+- [Advanced Visual Parsing](nemotron-parse.md)
+- [Use the NeMo Retriever Library with the Parakeet ASR NIM for Audio Processing](audio-video.md)
+- [Use Multimodal Embedding](embedding.md)

--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -1,0 +1,511 @@
+# Deploy With Docker Compose (Self-Hosted) for NeMo Retriever Library
+
+!!! note
+
+    This documentation describes NeMo Retriever Library.
+
+
+This guide helps you get started using [NeMo Retriever Library](overview.md) in self-hosted mode.
+
+
+## Step 1: Start Containers
+
+Use the provided [docker-compose.yaml](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docker-compose.yaml) to start all needed services with a few commands.
+
+!!! warning
+
+    NIM containers on their first startup can take 10-15 minutes to pull and fully load models.
+
+
+If you prefer, you can run on Kubernetes by using [our Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/helm/README.md). Also, there are [additional environment variables](environment-config.md) you can configure.
+
+a. Git clone the repo:
+
+    `git clone https://github.com/NVIDIA/NeMo-Retriever`
+
+b. Change the directory to the cloned repo by running the following code.
+   
+    `cd NeMo-Retriever`.
+
+c. [Generate API keys](api-keys.md) and authenticate with NGC with the `docker login` command.
+
+    ```shell
+    # This is required to access pre-built containers and NIM microservices
+    $ docker login nvcr.io
+    Username: $oauthtoken
+    Password: <Your Key>
+    ```
+   
+d. Create a .env file that contains your NVIDIA Build API key.
+
+    !!! note
+
+        If you use an NGC personal key, then you should provide the same value for all keys, but you must specify each environment variable individually. In the past, you could create an API key. If you have an API key, you can still use that. For more information, refer to [Generate Your NGC Keys](api-keys.md) and [Environment Configuration Variables](environment-config.md).
+
+    ```
+    # Container images must access resources from NGC.
+
+    NGC_API_KEY=<key to download containers from NGC>
+    NIM_NGC_API_KEY=<key to download model files after containers start>
+    ```
+   
+e. Make sure that NVIDIA is set as your default container runtime before you run the docker compose command by running the following code.
+
+    `sudo nvidia-ctk runtime configure --runtime=docker --set-as-default`
+
+f. Start core services. By default, the pipeline uses **LanceDB** as the vector database (embedded, in-process); no extra Docker profile is required. If you want to use **Milvus** instead, start with the retrieval profile. This example uses the retrieval profile to run Milvus. For more information about other profiles, refer to [Profile Information](#profile-information).
+
+    `docker compose --profile retrieval up`
+
+    !!! tip "LanceDB (default)"
+
+        To use the default LanceDB backend, you can run `docker compose up` without `--profile retrieval`. LanceDB runs in-process and does not require Milvus, etcd, or MinIO. For details, refer to [Data Upload](vdbs.md).
+
+    !!! tip
+
+        By default, we have [configured log levels to be verbose](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docker-compose.yaml). It's possible to observe service startup proceeding. You will notice a lot of log messages. Disable verbose logging by configuring `NIM_TRITON_LOG_VERBOSE=0` for each NIM in [docker-compose.yaml](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docker-compose.yaml).
+
+    !!! tip
+
+        The default configuration might not fit on a single GPU for some hardware targets. Use a [docker compose override file](#docker-compose-override-files) to reduce VRAM usage. Override files typically lower per-service memory allocation, batch sizes, or concurrency, trading peak throughput for making the full pipeline runnable on the available GPU.
+
+g. When core services have fully started, `nvidia-smi` should show processes like the following:
+
+    ```
+    # If it's taking > 1m for `nvidia-smi` to return, the bus will likely be busy setting up the models.
+    +---------------------------------------------------------------------------------------+
+    | Processes:                                                                            |
+    |  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
+    |        ID   ID                                                             Usage      |
+    |=======================================================================================|
+    |    0   N/A  N/A     80461      C   milvus                                     1438MiB |
+    |    0   N/A  N/A     83791      C   tritonserver                               2492MiB |
+    |    0   N/A  N/A     85605      C   tritonserver                               1896MiB |
+    |    0   N/A  N/A     85889      C   tritonserver                               2824MiB |
+    |    0   N/A  N/A     88253      C   tritonserver                               2824MiB |
+    |    0   N/A  N/A     91194      C   tritonserver                               4546MiB |
+    +---------------------------------------------------------------------------------------+
+    ```
+
+h. Run the command `docker ps`. You should see output similar to the following. Confirm that the status of the containers is `Up`.
+
+    ```
+    CONTAINER ID  IMAGE                                            COMMAND                 CREATED         STATUS                  PORTS            NAMES
+    1b885f37c991  nvcr.io/nvidia/nemo-microservices/...            "/usr/bin/tini -- /w…"  7 minutes ago   Up 7 minutes (healthy)  0.0.0.0:7670...  nemo-retriever-ms-runtime-1
+    14ef31ed7f49  milvusdb/milvus:v2.5.3-gpu                       "/tini -- bash -c 's…"  7 minutes ago   Up 7 minutes (healthy)  0.0.0.0:9091...  milvus-standalone
+    dceaf36cc5df  otel/opentelemetry-collector-contrib:...         "/otelcol-contrib --…"  7 minutes ago   Up 7 minutes            0.0.0.0:4317...  nemo-retriever-otel-collector-1
+    5bd0b48eb71b  nvcr.io/nim/nvidia/nemoretriever-graphic-ele...  "/opt/nvidia/nvidia_…"  7 minutes ago   Up 7 minutes            0.0.0.0:8003...  nemo-retriever-graphic-elements-1
+    daf878669036  nvcr.io/nim/nvidia/nemoretriever-ocr-v1:1.2.1    "/opt/nvidia/nvidia_…"  7 minutes ago   Up 7 minutes            0.0.0.0:8009...  nemo-retriever-ocr-1
+    216bdf11c566  nvcr.io/nim/nvidia/nemoretriever-page-elements-v3:1.7.0  "/opt/nvidia/nvidia_…"  7 minutes ago   Up 7 minutes            0.0.0.0:8000...  nemo-retriever-page-elements-1
+    aee9580b0b9a  nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2:1.10.0  "/opt/nvidia/nvidia_…"  7 minutes ago   Up 7 minutes            0.0.0.0:8012...  nemo-retriever-embedding-1
+    178a92bf6f7f  nvcr.io/nim/nvidia/nemoretriever-table-struc...  "/opt/nvidia/nvidia_…"  7 minutes ago   Up 7 minutes            0.0.0.0:8006...  nemo-retriever-table-structure-1
+    7ddbf7690036  openzipkin/zipkin                                "start-zipkin"          7 minutes ago   Up 7 minutes (healthy)  9410/tcp...      nemo-retriever-zipkin-1
+    b73bbe0c202d  minio/minio:RELEASE.2023-03-20T20-16-18Z         "/usr/bin/docker-ent…"  7 minutes ago   Up 7 minutes (healthy)  0.0.0.0:9000...  minio
+    97fa798dbe4f  prom/prometheus:latest                           "/bin/prometheus --w…"  7 minutes ago   Up 7 minutes            0.0.0.0:9090...  nemo-retriever-prometheus-1
+    f17cb556b086  grafana/grafana                                  "/run.sh"               7 minutes ago   Up 7 minutes            0.0.0.0:3000...  grafana-service
+    3403c5a0e7be  redis/redis-stack                                "/entrypoint.sh"        7 minutes ago   Up 7 minutes            0.0.0.0:6379...  nemo-retriever-redis-1
+    ```
+
+## Step 2: Ingest Documents
+
+You can submit jobs programmatically in Python or using the [CLI](cli-reference.md).
+
+!!! important "Python version"
+
+    Install the client and CLI into an environment that uses Python 3.12 or later. The published packages require Python `>= 3.12`; using Python 3.10 or 3.11 typically fails with dependency resolution errors. Refer to [Prerequisites](prerequisites.md) and [Support Matrix](support-matrix.md).
+
+The following examples demonstrate how to extract text, charts, tables, and images:
+
+- **extract_text** — Uses [PDFium](https://github.com/pypdfium2-team/pypdfium2/) to find and extract text from pages.
+- **extract_images** — Uses [PDFium](https://github.com/pypdfium2-team/pypdfium2/) to extract images.
+- **extract_tables** — Uses [object detection family of NIMs](https://docs.nvidia.com/nim/ingestion/object-detection/latest/overview.html) to find tables and charts, and NemoRetriever OCR for table extraction.
+- **extract_charts** — Enables or disables chart extraction, also based on the object detection NIM family.
+
+
+### In Python
+
+!!! tip
+
+    For more Python examples, refer to the [Python Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/python_client_usage.ipynb).
+
+<a id="ingest_python_example"></a>
+```python
+import logging, os, time
+from nv_ingest_client.client import Ingestor, NvIngestClient
+from nv_ingest_client.util.process_json_files import ingest_json_results_to_blob
+client = NvIngestClient(                                                                         
+    message_client_port=7670,                                                               
+    message_client_hostname="localhost"        
+)                                                                 
+# do content extraction from files                               
+ingestor = (
+    Ingestor(client=client)
+    .files("data/multimodal_test.pdf")
+    .extract(             
+        extract_text=True,
+        extract_tables=True,
+        extract_charts=True,
+        extract_images=True,
+        table_output_format="markdown",
+        extract_infographics=True,
+        # extract_method="nemotron_parse", # Slower, but maximally accurate, especially for PDFs with pages that are scanned images
+        text_depth="page"
+    ).embed()
+    .vdb_upload(
+        collection_name="test",
+        sparse=False,
+        # for llama-3.2 embedder, use 1024 for e5-v5
+        dense_dim=2048,
+        # milvus_uri="http://milvus:19530"  # When running from within a container, the URI to the Milvus service is specified using the internal Docker network.
+    )
+)
+
+print("Starting ingestion..")
+t0 = time.time()
+
+# Return both successes and failures
+# Use for large batches where you want successful chunks/pages to be committed, while collecting detailed diagnostics for failures.
+results, failures = ingestor.ingest(show_progress=True, return_failures=True)
+
+# Return only successes
+# results = ingestor.ingest(show_progress=True)
+
+t1 = time.time()
+print(f"Total time: {t1-t0} seconds")
+
+# results blob is directly inspectable
+print(ingest_json_results_to_blob(results[0]))
+
+if failures:
+    print(f"There were {len(failures)} failures. Sample: {failures[0]}")
+```
+
+!!! note
+
+    For advanced visual parsing in self-hosted mode, uncomment `extract_method="nemotron_parse"` in the previous code. For more information, refer to [Advanced Visual Parsing](nemotron-parse.md).
+
+
+The output looks similar to the following.
+
+```
+Starting ingestion..
+1 records to insert to milvus
+logged 8 records
+Total time: 5.479151725769043 seconds
+This chart shows some gadgets, and some very fictitious costs. Gadgets and their cost   Chart 1 - Hammer - Powerdrill - Bluetooth speaker - Minifridge - Premium desk fan Dollars $- - $20.00 - $40.00 - $60.00 - $80.00 - $100.00 - $120.00 - $140.00 - $160.00 Cost
+Table 1
+| This table describes some animals, and some activities they might be doing in specific locations. | This table describes some animals, and some activities they might be doing in specific locations. | This table describes some animals, and some activities they might be doing in specific locations. |
+| Animal | Activity | Place |
+| Giraffe | Driving a car | At the beach |
+| Lion | Putting on sunscreen | At the park |
+| Cat | Jumping onto a laptop | In a home office |
+| Dog | Chasing a squirrel | In the front yard |
+TestingDocument
+A sample document with headings and placeholder text
+Introduction
+This is a placeholder document that can be used for any purpose. It contains some 
+headings and some placeholder text to fill the space. The text is not important and contains 
+no real value, but it is useful for testing. Below, we will have some simple tables and charts 
+that we can use to confirm Ingest is working as expected.
+Table 1
+This table describes some animals, and some activities they might be doing in specific 
+locations.
+Animal Activity Place
+Gira@e Driving a car At the beach
+Lion Putting on sunscreen At the park
+Cat Jumping onto a laptop In a home o@ice
+Dog Chasing a squirrel In the front yard
+Chart 1
+This chart shows some gadgets, and some very fictitious costs.
+image_caption:[]
+image_caption:[]
+Below,is a high-quality picture of some shapes          Picture
+Table 2
+| This table shows some popular colors that cars might come in | This table shows some popular colors that cars might come in | This table shows some popular colors that cars might come in | This table shows some popular colors that cars might come in |
+| Car | Color1 | Color2 | Color3 |
+| Coupe | White | Silver | Flat Gray |
+| Sedan | White | Metallic Gray | Matte Gray |
+| Minivan | Gray | Beige | Black |
+| Truck | Dark Gray | Titanium Gray | Charcoal |
+| Convertible | Light Gray | Graphite | Slate Gray |
+Section One
+This is the first section of the document. It has some more placeholder text to show how 
+the document looks like. The text is not meant to be meaningful or informative, but rather to 
+demonstrate the layout and formatting of the document.
+• This is the first bullet point
+• This is the second bullet point
+• This is the third bullet point
+Section Two
+This is the second section of the document. It is more of the same as we’ve seen in the rest 
+of the document. The content is meaningless, but the intent is to create a very simple 
+smoke test to ensure extraction is working as intended. This will be used in CI as time goes 
+on to ensure that changes we make to the library do not negatively impact our accuracy.
+Table 2
+This table shows some popular colors that cars might come in.
+Car Color1 Color2 Color3
+Coupe White Silver Flat Gray
+Sedan White Metallic Gray Matte Gray
+Minivan Gray Beige Black
+Truck Dark Gray Titanium Gray Charcoal
+Convertible Light Gray Graphite Slate Gray
+Picture
+Below, is a high-quality picture of some shapes.
+image_caption:[]
+image_caption:[]
+This chart shows some average frequency ranges for speaker drivers. Frequency Ranges ofSpeaker Drivers   Tweeter - Midrange - Midwoofer - Subwoofer Chart2 Hertz (log scale) 1 - 10 - 100 - 1000 - 10000 - 100000 FrequencyRange Start (Hz) - Frequency Range End (Hz)
+Chart 2
+This chart shows some average frequency ranges for speaker drivers.
+Conclusion
+This is the conclusion of the document. It has some more placeholder text, but the most 
+important thing is that this is the conclusion. As we end this document, we should have 
+been able to extract 2 tables, 2 charts, and some text including 3 bullet points.
+image_caption:[]
+
+```
+
+### Using the CLI
+
+!!! tip
+
+    There is a Jupyter notebook available to help you get started with the CLI. For more information, refer to the [CLI Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/cli_client_usage.ipynb).
+
+<a id="ingest_cli_example"></a>
+```shell
+nemo-retriever \
+  --doc ./data/multimodal_test.pdf \
+  --output_directory ./processed_docs \
+  --task='extract:{"document_type": "pdf", "extract_method": "pdfium", "extract_tables": "true", "extract_images": "true", "extract_charts": "true"}' \
+  --client_host=localhost \
+  --client_port=7670
+```
+
+You should see output that indicates the document processing status followed by a breakdown of time spent during job execution.
+
+```
+None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
+[nltk_data] Downloading package punkt_tab to
+[nltk_data]     /path/to/your/venv/lib/python3.12/site-
+[nltk_data]     packages/llama_index/core/_static/nltk_cache...
+[nltk_data]   Package punkt_tab is already up-to-date!
+INFO:retriever_client.cli:Processing 1 documents.
+INFO:retriever_client.cli:Output will be written to: ./processed_docs
+Processing files: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.34s/file, pages_per_sec=1.28]
+INFO:retriever_client.processing:message_broker_task_source: Avg: 2.39 ms, Median: 2.39 ms, Total Time: 2.39 ms, Total % of Trace Computation: 0.06%
+INFO:retriever_client.processing:broker_source_network_in: Avg: 9.51 ms, Median: 9.51 ms, Total Time: 9.51 ms, Total % of Trace Computation: 0.25%
+INFO:retriever_client.processing:job_counter: Avg: 1.47 ms, Median: 1.47 ms, Total Time: 1.47 ms, Total % of Trace Computation: 0.04%
+INFO:retriever_client.processing:job_counter_channel_in: Avg: 0.46 ms, Median: 0.46 ms, Total Time: 0.46 ms, Total % of Trace Computation: 0.01%
+INFO:retriever_client.processing:metadata_injection: Avg: 3.52 ms, Median: 3.52 ms, Total Time: 3.52 ms, Total % of Trace Computation: 0.09%
+INFO:retriever_client.processing:metadata_injection_channel_in: Avg: 0.16 ms, Median: 0.16 ms, Total Time: 0.16 ms, Total % of Trace Computation: 0.00%
+INFO:retriever_client.processing:pdf_content_extractor: Avg: 475.64 ms, Median: 163.77 ms, Total Time: 2378.21 ms, Total % of Trace Computation: 62.73%
+INFO:retriever_client.processing:pdf_content_extractor_channel_in: Avg: 0.31 ms, Median: 0.31 ms, Total Time: 0.31 ms, Total % of Trace Computation: 0.01%
+INFO:retriever_client.processing:image_content_extractor: Avg: 0.67 ms, Median: 0.67 ms, Total Time: 0.67 ms, Total % of Trace Computation: 0.02%
+INFO:retriever_client.processing:image_content_extractor_channel_in: Avg: 0.21 ms, Median: 0.21 ms, Total Time: 0.21 ms, Total % of Trace Computation: 0.01%
+INFO:retriever_client.processing:docx_content_extractor: Avg: 0.46 ms, Median: 0.46 ms, Total Time: 0.46 ms, Total % of Trace Computation: 0.01%
+INFO:retriever_client.processing:docx_content_extractor_channel_in: Avg: 0.20 ms, Median: 0.20 ms, Total Time: 0.20 ms, Total % of Trace Computation: 0.01%
+INFO:retriever_client.processing:pptx_content_extractor: Avg: 0.68 ms, Median: 0.68 ms, Total Time: 0.68 ms, Total % of Trace Computation: 0.02%
+INFO:retriever_client.processing:pptx_content_extractor_channel_in: Avg: 0.46 ms, Median: 0.46 ms, Total Time: 0.46 ms, Total % of Trace Computation: 0.01%
+INFO:retriever_client.processing:audio_data_extraction: Avg: 1.08 ms, Median: 1.08 ms, Total Time: 1.08 ms, Total % of Trace Computation: 0.03%
+INFO:retriever_client.processing:audio_data_extraction_channel_in: Avg: 0.20 ms, Median: 0.20 ms, Total Time: 0.20 ms, Total % of Trace Computation: 0.01%
+INFO:retriever_client.processing:dedup_images: Avg: 0.42 ms, Median: 0.42 ms, Total Time: 0.42 ms, Total % of Trace Computation: 0.01%
+INFO:retriever_client.processing:dedup_images_channel_in: Avg: 0.42 ms, Median: 0.42 ms, Total Time: 0.42 ms, Total % of Trace Computation: 0.01%
+INFO:retriever_client.processing:filter_images: Avg: 0.59 ms, Median: 0.59 ms, Total Time: 0.59 ms, Total % of Trace Computation: 0.02%
+INFO:retriever_client.processing:filter_images_channel_in: Avg: 0.57 ms, Median: 0.57 ms, Total Time: 0.57 ms, Total % of Trace Computation: 0.02%
+INFO:retriever_client.processing:table_data_extraction: Avg: 240.75 ms, Median: 240.75 ms, Total Time: 481.49 ms, Total % of Trace Computation: 12.70%
+INFO:retriever_client.processing:table_data_extraction_channel_in: Avg: 0.38 ms, Median: 0.38 ms, Total Time: 0.38 ms, Total % of Trace Computation: 0.01%
+INFO:retriever_client.processing:chart_data_extraction: Avg: 300.54 ms, Median: 299.94 ms, Total Time: 901.62 ms, Total % of Trace Computation: 23.78%
+INFO:retriever_client.processing:chart_data_extraction_channel_in: Avg: 0.23 ms, Median: 0.23 ms, Total Time: 0.23 ms, Total % of Trace Computation: 0.01%
+INFO:retriever_client.processing:infographic_data_extraction: Avg: 0.77 ms, Median: 0.77 ms, Total Time: 0.77 ms, Total % of Trace Computation: 0.02%
+INFO:retriever_client.processing:infographic_data_extraction_channel_in: Avg: 0.25 ms, Median: 0.25 ms, Total Time: 0.25 ms, Total % of Trace Computation: 0.01%
+INFO:retriever_client.processing:caption_ext: Avg: 0.55 ms, Median: 0.55 ms, Total Time: 0.55 ms, Total % of Trace Computation: 0.01%
+INFO:retriever_client.processing:caption_ext_channel_in: Avg: 0.51 ms, Median: 0.51 ms, Total Time: 0.51 ms, Total % of Trace Computation: 0.01%
+INFO:retriever_client.processing:embed_text: Avg: 1.21 ms, Median: 1.21 ms, Total Time: 1.21 ms, Total % of Trace Computation: 0.03%
+INFO:retriever_client.processing:embed_text_channel_in: Avg: 0.21 ms, Median: 0.21 ms, Total Time: 0.21 ms, Total % of Trace Computation: 0.01%
+INFO:retriever_client.processing:store_embedding_minio: Avg: 0.32 ms, Median: 0.32 ms, Total Time: 0.32 ms, Total % of Trace Computation: 0.01%
+INFO:retriever_client.processing:store_embedding_minio_channel_in: Avg: 1.18 ms, Median: 1.18 ms, Total Time: 1.18 ms, Total % of Trace Computation: 0.03%
+INFO:retriever_client.processing:message_broker_task_sink_channel_in: Avg: 0.42 ms, Median: 0.42 ms, Total Time: 0.42 ms, Total % of Trace Computation: 0.01%
+INFO:retriever_client.processing:No unresolved time detected. Trace times account for the entire elapsed duration.
+INFO:retriever_client.processing:Processed 1 files in 2.34 seconds.
+INFO:retriever_client.processing:Total pages processed: 3
+INFO:retriever_client.processing:Throughput (Pages/sec): 1.28
+INFO:retriever_client.processing:Throughput (Files/sec): 0.43
+```
+
+## Step 3: Inspecting and Consuming Results
+
+After the ingestion steps above have been completed, you should be able to find the `text` and `image` subfolders inside your processed docs folder. Each will contain JSON-formatted extracted content and metadata.
+
+When processing has completed, you'll have separate result files for text and image data:
+```shell
+ls -R processed_docs/
+```
+```shell
+processed_docs/:
+image  structured  text
+
+processed_docs/image:
+multimodal_test.pdf.metadata.json
+
+processed_docs/structured:
+multimodal_test.pdf.metadata.json
+
+processed_docs/text:
+multimodal_test.pdf.metadata.json
+```
+
+For the full metadata definitions, refer to [Content Metadata](content-metadata.md). 
+
+We also provide a script for inspecting [extracted images](https://github.com/NVIDIA/NeMo-Retriever/blob/main/src/util/image_viewer.py).
+
+First, install `tkinter` by running the following code. Choose the code for your OS.
+
+- For Ubuntu/Debian Linux:
+
+    ```shell
+    sudo apt-get update
+    sudo apt-get install python3-tk
+    ```
+
+- For Fedora/RHEL Linux:
+
+    ```shell
+    sudo dnf install python3-tkinter
+    ```
+
+- For macOS using Homebrew:
+
+    ```shell
+    brew install python-tk
+    ```
+
+Then, run the following command to execute the script for inspecting the extracted image:
+
+```shell
+python src/util/image_viewer.py --file_path ./processed_docs/image/multimodal_test.pdf.metadata.json
+```
+
+!!! tip
+
+    Beyond inspecting the results, you can read them into things like [llama-index](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/llama_index_multimodal_rag.ipynb) or [langchain](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/langchain_multimodal_rag.ipynb) retrieval pipelines. Also, checkout our [Enterprise RAG Blueprint on build.nvidia.com](https://build.nvidia.com/nvidia/multimodal-pdf-data-extraction-for-enterprise-rag) to query over document content pre-extracted with the retriever pipeline.
+
+
+
+## Profile Information
+
+The values that you specify in the `--profile` option of your `docker compose up` command are explained in the following table. 
+You can specify multiple `--profile` options.
+
+| Profile               | Type     | Description                                                       | 
+|-----------------------|----------|-------------------------------------------------------------------| 
+| `retrieval`           | Core     | Enables the embedding NIM and (optional) GPU-accelerated Milvus. Omit this profile to use the default LanceDB backend.           | 
+| `audio`               | Advanced | Use the [parakeet-1-1b-ctc-en-us](https://docs.nvidia.com/nim/speech/latest/asr/deploy-asr-models/parakeet-ctc-en-us.html) ASR NIM (`nvcr.io/nim/nvidia/parakeet-1-1b-ctc-en-us`) for processing audio files. For more information, refer to [Audio Processing](audio-video.md). | 
+| `nemotron-parse`      | Advanced | Use [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse), which adds state-of-the-art text and table extraction. For more information, refer to [Advanced Visual Parsing](nemotron-parse.md). | 
+| `vlm`                 | Advanced | Use [Nemotron Nano 12B v2 VL](https://build.nvidia.com/nvidia/nemotron-nano-12b-v2-vl/modelcard) for image captioning of unstructured images and infographics. This profile enables the `caption` method in the Python API to generate text descriptions of visual content. For more information, refer to [Use Multimodal Embedding](embedding.md) and [Extract Captions from Images](python-api-reference.md#extract-captions-from-images). | 
+
+### Example: Using the VLM Profile for Infographic Captioning
+
+Infographics often combine text, charts, and diagrams into complex visuals. Vision-language model (VLM) captioning generates natural language descriptions that capture this complexity, making the content searchable and more accessible for downstream applications.
+
+To use VLM captioning for infographics, start NeMo Retriever Library with both the `retrieval` and `vlm` profiles by running the following code.
+```shell
+docker compose \
+  -f docker-compose.yaml \
+  --profile retrieval \
+  --profile vlm up
+```
+
+## Air-Gapped Deployment (Docker Compose)
+
+When deploying in an air-gapped environment (no internet or NGC registry access), you must pre-stage container images on a machine with network access, then transfer and load them in the isolated environment.
+
+1. On a machine with network access: Clone the repo, authenticate with NGC (`docker login nvcr.io`), and pull all images used by your chosen profile (for example, `docker compose --profile retrieval pull`).
+2. Save images: Export the images to archives (for example, using `docker save` for each image or a script that saves all images referenced by your [docker-compose.yaml](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docker-compose.yaml)).
+3. Transfer the image archives and your `docker-compose.yaml` (and `.env` if used) to the air-gapped system.
+4. On the air-gapped machine: Load the images (`docker load -i <archive>`) and start the stack with the same profile (for example, `docker compose --profile retrieval up`).
+
+Ensure the same image tags and `docker-compose.yaml` version are used in both environments so that service configuration stays consistent.
+
+## Docker Compose override files
+
+The default [docker-compose.yaml](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docker-compose.yaml) might exceed VRAM on a single GPU for some hardware. Override files reduce per-service memory, batch sizes, or concurrency so the full pipeline can run on the available GPU. To use an override, pass a second `-f` file after the base compose file; Docker Compose merges them and the override takes precedence.
+
+| Override file | GPU target |
+|---------------|------------|
+| `docker-compose.a10g.yaml` | NVIDIA A10G |
+| `docker-compose.a100-40gb.yaml` | NVIDIA A100-SXM4-40GB |
+| `docker-compose.l40s.yaml` | NVIDIA L40S |
+
+For RTX Pro 6000 Server Edition and other GPUs with limited VRAM, use the override that best matches your GPU memory (for example, `docker-compose.l40s.yaml` or `docker-compose.a10g.yaml`).
+
+For the VLM profile and infographic captioning, see the example under [Profile Information](#profile-information) (add `-f docker-compose.<override>.yaml` as needed when using an override file).
+
+### Example with A100 40GB
+
+The following example uses an override file for an A100 40GB GPU.
+
+```shell
+docker compose \
+  -f docker-compose.yaml \
+  -f docker-compose.a100-40gb.yaml \
+  --profile retrieval up
+```
+
+### Example with A10G
+
+```shell
+docker compose \
+  -f docker-compose.yaml \
+  -f docker-compose.a10g.yaml \
+  --profile retrieval up
+```
+
+### Example with L40S
+
+```shell
+docker compose \
+  -f docker-compose.yaml \
+  -f docker-compose.l40s.yaml \
+  --profile retrieval up
+```
+
+
+## Specify MIG slices for NIM models
+
+When you deploy the pipeline with NIM models on MIG‑enabled GPUs, MIG device slices are requested and scheduled through the `values.yaml` file for the corresponding NIM microservice. For IBM Content-Aware Storage (CAS) deployments, this allows NIM pods to land only on nodes that expose the desired MIG profiles (see the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/helm/README.md)).
+
+To target a specific MIG profile—for example, a 3g.20gb slice on an A100, which is a hardware-partitioned virtual GPU instance that gives your workload a fixed mid-sized share of the A100’s compute plus 20 GB of dedicated GPU memory and behaves like a smaller independent GPU—for a given NIM, configure the `resources` and `nodeSelector` under that NIM’s values path in `values.yaml`.
+
+The following example shows the pattern. Paths vary by NIM, such as `nvingest.nvidiaNim.nemoretrieverPageElements` instead of the generic `nvingest.nim` placeholder. For details refer to the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/helm/README.md) and the chart listing on [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/nemo-microservices/containers).
+Set `resources.requests` and `resources.limits` to the name of the MIG resource that you want (for example, `nvidia.com/mig-3g.20gb`).
+```shell
+nvingest:
+  nvidiaNim:
+    nemoretrieverPageElements:
+      modelName: "nvidia/nemotron-page-elements-v3"  # Page-elements NIM (not a text LLM)
+      resources:
+        limits:
+          nvidia.com/mig-3g.20gb: 1               # MIG profile resource
+        requests:
+          nvidia.com/mig-3g.20gb: 1
+      nodeSelector:
+        nvidia.com/gpu.product: A100-SXM4-40GB-MIG-3g.20gb
+```
+Key points:
+
+ * Use the appropriate NIM‑specific values path (for example, `nvingest.nvidiaNim.nemoretrieverPageElements.resources`) rather than the generic `nvingest.nim` placeholder.
+ * Set `resources.requests` and `resources.limits` to the desired MIG resource name (for example, `nvidia.com/mig-3g.20gb`).
+ * Use `nodeSelector` (or tolerations/affinity, if you prefer) to target nodes labeled with the corresponding MIG‑enabled GPU product (for example, `nvidia.com/gpu.product: A100-SXM4-40GB-MIG-3g.20gb`).
+This syntax and structure can be repeated for each NIM model used by CAS, ensuring that each NeMo Retriever Library NIM pod is mapped to the correct MIG slice type and scheduled onto compatible nodes.
+
+!!! important
+
+    Advanced features require additional GPU support and disk space. For more information, refer to [Support Matrix](support-matrix.md).
+
+## Related Topics
+
+- [Troubleshoot](troubleshoot.md)
+- [Prerequisites](prerequisites.md)
+- [Support Matrix](support-matrix.md)
+- [Deploy Without Containers (Library Mode)](quickstart-library-mode.md)
+- [Deploy with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/main/helm/README.md)
+- [Notebooks](notebooks.md)
+- [Enterprise RAG Blueprint](https://build.nvidia.com/nvidia/multimodal-pdf-data-extraction-for-enterprise-rag)

--- a/docs/docs/extraction/quickstart-library-mode.md
+++ b/docs/docs/extraction/quickstart-library-mode.md
@@ -1,0 +1,3 @@
+# Deploy As a Bare Metal Python Library
+
+See the [quickstart guide](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever).

--- a/docs/docs/extraction/reranking.md
+++ b/docs/docs/extraction/reranking.md
@@ -11,7 +11,7 @@ Enable reranking when both of the following apply:
 
 **Configuration pointers**
 
-Reranker options appear in benchmarking and recall configurations. Start with [Benchmarking](benchmarking.md) and your vector store setup in [Vector databases](data-store.md).
+Reranker options appear in benchmarking and recall configurations. Start with [Benchmarking](benchmarking.md) and your vector store setup in [Vector databases](vdbs.md).
 
 **Related**
 

--- a/docs/docs/extraction/semantic-hybrid-retrieval.md
+++ b/docs/docs/extraction/semantic-hybrid-retrieval.md
@@ -5,7 +5,7 @@
 In NeMo Retriever Library, use these resources:
 
 - [Concepts](concepts.md) for pipeline and search patterns
-- [Vector databases](data-store.md) for LanceDB hybrid mode (dense, BM25, and RRF) and Milvus dense or sparse patterns
+- [Vector databases](vdbs.md) for LanceDB hybrid mode (dense, BM25, and RRF) and Milvus dense or sparse patterns
 - [Environment variables](environment-config.md) for hybrid-related flags where documented
 - [Custom metadata and filtering](custom-metadata.md) for filtering
 

--- a/docs/docs/extraction/support-matrix.md
+++ b/docs/docs/extraction/support-matrix.md
@@ -16,8 +16,8 @@ The core pipeline models (for document type inputs) include the following:
 Advanced features (for example, for audio/video) require additional GPU support and disk space. 
 This includes the following:
 
-- [parakeet-1-1b-ctc-en-us](https://huggingface.co/nvidia/parakeet-ctc-1.1b) for transcript extraction from [audio and video](audio.md). NVIDIA NIM: [Parakeet CTC (en-US) ASR](https://docs.nvidia.com/nim/speech/latest/asr/deploy-asr-models/parakeet-ctc-en-us.html).
-- [nemotron-parse](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2) - for [maximally accurate table extraction](nemoretriever-parse.md). NVIDIA NIM: [Query the Nemotron-Parse-v1.2 API](https://docs.nvidia.com/nim/vision-language-models/latest/examples/nemotron-parse/api.html).
+- [parakeet-1-1b-ctc-en-us](https://huggingface.co/nvidia/parakeet-ctc-1.1b) for transcript extraction from [audio and video](audio-video.md). NVIDIA NIM: [Parakeet CTC (en-US) ASR](https://docs.nvidia.com/nim/speech/latest/asr/deploy-asr-models/parakeet-ctc-en-us.html).
+- [nemotron-parse](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2) - for [maximally accurate table extraction](nemotron-parse.md). NVIDIA NIM: [Query the Nemotron-Parse-v1.2 API](https://docs.nvidia.com/nim/vision-language-models/latest/examples/nemotron-parse/api.html).
 - [nemotron-nano-12b-v2-vl](https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2) for image captioning of unstructured (not charts, tables, infographics) images. NVIDIA NIM: [Query the Nemotron Nano 12B v2 VL API](https://docs.nvidia.com/nim/vision-language-models/latest/examples/nemotron-nano-12b-v2-vl/api.html).
     
     !!! note

--- a/docs/docs/extraction/supported-file-types.md
+++ b/docs/docs/extraction/supported-file-types.md
@@ -6,4 +6,4 @@ NeMo Retriever Library accepts multiple document and media types. A current list
 
 - [Troubleshoot](troubleshoot.md) for format-specific issues
 - [Text and layout extraction](text-layout-extraction.md)
-- [Speech and audio](audio.md)
+- [Speech and audio](audio-video.md)

--- a/docs/docs/extraction/vector-db-partners.md
+++ b/docs/docs/extraction/vector-db-partners.md
@@ -1,6 +1,6 @@
 # Vector database partners
 
-NeMo Retriever Library integrates with vector databases used for RAG collections. Documentation here focuses on stores used in the library and harnesses, such as LanceDB and Milvus, and cuVS where it applies. Refer to [Vector databases](data-store.md) and [Chunking and splitting](chunking.md).
+NeMo Retriever Library integrates with vector databases used for RAG collections. Documentation here focuses on stores used in the library and harnesses, such as LanceDB and Milvus, and cuVS where it applies. Refer to [Vector databases](vdbs.md) and [Chunking and splitting](chunking.md).
 
 **Related**
 

--- a/docs/docs/extraction/workflow-build-searchable-collection.md
+++ b/docs/docs/extraction/workflow-build-searchable-collection.md
@@ -1,7 +1,7 @@
 # Workflow: Build a searchable collection
 
-After [document ingestion](workflow-document-ingestion.md), configure [chunking](chunking.md) and your [vector database](data-store.md) so extracted content is embedded, indexed, and ready for search.
+After [document ingestion](workflow-document-ingestion.md), configure [chunking](chunking.md) and your [vector database](vdbs.md) so extracted content is embedded, indexed, and ready for search.
 
-Technical detail for storage and chunking is in the **Embedding, indexing, and storage** section of the navigation ([Vector databases](data-store.md), [Chunking and splitting](chunking.md)).
+Technical detail for storage and chunking is in the **Embedding, indexing, and storage** section of the navigation ([Vector databases](vdbs.md), [Chunking and splitting](chunking.md)).
 
 **Next:** [Workflow: Query and rerank](workflow-query-rerank.md).

--- a/docs/docs/extraction/workflow-query-rerank.md
+++ b/docs/docs/extraction/workflow-query-rerank.md
@@ -1,11 +1,11 @@
 # Workflow: Query and rerank
 
-After documents are [ingested](workflow-document-ingestion.md), [chunked](chunking.md), and [indexed](data-store.md), applications run retrieval (semantic and optionally hybrid search) and optional reranking to improve top-K quality.
+After documents are [ingested](workflow-document-ingestion.md), [chunked](chunking.md), and [indexed](vdbs.md), applications run retrieval (semantic and optionally hybrid search) and optional reranking to improve top-K quality.
 
 Follow these steps:
 
 1. **Query.** Run searches against your vector store with filters as needed. Refer to [Semantic and hybrid retrieval](semantic-hybrid-retrieval.md) and [Custom metadata and filtering](custom-metadata.md).
-2. **Combine hybrid patterns.** Merge dense vectors with sparse or full-text signals where supported, such as LanceDB hybrid mode in [Vector databases](data-store.md).
+2. **Combine hybrid patterns.** Merge dense vectors with sparse or full-text signals where supported, such as LanceDB hybrid mode in [Vector databases](vdbs.md).
 3. **Rerank.** Apply a reranker NIM for a second-stage score on candidates. Refer to [Reranking](reranking.md) and the [Support matrix](support-matrix.md) for reranker NIM options and GPU notes.
 
 **Bridge from extraction**

--- a/docs/docs/extraction/workflow-video-ocr.md
+++ b/docs/docs/extraction/workflow-video-ocr.md
@@ -2,9 +2,9 @@
 
 For video assets, NeMo Retriever Library can combine audio or speech processing with visual text extraction when OCR applies to frames or derived images.
 
-For the audio and speech path, refer to [Speech and audio](audio.md) for RIVA ASR and related ingestion paths.
+For the audio and speech path, refer to [Speech and audio](audio-video.md) for RIVA ASR and related ingestion paths.
 
-For visual text and OCR, scanned or image-heavy content often uses OCR-oriented extract methods. Refer to [OCR and scanned documents](extraction-ocr-scanned.md), [Text and layout extraction](text-layout-extraction.md), and [Nemotron Parse](nemoretriever-parse.md) for advanced visual parsing.
+For visual text and OCR, scanned or image-heavy content often uses OCR-oriented extract methods. Refer to [OCR and scanned documents](extraction-ocr-scanned.md), [Text and layout extraction](text-layout-extraction.md), and [Nemotron Parse](nemotron-parse.md) for advanced visual parsing.
 
 Container formats and early-access video types are listed in [Supported file types and formats](supported-file-types.md).
 

--- a/docs/mkdocs.nrl-github-pages.yml
+++ b/docs/mkdocs.nrl-github-pages.yml
@@ -166,7 +166,6 @@ plugins:
         extraction/nemoretriever-parse.md: extraction/nemotron-parse.md
         extraction/vlm-embed.md: extraction/embedding.md
         extraction/audio.md: extraction/audio-video.md
-        extraction/audio.md: extraction/audio-video.md
   - site-urls
 
 markdown_extensions:

--- a/docs/mkdocs.nrl-github-pages.yml
+++ b/docs/mkdocs.nrl-github-pages.yml
@@ -72,7 +72,7 @@ nav:
           - "Hardware and support matrix": extraction/support-matrix.md
           - "Quickstart: NeMo Retriever Library (local)": extraction/quickstart-library-mode.md
           - "Deploy (Docker Compose)": extraction/quickstart-guide.md
-          - "Authentication and API keys": extraction/api-keys.md
+          - "Authentication and API keys": extraction/ngc-api-key.md
       - "3. Choose your deployment":
           - Compare deployment options: extraction/choose-your-path.md
           - When to use NVIDIA-hosted NIMs: extraction/hosted-nims-when-to-use.md
@@ -82,7 +82,7 @@ nav:
           - "Workflow: Build a searchable collection": extraction/workflow-build-searchable-collection.md
           - "Workflow: Query and rerank": extraction/workflow-query-rerank.md
           - "Workflow: Agentic retrieval": extraction/workflow-agentic-retrieval.md
-          - "Workflow: Audio or video to text": extraction/audio-video.md
+          - "Workflow: Audio or video to text": extraction/audio.md
           - "Workflow: Video processing with OCR": extraction/workflow-video-ocr.md
           - "Workflow: End-to-end RAG with NVIDIA Blueprints": extraction/workflow-e2e-blueprints.md
       - "5. Multimodal extraction":
@@ -91,35 +91,35 @@ nav:
           - Tables: extraction/extraction-tables.md
           - "Charts and infographics": extraction/extraction-charts-infographics.md
           - "OCR and scanned documents": extraction/extraction-ocr-scanned.md
-          - "Nemotron Parse based parsing": extraction/nemotron-parse.md
+          - "Nemotron Parse based parsing": extraction/nemoretriever-parse.md
           - Image captioning: extraction/image-captioning.md
           - "Metadata and content schema": extraction/multimodal-metadata-schema.md
           - "Extraction limitations and quality": extraction/throughput-is-dataset-dependent.md
-      - "6. Embedding, indexing & storage":
+      - "6. Embedding, indexing, and storage":
           - "Embedding NIMs and models": extraction/embedding-nims-models.md
-          - "Multimodal embeddings (VLM)": extraction/embedding.md
-          - Vector databases: extraction/vdbs.md
+          - "Multimodal embeddings (VLM)": extraction/vlm-embed.md
+          - Vector databases: extraction/data-store.md
           - "Chunking and splitting": extraction/chunking.md
-      - "7. Retrieval & ranking":
+      - "7. Retrieval and ranking":
           - "Semantic and hybrid retrieval": extraction/semantic-hybrid-retrieval.md
           - Reranking: extraction/reranking.md
           - "Custom metadata and filtering": extraction/custom-metadata.md
           - "Agentic retrieval (concept)": extraction/agentic-retrieval-concept.md
-      - "8. Deployment & operations":
+      - "8. Deployment and operations":
           - "Scaling: static and dynamic": extraction/scaling-modes.md
           - "Ray and distributed ingest": extraction/ray-logging.md
           - "Telemetry and observability": extraction/telemetry.md
           - Production checklist: extraction/production-checklist.md
-      - "9. Customize & extend":
+      - "9. Customize and extend":
           - User-defined functions: extraction/user-defined-functions.md
           - User-defined stages: extraction/user-defined-stages.md
           - "NimClient and custom NIM endpoints": extraction/nimclient.md
-      - "10. Integrations & ecosystem":
+      - "10. Integrations and ecosystem":
           - "NVIDIA AI Blueprints": extraction/resources-links.md
           - "Framework integrations": extraction/integrations-langchain-llamaindex-haystack.md
           - "Vector database partners": extraction/vector-db-partners.md
           - "Starter kits": extraction/notebooks.md
-      - "11. Evaluation & benchmarks":
+      - "11. Evaluation and benchmarks":
           - "Benchmarking methodology and evaluation harnesses": extraction/benchmarking.md
           - "Evaluate on your own documents": extraction/evaluate-on-your-data.md
           - "Published metrics and comparisons": extraction/published-metrics-comparisons.md
@@ -161,11 +161,6 @@ plugins:
         extraction/nv-ingest-python-api.md: extraction/python-api-reference.md
         # Helm stub removed; send bookmarks to Docker Compose quickstart (Kubernetes + Helm links on page).
         extraction/helm.md: extraction/quickstart-guide.md
-        extraction/ngc-api-key.md: extraction/api-keys.md
-        extraction/data-store.md: extraction/vdbs.md
-        extraction/nemoretriever-parse.md: extraction/nemotron-parse.md
-        extraction/vlm-embed.md: extraction/embedding.md
-        extraction/audio.md: extraction/audio-video.md
   - site-urls
 
 markdown_extensions:

--- a/docs/mkdocs.nrl-github-pages.yml
+++ b/docs/mkdocs.nrl-github-pages.yml
@@ -166,6 +166,7 @@ plugins:
         extraction/nemoretriever-parse.md: extraction/nemotron-parse.md
         extraction/vlm-embed.md: extraction/embedding.md
         extraction/audio.md: extraction/audio-video.md
+        extraction/audio.md: extraction/audio-video.md
   - site-urls
 
 markdown_extensions:

--- a/docs/mkdocs.nrl-github-pages.yml
+++ b/docs/mkdocs.nrl-github-pages.yml
@@ -72,7 +72,7 @@ nav:
           - "Hardware and support matrix": extraction/support-matrix.md
           - "Quickstart: NeMo Retriever Library (local)": extraction/quickstart-library-mode.md
           - "Deploy (Docker Compose)": extraction/quickstart-guide.md
-          - "Authentication and API keys": extraction/ngc-api-key.md
+          - "Authentication and API keys": extraction/api-keys.md
       - "3. Choose your deployment":
           - Compare deployment options: extraction/choose-your-path.md
           - When to use NVIDIA-hosted NIMs: extraction/hosted-nims-when-to-use.md
@@ -82,7 +82,7 @@ nav:
           - "Workflow: Build a searchable collection": extraction/workflow-build-searchable-collection.md
           - "Workflow: Query and rerank": extraction/workflow-query-rerank.md
           - "Workflow: Agentic retrieval": extraction/workflow-agentic-retrieval.md
-          - "Workflow: Audio or video to text": extraction/audio.md
+          - "Workflow: Audio or video to text": extraction/audio-video.md
           - "Workflow: Video processing with OCR": extraction/workflow-video-ocr.md
           - "Workflow: End-to-end RAG with NVIDIA Blueprints": extraction/workflow-e2e-blueprints.md
       - "5. Multimodal extraction":
@@ -91,35 +91,35 @@ nav:
           - Tables: extraction/extraction-tables.md
           - "Charts and infographics": extraction/extraction-charts-infographics.md
           - "OCR and scanned documents": extraction/extraction-ocr-scanned.md
-          - "Nemotron Parse based parsing": extraction/nemoretriever-parse.md
+          - "Nemotron Parse based parsing": extraction/nemotron-parse.md
           - Image captioning: extraction/image-captioning.md
           - "Metadata and content schema": extraction/multimodal-metadata-schema.md
           - "Extraction limitations and quality": extraction/throughput-is-dataset-dependent.md
-      - "6. Embedding, indexing, and storage":
+      - "6. Embedding, indexing & storage":
           - "Embedding NIMs and models": extraction/embedding-nims-models.md
-          - "Multimodal embeddings (VLM)": extraction/vlm-embed.md
-          - Vector databases: extraction/data-store.md
+          - "Multimodal embeddings (VLM)": extraction/embedding.md
+          - Vector databases: extraction/vdbs.md
           - "Chunking and splitting": extraction/chunking.md
-      - "7. Retrieval and ranking":
+      - "7. Retrieval & ranking":
           - "Semantic and hybrid retrieval": extraction/semantic-hybrid-retrieval.md
           - Reranking: extraction/reranking.md
           - "Custom metadata and filtering": extraction/custom-metadata.md
           - "Agentic retrieval (concept)": extraction/agentic-retrieval-concept.md
-      - "8. Deployment and operations":
+      - "8. Deployment & operations":
           - "Scaling: static and dynamic": extraction/scaling-modes.md
           - "Ray and distributed ingest": extraction/ray-logging.md
           - "Telemetry and observability": extraction/telemetry.md
           - Production checklist: extraction/production-checklist.md
-      - "9. Customize and extend":
+      - "9. Customize & extend":
           - User-defined functions: extraction/user-defined-functions.md
           - User-defined stages: extraction/user-defined-stages.md
           - "NimClient and custom NIM endpoints": extraction/nimclient.md
-      - "10. Integrations and ecosystem":
+      - "10. Integrations & ecosystem":
           - "NVIDIA AI Blueprints": extraction/resources-links.md
           - "Framework integrations": extraction/integrations-langchain-llamaindex-haystack.md
           - "Vector database partners": extraction/vector-db-partners.md
           - "Starter kits": extraction/notebooks.md
-      - "11. Evaluation and benchmarks":
+      - "11. Evaluation & benchmarks":
           - "Benchmarking methodology and evaluation harnesses": extraction/benchmarking.md
           - "Evaluate on your own documents": extraction/evaluate-on-your-data.md
           - "Published metrics and comparisons": extraction/published-metrics-comparisons.md
@@ -161,6 +161,10 @@ plugins:
         extraction/nv-ingest-python-api.md: extraction/python-api-reference.md
         # Helm stub removed; send bookmarks to Docker Compose quickstart (Kubernetes + Helm links on page).
         extraction/helm.md: extraction/quickstart-guide.md
+        extraction/ngc-api-key.md: extraction/api-keys.md
+        extraction/data-store.md: extraction/vdbs.md
+        extraction/nemoretriever-parse.md: extraction/nemotron-parse.md
+        extraction/vlm-embed.md: extraction/embedding.md
   - site-urls
 
 markdown_extensions:

--- a/docs/mkdocs.nrl-github-pages.yml
+++ b/docs/mkdocs.nrl-github-pages.yml
@@ -165,6 +165,7 @@ plugins:
         extraction/data-store.md: extraction/vdbs.md
         extraction/nemoretriever-parse.md: extraction/nemotron-parse.md
         extraction/vlm-embed.md: extraction/embedding.md
+        extraction/audio.md: extraction/audio-video.md
   - site-urls
 
 markdown_extensions:

--- a/nemo_retriever/src/nemo_retriever/retriever.py
+++ b/nemo_retriever/src/nemo_retriever/retriever.py
@@ -395,7 +395,7 @@ class Retriever:
     ) -> "RetrievalResult":
         """Run retrieval for a single query and return a structured result.
 
-        Thin adapter over :meth:`query` that reshapes the raw LanceDB hits
+        Thin adapter over :meth:`~nemo_retriever.retriever.Retriever.query` that reshapes the raw LanceDB hits
         into a :class:`~nemo_retriever.llm.RetrievalResult` with ``chunks``
         (the retrieved text, in rank order) and aligned ``metadata``
         (source, page_number, etc.).  Satisfies the
@@ -416,8 +416,8 @@ class Retriever:
         Example:
             >>> retriever = Retriever(lancedb_uri="./kb")
             >>> result = retriever.retrieve("What is RAG?", top_k=3)
-            >>> result.chunks[0][:40]  # doctest: +SKIP
-            'Retrieval augmented generation combines...'
+            >>> bool(result.chunks[0])  # doctest: +SKIP
+            True
         """
         from nemo_retriever.llm.types import RetrievalResult
 

--- a/nemo_retriever/src/nemo_retriever/retriever.py
+++ b/nemo_retriever/src/nemo_retriever/retriever.py
@@ -395,7 +395,7 @@ class Retriever:
     ) -> "RetrievalResult":
         """Run retrieval for a single query and return a structured result.
 
-        Thin adapter over :meth:`~nemo_retriever.retriever.Retriever.query` that reshapes the raw LanceDB hits
+        Thin adapter over :meth:`query` that reshapes the raw LanceDB hits
         into a :class:`~nemo_retriever.llm.RetrievalResult` with ``chunks``
         (the retrieved text, in rank order) and aligned ``metadata``
         (source, page_number, etc.).  Satisfies the
@@ -416,8 +416,8 @@ class Retriever:
         Example:
             >>> retriever = Retriever(lancedb_uri="./kb")
             >>> result = retriever.retrieve("What is RAG?", top_k=3)
-            >>> bool(result.chunks[0])  # doctest: +SKIP
-            True
+            >>> result.chunks[0][:40]  # doctest: +SKIP
+            'Retrieval augmented generation combines...'
         """
         from nemo_retriever.llm.types import RetrievalResult
 


### PR DESCRIPTION
Updated 04/24

## Summary
### Overview
This branch keeps **https://nvidia.github.io/NeMo-Retriever/** under the control of the **NRL MkDocs** workflow only, and updates **extraction** documentation so paths and anchors line up with the current filenames and **strict** MkDocs builds. It **does not** change `docs/mkdocs.nrl-github-pages.yml` or `nemo_retriever/src/nemo_retriever/retriever.py` relative to **`main`** (those files match upstream after the latest commit).
### What changes
1. **`.github/workflows/build-docs.yml` (legacy Docker full-site build)**  
   - Runs only on **`workflow_dispatch`** (no automatic run on every push to `main`).  
   - **Removes** GitHub Pages deployment (`configure-pages`, `upload-pages-artifact`, `deploy-pages`) and **`pages` / OIDC** permissions.  
   - Uses a dedicated **`concurrency` group** (`docs-legacy-docker-artifact`) so it no longer competes with the **`pages`** group used by the NRL Pages workflow.  
   - Uploads the built site as a normal **`actions/upload-artifact`** artifact (`nv-ingest-docs-docker-site`) for optional inspection or downstream use.
2. **`docs/docs/extraction/`**  
   - Updates **internal links** to match renamed pages (e.g. API keys, audio/video, Nemotron Parse, embedding, vector DBs).  
   - **`chunking.md`**: fixes strict-build issues (anchor / cross-link adjustments).  
   - Touch-ups across FAQ, workflows, API reference pages, support matrix, and related topics for consistency.
3. **Quickstart markdown**  
   - Adds **`quickstart-guide.md`** (Docker Compose–oriented guide) and **`quickstart-library-mode.md`** (short pointer) so existing **nav** targets and links resolve under **`mkdocs build --strict`**.
### What is unchanged vs `main`
- **`docs/mkdocs.nrl-github-pages.yml`** — same as **`main`** (no net TOC / redirect changes from this PR).  
- **`nemo_retriever/src/nemo_retriever/retriever.py`** — same as **`main`**.
### Merge impact
After merge, **NRL GitHub Pages** publishing stays defined by the existing NRL workflow and config on **`main`**; this PR mainly **prevents the legacy Docker doc build from overwriting that site** and **keeps extraction content and quickstarts consistent** with strict builds and current paths.


