### PR TITLE
Repair NRL GitHub Pages MkDocs nav and strict CI build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -64,6 +64,12 @@ mkdocs:
 	@echo "📚 Building MkDocs site..."
 	mkdocs build
 
+# NeMo Retriever Library (NRL) staging site: flat 13-section nav (see mkdocs.nrl-github-pages.yml).
+.PHONY: nrl-github-pages
+nrl-github-pages:
+	@echo "📚 Building NRL GitHub Pages MkDocs site (strict)..."
+	mkdocs build -f mkdocs.nrl-github-pages.yml --strict
+
 # Full docs pipeline
 .PHONY: docs
 docs: sphinx-apidoc generate-openapi-schema sphinx copy-sphinx mkdocs

--- a/docs/mkdocs.nrl-github-pages.yml
+++ b/docs/mkdocs.nrl-github-pages.yml
@@ -1,20 +1,26 @@
-# NeMo Retriever Library (NRL) only — GitHub Pages staging/nightly build.
+# NeMo Retriever Library (NRL) only - GitHub Pages staging/nightly build.
 # Does not include the broader NeMo Retriever suite landing page (docs/docs/index.md),
 # full multi-package Sphinx API dumps, or legacy nv-ingest markdown aliases in the built site.
 #
 # Build: make nrl-github-pages   OR   mkdocs build -f mkdocs.nrl-github-pages.yml
 # Optional: SITE_URL=https://owner.github.io/repo/ mkdocs build -f mkdocs.nrl-github-pages.yml
+#
+# Nav is a flat list of numbered sections (no single "NeMo Retriever" wrapper) so the
+# left sidebar shows the full TOC on GitHub Pages. Material hides the tab bar when there
+# is only one top-level tab, which made the structure easy to miss.
 
 site_name: NeMo Retriever (staging)
-site_description: NeMo Retriever documentation — staging / nightly (not a production release)
+site_description: NeMo Retriever documentation - staging / nightly (not a production release)
 site_url: !ENV [SITE_URL, 'https://example.invalid/']
+
+repo_name: NVIDIA/NeMo-Retriever
+repo_url: https://github.com/NVIDIA/NeMo-Retriever
 
 theme:
   name: material
   custom_dir: overrides-nrl-staging
   features:
     - content.code.annotate
-    - navigation.tabs
     - navigation.indexes
     - navigation.instant
     - navigation.path
@@ -22,6 +28,7 @@ theme:
     - navigation.top
     - navigation.footer
     - navigation.expand
+    - toc.follow
     - search.suggest
     - search.highlight
     - content.code.copy
@@ -29,7 +36,7 @@ theme:
     code: Roboto Mono
   favicon: assets/images/favicon.png
   language: en
-  # Visible on every page — staging / not a release build
+  # Visible on every page - staging / not a release build
   announcement: |
     **Staging (nightly):** NeMo Retriever documentation only. This site is not a production or release publication.
   palette:
@@ -59,83 +66,82 @@ extra_css:
 
 # Broader suite overview and legacy duplicate pages are excluded from the build (see exclude_docs).
 nav:
-  - NeMo Retriever:
-      - "1. Introduction":
-          - "What is NeMo Retriever?": extraction/overview.md
-          - Key features: extraction/key-features.md
-          - Key concepts: extraction/concepts.md
-          - How to use this documentation: extraction/how-to-use-this-documentation.md
-          - Release notes: extraction/releasenotes.md
-      - "2. Get started":
-          - About this section: extraction/getting-started-about.md
-          - Prerequisites: extraction/prerequisites.md
-          - "Hardware and support matrix": extraction/support-matrix.md
-          - "Quickstart: NeMo Retriever Library (local)": extraction/quickstart-library-mode.md
-          - "Deploy (Docker Compose)": extraction/quickstart-guide.md
-          - "Authentication and API keys": extraction/ngc-api-key.md
-      - "3. Choose your deployment":
-          - Compare deployment options: extraction/choose-your-path.md
-          - When to use NVIDIA-hosted NIMs: extraction/hosted-nims-when-to-use.md
-          - When to self-host NIMs: extraction/self-host-nims-when-to-use.md
-      - "4. Core workflows":
-          - "Workflow: Document ingestion": extraction/workflow-document-ingestion.md
-          - "Workflow: Build a searchable collection": extraction/workflow-build-searchable-collection.md
-          - "Workflow: Query and rerank": extraction/workflow-query-rerank.md
-          - "Workflow: Agentic retrieval": extraction/workflow-agentic-retrieval.md
-          - "Workflow: Audio or video to text": extraction/audio.md
-          - "Workflow: Video processing with OCR": extraction/workflow-video-ocr.md
-          - "Workflow: End-to-end RAG with NVIDIA Blueprints": extraction/workflow-e2e-blueprints.md
-      - "5. Multimodal extraction":
-          - "Supported file types and formats": extraction/supported-file-types.md
-          - "Text and layout extraction": extraction/text-layout-extraction.md
-          - Tables: extraction/extraction-tables.md
-          - "Charts and infographics": extraction/extraction-charts-infographics.md
-          - "OCR and scanned documents": extraction/extraction-ocr-scanned.md
-          - "Nemotron Parse based parsing": extraction/nemoretriever-parse.md
-          - Image captioning: extraction/image-captioning.md
-          - "Metadata and content schema": extraction/multimodal-metadata-schema.md
-          - "Extraction limitations and quality": extraction/throughput-is-dataset-dependent.md
-      - "6. Embedding, indexing, and storage":
-          - "Embedding NIMs and models": extraction/embedding-nims-models.md
-          - "Multimodal embeddings (VLM)": extraction/vlm-embed.md
-          - Vector databases: extraction/data-store.md
-          - "Chunking and splitting": extraction/chunking.md
-      - "7. Retrieval and ranking":
-          - "Semantic and hybrid retrieval": extraction/semantic-hybrid-retrieval.md
-          - Reranking: extraction/reranking.md
-          - "Custom metadata and filtering": extraction/custom-metadata.md
-          - "Agentic retrieval (concept)": extraction/agentic-retrieval-concept.md
-      - "8. Deployment and operations":
-          - "Scaling: static and dynamic": extraction/scaling-modes.md
-          - "Ray and distributed ingest": extraction/ray-logging.md
-          - "Telemetry and observability": extraction/telemetry.md
-          - Production checklist: extraction/production-checklist.md
-      - "9. Customize and extend":
-          - User-defined functions: extraction/user-defined-functions.md
-          - User-defined stages: extraction/user-defined-stages.md
-          - "NimClient and custom NIM endpoints": extraction/nimclient.md
-      - "10. Integrations and ecosystem":
-          - "NVIDIA AI Blueprints": extraction/resources-links.md
-          - "Framework integrations": extraction/integrations-langchain-llamaindex-haystack.md
-          - "Vector database partners": extraction/vector-db-partners.md
-          - "Starter kits": extraction/notebooks.md
-      - "11. Evaluation and benchmarks":
-          - "Benchmarking methodology and evaluation harnesses": extraction/benchmarking.md
-          - "Evaluate on your own documents": extraction/evaluate-on-your-data.md
-          - "Published metrics and comparisons": extraction/published-metrics-comparisons.md
-      - "12. Reference":
-          - "API guide": extraction/nemo-retriever-api-reference.md
-          - "HTTP API (V2)": extraction/v2-api-guide.md
-          - "Python API": extraction/python-api-reference.md
-          - "CLI reference": extraction/cli-reference.md
-          - Environment variables: extraction/environment-config.md
-          - "Metadata reference": extraction/content-metadata.md
-      - "13. Support and community":
-          - Troubleshooting: extraction/troubleshoot.md
-          - FAQ: extraction/faq.md
-          - Contributing: extraction/contributing.md
-      - Additional resources:
-          - "OSS licences": license.md
+  - "1. Introduction":
+      - "What is NeMo Retriever?": extraction/overview.md
+      - Key features: extraction/key-features.md
+      - Key concepts: extraction/concepts.md
+      - How to use this documentation: extraction/how-to-use-this-documentation.md
+      - Release notes: extraction/releasenotes.md
+  - "2. Get started":
+      - About this section: extraction/getting-started-about.md
+      - Prerequisites: extraction/prerequisites.md
+      - "Hardware and support matrix": extraction/support-matrix.md
+      - "Quickstart: NeMo Retriever Library (local)": extraction/quickstart-library-mode.md
+      - "Deploy (Docker Compose)": extraction/quickstart-guide.md
+      - "Authentication and API keys": extraction/api-keys.md
+  - "3. Choose your deployment":
+      - Compare deployment options: extraction/choose-your-path.md
+      - When to use NVIDIA-hosted NIMs: extraction/hosted-nims-when-to-use.md
+      - When to self-host NIMs: extraction/self-host-nims-when-to-use.md
+  - "4. Core workflows":
+      - "Workflow: Document ingestion": extraction/workflow-document-ingestion.md
+      - "Workflow: Build a searchable collection": extraction/workflow-build-searchable-collection.md
+      - "Workflow: Query and rerank": extraction/workflow-query-rerank.md
+      - "Workflow: Agentic retrieval": extraction/workflow-agentic-retrieval.md
+      - "Workflow: Audio or video to text": extraction/audio-video.md
+      - "Workflow: Video processing with OCR": extraction/workflow-video-ocr.md
+      - "Workflow: End-to-end RAG with NVIDIA Blueprints": extraction/workflow-e2e-blueprints.md
+  - "5. Multimodal extraction":
+      - "Supported file types and formats": extraction/supported-file-types.md
+      - "Text and layout extraction": extraction/text-layout-extraction.md
+      - Tables: extraction/extraction-tables.md
+      - "Charts and infographics": extraction/extraction-charts-infographics.md
+      - "OCR and scanned documents": extraction/extraction-ocr-scanned.md
+      - "Nemotron Parse based parsing": extraction/nemotron-parse.md
+      - Image captioning: extraction/image-captioning.md
+      - "Metadata and content schema": extraction/multimodal-metadata-schema.md
+      - "Extraction limitations and quality": extraction/throughput-is-dataset-dependent.md
+  - "6. Embedding, indexing & storage":
+      - "Embedding NIMs and models": extraction/embedding-nims-models.md
+      - "Multimodal embeddings (VLM)": extraction/embedding.md
+      - Vector databases: extraction/vdbs.md
+      - "Chunking and splitting": extraction/chunking.md
+  - "7. Retrieval & ranking":
+      - "Semantic and hybrid retrieval": extraction/semantic-hybrid-retrieval.md
+      - Reranking: extraction/reranking.md
+      - "Custom metadata and filtering": extraction/custom-metadata.md
+      - "Agentic retrieval (concept)": extraction/agentic-retrieval-concept.md
+  - "8. Deployment & operations":
+      - "Scaling: static and dynamic": extraction/scaling-modes.md
+      - "Ray and distributed ingest": extraction/ray-logging.md
+      - "Telemetry and observability": extraction/telemetry.md
+      - Production checklist: extraction/production-checklist.md
+  - "9. Customize & extend":
+      - User-defined functions: extraction/user-defined-functions.md
+      - User-defined stages: extraction/user-defined-stages.md
+      - "NimClient and custom NIM endpoints": extraction/nimclient.md
+  - "10. Integrations & ecosystem":
+      - "NVIDIA AI Blueprints": extraction/resources-links.md
+      - "Framework integrations": extraction/integrations-langchain-llamaindex-haystack.md
+      - "Vector database partners": extraction/vector-db-partners.md
+      - "Starter kits": extraction/notebooks.md
+  - "11. Evaluation & benchmarks":
+      - "Benchmarking methodology and evaluation harnesses": extraction/benchmarking.md
+      - "Evaluate on your own documents": extraction/evaluate-on-your-data.md
+      - "Published metrics and comparisons": extraction/published-metrics-comparisons.md
+  - "12. Reference":
+      - "API guide": extraction/nemo-retriever-api-reference.md
+      - "HTTP API (V2)": extraction/v2-api-guide.md
+      - "Python API": extraction/python-api-reference.md
+      - "CLI reference": extraction/cli-reference.md
+      - Environment variables: extraction/environment-config.md
+      - "Metadata reference": extraction/content-metadata.md
+  - "13. Support & community":
+      - Troubleshooting: extraction/troubleshoot.md
+      - FAQ: extraction/faq.md
+      - Contributing: extraction/contributing.md
+  - Additional resources:
+      - "OSS licences": license.md
 
 plugins:
   - search
@@ -159,8 +165,15 @@ plugins:
         extraction/index.md: extraction/overview.md
         extraction/nv-ingest_cli.md: extraction/cli-reference.md
         extraction/nv-ingest-python-api.md: extraction/python-api-reference.md
-        # Helm stub removed; send bookmarks to Docker Compose quickstart (Kubernetes + Helm links on page).
+        # Legacy Helm doc URL (page excluded from NRL); keep redirect for bookmarks / external links.
         extraction/helm.md: extraction/quickstart-guide.md
+        # Legacy filename; canonical NRL release notes are extraction/releasenotes.md
+        extraction/releasenotes-nv-ingest.md: extraction/releasenotes.md
+        extraction/ngc-api-key.md: extraction/api-keys.md
+        extraction/data-store.md: extraction/vdbs.md
+        extraction/nemoretriever-parse.md: extraction/nemotron-parse.md
+        extraction/vlm-embed.md: extraction/embedding.md
+        extraction/audio.md: extraction/audio-video.md
   - site-urls
 
 markdown_extensions:
@@ -187,9 +200,11 @@ exclude_docs: |
   index.md
   extraction/nv-ingest_cli.md
   extraction/nv-ingest-python-api.md
+  extraction/helm.md
+  extraction/releasenotes-nv-ingest.md
 
 extra:
   generator: false
 
 copyright: |
-  &copy; Copyright 2023–2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. Staging documentation build.
+  &copy; Copyright 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. Staging documentation build.


### PR DESCRIPTION
## Summary
Aligns the NeMo Retriever Library (NRL) GitHub Pages MkDocs config with the intended flat 13-section TOC and canonical `extraction/*.md` paths so `mkdocs build -f mkdocs.nrl-github-pages.yml --strict` succeeds in CI. Adds a matching `make nrl-github-pages` target for local builds and fixes a doctest line that triggered mkdocstrings autoref warnings under strict mode.
## Changes
- **`docs/mkdocs.nrl-github-pages.yml`** — Flat top-level nav (sections 1–13 + Additional resources), update nav targets to existing pages (`api-keys`, `audio-video`, `nemotron-parse`, `embedding`, `vdbs`, etc.), keep legacy URL redirects, and align theme/metadata (`repo_*`, `toc.follow`) with the NRL-only site.
- **`docs/Makefile`** — New `nrl-github-pages` phony target that runs the same strict MkDocs build as `.github/workflows/nrl-docs-github-pages.yml`.
- **`nemo_retriever/src/nemo_retriever/retriever.py`** — Replace `result.chunks[0][:40]` in the `retrieve` docstring example with `bool(result.chunks[0])` so `[:40]` is not parsed as a bogus cross-reference under `--strict`.
## Why
CI publishes NRL docs with `--strict`. The previous nav referenced missing markdown paths and the doctest slice caused mkdocstrings to emit warnings, which abort a strict build.
## How tested
- `py -3 -m mkdocs build -f mkdocs.nrl-github-pages.yml --strict` from `docs/` (or `make nrl-github-pages` where `make` is available).




