### PR TITLE
Fix TableStructureActor crash when ocr_invoke_url is set

### DIFF
--- a/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
+++ b/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
@@ -630,6 +630,8 @@ def build_graph(
             table_kwargs: dict[str, Any] = {}
             if extract_params.table_structure_invoke_url:
                 table_kwargs["table_structure_invoke_url"] = extract_params.table_structure_invoke_url
+            if extract_params.ocr_invoke_url:
+                table_kwargs["ocr_invoke_url"] = extract_params.ocr_invoke_url
             if extract_params.api_key:
                 table_kwargs["api_key"] = extract_params.api_key
             if extract_params.table_output_format:

--- a/nemo_retriever/src/nemo_retriever/graph/multi_type_extract_operator.py
+++ b/nemo_retriever/src/nemo_retriever/graph/multi_type_extract_operator.py
@@ -41,7 +41,6 @@ from nemo_retriever.utils.convert.to_pdf import DocToPdfConversionActor
 from nemo_retriever.graph.designer import designer_component
 from nemo_retriever.utils.ray_resource_hueristics import gather_local_resources
 
-
 # Define file type mappings
 PDF_EXTENSIONS = {".pdf", ".docx", ".pptx"}
 TEXT_EXTENSIONS = {".txt"}
@@ -292,6 +291,8 @@ class _MultiTypeExtractBase(AbstractOperator):
             table_kwargs: dict[str, Any] = {}
             if extract_params.table_structure_invoke_url:
                 table_kwargs["table_structure_invoke_url"] = extract_params.table_structure_invoke_url
+            if extract_params.ocr_invoke_url:
+                table_kwargs["ocr_invoke_url"] = extract_params.ocr_invoke_url
             if extract_params.api_key:
                 table_kwargs["api_key"] = extract_params.api_key
             if extract_params.table_output_format:

--- a/nemo_retriever/src/nemo_retriever/table/gpu_actor.py
+++ b/nemo_retriever/src/nemo_retriever/table/gpu_actor.py
@@ -25,6 +25,7 @@ class TableStructureActor(AbstractOperator, GPUOperator):
         self,
         *,
         table_structure_invoke_url: Optional[str] = None,
+        ocr_invoke_url: Optional[str] = None,
         invoke_url: Optional[str] = None,
         api_key: Optional[str] = None,
         table_output_format: Optional[str] = None,
@@ -35,6 +36,7 @@ class TableStructureActor(AbstractOperator, GPUOperator):
     ) -> None:
         super().__init__()
         self._table_structure_invoke_url = (table_structure_invoke_url or invoke_url or "").strip()
+        self._ocr_invoke_url = (ocr_invoke_url or "").strip()
         self._api_key = api_key
         self._request_timeout_s = float(request_timeout_s)
         self._table_output_format = table_output_format

--- a/nemo_retriever/tests/test_actor_operators.py
+++ b/nemo_retriever/tests/test_actor_operators.py
@@ -252,6 +252,83 @@ class TestTableStructureActor:
 
 
 # ---------------------------------------------------------------------------
+# 5b. TableStructureActor (GPU variant) regression tests
+# ---------------------------------------------------------------------------
+class TestTableStructureGPUActor:
+    """Regression tests for the GPU variant of TableStructureActor.
+
+    The GPU variant lives in nemo_retriever.table.gpu_actor and is selected
+    by the archetype resolver when GPUs are available and no CPU-only
+    endpoint is configured. Prior to this fix, its __init__ referenced
+    ``self._ocr_invoke_url`` without ever assigning it, raising
+    ``AttributeError`` for any non-CPU dispatch. These tests pin the
+    contract so the regression cannot reappear.
+    """
+
+    @patch("nemo_retriever.model.local.NemotronOCRV1")
+    @patch("nemo_retriever.model.local.NemotronTableStructureV1")
+    def test_init_with_no_kwargs_loads_local_models(self, mock_ts, mock_ocr):
+        from nemo_retriever.table.gpu_actor import TableStructureActor as GPUActor
+
+        actor = GPUActor()
+
+        assert actor._table_structure_invoke_url == ""
+        assert actor._ocr_invoke_url == ""
+        mock_ts.assert_called_once_with()
+        mock_ocr.assert_called_once_with()
+        assert actor._nim_client is None
+
+    @patch("nemo_retriever.model.local.NemotronOCRV1")
+    @patch("nemo_retriever.model.local.NemotronTableStructureV1")
+    def test_init_with_ocr_invoke_url_skips_local_ocr(self, mock_ts, mock_ocr):
+        from nemo_retriever.table.gpu_actor import TableStructureActor as GPUActor
+
+        actor = GPUActor(ocr_invoke_url="http://ocr.example/v1/cv/nvidia/nemotron-ocr-v1")
+
+        assert actor._ocr_invoke_url == "http://ocr.example/v1/cv/nvidia/nemotron-ocr-v1"
+        assert actor._ocr_model is None
+        mock_ocr.assert_not_called()
+        mock_ts.assert_called_once_with()
+        assert actor._nim_client is not None
+
+    @patch("nemo_retriever.model.local.NemotronOCRV1")
+    def test_init_with_both_urls_skips_all_local_models(self, mock_ocr):
+        from nemo_retriever.table.gpu_actor import TableStructureActor as GPUActor
+
+        actor = GPUActor(
+            table_structure_invoke_url="http://ts.example/v1",
+            ocr_invoke_url="http://ocr.example/v1",
+        )
+
+        assert actor._table_structure_model is None
+        assert actor._ocr_model is None
+        mock_ocr.assert_not_called()
+        assert actor._nim_client is not None
+
+    def test_init_strips_whitespace_from_ocr_invoke_url(self):
+        from nemo_retriever.table.gpu_actor import TableStructureActor as GPUActor
+
+        actor = GPUActor(
+            table_structure_invoke_url="http://ts.example/v1",
+            ocr_invoke_url="  http://ocr.example/v1  ",
+        )
+
+        assert actor._ocr_invoke_url == "http://ocr.example/v1"
+
+    def test_init_treats_none_ocr_invoke_url_as_empty(self):
+        with patch("nemo_retriever.model.local.NemotronOCRV1") as mock_ocr:
+            from nemo_retriever.table.gpu_actor import TableStructureActor as GPUActor
+
+            actor = GPUActor(
+                table_structure_invoke_url="http://ts.example/v1",
+                ocr_invoke_url=None,
+            )
+
+            assert actor._ocr_invoke_url == ""
+            mock_ocr.assert_called_once_with()
+
+
+# ---------------------------------------------------------------------------
 # 6. OCRActor
 # ---------------------------------------------------------------------------
 class TestOCRActor:


### PR DESCRIPTION
## Description
- The GPU variant of TableStructureActor referenced self._ocr_invoke_url in
its __init__ without declaring the kwarg or assigning the attribute,
causing AttributeError on every Ray actor that didn't dispatch to the CPU
variant. 

- Mirror the CPU variant's API by accepting ocr_invoke_url and
assigning self._ocr_invoke_url early, and thread extract_params.ocr_invoke_url
into table_kwargs in both the Ray and in-process graph builders.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
