### PR TITLE
Fix variable-length vectors crashing LanceDB upload

### DIFF
--- a/client/client_tests/util/test_lancedb_util.py
+++ b/client/client_tests/util/test_lancedb_util.py
@@ -50,7 +50,7 @@ def make_sample_results():
 def test_create_lancedb_results_filters_and_transforms():
     """Test that create_lancedb_results correctly filters and transforms records."""
     results = make_sample_results()
-    out = lancedb_mod.create_lancedb_results(results, expected_dim=2)
+    out, _counts = lancedb_mod.create_lancedb_results(results, expected_dim=2)
     assert isinstance(out, list)
     assert len(out) == 2
     assert out[0]["vector"] == [0.1, 0.2]
@@ -140,7 +140,7 @@ def test_init_default_uri_and_overwrite():
 def test_create_lancedb_results_empty_list():
     """Test create_lancedb_results with empty input."""
     results = []
-    out = lancedb_mod.create_lancedb_results(results)
+    out, _counts = lancedb_mod.create_lancedb_results(results)
     assert out == []
 
 
@@ -159,7 +159,7 @@ def test_create_lancedb_results_all_none_embeddings():
             },
         ]
     ]
-    out = lancedb_mod.create_lancedb_results(results, expected_dim=1)
+    out, _counts = lancedb_mod.create_lancedb_results(results, expected_dim=1)
     assert out == []
 
 
@@ -196,7 +196,7 @@ def test_create_lancedb_results_mixed_embeddings():
             },
         ]
     ]
-    out = lancedb_mod.create_lancedb_results(results, expected_dim=2)
+    out, _counts = lancedb_mod.create_lancedb_results(results, expected_dim=2)
     assert len(out) == 2
     assert out[0]["text"] == "keep"
     assert out[1]["text"] == "keep2"
@@ -366,7 +366,7 @@ def test_create_lancedb_results_missing_content_metadata_graceful():
             }
         ]
     ]
-    out = lancedb_mod.create_lancedb_results(results, expected_dim=1)
+    out, _counts = lancedb_mod.create_lancedb_results(results, expected_dim=1)
     assert len(out) == 1
     assert out[0]["metadata"] == "{}"
     assert out[0]["text"] == "text with missing content_metadata"
@@ -524,8 +524,8 @@ def test_create_lancedb_results_drops_variable_length_vectors(caplog):
         ]
     ]
 
-    with caplog.at_level(logging.WARNING, logger=lancedb_mod.logger.name):
-        out = lancedb_mod.create_lancedb_results(results, expected_dim=expected_dim)
+    with caplog.at_level(logging.WARNING, logger="nv_ingest_client.util.vdb.lancedb"):
+        out, _counts = lancedb_mod.create_lancedb_results(results, expected_dim=expected_dim)
 
     assert [row["text"] for row in out] == ["good_a", "good_b"]
     summary_records = [
@@ -547,7 +547,7 @@ def test_create_lancedb_results_respects_expected_dim():
             _embedding_record([0.0] * 256, page=2, content="dim_256_should_drop"),
         ]
     ]
-    out = lancedb_mod.create_lancedb_results(results, expected_dim=128)
+    out, _counts = lancedb_mod.create_lancedb_results(results, expected_dim=128)
     assert len(out) == 1
     assert out[0]["text"] == "dim_128"
     assert len(out[0]["vector"]) == 128
@@ -634,3 +634,110 @@ def test_create_index_uses_configured_vector_dim_in_schema(monkeypatch):
     ldb.create_index(records=[])
 
     assert 512 in captured_dims
+
+
+def test_create_lancedb_results_skips_length_check_when_expected_dim_none():
+    """``expected_dim=None`` disables the length check; mixed-length rows all pass through.
+
+    Defers length policy entirely to the writer side (LanceDB's
+    ``on_bad_vectors``), which is required for ``on_bad_vectors="error"`` to
+    actually surface a LanceDB error instead of silently dropping rows here.
+    """
+    results = [
+        [
+            _embedding_record([0.1, 0.2, 0.3, 0.4], page=1, content="dim_4"),
+            _embedding_record([0.1, 0.2], page=2, content="dim_2"),
+            _embedding_record([], page=3, content="dim_0"),
+            _embedding_record(None, page=4, content="none_still_dropped"),
+        ]
+    ]
+
+    out, counts = lancedb_mod.create_lancedb_results(results, expected_dim=None)
+
+    assert [row["text"] for row in out] == ["dim_4", "dim_2", "dim_0"]
+    assert counts["accepted"] == 3
+    assert counts["dropped_bad_length"] == 0
+    assert counts["dropped_no_embedding"] == 1
+    assert counts["dropped_no_text"] == 0
+
+
+def test_create_index_skips_row_builder_filter_when_on_bad_vectors_error(monkeypatch):
+    """``on_bad_vectors="error"`` must forward ``expected_dim=None`` so LanceDB itself raises.
+
+    Otherwise the row-builder filter would silently drop the bad row before
+    LanceDB ever sees it, contradicting the documented strict-fail semantics
+    of the ``"error"`` policy.
+    """
+    fake_db = Mock()
+    fake_table = Mock()
+    fake_db.create_table = Mock(return_value=fake_table)
+
+    monkeypatch.setattr(lancedb_mod, "lancedb", Mock(connect=Mock(return_value=fake_db)))
+    monkeypatch.setattr(lancedb_mod, "pa", Mock(schema=Mock(return_value="schema")))
+
+    captured_kwargs: dict = {}
+
+    real_create_lancedb_results = lancedb_mod.create_lancedb_results
+
+    def spy(records, **kwargs):
+        captured_kwargs.update(kwargs)
+        return real_create_lancedb_results(records, **kwargs)
+
+    monkeypatch.setattr(lancedb_mod, "create_lancedb_results", spy)
+
+    results = [
+        [
+            _embedding_record([0.1, 0.2, 0.3, 0.4], page=1, content="ok"),
+            _embedding_record([0.1, 0.2], page=2, content="bad_length"),
+        ]
+    ]
+
+    ldb = lancedb_mod.LanceDB(vector_dim=4, on_bad_vectors="error")
+    ldb.create_index(records=results)
+
+    assert captured_kwargs.get("expected_dim") is None
+    forwarded_data = fake_db.create_table.call_args.kwargs["data"]
+    assert [row["text"] for row in forwarded_data] == ["ok", "bad_length"]
+    assert fake_db.create_table.call_args.kwargs["on_bad_vectors"] == "error"
+
+
+def test_create_index_records_drop_counts_via_record_timing(monkeypatch):
+    """Drop counts ride along on the existing ``_record_timing`` sidecar for ``lancedb.create_table``.
+
+    Surfaces accepted/dropped tallies as first-class telemetry without
+    introducing a new metrics dependency.
+    """
+    fake_db = Mock()
+    fake_table = Mock()
+    fake_db.create_table = Mock(return_value=fake_table)
+
+    monkeypatch.setattr(lancedb_mod, "lancedb", Mock(connect=Mock(return_value=fake_db)))
+    monkeypatch.setattr(lancedb_mod, "pa", Mock(schema=Mock(return_value="schema")))
+
+    timings: list[tuple[str, dict]] = []
+
+    def fake_record_timing(name, _duration, extra=None):
+        timings.append((name, dict(extra) if extra else {}))
+
+    monkeypatch.setattr(lancedb_mod, "_record_timing", fake_record_timing)
+
+    results = [
+        [
+            _embedding_record([0.1, 0.2, 0.3, 0.4], page=1, content="ok_a"),
+            _embedding_record([0.1, 0.2], page=2, content="bad_length"),
+            _embedding_record(None, page=3, content="no_embedding"),
+            _embedding_record([0.5, 0.6, 0.7, 0.8], page=4, content="ok_b"),
+        ]
+    ]
+
+    ldb = lancedb_mod.LanceDB(vector_dim=4)
+    ldb.create_index(records=results)
+
+    create_table_events = [extra for name, extra in timings if name == "lancedb.create_table"]
+    assert len(create_table_events) == 1
+    extra = create_table_events[0]
+    assert extra["rows"] == 2
+    assert extra["accepted"] == 2
+    assert extra["dropped_bad_length"] == 1
+    assert extra["dropped_no_embedding"] == 1
+    assert extra["dropped_no_text"] == 0

--- a/client/client_tests/util/test_lancedb_util.py
+++ b/client/client_tests/util/test_lancedb_util.py
@@ -48,9 +48,9 @@ def make_sample_results():
 
 
 def test_create_lancedb_results_filters_and_transforms():
-    """Test that create_lancedb_results correctly filters and transforms records."""
+    """Test that _create_lancedb_results correctly filters and transforms records."""
     results = make_sample_results()
-    out, _counts = lancedb_mod.create_lancedb_results(results, expected_dim=2)
+    out, _counts = lancedb_mod._create_lancedb_results(results, expected_dim=2)
     assert isinstance(out, list)
     assert len(out) == 2
     assert out[0]["vector"] == [0.1, 0.2]
@@ -138,14 +138,14 @@ def test_init_default_uri_and_overwrite():
 
 
 def test_create_lancedb_results_empty_list():
-    """Test create_lancedb_results with empty input."""
+    """Test _create_lancedb_results with empty input."""
     results = []
-    out, _counts = lancedb_mod.create_lancedb_results(results)
+    out, _counts = lancedb_mod._create_lancedb_results(results)
     assert out == []
 
 
 def test_create_lancedb_results_all_none_embeddings():
-    """Test create_lancedb_results when all embeddings are None."""
+    """Test _create_lancedb_results when all embeddings are None."""
     results = [
         [
             {
@@ -159,12 +159,12 @@ def test_create_lancedb_results_all_none_embeddings():
             },
         ]
     ]
-    out, _counts = lancedb_mod.create_lancedb_results(results, expected_dim=1)
+    out, _counts = lancedb_mod._create_lancedb_results(results, expected_dim=1)
     assert out == []
 
 
 def test_create_lancedb_results_mixed_embeddings():
-    """Test create_lancedb_results retains only rows whose embedding length matches expected_dim."""
+    """Test _create_lancedb_results retains only rows whose embedding length matches expected_dim."""
     results = [
         [
             {
@@ -196,7 +196,7 @@ def test_create_lancedb_results_mixed_embeddings():
             },
         ]
     ]
-    out, _counts = lancedb_mod.create_lancedb_results(results, expected_dim=2)
+    out, _counts = lancedb_mod._create_lancedb_results(results, expected_dim=2)
     assert len(out) == 2
     assert out[0]["text"] == "keep"
     assert out[1]["text"] == "keep2"
@@ -366,7 +366,7 @@ def test_create_lancedb_results_missing_content_metadata_graceful():
             }
         ]
     ]
-    out, _counts = lancedb_mod.create_lancedb_results(results, expected_dim=1)
+    out, _counts = lancedb_mod._create_lancedb_results(results, expected_dim=1)
     assert len(out) == 1
     assert out[0]["metadata"] == "{}"
     assert out[0]["text"] == "text with missing content_metadata"
@@ -525,11 +525,11 @@ def test_create_lancedb_results_drops_variable_length_vectors(caplog):
     ]
 
     with caplog.at_level(logging.WARNING, logger="nv_ingest_client.util.vdb.lancedb"):
-        out, _counts = lancedb_mod.create_lancedb_results(results, expected_dim=expected_dim)
+        out, _counts = lancedb_mod._create_lancedb_results(results, expected_dim=expected_dim)
 
     assert [row["text"] for row in out] == ["good_a", "good_b"]
     summary_records = [
-        r for r in caplog.records if r.levelno == logging.WARNING and "create_lancedb_results" in r.getMessage()
+        r for r in caplog.records if r.levelno == logging.WARNING and "_create_lancedb_results" in r.getMessage()
     ]
     assert len(summary_records) == 1
     summary = summary_records[0].getMessage()
@@ -540,14 +540,14 @@ def test_create_lancedb_results_drops_variable_length_vectors(caplog):
 
 
 def test_create_lancedb_results_respects_expected_dim():
-    """create_lancedb_results filters strictly by the caller-specified expected_dim."""
+    """_create_lancedb_results filters strictly by the caller-specified expected_dim."""
     results = [
         [
             _embedding_record([0.0] * 128, page=1, content="dim_128"),
             _embedding_record([0.0] * 256, page=2, content="dim_256_should_drop"),
         ]
     ]
-    out, _counts = lancedb_mod.create_lancedb_results(results, expected_dim=128)
+    out, _counts = lancedb_mod._create_lancedb_results(results, expected_dim=128)
     assert len(out) == 1
     assert out[0]["text"] == "dim_128"
     assert len(out[0]["vector"]) == 128
@@ -652,7 +652,7 @@ def test_create_lancedb_results_skips_length_check_when_expected_dim_none():
         ]
     ]
 
-    out, counts = lancedb_mod.create_lancedb_results(results, expected_dim=None)
+    out, counts = lancedb_mod._create_lancedb_results(results, expected_dim=None)
 
     assert [row["text"] for row in out] == ["dim_4", "dim_2", "dim_0"]
     assert counts["accepted"] == 3
@@ -677,13 +677,13 @@ def test_create_index_skips_row_builder_filter_when_on_bad_vectors_error(monkeyp
 
     captured_kwargs: dict = {}
 
-    real_create_lancedb_results = lancedb_mod.create_lancedb_results
+    real_create_lancedb_results = lancedb_mod._create_lancedb_results
 
     def spy(records, **kwargs):
         captured_kwargs.update(kwargs)
         return real_create_lancedb_results(records, **kwargs)
 
-    monkeypatch.setattr(lancedb_mod, "create_lancedb_results", spy)
+    monkeypatch.setattr(lancedb_mod, "_create_lancedb_results", spy)
 
     results = [
         [

--- a/client/client_tests/util/test_lancedb_util.py
+++ b/client/client_tests/util/test_lancedb_util.py
@@ -1,3 +1,4 @@
+import logging
 import types
 from unittest.mock import Mock
 
@@ -49,7 +50,7 @@ def make_sample_results():
 def test_create_lancedb_results_filters_and_transforms():
     """Test that create_lancedb_results correctly filters and transforms records."""
     results = make_sample_results()
-    out = lancedb_mod.create_lancedb_results(results)
+    out = lancedb_mod.create_lancedb_results(results, expected_dim=2)
     assert isinstance(out, list)
     assert len(out) == 2
     assert out[0]["vector"] == [0.1, 0.2]
@@ -67,7 +68,7 @@ def test_create_index_uses_lancedb_and_pa_schema(monkeypatch):
     monkeypatch.setattr(lancedb_mod, "pa", Mock(schema=Mock(return_value="schema")))
 
     sample = make_sample_results()
-    table = lancedb_mod.LanceDB().create_index(records=sample)
+    table = lancedb_mod.LanceDB(vector_dim=2).create_index(records=sample)
 
     fake_db.create_table.assert_called()
     assert table is fake_table
@@ -158,18 +159,18 @@ def test_create_lancedb_results_all_none_embeddings():
             },
         ]
     ]
-    out = lancedb_mod.create_lancedb_results(results)
+    out = lancedb_mod.create_lancedb_results(results, expected_dim=1)
     assert out == []
 
 
 def test_create_lancedb_results_mixed_embeddings():
-    """Test create_lancedb_results with mixed None and valid embeddings."""
+    """Test create_lancedb_results retains only rows whose embedding length matches expected_dim."""
     results = [
         [
             {
                 "document_type": "text",
                 "metadata": {
-                    "embedding": [0.1],
+                    "embedding": [0.1, 0.2],
                     "content": "keep",
                     "content_metadata": {"page_number": 1},
                     "source_metadata": {"source_id": "s1"},
@@ -179,7 +180,7 @@ def test_create_lancedb_results_mixed_embeddings():
                 "document_type": "text",
                 "metadata": {
                     "embedding": None,
-                    "content": "skip",
+                    "content": "skip-no-embedding",
                     "content_metadata": {"page_number": 2},
                     "source_metadata": {"source_id": "s1"},
                 },
@@ -187,7 +188,7 @@ def test_create_lancedb_results_mixed_embeddings():
             {
                 "document_type": "text",
                 "metadata": {
-                    "embedding": [0.2, 0.3],
+                    "embedding": [0.3, 0.4],
                     "content": "keep2",
                     "content_metadata": {"page_number": 3},
                     "source_metadata": {"source_id": "s2"},
@@ -195,7 +196,7 @@ def test_create_lancedb_results_mixed_embeddings():
             },
         ]
     ]
-    out = lancedb_mod.create_lancedb_results(results)
+    out = lancedb_mod.create_lancedb_results(results, expected_dim=2)
     assert len(out) == 2
     assert out[0]["text"] == "keep"
     assert out[1]["text"] == "keep2"
@@ -210,11 +211,10 @@ def test_create_index_uses_uri_from_instance(monkeypatch):
     monkeypatch.setattr(lancedb_mod, "lancedb", Mock(connect=Mock(return_value=fake_db)))
     monkeypatch.setattr(lancedb_mod, "pa", Mock(schema=Mock(return_value="schema")))
 
-    ldb = lancedb_mod.LanceDB(uri="my_custom_uri")
+    ldb = lancedb_mod.LanceDB(uri="my_custom_uri", vector_dim=2)
     sample = make_sample_results()
     ldb.create_index(records=sample)
 
-    # Verify lancedb.connect was called with the custom uri
     lancedb_mod.lancedb.connect.assert_called_once_with(uri="my_custom_uri")
 
 
@@ -227,11 +227,10 @@ def test_create_index_uses_table_name_kwarg(monkeypatch):
     monkeypatch.setattr(lancedb_mod, "lancedb", Mock(connect=Mock(return_value=fake_db)))
     monkeypatch.setattr(lancedb_mod, "pa", Mock(schema=Mock(return_value="schema")))
 
-    ldb = lancedb_mod.LanceDB()
+    ldb = lancedb_mod.LanceDB(vector_dim=2)
     sample = make_sample_results()
     ldb.create_index(records=sample, table_name="custom_table")
 
-    # Verify create_table was called with custom_table
     call_args = fake_db.create_table.call_args
     assert call_args[0][0] == "custom_table"
 
@@ -245,17 +244,15 @@ def test_create_index_uses_overwrite_mode(monkeypatch):
     monkeypatch.setattr(lancedb_mod, "lancedb", Mock(connect=Mock(return_value=fake_db)))
     monkeypatch.setattr(lancedb_mod, "pa", Mock(schema=Mock(return_value="schema")))
 
-    # Test with overwrite=False (should use "append" mode)
-    ldb = lancedb_mod.LanceDB(overwrite=False)
+    ldb = lancedb_mod.LanceDB(overwrite=False, vector_dim=2)
     sample = make_sample_results()
     ldb.create_index(records=sample)
 
     call_kwargs = fake_db.create_table.call_args[1]
     assert call_kwargs["mode"] == "append"
 
-    # Reset and test with overwrite=True (should use "overwrite" mode)
     fake_db.reset_mock()
-    ldb2 = lancedb_mod.LanceDB(overwrite=True)
+    ldb2 = lancedb_mod.LanceDB(overwrite=True, vector_dim=2)
     ldb2.create_index(records=sample)
 
     call_kwargs = fake_db.create_table.call_args[1]
@@ -364,14 +361,12 @@ def test_create_lancedb_results_missing_content_metadata_graceful():
                 "metadata": {
                     "embedding": [0.1],
                     "content": "text with missing content_metadata",
-                    # Missing content_metadata - should use empty dict default
                     "source_metadata": {"source_id": "s1"},
                 },
             }
         ]
     ]
-    out = lancedb_mod.create_lancedb_results(results)
-    # Should still produce output with JSON-serialized empty metadata.
+    out = lancedb_mod.create_lancedb_results(results, expected_dim=1)
     assert len(out) == 1
     assert out[0]["metadata"] == "{}"
     assert out[0]["text"] == "text with missing content_metadata"
@@ -492,3 +487,150 @@ def test_get_text_for_element_missing_metadata():
     }
     result = lancedb_mod._get_text_for_element(element)
     assert result is None
+
+
+# ============ Regression tests for variable-length vector handling ============
+
+
+def _embedding_record(embedding, page: int = 1, content: str = "row"):
+    """Build a minimal NV-Ingest pipeline record for variable-length-vector tests."""
+    return {
+        "document_type": "text",
+        "metadata": {
+            "embedding": embedding,
+            "content": content,
+            "content_metadata": {"page_number": page},
+            "source_metadata": {"source_id": f"s{page}"},
+        },
+    }
+
+
+def test_create_lancedb_results_drops_variable_length_vectors(caplog):
+    """Mixed-length embeddings: only rows whose length matches expected_dim survive,
+    and a single structured WARNING summary is emitted listing the drop counts.
+
+    This guards against the regression where a small fraction of empty/short
+    embeddings caused LanceDB's strict fixed-size schema to abort the entire
+    write at the end of a long ingestion run.
+    """
+    expected_dim = 4
+    results = [
+        [
+            _embedding_record([0.1, 0.2, 0.3, 0.4], page=1, content="good_a"),
+            _embedding_record([], page=2, content="empty_should_drop"),
+            _embedding_record([0.1, 0.2], page=3, content="short_should_drop"),
+            _embedding_record(None, page=4, content="none_should_drop"),
+            _embedding_record([0.5, 0.6, 0.7, 0.8], page=5, content="good_b"),
+        ]
+    ]
+
+    with caplog.at_level(logging.WARNING, logger=lancedb_mod.logger.name):
+        out = lancedb_mod.create_lancedb_results(results, expected_dim=expected_dim)
+
+    assert [row["text"] for row in out] == ["good_a", "good_b"]
+    summary_records = [
+        r for r in caplog.records if r.levelno == logging.WARNING and "create_lancedb_results" in r.getMessage()
+    ]
+    assert len(summary_records) == 1
+    summary = summary_records[0].getMessage()
+    assert "accepted=2" in summary
+    assert "dropped_no_embedding=1" in summary
+    assert "dropped_bad_length=2" in summary
+    assert f"expected_dim={expected_dim}" in summary
+
+
+def test_create_lancedb_results_respects_expected_dim():
+    """create_lancedb_results filters strictly by the caller-specified expected_dim."""
+    results = [
+        [
+            _embedding_record([0.0] * 128, page=1, content="dim_128"),
+            _embedding_record([0.0] * 256, page=2, content="dim_256_should_drop"),
+        ]
+    ]
+    out = lancedb_mod.create_lancedb_results(results, expected_dim=128)
+    assert len(out) == 1
+    assert out[0]["text"] == "dim_128"
+    assert len(out[0]["vector"]) == 128
+
+
+def test_lancedb_init_validates_on_bad_vectors():
+    """LanceDB.__init__ rejects unknown on_bad_vectors policies and non-positive vector_dim."""
+    import pytest
+
+    with pytest.raises(ValueError, match="on_bad_vectors must be one of"):
+        lancedb_mod.LanceDB(on_bad_vectors="bogus")
+
+    with pytest.raises(ValueError, match="vector_dim must be positive"):
+        lancedb_mod.LanceDB(vector_dim=0)
+
+    with pytest.raises(ValueError, match="vector_dim must be positive"):
+        lancedb_mod.LanceDB(vector_dim=-5)
+
+    ldb = lancedb_mod.LanceDB(on_bad_vectors="DROP")
+    assert ldb.on_bad_vectors == "drop"
+    ldb_fill = lancedb_mod.LanceDB(on_bad_vectors=" Fill ", fill_value=1.5)
+    assert ldb_fill.on_bad_vectors == "fill"
+    assert ldb_fill.fill_value == 1.5
+
+
+def test_create_index_passes_on_bad_vectors_to_lancedb(monkeypatch):
+    """create_index forwards on_bad_vectors (and fill_value when applicable) to db.create_table."""
+    fake_db = Mock()
+    fake_table = Mock()
+    fake_db.create_table = Mock(return_value=fake_table)
+
+    monkeypatch.setattr(lancedb_mod, "lancedb", Mock(connect=Mock(return_value=fake_db)))
+    monkeypatch.setattr(lancedb_mod, "pa", Mock(schema=Mock(return_value="schema")))
+
+    sample = make_sample_results()
+
+    ldb_default = lancedb_mod.LanceDB(vector_dim=2)
+    ldb_default.create_index(records=sample)
+    default_kwargs = fake_db.create_table.call_args.kwargs
+    assert default_kwargs["on_bad_vectors"] == "drop"
+    assert "fill_value" not in default_kwargs
+
+    fake_db.create_table.reset_mock()
+
+    ldb_fill = lancedb_mod.LanceDB(vector_dim=2, on_bad_vectors="fill", fill_value=0.0)
+    ldb_fill.create_index(records=sample)
+    fill_kwargs = fake_db.create_table.call_args.kwargs
+    assert fill_kwargs["on_bad_vectors"] == "fill"
+    assert fill_kwargs["fill_value"] == 0.0
+
+    fake_db.create_table.reset_mock()
+
+    ldb_null = lancedb_mod.LanceDB(vector_dim=2, on_bad_vectors="null")
+    ldb_null.create_index(records=sample)
+    null_kwargs = fake_db.create_table.call_args.kwargs
+    assert null_kwargs["on_bad_vectors"] == "null"
+    assert "fill_value" not in null_kwargs
+
+
+def test_create_index_uses_configured_vector_dim_in_schema(monkeypatch):
+    """The vector field declared on the LanceDB schema reflects the configured vector_dim."""
+    fake_db = Mock()
+    fake_table = Mock()
+    fake_db.create_table = Mock(return_value=fake_table)
+
+    captured_dims = []
+
+    def fake_list_(_dtype, dim):
+        captured_dims.append(dim)
+        return ("fixed_size_list", dim)
+
+    fake_pa = Mock(
+        schema=Mock(return_value="schema"),
+        list_=Mock(side_effect=fake_list_),
+        float32=Mock(return_value="float32"),
+        string=Mock(return_value="string"),
+        field=Mock(side_effect=lambda name, dtype: (name, dtype)),
+    )
+
+    monkeypatch.setattr(lancedb_mod, "lancedb", Mock(connect=Mock(return_value=fake_db)))
+    monkeypatch.setattr(lancedb_mod, "pa", fake_pa)
+
+    ldb = lancedb_mod.LanceDB(vector_dim=512)
+    ldb.create_index(records=[])
+
+    assert 512 in captured_dims

--- a/client/src/nv_ingest_client/util/vdb/lancedb.py
+++ b/client/src/nv_ingest_client/util/vdb/lancedb.py
@@ -132,33 +132,47 @@ def _get_text_for_element(element):
         return metadata.get("content")
 
 
-def create_lancedb_results(results, *, expected_dim: int = _DEFAULT_VECTOR_DIM) -> list:
+def create_lancedb_results(
+    results,
+    *,
+    expected_dim: int | None = _DEFAULT_VECTOR_DIM,
+) -> tuple[list, dict[str, int]]:
     """Transform NV-Ingest pipeline results into LanceDB ingestible rows.
 
-    Extracts the appropriate searchable text per ``document_type`` and validates
-    that each row's embedding is shaped consistently with the LanceDB
-    fixed-size-list schema before forwarding it to the writer. Rows whose
-    embedding is missing, of the wrong type, or of the wrong length are
-    dropped and counted; per-row reasons are emitted at ``DEBUG`` and a single
-    structured ``WARNING`` summary is emitted at the end of the call when any
-    drops occurred.
+    Extracts the appropriate searchable text per ``document_type`` and, when
+    ``expected_dim`` is set, validates that each row's embedding is shaped
+    consistently with the LanceDB fixed-size-list schema before forwarding it
+    to the writer. Rows whose embedding is missing, of the wrong type, or of
+    the wrong length are dropped and counted; per-row reasons are emitted at
+    ``DEBUG`` and a single structured ``WARNING`` summary is emitted at the
+    end of the call when any drops occurred.
+
+    Passing ``expected_dim=None`` disables the length check entirely. Callers
+    that prefer to defer to LanceDB's ``on_bad_vectors`` policy on the writer
+    side (e.g. ``LanceDB(on_bad_vectors="error")``) should use this mode so
+    bad rows reach LanceDB rather than being silently dropped at the wrapper.
 
     Args:
         results: Iterable of pipeline output result lists, where each element
             is a per-document list of NV-Ingest record dicts.
-        expected_dim: Required vector length. Embeddings whose ``len()`` does
-            not match this value are dropped. Defaults to
-            :data:`_DEFAULT_VECTOR_DIM`.
+        expected_dim: Required vector length, or ``None`` to skip the length
+            check. Defaults to :data:`_DEFAULT_VECTOR_DIM`.
 
     Returns:
-        List of dicts shaped for LanceDB ingestion, each containing
-        ``vector``, ``text``, ``metadata`` (JSON), and ``source`` (JSON).
+        ``(rows, counts)`` where ``rows`` is the list of dicts shaped for
+        LanceDB ingestion (``vector``, ``text``, ``metadata``, ``source``)
+        and ``counts`` is a dict containing ``accepted``,
+        ``dropped_no_embedding``, ``dropped_bad_length``, and
+        ``dropped_no_text`` keys.
     """
     lancedb_rows: list = []
     accepted = 0
     dropped_no_embedding = 0
     dropped_bad_length = 0
     dropped_no_text = 0
+
+    enforce_length = expected_dim is not None
+    expected_dim_int = int(expected_dim) if enforce_length else None
 
     for result in results:
         for element in result:
@@ -170,13 +184,13 @@ def create_lancedb_results(results, *, expected_dim: int = _DEFAULT_VECTOR_DIM) 
                 dropped_no_embedding += 1
                 continue
 
-            if not isinstance(embedding, (list, tuple)) or len(embedding) != int(expected_dim):
+            if enforce_length and (not isinstance(embedding, (list, tuple)) or len(embedding) != expected_dim_int):
                 dropped_bad_length += 1
                 got_len: Any = len(embedding) if hasattr(embedding, "__len__") else "n/a"
                 logger.debug(
                     "Dropping row with bad embedding (got_len=%s, expected=%d, doc_type=%s)",
                     got_len,
-                    int(expected_dim),
+                    expected_dim_int,
                     doc_type,
                 )
                 continue
@@ -202,18 +216,26 @@ def create_lancedb_results(results, *, expected_dim: int = _DEFAULT_VECTOR_DIM) 
             )
             accepted += 1
 
+    counts: dict[str, int] = {
+        "accepted": accepted,
+        "dropped_no_embedding": dropped_no_embedding,
+        "dropped_bad_length": dropped_bad_length,
+        "dropped_no_text": dropped_no_text,
+    }
+
     if dropped_no_embedding or dropped_bad_length or dropped_no_text:
+        expected_dim_repr = expected_dim_int if enforce_length else "None"
         logger.warning(
             "create_lancedb_results: accepted=%d dropped_no_embedding=%d "
-            "dropped_bad_length=%d dropped_no_text=%d expected_dim=%d",
+            "dropped_bad_length=%d dropped_no_text=%d expected_dim=%s",
             accepted,
             dropped_no_embedding,
             dropped_bad_length,
             dropped_no_text,
-            int(expected_dim),
+            expected_dim_repr,
         )
 
-    return lancedb_rows
+    return lancedb_rows, counts
 
 
 class LanceDB(VDB):
@@ -221,7 +243,7 @@ class LanceDB(VDB):
 
     def __init__(
         self,
-        uri=None,
+        uri: str | None = None,
         overwrite: bool = True,
         table_name: str = "nv-ingest",
         index_type: str = "IVF_HNSW_SQ",
@@ -257,16 +279,24 @@ class LanceDB(VDB):
         """Create a LanceDB table and populate it with transformed records.
 
         Validates per-row vector shape (when ``validate_vector_length`` is set
-        on the instance) and forwards LanceDB's ``on_bad_vectors`` policy as
-        defense-in-depth so that any rows escaping the row-builder check are
-        still handled by the LanceDB writer instead of aborting the run.
+        on the instance and ``on_bad_vectors`` is not ``"error"``) and forwards
+        LanceDB's ``on_bad_vectors`` policy as defense-in-depth so that any
+        rows escaping the row-builder check are still handled by the LanceDB
+        writer instead of aborting the run. When ``on_bad_vectors == "error"``
+        the wrapper deliberately skips its own length check so that LanceDB
+        itself raises on the bad row, matching the documented strict-fail
+        semantics of that policy.
         """
         connect_start = time.perf_counter()
         db = lancedb.connect(uri=self.uri)
         _record_timing("lancedb.connect", time.perf_counter() - connect_start)
 
-        expected_dim = self.vector_dim if self.validate_vector_length else _DEFAULT_VECTOR_DIM
-        results = create_lancedb_results(records, expected_dim=expected_dim)
+        if self.validate_vector_length and self.on_bad_vectors != "error":
+            expected_dim: int | None = self.vector_dim
+        else:
+            expected_dim = None
+
+        results, counts = create_lancedb_results(records, expected_dim=expected_dim)
         schema = pa.schema(
             [
                 pa.field("vector", pa.list_(pa.float32(), self.vector_dim)),
@@ -288,7 +318,7 @@ class LanceDB(VDB):
         _record_timing(
             "lancedb.create_table",
             time.perf_counter() - create_start,
-            {"rows": len(results)},
+            {"rows": len(results), **counts},
         )
         return table
 

--- a/client/src/nv_ingest_client/util/vdb/lancedb.py
+++ b/client/src/nv_ingest_client/util/vdb/lancedb.py
@@ -5,6 +5,7 @@ import time
 
 from datetime import timedelta
 from functools import partial
+from typing import Any, Final, FrozenSet
 from urllib.parse import urlparse
 
 import lancedb
@@ -16,6 +17,34 @@ from nv_ingest_client.util.vdb.adt_vdb import VDB
 from nv_ingest_client.util.vdb.milvus import nv_rerank
 
 logger = logging.getLogger(__name__)
+
+
+_DEFAULT_VECTOR_DIM: Final[int] = 2048
+_VALID_ON_BAD_VECTORS: Final[FrozenSet[str]] = frozenset({"drop", "fill", "null", "error"})
+
+
+def _normalize_on_bad_vectors(value: str) -> str:
+    """Validate and normalize an ``on_bad_vectors`` policy string.
+
+    LanceDB's ``Table.create`` accepts a fixed set of policies for handling rows
+    whose vector column does not match the declared fixed-size schema. We
+    surface the same vocabulary on this wrapper so callers can configure the
+    behavior through ``--vdb-kwargs-json``.
+
+    Args:
+        value: User-supplied policy name. Whitespace and case are ignored.
+
+    Returns:
+        The normalized lower-case policy string.
+
+    Raises:
+        ValueError: If ``value`` is not one of ``drop``, ``fill``, ``null``,
+            or ``error``.
+    """
+    normalized = (value or "drop").strip().lower()
+    if normalized not in _VALID_ON_BAD_VECTORS:
+        raise ValueError(f"on_bad_vectors must be one of {sorted(_VALID_ON_BAD_VECTORS)}; got {value!r}")
+    return normalized
 
 
 def _json_str(value) -> str:
@@ -103,36 +132,61 @@ def _get_text_for_element(element):
         return metadata.get("content")
 
 
-def create_lancedb_results(results):
-    """
-    Transform NV-Ingest pipeline results into LanceDB ingestible rows.
+def create_lancedb_results(results, *, expected_dim: int = _DEFAULT_VECTOR_DIM) -> list:
+    """Transform NV-Ingest pipeline results into LanceDB ingestible rows.
 
-    Extracts appropriate text based on document_type rather than storing
-    raw content (which may include base64 images).
+    Extracts the appropriate searchable text per ``document_type`` and validates
+    that each row's embedding is shaped consistently with the LanceDB
+    fixed-size-list schema before forwarding it to the writer. Rows whose
+    embedding is missing, of the wrong type, or of the wrong length are
+    dropped and counted; per-row reasons are emitted at ``DEBUG`` and a single
+    structured ``WARNING`` summary is emitted at the end of the call when any
+    drops occurred.
 
-    Parameters
-    ----------
-    results : list
-        Pipeline output results.
+    Args:
+        results: Iterable of pipeline output result lists, where each element
+            is a per-document list of NV-Ingest record dicts.
+        expected_dim: Required vector length. Embeddings whose ``len()`` does
+            not match this value are dropped. Defaults to
+            :data:`_DEFAULT_VECTOR_DIM`.
+
+    Returns:
+        List of dicts shaped for LanceDB ingestion, each containing
+        ``vector``, ``text``, ``metadata`` (JSON), and ``source`` (JSON).
     """
-    lancedb_rows = []
+    lancedb_rows: list = []
+    accepted = 0
+    dropped_no_embedding = 0
+    dropped_bad_length = 0
+    dropped_no_text = 0
 
     for result in results:
         for element in result:
             metadata = element.get("metadata", {})
             doc_type = element.get("document_type")
 
-            # Check if embedding exists
             embedding = metadata.get("embedding")
             if embedding is None:
+                dropped_no_embedding += 1
+                continue
+
+            if not isinstance(embedding, (list, tuple)) or len(embedding) != int(expected_dim):
+                dropped_bad_length += 1
+                got_len: Any = len(embedding) if hasattr(embedding, "__len__") else "n/a"
+                logger.debug(
+                    "Dropping row with bad embedding (got_len=%s, expected=%d, doc_type=%s)",
+                    got_len,
+                    int(expected_dim),
+                    doc_type,
+                )
                 continue
 
             content_meta = metadata.get("content_metadata", {})
 
-            # Extract appropriate text based on document type
             text = _get_text_for_element(element)
 
             if not text:
+                dropped_no_text += 1
                 source_name = metadata.get("source_metadata", {}).get("source_name", "unknown")
                 pg_num = content_meta.get("page_number")
                 logger.debug(f"No text found for entity: {source_name} page: {pg_num} type: {doc_type}")
@@ -142,11 +196,22 @@ def create_lancedb_results(results):
                 {
                     "vector": embedding,
                     "text": text,
-                    # Stored as strings in LanceDB; serialize nested structures.
                     "metadata": _json_str(content_meta),
                     "source": _json_str(metadata.get("source_metadata", {})),
                 }
             )
+            accepted += 1
+
+    if dropped_no_embedding or dropped_bad_length or dropped_no_text:
+        logger.warning(
+            "create_lancedb_results: accepted=%d dropped_no_embedding=%d "
+            "dropped_bad_length=%d dropped_no_text=%d expected_dim=%d",
+            accepted,
+            dropped_no_embedding,
+            dropped_bad_length,
+            dropped_no_text,
+            int(expected_dim),
+        )
 
     return lancedb_rows
 
@@ -157,16 +222,22 @@ class LanceDB(VDB):
     def __init__(
         self,
         uri=None,
-        overwrite=True,
-        table_name="nv-ingest",
-        index_type="IVF_HNSW_SQ",
-        metric="l2",
-        num_partitions=16,
-        num_sub_vectors=256,
+        overwrite: bool = True,
+        table_name: str = "nv-ingest",
+        index_type: str = "IVF_HNSW_SQ",
+        metric: str = "l2",
+        num_partitions: int = 16,
+        num_sub_vectors: int = 256,
         hybrid: bool = False,
         fts_language: str = "English",
+        vector_dim: int = _DEFAULT_VECTOR_DIM,
+        on_bad_vectors: str = "drop",
+        fill_value: float = 0.0,
+        validate_vector_length: bool = True,
         **kwargs,
     ):
+        if int(vector_dim) <= 0:
+            raise ValueError(f"vector_dim must be positive; got {vector_dim}")
         self.uri = uri or "lancedb"
         self.overwrite = overwrite
         self.table_name = table_name
@@ -176,26 +247,44 @@ class LanceDB(VDB):
         self.num_sub_vectors = num_sub_vectors
         self.hybrid = hybrid
         self.fts_language = fts_language
+        self.vector_dim = int(vector_dim)
+        self.on_bad_vectors = _normalize_on_bad_vectors(on_bad_vectors)
+        self.fill_value = float(fill_value)
+        self.validate_vector_length = bool(validate_vector_length)
         super().__init__(**kwargs)
 
-    def create_index(self, records=None, table_name="nv-ingest", **kwargs):
-        """Create a LanceDB table and populate it with transformed records."""
+    def create_index(self, records=None, table_name: str = "nv-ingest", **kwargs):
+        """Create a LanceDB table and populate it with transformed records.
+
+        Validates per-row vector shape (when ``validate_vector_length`` is set
+        on the instance) and forwards LanceDB's ``on_bad_vectors`` policy as
+        defense-in-depth so that any rows escaping the row-builder check are
+        still handled by the LanceDB writer instead of aborting the run.
+        """
         connect_start = time.perf_counter()
         db = lancedb.connect(uri=self.uri)
         _record_timing("lancedb.connect", time.perf_counter() - connect_start)
-        results = create_lancedb_results(records)
+
+        expected_dim = self.vector_dim if self.validate_vector_length else _DEFAULT_VECTOR_DIM
+        results = create_lancedb_results(records, expected_dim=expected_dim)
         schema = pa.schema(
             [
-                pa.field("vector", pa.list_(pa.float32(), 2048)),
+                pa.field("vector", pa.list_(pa.float32(), self.vector_dim)),
                 pa.field("text", pa.string()),
                 pa.field("metadata", pa.string()),
                 pa.field("source", pa.string()),
             ]
         )
+        create_kwargs: dict[str, Any] = {
+            "data": results,
+            "schema": schema,
+            "mode": "overwrite" if self.overwrite else "append",
+            "on_bad_vectors": self.on_bad_vectors,
+        }
+        if self.on_bad_vectors == "fill":
+            create_kwargs["fill_value"] = self.fill_value
         create_start = time.perf_counter()
-        table = db.create_table(
-            table_name, data=results, schema=schema, mode="overwrite" if self.overwrite else "append"
-        )
+        table = db.create_table(table_name, **create_kwargs)
         _record_timing(
             "lancedb.create_table",
             time.perf_counter() - create_start,

--- a/client/src/nv_ingest_client/util/vdb/lancedb.py
+++ b/client/src/nv_ingest_client/util/vdb/lancedb.py
@@ -132,7 +132,7 @@ def _get_text_for_element(element):
         return metadata.get("content")
 
 
-def create_lancedb_results(
+def _create_lancedb_results(
     results,
     *,
     expected_dim: int | None = _DEFAULT_VECTOR_DIM,
@@ -226,7 +226,7 @@ def create_lancedb_results(
     if dropped_no_embedding or dropped_bad_length or dropped_no_text:
         expected_dim_repr = expected_dim_int if enforce_length else "None"
         logger.warning(
-            "create_lancedb_results: accepted=%d dropped_no_embedding=%d "
+            "_create_lancedb_results: accepted=%d dropped_no_embedding=%d "
             "dropped_bad_length=%d dropped_no_text=%d expected_dim=%s",
             accepted,
             dropped_no_embedding,
@@ -296,7 +296,7 @@ class LanceDB(VDB):
         else:
             expected_dim = None
 
-        results, counts = create_lancedb_results(records, expected_dim=expected_dim)
+        results, counts = _create_lancedb_results(records, expected_dim=expected_dim)
         schema = pa.schema(
             [
                 pa.field("vector", pa.list_(pa.float32(), self.vector_dim)),


### PR DESCRIPTION
## Description
- Fixes a regression from #1921 where short/empty embeddings crash the LanceDB upload at the end of long ingests.
- Adds per-row vector-length validation in create_lancedb_results so malformed embeddings no longer reach LanceDB's strict fixed-size schema.
- Forwards LanceDB's on_bad_vectors policy (default "drop") and optional fill_value to db.create_table as defense-in-depth.
Makes the embedding dimension configurable via a typed vector_dim constructor kwarg instead of a hardcoded 2048.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
