### PR TITLE
fix(nemo_retriever): stop Retriever.retrieve doctest from breaking NRL MkDocs --strict builds

### DIFF
--- a/nemo_retriever/src/nemo_retriever/retriever.py
+++ b/nemo_retriever/src/nemo_retriever/retriever.py
@@ -416,7 +416,7 @@ class Retriever:
         Example:
             >>> retriever = Retriever(lancedb_uri="./kb")
             >>> result = retriever.retrieve("What is RAG?", top_k=3)
-            >>> result.chunks[0][:40]  # doctest: +SKIP
+            >>> bool(result.chunks[0])  # doctest: +SKIP
             'Retrieval augmented generation combines...'
         """
         from nemo_retriever.llm.types import RetrievalResult

--- a/nemo_retriever/src/nemo_retriever/retriever.py
+++ b/nemo_retriever/src/nemo_retriever/retriever.py
@@ -417,7 +417,7 @@ class Retriever:
             >>> retriever = Retriever(lancedb_uri="./kb")
             >>> result = retriever.retrieve("What is RAG?", top_k=3)
             >>> bool(result.chunks[0])  # doctest: +SKIP
-            'Retrieval augmented generation combines...'
+            True
         """
         from nemo_retriever.llm.types import RetrievalResult
 


### PR DESCRIPTION
## Summary

One-line change in `Retriever.retrieve`’s docstring example: replace `result.chunks[0][:40]` with `bool(result.chunks[0])` in the doctest block. No runtime behavior change.

## Problem

The NRL documentation workflow runs:

`mkdocs build -f mkdocs.nrl-github-pages.yml --strict`

With **mkdocstrings** enabled, docstrings are parsed for reStructuredText-style roles (e.g. ``:meth:``, ``:class:``). The substring **`[:40]`** inside the example line is mis-read as a cross-reference whose “role” is parsed as **`:40`**, which does not exist. **mkdocs_autorefs** then emits a warning such as:

> Could not find cross-reference target `:40'

Under **`--strict`**, warnings fail the build, so the **“NRL documentation — GitHub Pages”** job exits with code **1** even though the rest of the site and nav are fine.

This failure is easy to misattribute to “docs” or “TOC” changes because it surfaces during the MkDocs step, but the root cause is this **single character sequence in a Python docstring** processed by the API reference pipeline (`extraction/nemo-retriever-api-reference.md` pulls in `::: nemo_retriever.retriever`).

## Solution

Keep the example’s intent (“show something you can assert after `retrieve`”) without a slice that starts with **`[:`**. Using **`bool(result.chunks[0])`** avoids the bogus `:40` parse, satisfies the same “smoke check” idea, and keeps `# doctest: +SKIP` so environments without a real LanceDB fixture do not need to execute the full example.

## Scope

- **Touched:** `nemo_retriever/src/nemo_retriever/retriever.py` only (intentionally isolated for review and stakeholder clarity).
- **Not changed:** MkDocs config, nav, or other docs—those belong to separate PRs.

## How to verify

From `docs/`:

```bash
python -m pip install -r requirements.txt
pip install -e ../nemo_retriever
mkdocs build -f mkdocs.nrl-github-pages.yml --strict

## Greptile review follow-up

After switching the example to bool(result.chunks[0]), the expected line was updated to True so rendered docs match what the expression returns (review feedback).