### PR TITLE
[bug-fix] Added handling for unsupported file extension extraction in graph pipeline

### DIFF
--- a/nemo_retriever/src/nemo_retriever/graph/multi_type_extract_operator.py
+++ b/nemo_retriever/src/nemo_retriever/graph/multi_type_extract_operator.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import os
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -50,6 +51,8 @@ from nemo_retriever.video import dedup_video_frames
 from nemo_retriever.graph.designer import designer_component
 from nemo_retriever.utils.ray_resource_hueristics import gather_local_resources
 
+logger = logging.getLogger(__name__)
+
 # Define file type mappings
 PDF_EXTENSIONS = {".pdf", ".docx", ".pptx"}
 TEXT_EXTENSIONS = {".txt"}
@@ -59,9 +62,9 @@ IMAGE_EXTENSIONS = SUPPORTED_IMAGE_EXTENSIONS
 VIDEO_EXTENSIONS = {".mp4", ".mov", ".mkv"}
 
 
-def _unsupported_extension_error(ext: str) -> ValueError:
+def _unsupported_extension_message(ext: str) -> str:
     display_ext = ext or "<none>"
-    return ValueError(
+    return (
         f"Unsupported file extension '{display_ext}' for extraction_mode='auto'. "
         "Provide a supported extension or set extraction_mode explicitly."
     )
@@ -205,7 +208,8 @@ class _MultiTypeExtractBase(AbstractOperator):
             ext = Path(path).suffix.lower()
             target = explicit_mode if explicit_mode != "auto" else self._mode_for_extension(ext)
             if explicit_mode == "auto" and target == "":
-                raise _unsupported_extension_error(ext)
+                logger.warning("%s path=%s", _unsupported_extension_message(ext), path)
+                continue
             if target in grouped:
                 grouped[target].append(idx)
 
@@ -248,7 +252,8 @@ class _MultiTypeExtractBase(AbstractOperator):
             ext = Path(path).suffix.lower()
             target = explicit_mode if explicit_mode != "auto" else self._mode_for_extension(ext)
             if explicit_mode == "auto" and target == "":
-                raise _unsupported_extension_error(ext)
+                logger.warning("%s path=%s", _unsupported_extension_message(ext), path)
+                continue
             if target in grouped:
                 grouped[target].append(path)
 

--- a/nemo_retriever/src/nemo_retriever/graph/multi_type_extract_operator.py
+++ b/nemo_retriever/src/nemo_retriever/graph/multi_type_extract_operator.py
@@ -208,7 +208,10 @@ class _MultiTypeExtractBase(AbstractOperator):
             ext = Path(path).suffix.lower()
             target = explicit_mode if explicit_mode != "auto" else self._mode_for_extension(ext)
             if explicit_mode == "auto" and target == "":
-                logger.warning("%s path=%s", _unsupported_extension_message(ext), path)
+                logger.warning(
+                    _unsupported_extension_message(ext),
+                    extra={"path": path},
+                )
                 continue
             if target in grouped:
                 grouped[target].append(idx)
@@ -252,7 +255,10 @@ class _MultiTypeExtractBase(AbstractOperator):
             ext = Path(path).suffix.lower()
             target = explicit_mode if explicit_mode != "auto" else self._mode_for_extension(ext)
             if explicit_mode == "auto" and target == "":
-                logger.warning("%s path=%s", _unsupported_extension_message(ext), path)
+                logger.warning(
+                    _unsupported_extension_message(ext),
+                    extra={"path": path},
+                )
                 continue
             if target in grouped:
                 grouped[target].append(path)

--- a/nemo_retriever/src/nemo_retriever/graph/multi_type_extract_operator.py
+++ b/nemo_retriever/src/nemo_retriever/graph/multi_type_extract_operator.py
@@ -59,6 +59,14 @@ IMAGE_EXTENSIONS = SUPPORTED_IMAGE_EXTENSIONS
 VIDEO_EXTENSIONS = {".mp4", ".mov", ".mkv"}
 
 
+def _unsupported_extension_error(ext: str) -> ValueError:
+    display_ext = ext or "<none>"
+    return ValueError(
+        f"Unsupported file extension '{display_ext}' for extraction_mode='auto'. "
+        "Provide a supported extension or set extraction_mode explicitly."
+    )
+
+
 def _has_endpoint(*values: Any) -> bool:
     return any(bool(str(value or "").strip()) for value in values)
 
@@ -196,6 +204,8 @@ class _MultiTypeExtractBase(AbstractOperator):
             path = str(row.get("path") or "")
             ext = Path(path).suffix.lower()
             target = explicit_mode if explicit_mode != "auto" else self._mode_for_extension(ext)
+            if explicit_mode == "auto" and target == "":
+                raise _unsupported_extension_error(ext)
             if target in grouped:
                 grouped[target].append(idx)
 
@@ -237,6 +247,8 @@ class _MultiTypeExtractBase(AbstractOperator):
         for path in files:
             ext = Path(path).suffix.lower()
             target = explicit_mode if explicit_mode != "auto" else self._mode_for_extension(ext)
+            if explicit_mode == "auto" and target == "":
+                raise _unsupported_extension_error(ext)
             if target in grouped:
                 grouped[target].append(path)
 

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -4,6 +4,7 @@
 
 """Unit tests for Node, Graph, >> chaining (including auto-wrap), and Executors."""
 
+import logging
 from typing import Any
 
 import pandas as pd
@@ -620,20 +621,32 @@ class TestMultiTypeExtractOperator:
         assert grouped["audio"] == ["/folder/audio.mp3"]
         assert grouped["video"] == ["/folder/video.mp4"]
 
-    def test_auto_mode_rejects_unsupported_extension_in_file_list(self):
+    def test_auto_mode_logs_and_skips_unsupported_extension_in_file_list(self, caplog):
         op = MultiTypeExtractOperator(extraction_mode="auto")
 
-        with pytest.raises(ValueError, match=r"Unsupported file extension '\.xyz'"):
-            op.preprocess(["/folder/unknown.xyz"])
+        with caplog.at_level(logging.WARNING, logger="nemo_retriever.graph.multi_type_extract_operator"):
+            grouped = op.preprocess(["/folder/known.txt", "/folder/unknown.xyz"])
 
-    def test_auto_mode_rejects_unsupported_extension_in_dataframe_batch(self):
+        assert grouped["text"] == ["/folder/known.txt"]
+        assert grouped["pdf"] == []
+        assert grouped["image"] == []
+        assert grouped["html"] == []
+        assert grouped["audio"] == []
+        assert grouped["video"] == []
+        assert "Unsupported file extension '.xyz'" in caplog.text
+
+    def test_auto_mode_logs_and_skips_unsupported_extension_in_dataframe_batch(self, caplog):
         from nemo_retriever.graph.multi_type_extract_operator import MultiTypeExtractCPUActor
 
         op = MultiTypeExtractCPUActor(extraction_mode="auto")
         batch = pd.DataFrame({"path": ["/folder/unknown.xyz"], "bytes": [b"unsupported"]})
 
-        with pytest.raises(ValueError, match=r"Unsupported file extension '\.xyz'"):
-            op.process(batch)
+        with caplog.at_level(logging.WARNING, logger="nemo_retriever.graph.multi_type_extract_operator"):
+            result = op.process(batch)
+
+        assert isinstance(result, pd.DataFrame)
+        assert result.empty
+        assert "Unsupported file extension '.xyz'" in caplog.text
 
     def test_preprocess_folder_path(self):
         """Test preprocessing with folder path."""

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -609,7 +609,6 @@ class TestMultiTypeExtractOperator:
             "/folder/page.html",
             "/folder/audio.mp3",
             "/folder/video.mp4",
-            "/folder/unknown.xyz",
         ]
 
         grouped = op.preprocess(files)
@@ -620,6 +619,21 @@ class TestMultiTypeExtractOperator:
         assert grouped["html"] == ["/folder/page.html"]
         assert grouped["audio"] == ["/folder/audio.mp3"]
         assert grouped["video"] == ["/folder/video.mp4"]
+
+    def test_auto_mode_rejects_unsupported_extension_in_file_list(self):
+        op = MultiTypeExtractOperator(extraction_mode="auto")
+
+        with pytest.raises(ValueError, match=r"Unsupported file extension '\.xyz'"):
+            op.preprocess(["/folder/unknown.xyz"])
+
+    def test_auto_mode_rejects_unsupported_extension_in_dataframe_batch(self):
+        from nemo_retriever.graph.multi_type_extract_operator import MultiTypeExtractCPUActor
+
+        op = MultiTypeExtractCPUActor(extraction_mode="auto")
+        batch = pd.DataFrame({"path": ["/folder/unknown.xyz"], "bytes": [b"unsupported"]})
+
+        with pytest.raises(ValueError, match=r"Unsupported file extension '\.xyz'"):
+            op.process(batch)
 
     def test_preprocess_folder_path(self):
         """Test preprocessing with folder path."""


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->
Adding warning logs for unsupported file type extractions to ensure those files aren't skipped silently but also don't fail too loudly (eg: error raises halting the pipeline)

Addresses https://nvbugspro.nvidia.com/bug/6113544 
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
