### PR TITLE
NVIDIA_API_KEY (build.nvidia.com), Helm-focused NGC auth, and README links

### DIFF
--- a/docs/docs/extraction/api-keys.md
+++ b/docs/docs/extraction/api-keys.md
@@ -1,7 +1,35 @@
-# Generate Your NGC Keys
+# Authentication and API keys
 
-NGC contains many public images, models, and datasets that can be pulled immediately without authentication. 
-To push and pull custom images, you must generate a key and authenticate with NGC.
+NeMo Retriever uses different credentials depending on what you are doing:
+
+- **`NVIDIA_API_KEY`** — Authorizes HTTP calls to [NVIDIA-hosted NIMs](https://build.nvidia.com/) (for example `ai.api.nvidia.com` and `integrate.api.nvidia.com`). Obtain this key from [build.nvidia.com](https://build.nvidia.com/). Keys typically start with `nvapi-`.
+- **NGC personal key** — Used when you install the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/helm/README.md) so the cluster can authenticate to NGC Helm repos, pull images from `nvcr.io`, and provide `NGC_API_KEY` to in-cluster NIM workloads.
+
+You may need one or both, for example if you deploy with Helm from NGC and also call hosted inference APIs.
+
+## NVIDIA API key (`NVIDIA_API_KEY`) {#nvidia-api-key}
+
+Use this key when you run [library mode](quickstart-library-mode.md), remote NIM URLs, or any workflow that calls NVIDIA-hosted inference without supplying a separate per-service secret.
+
+1. Sign in at [build.nvidia.com](https://build.nvidia.com/) with your NVIDIA developer account.
+2. Open [API keys](https://build.nvidia.com/settings/api-keys) (profile menu → **Settings** → **API keys**, or use that link after you are signed in).
+3. Create a key, copy it when it is shown (you may not be able to read the full secret again later), and set it in your environment:
+
+```bash
+export NVIDIA_API_KEY="nvapi-..."
+```
+
+On Windows PowerShell you can use `$env:NVIDIA_API_KEY = "nvapi-..."`.
+
+For a full list of related variables, see [Environment configuration variables](environment-config.md).
+
+!!! note
+
+    The `NVIDIA_API_KEY` from build.nvidia.com is not the same string as your NGC personal key used for Helm and `nvcr.io` access. Do not substitute one for the other unless your tooling explicitly documents that mapping.
+
+## NGC personal key (Helm and `nvcr.io`)
+
+Many public assets on NGC can be used without authentication. For a Kubernetes deployment, the cluster must still pull NIM and microservice images from `nvcr.io` and may need NGC API access; the Helm chart expects credentials derived from an NGC personal key.
 
 To create a key, go to [https://org.ngc.nvidia.com/setup/api-keys](https://org.ngc.nvidia.com/setup/api-keys).
 
@@ -17,15 +45,6 @@ When you create an NGC key, select the following for **Services Included**.
 ![Generate Personal Key](images/generate_personal_key.png)
 
 
-## Docker Login to NGC
+## Using your NGC key with Helm
 
-To pull the NIM container image from NGC, use your key to log in to the NGC registry by entering the following command and then following the prompts. 
-For the username, enter `$oauthtoken` exactly as shown. 
-It is a special authentication key for all users.
-
-
-```shell
-$ docker login nvcr.io
-Username: $oauthtoken
-Password: <Your Key>
-```
+Configure your key through the chart values and flags described in the [NeMo Retriever Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/helm/README.md): for example `ngcImagePullSecret` and `ngcApiSecret` on `helm upgrade --install`, Helm repo authentication with username `$oauthtoken` and your key as the password, or equivalent pre-created Kubernetes `Secret` resources if your organization manages credentials outside the chart.

--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -42,11 +42,13 @@ Use the following procedure to run the NIM on your own infrastructure. Self-host
 
 1. Create [your NGC personal key](api-keys.md) with the scopes required for `nvcr.io` image pulls and NGC API access. Configure it for the cluster using the [NeMo Retriever Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/helm/README.md) (for example `ngcImagePullSecret` / `ngcApiSecret` on `helm upgrade --install`, or pre-created secrets with username `$oauthtoken`).
 
-2. For convenience when using clients or scripts that read credentials from disk, store [your NGC key](api-keys.md) in an environment variable file (`.env`). Create a `.env` file in your working directory and add the following line. Replace `<your-ngc-key>` with your actual NGC key.
+2. **Optional — local tooling only.** Helm-managed pods get NGC credentials from chart secrets (step 1), not from a file on your laptop. If you also run **Python clients, CLIs, or other scripts on your machine** (outside the cluster) that load `NGC_API_KEY` from disk, create a `.env` in that working directory:
 
     ```ini
     NGC_API_KEY=<your-ngc-key>
     ```
+
+    Skip this step if you only operate the cluster through Helm and do not run such local processes.
 
 3. Deploy or upgrade NeMo Retriever Library with the Helm chart and enable the ASR / audio components your release requires (Parakeet and related services). Follow [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/helm/README.md) and [Deployment options](deployment-options.md). Ensure the chart values for your cluster request the ASR NIM.
 

--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -40,18 +40,9 @@ Use the following procedure to run the NIM on your own infrastructure. Self-host
 
     The parakeet-1-1b-ctc-en-us ASR NIM microservice must run on a [dedicated additional GPU](support-matrix.md). Pin the workload to that GPU with your Helm values or the [NIM Operator](https://docs.nvidia.com/nim-operator/latest/index.html) (for example, node selectors, resource limits, or device requests appropriate to your cluster).
 
-1. To access the required container images, log in to the NVIDIA Container Registry (nvcr.io). Use [your NGC key](api-keys.md) as the password. Run the following command in your terminal.
+1. Create [your NGC personal key](api-keys.md) with the scopes required for `nvcr.io` image pulls and NGC API access. Configure it for the cluster using the [NeMo Retriever Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/helm/README.md) (for example `ngcImagePullSecret` / `ngcApiSecret` on `helm upgrade --install`, or pre-created secrets with username `$oauthtoken`).
 
-    - Replace `<your-ngc-key>` with your actual NGC API key.
-    - The username is always `$oauthtoken`.
-
-    ```shell
-    $ docker login nvcr.io
-    Username: $oauthtoken
-    Password: <your-ngc-key>
-    ```
-
-2. For convenience and security, store [your NGC key](api-keys.md) in an environment variable file (`.env`). This enables services to access it without needing to enter the key manually each time. Create a .env file in your working directory and add the following line. Replace `<your-ngc-key>` with your actual NGC key.
+2. For convenience when using clients or scripts that read credentials from disk, store [your NGC key](api-keys.md) in an environment variable file (`.env`). Create a `.env` file in your working directory and add the following line. Replace `<your-ngc-key>` with your actual NGC key.
 
     ```ini
     NGC_API_KEY=<your-ngc-key>

--- a/docs/docs/extraction/environment-config.md
+++ b/docs/docs/extraction/environment-config.md
@@ -11,7 +11,7 @@ You can specify these in a .env file in your working directory or directly as sh
 | `HF_ACCESS_TOKEN`                | -                                                         | A token to access HuggingFace models. For details, refer to [Token-Based Splitting](chunking.md#token-based-splitting). |
 | `INGEST_LOG_LEVEL`               | - `DEBUG` <br/> - `INFO` <br/> - `WARNING` <br/> - `ERROR` <br/> - `CRITICAL` <br/> | The log level for the ingest service, which controls the verbosity of the logging output. |
 | `NVIDIA_API_KEY`                    | `nvapi-*************` <br/>                              | An authorized build.nvidia.com API key, used to interact with nvidia hosted NIMs. Create via build.nvidia.com or via [NGC](https://org.ngc.nvidia.com/setup/api-keys). |
-| `NGC_API_KEY`                | —                                                          | The key that NIM microservices inside docker containers use to access NGC resources. |
+| `NGC_API_KEY`                | —                                                          | The key that NIM microservices in the cluster use to access NGC resources. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT`    | `http://otel-collector:4317` <br/>                       | The endpoint for the OpenTelemetry exporter, used for sending telemetry data. |
 
 

--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -43,7 +43,7 @@ For more information, refer to [Nemotron Parse](https://build.nvidia.com/nvidia/
 ### Self-Hosted Deployments
 
 For [self-hosted deployments](deployment-options.md#when-to-self-host-nims), you should set the environment variables `NGC_API_KEY` and `NIM_NGC_API_KEY`.
-For more information, refer to [Generate Your NGC Keys](api-keys.md).
+For more information, refer to [Authentication and API keys](api-keys.md).
 
 For advanced scenarios, you might want to set environment variables for NIM container paths, tags, and batch sizes on the ingestion runtime. Configure them in your Helm values, Kubernetes `Secret`/`ConfigMap`, or follow [Environment variables](environment-config.md).
 

--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -29,7 +29,7 @@ b. Change the directory to the cloned repo by running the following code.
 
 c. [Generate API keys](api-keys.md) for your deployment: create an NGC personal key with the scopes listed there, then supply it to the cluster through the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/helm/README.md) (`helm upgrade` flags such as `ngcImagePullSecret` / `ngcApiSecret`, Helm repo login with username `$oauthtoken`, or your organization’s equivalent secrets).
 
-d. Create a .env file that contains your NVIDIA Build API key.
+d. If tools on this machine read keys from a `.env` file, add the NGC-scoped variables below (see note — not the same as `NVIDIA_API_KEY` for build.nvidia.com).
 
     !!! note
 

--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -27,20 +27,13 @@ b. Change the directory to the cloned repo by running the following code.
    
     `cd NeMo-Retriever`.
 
-c. [Generate API keys](api-keys.md) and authenticate with NGC with the `docker login` command.
+c. [Generate API keys](api-keys.md) for your deployment: create an NGC personal key with the scopes listed there, then supply it to the cluster through the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/helm/README.md) (`helm upgrade` flags such as `ngcImagePullSecret` / `ngcApiSecret`, Helm repo login with username `$oauthtoken`, or your organization’s equivalent secrets).
 
-    ```shell
-    # This is required to access pre-built containers and NIM microservices
-    $ docker login nvcr.io
-    Username: $oauthtoken
-    Password: <Your Key>
-    ```
-   
 d. Create a .env file that contains your NVIDIA Build API key.
 
     !!! note
 
-        If you use an NGC personal key, then you should provide the same value for all keys, but you must specify each environment variable individually. In the past, you could create an API key. If you have an API key, you can still use that. For more information, refer to [Generate Your NGC Keys](api-keys.md) and [Environment Configuration Variables](environment-config.md).
+        If you use an NGC personal key, then you should provide the same value for all keys, but you must specify each environment variable individually. In the past, you could create an API key. If you have an API key, you can still use that. For more information, refer to [Authentication and API keys](api-keys.md) and [Environment Configuration Variables](environment-config.md).
 
     ```
     # Container images must access resources from NGC.

--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -33,7 +33,7 @@ d. Create a .env file that contains your NVIDIA Build API key.
 
     !!! note
 
-        If you use an NGC personal key, then you should provide the same value for all keys, but you must specify each environment variable individually. In the past, you could create an API key. If you have an API key, you can still use that. For more information, refer to [Authentication and API keys](api-keys.md) and [Environment Configuration Variables](environment-config.md).
+        If you use an NGC personal key for cluster access, supply the same NGC personal key value for each of the NGC-scoped variables listed below (`NGC_API_KEY`, `NIM_NGC_API_KEY`), specifying each variable individually. The `NVIDIA_API_KEY` for hosted build.nvidia.com inference is a separate credential — see [Authentication and API keys](api-keys.md). If you have a legacy NGC API key, you can still use it for the NGC-scoped variables. Refer to [Environment variables](environment-config.md) for details.
 
     ```
     # Container images must access resources from NGC.

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -31,7 +31,7 @@ This error occurs when the maximum number of processes available to a single use
 To resolve the issue, set or raise the maximum number of processes (`-u`) by using the [ulimit](https://ss64.com/bash/ulimit.html) command.
 Before you change the `-u` setting, consider the following:
 
-- Apply the `-u` setting directly to the user (or the Docker container environment) that runs your ingest service.
+- Apply the `-u` setting directly to the user (or the environment of the pod or process) that runs your ingest service.
 - For `-u` we recommend 10,000 as a baseline, but you might need to raise or lower it based on your actual usage and system configuration.
 
 ```bash
@@ -80,7 +80,7 @@ This error occurs when the open file descriptor limit for your service user acco
 To resolve the issue, set or raise the maximum number of open file descriptors (`-n`) by using the [ulimit](https://ss64.com/bash/ulimit.html) command.
 Before you change the `-n` setting, consider the following:
 
-- Apply the `-n` setting directly to the user (or the Docker container environment) that runs your ingest service.
+- Apply the `-n` setting directly to the user (or the environment of the pod or process) that runs your ingest service.
 - For `-n` we recommend 10,000 as a baseline, but you might need to raise or lower it based on your actual usage and system configuration.
 
 ```bash

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -141,7 +141,7 @@ constructor used in [Run a recall query](#run-a-recall-query) below. With the
 and embedding. For a realistic retrieval corpus, see
 [QA evaluation -- Step 1](./src/nemo_retriever/evaluation/README.md#step-1-ingest-and-embed-pdfs-nemo-retriever).
 
-**No local GPU?** Set `NVIDIA_API_KEY` and route extraction and embedding
+**No local GPU?** Set [`NVIDIA_API_KEY`](https://nvidia.github.io/NeMo-Retriever/extraction/api-keys/#nvidia-api-key) (see [Authentication and API keys](https://nvidia.github.io/NeMo-Retriever/extraction/api-keys/)) and route extraction and embedding
 through [build.nvidia.com](https://build.nvidia.com/) NIMs instead:
 
 ```bash
@@ -479,7 +479,7 @@ ingestor = ingestor.files(documents).extract(method="nemotron_parse")
 
 ## Run with remote inference, no local GPU required:
 
-For build.nvidia.com hosted inference, make sure you have NVIDIA_API_KEY set as an environment variable. 
+For build.nvidia.com hosted inference, set [`NVIDIA_API_KEY`](https://nvidia.github.io/NeMo-Retriever/extraction/api-keys/#nvidia-api-key) as an environment variable (see [Authentication and API keys](https://nvidia.github.io/NeMo-Retriever/extraction/api-keys/)). 
 
 ```python
 ingestor = (


### PR DESCRIPTION
## Summary

- Expands [Authentication and API keys](docs/docs/extraction/api-keys.md) so it covers both **`NVIDIA_API_KEY`** from [build.nvidia.com](https://build.nvidia.com/) (including [API keys](https://build.nvidia.com/settings/api-keys)) and the **NGC personal key** used with Kubernetes / Helm.
- Removes **`docker login nvcr.io`** from the extraction docs path in favor of configuring credentials via the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/helm/README.md) (`ngcImagePullSecret`, `ngcApiSecret`, Helm repo auth with `$oauthtoken`, etc.).
- Adds stable anchor `{#nvidia-api-key}` for deep links.
- Updates the [NeMo Retriever Library README](nemo_retriever/README.md) so remote-inference quickstart sections link to the published API keys page.
- 
## Files touched

| Area | Change |
|------|--------|
| `docs/docs/extraction/api-keys.md` | Restructure: hosted API key + NGC for Helm; drop Docker registry login section |
| `docs/docs/extraction/quickstart-guide.md` | Helm quickstart step (c): API keys + chart instead of `docker login` |
| `docs/docs/extraction/audio-video.md` | Local Helm flow: NGC key + chart instead of `docker login` |
| `docs/docs/extraction/faq.md` | Link text → “Authentication and API keys” |
| `docs/docs/extraction/environment-config.md` | Clarify NGC key applies to in-cluster NIMs (no “docker containers” wording) |
| `docs/docs/extraction/troubleshoot.md` | “Pod or process” instead of Docker container environment |
| `nemo_retriever/README.md` | Links to GitHub Pages API keys doc for `NVIDIA_API_KEY` |
