### PR TITLE
Serialize LanceDB metadata column as JSON instead of str

### DIFF
--- a/nemo_retriever/src/nemo_retriever/vector_store/lancedb_store.py
+++ b/nemo_retriever/src/nemo_retriever/vector_store/lancedb_store.py
@@ -178,7 +178,7 @@ def _build_lancedb_rows_from_df(rows: List[Dict[str, Any]]) -> List[Dict[str, An
                 "source_id": source_id,
                 "path": path,
                 "text": row.get("text", ""),
-                "metadata": str(meta),
+                "metadata": json.dumps(meta, default=str),
                 "stored_image_uri": str(stored_uri) if stored_uri else "",
                 "content_type": str(row.get("_content_type") or ""),
                 "bbox_xyxy_norm": json.dumps(row.get("_bbox_xyxy_norm")) if row.get("_bbox_xyxy_norm") else "",

--- a/nemo_retriever/src/nemo_retriever/vector_store/lancedb_store.py
+++ b/nemo_retriever/src/nemo_retriever/vector_store/lancedb_store.py
@@ -178,7 +178,7 @@ def _build_lancedb_rows_from_df(rows: List[Dict[str, Any]]) -> List[Dict[str, An
                 "source_id": source_id,
                 "path": path,
                 "text": row.get("text", ""),
-                "metadata": json.dumps(meta, default=str),
+                "metadata": json.dumps(meta, default=str, ensure_ascii=False),
                 "stored_image_uri": str(stored_uri) if stored_uri else "",
                 "content_type": str(row.get("_content_type") or ""),
                 "bbox_xyxy_norm": json.dumps(row.get("_bbox_xyxy_norm")) if row.get("_bbox_xyxy_norm") else "",


### PR DESCRIPTION
_build_lancedb_rows_from_df was writing metadata via str(dict), which produces a Python repr (single-quoted) that consumers cannot json.loads. lancedb_utils already uses json.dumps for the same column, so this brings the two writers in sync and lets downstream code parse the metadata directly. default=str keeps the call safe for non-JSON-native values (datetimes, UUIDs, numpy scalars).

Made-with: Cursor

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nv-ingest/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
