### PR TITLE
Pin Nemotron OCR consumers to 1.0.2 dev nightlies

### DIFF
--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -84,7 +84,8 @@ local = [
   "nemotron-page-elements-v3>=0.dev0",
   "nemotron-graphic-elements-v1>=0.dev0",
   "nemotron-table-structure-v1>=0.dev0",
-  "nemotron-ocr>=0.dev0; sys_platform == 'linux'",
+  # Stay on the 1.0.2 OCR dev train and exclude older PyPI finals.
+  "nemotron-ocr>=1.0.2.dev0,<1.0.2a0; sys_platform == 'linux'",
   "nvidia-ml-py",
   "apscheduler>=3.10",
   "psutil>=5.9.0",

--- a/nemo_retriever/uv.lock
+++ b/nemo_retriever/uv.lock
@@ -2332,7 +2332,7 @@ requires-dist = [
     { name = "markitdown" },
     { name = "nemo-retriever", extras = ["benchmarks", "llm", "local", "multimedia", "stores"], marker = "extra == 'all'" },
     { name = "nemotron-graphic-elements-v1", marker = "extra == 'local'", specifier = ">=0.dev0", index = "https://test.pypi.org/simple/" },
-    { name = "nemotron-ocr", marker = "sys_platform == 'linux' and extra == 'local'", specifier = ">=0.dev0", index = "https://test.pypi.org/simple/" },
+    { name = "nemotron-ocr", marker = "sys_platform == 'linux' and extra == 'local'", specifier = ">=1.0.2.dev0,<1.0.2a0", index = "https://test.pypi.org/simple/" },
     { name = "nemotron-page-elements-v3", marker = "extra == 'local'", specifier = ">=0.dev0", index = "https://test.pypi.org/simple/" },
     { name = "nemotron-table-structure-v1", marker = "extra == 'local'", specifier = ">=0.dev0", index = "https://test.pypi.org/simple/" },
     { name = "neo4j", marker = "extra == 'stores'", specifier = ">=5.0" },
@@ -2396,7 +2396,7 @@ wheels = [
 
 [[package]]
 name = "nemotron-ocr"
-version = "1.0.0.dev20260428042913"
+version = "1.0.2.dev20260501161212"
 source = { registry = "https://test.pypi.org/simple/" }
 dependencies = [
     { name = "huggingface-hub", marker = "sys_platform == 'linux'" },
@@ -2407,10 +2407,10 @@ dependencies = [
     { name = "torch", version = "2.10.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux'" },
     { name = "torchvision", version = "0.25.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux'" },
 ]
-sdist = { url = "https://test-files.pythonhosted.org/packages/be/31/6b7501a406a3011800b96d2afb0b35e834fe3b777f95fed143ade8278f4a/nemotron_ocr-1.0.0.dev20260428042913.tar.gz", hash = "sha256:3ddf6c4404fff6e1e305057cba246193295dcb63d0a31c5d70b50346cbcc8fe0", size = 153218, upload-time = "2026-04-28T04:39:28.007Z" }
+sdist = { url = "https://test-files.pythonhosted.org/packages/6b/66/91c14964e71b4996d637e2f7b5fb8a1d6667a8ae89bc342c0355e37c6f1e/nemotron_ocr-1.0.2.dev20260501161212.tar.gz", hash = "sha256:2d589546b168e8526eb3ee3c05c22112b972180d65e1204783b92cc7116655c4", size = 153233, upload-time = "2026-05-01T16:22:41.113Z" }
 wheels = [
-    { url = "https://test-files.pythonhosted.org/packages/24/cd/1d308fdd79130b8d7ac6727fa63ac36f949b543aae12164ecb1f018aceeb/nemotron_ocr-1.0.0.dev20260428042913-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4483e8be710743579109cc1cd0b978fb1559d4c79e7ba73633fd46e8484db778", size = 36094416, upload-time = "2026-04-28T04:39:25.165Z" },
-    { url = "https://test-files.pythonhosted.org/packages/c3/6a/02382daa23f544adfb7b0e63426aed3d1b0e066f704b66bf07bbd6621657/nemotron_ocr-1.0.0.dev20260428042913-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:c4d0b8b71d20721d9b4cd847ff5c4f8984de3821a159730c9e58ec1f523a63ef", size = 36800011, upload-time = "2026-04-28T04:41:23.502Z" },
+    { url = "https://test-files.pythonhosted.org/packages/cd/26/75b37338788e039981781cec51edb56ed88809c807e50023cb0a2b5d953f/nemotron_ocr-1.0.2.dev20260501161212-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:f2b25279a9b1fb889aee0d673417f7dc12e66af4da527667eda557a7f76b7850", size = 36094403, upload-time = "2026-05-01T16:22:38.714Z" },
+    { url = "https://test-files.pythonhosted.org/packages/47/00/158545e4fd6168add3c244237b6ac5016ceb4f6e197f05586d9f696938f9/nemotron_ocr-1.0.2.dev20260501161212-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:384189507ab46e3e33c31cc973e580af3c0de3640e6ca6b3971b040233fd2f21", size = 36800021, upload-time = "2026-05-01T16:23:56.626Z" },
 ]
 
 [[package]]

--- a/tools/harness/nemotron-nightly.txt
+++ b/tools/harness/nemotron-nightly.txt
@@ -6,4 +6,4 @@
 nemotron-page-elements-v3>=0.dev0
 nemotron-graphic-elements-v1>=0.dev0
 nemotron-table-structure-v1>=0.dev0
-nemotron-ocr>=0.dev0
+nemotron-ocr>=1.0.2.dev0,<1.0.2a0

--- a/tools/harness/pyproject.toml
+++ b/tools/harness/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "nemotron-page-elements-v3>=0.dev0",
     "nemotron-graphic-elements-v1>=0.dev0",
     "nemotron-table-structure-v1>=0.dev0",
-    "nemotron-ocr>=0.dev0",
+    # Stay on the 1.0.2 OCR dev train and exclude older PyPI finals.
+    "nemotron-ocr>=1.0.2.dev0,<1.0.2a0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

Pins Nemotron OCR consumers to the new `1.0.2.dev*` nightly train now that the first post-1.0.1 OCR nightly exists on TestPyPI.

- Updates the `nemo_retriever[local]` OCR dependency and harness OCR dependency files to `nemotron-ocr>=1.0.2.dev0,<1.0.2a0`.
- Refreshes `nemo_retriever/uv.lock`, moving `nemotron-ocr` from `1.0.0.dev20260428042913` to `1.0.2.dev20260501161212`.
- Uses `<1.0.2a0` rather than `<1.0.2`: under PEP 440 specifier behavior, `<1.0.2` does not admit `1.0.2.dev*`, while `<1.0.2a0` keeps the range on the `1.0.2` dev releases and excludes alpha/final releases.

Resolver confirmation:

- Current TestPyPI candidates for `nemotron-ocr>=1.0.2.dev0,<1.0.2a0`: exactly one release, `1.0.2.dev20260501161212`, with non-yanked x86_64/aarch64 wheels and sdist.
- `uv lock` updates OCR to `1.0.2.dev20260501161212`.
- `uv pip install --dry-run --target /tmp/nemo-retriever-dry-run-target --python-version 3.12 --python-platform x86_64-manylinux_2_35 -e nemo_retriever[all,dev]` resolves `nemotron-ocr==1.0.2.dev20260501161212`.

Verification:

- `env UV_CACHE_DIR=/tmp/uv-cache uv lock`
- `env UV_CACHE_DIR=/tmp/uv-cache uv lock --check`
- `env UV_CACHE_DIR=/tmp/uv-cache uv pip install --dry-run --target /tmp/nemo-retriever-dry-run-target --python-version 3.12 --python-platform x86_64-manylinux_2_35 -e nemo_retriever[all,dev]`
- `git diff --check`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file. (N/A; no docker-compose changes.)
