### PR TITLE
 fix MkDocs nav, macro conflicts, and internal links

### DIFF
--- a/docs/docs/extraction/air-gapped-deployment.md
+++ b/docs/docs/extraction/air-gapped-deployment.md
@@ -71,7 +71,7 @@ If your process forbids live `helm install` from URLs, use `helm pull` on the st
 ## Pinning versions and digests
 
 - Tags — Align Compose `*_TAG` / Helm `image.tag` fields with the same release line you qualified (for example `26.3.0` for the ingest image, NIM tags from `docker-compose.yaml` / `nimOperator` in `values.yaml`).
-- Digests — After `docker pull nvcr.io/...:tag`, run `docker inspect --format='{{index .RepoDigests 0}}' image:tag` (or use crane / skopeo; see tooling below) and record `repository@sha256:...`. Prefer deploying with digests in highly regulated environments; keep a mapping table from digest → human-readable tag for operations.
+- Digests — After `docker pull nvcr.io/...:tag`, run `docker inspect --format='{% raw %}{{index .RepoDigests 0}}{% endraw %}' image:tag` (or use crane / skopeo; see tooling below) and record `repository@sha256:...`. Prefer deploying with digests in highly regulated environments; keep a mapping table from digest → human-readable tag for operations.
 
 ## Mirroring images into a private registry
 

--- a/docs/docs/extraction/chunking.md
+++ b/docs/docs/extraction/chunking.md
@@ -108,4 +108,4 @@ If you are building the container yourself and want to pre-download this model, 
 
 - [Use the Python API](nv-ingest-python-api.md)
 - [NeMo Retriever Library V2 API Guide](v2-api-guide.md)
-- [Environment Variables](environment-variables.md)
+- [Environment Variables](environment-config.md)

--- a/docs/docs/extraction/content-metadata.md
+++ b/docs/docs/extraction/content-metadata.md
@@ -164,7 +164,8 @@ Describes the structural location of content within a document.
 | `span`           | `int`                 | `-1`                       | Span identifier within a line, for finer granularity.                                                   |
 | `nearby_objects` | `NearbyObjectsSchema` | `NearbyObjectsSchema()`    | Information about objects (text, images, structured data) near the current content. See [NearbyObjectsSchema](#nearbyobjectsschema). |
 
-### `NearbyObjectsSchema` (Currently Unused) {#nearbyobjectsschema}
+<a id="nearbyobjectsschema"></a>
+### `NearbyObjectsSchema` (Currently Unused)
 Container for different types of nearby objects.
 
 | Field        | Type                   | Default Value                | Description                                                              |
@@ -243,7 +244,8 @@ Specific metadata for audio content.
 | `audio_transcript` | `str` | `""`          | Transcript of the audio content.                |
 | `audio_type`       | `str` | `""`          | Type or format of the audio (e.g., `mp3`, `wav`). |
 
-### `ErrorMetadataSchema` (Currently Unused) {#errormetadataschema}
+<a id="errormetadataschema"></a>
+### `ErrorMetadataSchema` (Currently Unused)
 Metadata describing errors encountered during processing.
 
 | Field       | Type           | Default Value | Description                                                              |
@@ -253,7 +255,8 @@ Metadata describing errors encountered during processing.
 | `source_id` | `str`          | `""`          | Identifier of the source item that caused the error, if applicable.        |
 | `error_msg` | `str`          | *Required*    | The error message.                                                       |
 
-### `InfoMessageMetadataSchema` (Currently Unused) {#infomessagemetadataschema}
+<a id="infomessagemetadataschema"></a>
+### `InfoMessageMetadataSchema` (Currently Unused)
 Informational messages related to processing.
 
 | Field     | Type           | Default Value | Description                                                              |
@@ -374,4 +377,4 @@ For the full file, refer to the [data folder](https://github.com/NVIDIA/nv-inges
 
 ## Related Topics
 
-- [Environment Variables](environment-variables.md)
+- [Environment Variables](environment-config.md)

--- a/docs/docs/extraction/scaling-modes.md
+++ b/docs/docs/extraction/scaling-modes.md
@@ -102,4 +102,4 @@ Open `docker-compose.yaml` and locate:
 
 - [Prerequisites](prerequisites.md)
 - [Support Matrix](support-matrix.md)
-- [Troubleshooting](troubleshooting.md)
+- [Troubleshooting](troubleshoot.md)

--- a/docs/docs/extraction/user-defined-functions.md
+++ b/docs/docs/extraction/user-defined-functions.md
@@ -264,7 +264,7 @@ def enhance_metadata(control_message: IngestControlMessage) -> IngestControlMess
     return control_message
 ```
 
-> **📖 For detailed metadata schema documentation, see:** [metadata_documentation.md](metadata_documentation.md)
+> **📖 For detailed metadata schema documentation, see:** [Metadata reference](content-metadata.md)
 
 ### UDF Targeting
 
@@ -537,7 +537,7 @@ For detailed guidance on creating custom NIM integrations, including:
 - Error handling and debugging
 - Performance best practices
 
-See the comprehensive [**NimClient Usage Guide**](nimclient_usage.md).
+See the comprehensive [**NimClient Usage Guide**](nimclient.md).
 
 ### Error Handling
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -93,7 +93,7 @@ nav:
         - Generate Your NGC Keys: extraction/ngc-api-key.md
         - Environment Variables: extraction/environment-config.md
         - Metadata Reference: extraction/content-metadata.md
-        - API Reference: extraction/api-docs
+        - API Reference: extraction/python-api-reference.md
       - Troubleshoot: extraction/troubleshoot.md
       - FAQ: extraction/faq.md
       - Contribute: extraction/contributing.md


### PR DESCRIPTION
## Summary
Fixes documentation build failures and warnings under `docs/` for the NeMo Retriever Extraction section.
### Changes
- **Navigation** — `mkdocs.yml` referenced `extraction/api-docs`, which does not exist. Point **Reference → API Reference** at `extraction/python-api-reference.md` so the nav matches published pages.
- **mkdocs-macros** — Escape the Docker Go template in `air-gapped-deployment.md` (`{{index .RepoDigests 0}}`) with `{% raw %}…{% endraw %}` so it is not parsed as Jinja.
- **mkdocs-macros** — Replace pymdown-style heading ids `{#…}` with explicit HTML `<a id="…"></a>` anchors in `content-metadata.md` for the three affected headings so they are not treated as Jinja comments.
- **Internal links** — Update targets to files that exist in the repo:
  - `environment-variables.md` → `environment-config.md` (`chunking.md`, `content-metadata.md`)
  - `troubleshooting.md` → `troubleshoot.md` (`scaling-modes.md`)
  - `metadata_documentation.md` → `content-metadata.md` (`user-defined-functions.md`)
  - `nimclient_usage.md` → `nimclient.md` (`user-defined-functions.md`)
### Verification
- `mkdocs build` completes without the previous nav, macro syntax, or missing-doc warnings for these paths..
