### PR TITLE
fix the ray data batch de/serialization lag

### DIFF
--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -361,4 +361,4 @@ class RayDataExecutor(AbstractExecutor):
                 **overrides,
             )
 
-        return ds.materialize()
+        return ds.to_pandas()

--- a/nemo_retriever/src/nemo_retriever/pipeline/__main__.py
+++ b/nemo_retriever/src/nemo_retriever/pipeline/__main__.py
@@ -34,6 +34,7 @@ import time
 from pathlib import Path
 from typing import Any, Optional, TextIO
 
+import pandas as pd
 import typer
 
 from nemo_retriever.audio import asr_params_from_env
@@ -452,10 +453,17 @@ def _build_ingestor(
 def _collect_results(run_mode: str, result: Any) -> tuple[list[dict[str, Any]], Any, float, int]:
     """Materialize the graph result into a list of records + DataFrame.
 
+    Ingest may return a ``pandas.DataFrame`` (in-process or after
+    ``ray.data.Dataset.to_pandas()`` in the executor) or a ``ray.data.Dataset``;
+    normalize via ``.to_pandas()`` when the result is not already a DataFrame.
+
     Returns ``(records, result_df, ray_download_secs, num_input_units)``.
     """
 
-    result_df = result
+    if isinstance(result, pd.DataFrame):
+        result_df = result
+    else:
+        result_df = result.to_pandas()
     records = result_df.to_dict("records")
     ray_download_time = 0.0
 

--- a/nemo_retriever/src/nemo_retriever/pipeline/__main__.py
+++ b/nemo_retriever/src/nemo_retriever/pipeline/__main__.py
@@ -455,17 +455,9 @@ def _collect_results(run_mode: str, result: Any) -> tuple[list[dict[str, Any]], 
     Returns ``(records, result_df, ray_download_secs, num_input_units)``.
     """
 
-    import pandas as pd
-
-    if run_mode == "batch":
-        ray_download_start = time.perf_counter()
-        records = result.take_all()
-        ray_download_time = time.perf_counter() - ray_download_start
-        result_df = pd.DataFrame(records)
-    else:
-        result_df = result
-        records = result_df.to_dict("records")
-        ray_download_time = 0.0
+    result_df = result
+    records = result_df.to_dict("records")
+    ray_download_time = 0.0
 
     return records, result_df, float(ray_download_time), _count_input_units(result_df)
 

--- a/nemo_retriever/tests/test_batch_pipeline.py
+++ b/nemo_retriever/tests/test_batch_pipeline.py
@@ -1,7 +1,8 @@
-import sys
 import json
+import sys
 from types import SimpleNamespace
 
+import pandas as pd
 from typer.testing import CliRunner
 
 import nemo_retriever.examples.graph_pipeline as batch_pipeline
@@ -20,6 +21,9 @@ class _FakeDataset:
 
     def take_all(self):
         return []
+
+    def to_pandas(self) -> pd.DataFrame:
+        return pd.DataFrame(self.take_all())
 
     def groupby(self, _key):
         class _FakeGrouped:

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -863,6 +863,9 @@ class TestRayDataExecutor:
             def materialize(self):
                 return self
 
+            def to_pandas(self):
+                return pd.DataFrame()
+
         captured: dict[str, object] = {}
 
         class _FakeDataContext:
@@ -896,7 +899,7 @@ class TestRayDataExecutor:
         executor = RayDataExecutor(Graph())
         result = executor.ingest([str(tmp_path / "**" / "*.pdf")])
 
-        assert isinstance(result, _FakeDataset)
+        assert isinstance(result, pd.DataFrame)
         assert captured["paths"] == [str(pdf_path)]
         assert captured["include_paths"] is True
 

--- a/nemo_retriever/tests/test_pipeline_helpers.py
+++ b/nemo_retriever/tests/test_pipeline_helpers.py
@@ -11,8 +11,9 @@ pipeline run`` command relies on:
 * ``_build_extract_params``     — translation from CLI flags to ``ExtractParams``
                                   and the nested ``BatchTuningParams``.
 * ``_build_embed_params``       — translation from CLI flags to ``EmbedParams``.
-* ``_collect_results``          — Ray ``take_all`` vs. in-process DataFrame
-                                  handling + ``_count_input_units`` fallback.
+* ``_collect_results``          — materialize ingest output (a pandas
+                                  DataFrame, after ``Dataset.to_pandas()`` in
+                                  the graph executor) + ``_count_input_units`` fallback.
 * ``_ensure_lancedb_table``     — idempotent LanceDB table creation.
 
 They also exercise the lazy attribute access in
@@ -23,7 +24,6 @@ exports stay wired to ``__main__``.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import pandas as pd
 import pyarrow as pa
@@ -478,44 +478,32 @@ class TestBuildEmbedParams:
 # =============================================================================
 
 
-class _FakeRayDataset:
-    """Minimal stand-in for a Ray Data dataset produced by ``ingestor.ingest()``."""
-
-    def __init__(self, records: list[dict[str, Any]]) -> None:
-        self._records = records
-        self.take_all_calls = 0
-
-    def take_all(self) -> list[dict[str, Any]]:
-        self.take_all_calls += 1
-        return list(self._records)
-
-
 class TestCollectResults:
-    """Ray (batch) and pandas (inprocess) result materialization."""
+    """Ingest returns a DataFrame (``ingestor.ingest()`` → ``ds.to_pandas()``); _collect_results consumes it."""
 
-    def test_batch_mode_calls_take_all_and_builds_dataframe(self):
+    def test_batch_mode_accepts_ingest_dataframe(self):
         rows = [
             {"source_id": "a", "text": "hello"},
             {"source_id": "a", "text": "world"},
             {"source_id": "b", "text": "!"},
         ]
-        fake = _FakeRayDataset(rows)
+        # Same shape as the graph executor return after ``Dataset.to_pandas()``.
+        result_df = pd.DataFrame(rows)
 
-        records, df, download_time, num_units = _collect_results("batch", fake)
+        records, df, download_time, num_units = _collect_results("batch", result_df)
 
-        assert fake.take_all_calls == 1
         assert records == rows
+        assert df is result_df
         assert isinstance(df, pd.DataFrame)
         assert list(df.columns) == ["source_id", "text"]
         assert len(df) == 3
         # ``source_id`` has two distinct values → that is the unit count.
         assert num_units == 2
-        # Elapsed time is measured with ``perf_counter``; it must be non-negative.
         assert download_time >= 0.0
 
     def test_batch_mode_handles_empty_result(self):
-        fake = _FakeRayDataset([])
-        records, df, download_time, num_units = _collect_results("batch", fake)
+        result_df = pd.DataFrame()
+        records, df, download_time, num_units = _collect_results("batch", result_df)
         assert records == []
         assert df.empty
         # Empty DataFrame has no columns → falls through to len(df.index) == 0.


### PR DESCRIPTION
## Description
So, we were seeing a discrepancy when running ray data. Where the graph would finish execution, we would wait a noticeable amount of time while the data was collated. This PR removes that wait time and makes it so the data is returned instantaneously.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
