### PR TITLE
fix for tritonimport and tests

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -27,6 +27,31 @@ jobs:
 
       - uses: pre-commit/action@v3.0.1
 
+  # Core install must not require tritonclient (remote NIM / slim API); see tests/test_slim_imports_no_triton.py
+  slim-import-contract:
+    name: Slim import contract (core deps, no tritonclient)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Install nemo-retriever without local extra and assert slim imports
+        working-directory: nemo_retriever
+        run: |
+          set -euo pipefail
+          uv venv .venv-slim
+          source .venv-slim/bin/activate
+          uv pip install -e ".[dev]"
+          uv pip uninstall tritonclient 2>/dev/null || true
+          python -c "import importlib.util; import sys; sys.exit(0 if importlib.util.find_spec('tritonclient') is None else 1)"
+          python -m pytest tests/test_slim_imports_no_triton.py -q
+
   # Docker build + test for x86_64 (single job so built image is available locally)
   docker-build-and-test:
     name: Build & Test Docker (amd64)
@@ -47,6 +72,7 @@ jobs:
     name: PR Validation Complete
     needs:
       - pre-commit
+      - slim-import-contract
       - docker-build-and-test
     runs-on: ubuntu-latest
     if: always()

--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 ]
 dependencies = [
   # Core orchestration and framework
+  "backoff",
   "ray[data,serve]>=2.49.0",
   "ffmpeg-python",
   "pandas>=2.0,<3",
@@ -69,10 +70,15 @@ dependencies = [
 
 [project.optional-dependencies]
 
+# Core ``pip install nemo-retriever`` (no extras) supports remote HTTP NIM and the
+# ``retriever pipeline`` CLI without ``tritonclient``. Triton gRPC is imported only
+# when a gRPC client is constructed; install ``nemo-retriever[local]`` for on-box
+# Triton + GPU stacks (``tritonclient`` is listed under ``local``).
+
 # ── Local model inference (GPU assumed; torch resolves to CUDA on Linux) ─────
 # Adds HuggingFace transformers, torch, nemotron models, GPU monitoring, and vLLM.
 local = [
-  "backoff",
+
   "glom",
   "transformers>=4.57.6,<5",
   "tokenizers>=0.20.3",

--- a/nemo_retriever/src/nemo_retriever/api/internal/primitives/nim/default_values.py
+++ b/nemo_retriever/src/nemo_retriever/api/internal/primitives/nim/default_values.py
@@ -4,6 +4,7 @@
 
 # Copyright (c) 2024, NVIDIA CORPORATION.
 
+import os
 
 YOLOX_MAX_BATCH_SIZE = 8
 YOLOX_MAX_WIDTH = 1536
@@ -12,3 +13,6 @@ YOLOX_CONF_THRESHOLD = 0.01
 YOLOX_IOU_THRESHOLD = 0.5
 YOLOX_MIN_SCORE = 0.1
 YOLOX_FINAL_SCORE = 0.48
+
+# Page render format for PDFium → NIM image payloads (no triton dependency).
+YOLOX_PAGE_IMAGE_FORMAT = os.getenv("YOLOX_PAGE_IMAGE_FORMAT", "PNG")

--- a/nemo_retriever/src/nemo_retriever/api/internal/primitives/nim/model_interface/ocr.py
+++ b/nemo_retriever/src/nemo_retriever/api/internal/primitives/nim/model_interface/ocr.py
@@ -13,7 +13,6 @@ from typing import Tuple
 
 import backoff
 import numpy as np
-import tritonclient.grpc as grpcclient
 
 from nemo_retriever.api.internal.primitives.nim import ModelInterface
 from nemo_retriever.api.internal.primitives.nim.model_interface.decorators import global_cache
@@ -781,6 +780,8 @@ def get_ocr_model_name(ocr_grpc_endpoint=None, default_model_name=DEFAULT_OCR_MO
 
     # 4. Attempt to query the gRPC endpoint to discover the model name.
     try:
+        import tritonclient.grpc as grpcclient  # noqa: PLC0415
+
         client = grpcclient.InferenceServerClient(ocr_grpc_endpoint)
         model_index = client.get_model_repository_index(as_json=True)
         model_names = [x["name"] for x in model_index.get("models", [])]

--- a/nemo_retriever/src/nemo_retriever/api/internal/primitives/nim/model_interface/yolox.py
+++ b/nemo_retriever/src/nemo_retriever/api/internal/primitives/nim/model_interface/yolox.py
@@ -2,7 +2,6 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import logging
 import warnings
 import threading
@@ -19,7 +18,7 @@ import json
 import pandas as pd
 
 from nemo_retriever.api.internal.primitives.nim import ModelInterface
-import tritonclient.grpc as grpcclient
+from nemo_retriever.api.internal.primitives.nim.default_values import YOLOX_PAGE_IMAGE_FORMAT
 from nemo_retriever.api.internal.primitives.nim.model_interface.decorators import global_cache
 from nemo_retriever.api.internal.primitives.nim.model_interface.decorators import lock
 from nemo_retriever.api.internal.primitives.nim.model_interface.decorators import multiprocessing_cache
@@ -41,7 +40,6 @@ YOLOX_PAGE_MIN_SCORE = 0.1
 YOLOX_PAGE_NIM_MAX_IMAGE_SIZE = 512_000
 YOLOX_PAGE_IMAGE_PREPROC_HEIGHT = 1024
 YOLOX_PAGE_IMAGE_PREPROC_WIDTH = 1024
-YOLOX_PAGE_IMAGE_FORMAT = os.getenv("YOLOX_PAGE_IMAGE_FORMAT", "PNG")
 
 # yolox-page-elements-v3 contants
 YOLOX_PAGE_FINAL_SCORE = YOLOX_PAGE_V3_FINAL_SCORE = {
@@ -2168,6 +2166,8 @@ def get_yolox_model_name(yolox_grpc_endpoint, default_model_name="yolox"):
             return global_cache[key]
 
     try:
+        import tritonclient.grpc as grpcclient  # noqa: PLC0415
+
         client = grpcclient.InferenceServerClient(yolox_grpc_endpoint)
         model_index = client.get_model_repository_index(as_json=True)
         model_names = [x.get("name") for x in model_index.get("models", []) if isinstance(x, dict)]

--- a/nemo_retriever/src/nemo_retriever/api/internal/primitives/nim/nim_client.py
+++ b/nemo_retriever/src/nemo_retriever/api/internal/primitives/nim/nim_client.py
@@ -17,13 +17,20 @@ from typing import Tuple, Union
 
 import numpy as np
 import requests
-import tritonclient.grpc as grpcclient
 
 from nemo_retriever.api.internal.primitives.tracing.tagging import traceable_func
 from nemo_retriever.api.util.string_processing import generate_url
 
 
 logger = logging.getLogger(__name__)
+
+
+def _triton_grpc():
+    """Load Triton gRPC client only when gRPC inference is used (slim installs skip tritonclient)."""
+    import tritonclient.grpc as grpcclient  # noqa: PLC0415
+
+    return grpcclient
+
 
 # Regex pattern to detect CUDA-related errors in Triton gRPC responses
 CUDA_ERROR_REGEX = re.compile(
@@ -93,7 +100,8 @@ class NimClient:
             if not self._grpc_endpoint:
                 raise ValueError("gRPC endpoint must be provided for gRPC protocol")
             logger.debug(f"Creating gRPC client with {self._grpc_endpoint}")
-            self.client = grpcclient.InferenceServerClient(url=self._grpc_endpoint)
+            grpc = _triton_grpc()
+            self.client = grpc.InferenceServerClient(url=self._grpc_endpoint)
         elif self.protocol == "http":
             if not self._http_endpoint:
                 raise ValueError("HTTP endpoint must be provided for HTTP protocol")
@@ -321,14 +329,15 @@ class NimClient:
         dtypes = kwargs.get("dtypes", ["FP32"])
         input_names = kwargs.get("input_names", ["input"])
 
+        grpc = _triton_grpc()
         input_tensors = []
         for input_name, input_data, dtype in zip(input_names, formatted_input, dtypes):
-            input_tensors.append(grpcclient.InferInput(input_name, input_data.shape, datatype=dtype))
+            input_tensors.append(grpc.InferInput(input_name, input_data.shape, datatype=dtype))
 
         for idx, input_data in enumerate(formatted_input):
             input_tensors[idx].set_data_from_numpy(input_data)
 
-        outputs = [grpcclient.InferRequestedOutput(output_name) for output_name in output_names]
+        outputs = [grpc.InferRequestedOutput(output_name) for output_name in output_names]
 
         base_delay = 2.0
         attempt = 0
@@ -348,7 +357,7 @@ class NimClient:
                 else:
                     return [response.as_numpy(output.name()) for output in outputs]
 
-            except grpcclient.InferenceServerException as e:
+            except grpc.InferenceServerException as e:
                 status = str(e.status())
                 message = e.message()
 
@@ -747,14 +756,14 @@ def get_nim_client_manager(*args, **kwargs) -> NimClientManager:
     return NimClientManager(*args, **kwargs)
 
 
-def reload_models(client: grpcclient.InferenceServerClient, exclude: list[str] = [], client_timeout: int = 120) -> bool:
+def reload_models(client: Any, exclude: list[str] = [], client_timeout: int = 120) -> bool:
     """
     Reloads all models in the Triton server except for the models in the exclude list.
 
     Parameters
     ----------
-    client : grpcclient.InferenceServerClient
-        The gRPC client connected to the Triton server.
+    client
+        The gRPC client connected to the Triton server (``tritonclient.grpc``).
     exclude : list[str], optional
         A list of model names to exclude from reloading.
     client_timeout : int, optional
@@ -765,6 +774,7 @@ def reload_models(client: grpcclient.InferenceServerClient, exclude: list[str] =
     bool
         True if all models were successfully reloaded, False otherwise.
     """
+    grpc = _triton_grpc()
     model_index = client.get_model_repository_index()
     exclude = set(exclude)
     names = [m.name for m in model_index.models if m.name not in exclude]
@@ -775,7 +785,7 @@ def reload_models(client: grpcclient.InferenceServerClient, exclude: list[str] =
     for name in names:
         try:
             client.unload_model(name)
-        except grpcclient.InferenceServerException as e:
+        except grpc.InferenceServerException as e:
             msg = e.message()
             if "explicit model load / unload" in msg.lower():
                 status = e.status()

--- a/nemo_retriever/src/nemo_retriever/api/util/pdf/pdfium.py
+++ b/nemo_retriever/src/nemo_retriever/api/util/pdf/pdfium.py
@@ -31,7 +31,7 @@ from nemo_retriever.api.util.image_processing.transforms import (
     scale_numpy_image,
 )
 from nemo_retriever.api.util.metadata.aggregators import Base64Image
-from nemo_retriever.api.internal.primitives.nim.model_interface.yolox import YOLOX_PAGE_IMAGE_FORMAT
+from nemo_retriever.api.internal.primitives.nim.default_values import YOLOX_PAGE_IMAGE_FORMAT
 
 logger = logging.getLogger(__name__)
 

--- a/nemo_retriever/src/nemo_retriever/model/local/nemotron_ocr_v2.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/nemotron_ocr_v2.py
@@ -38,7 +38,7 @@ class NemotronOCRV2(BaseModel):
         super().__init__()
         configure_global_hf_cache_base()
         try:
-            from nemotron_ocr_v2.inference import pipeline_v2 as _nemotron_ocr_pipeline_v2  # local-only import
+            from nemotron_ocr.inference import pipeline_v2 as _nemotron_ocr_pipeline_v2  # local-only import
         except ImportError as exc:
             raise ImportError(
                 "Local Nemotron OCR v2 requires the `nemotron_ocr_v2` package. "

--- a/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
+++ b/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
@@ -19,11 +19,8 @@ def test_local_extra_depends_on_versioned_ocr_v2_nightly() -> None:
     uv_sources = uv_tool["sources"]
 
     assert "nemotron-ocr>=1.0.2.dev0,<1.0.2a0; sys_platform == 'linux'" in local_deps
-    assert "nemotron-ocr-v2>=2.0.0.dev0,<2.0.0a0; sys_platform == 'linux'" in local_deps
     assert "nemotron-ocr" in uv_tool["no-build-package"]
-    assert "nemotron-ocr-v2" in uv_tool["no-build-package"]
     assert uv_sources["nemotron-ocr"] == {"index": "test-pypi"}
-    assert uv_sources["nemotron-ocr-v2"] == {"index": "test-pypi"}
 
 
 def test_local_ocr_v2_wrapper_imports_versioned_module() -> None:
@@ -31,6 +28,5 @@ def test_local_ocr_v2_wrapper_imports_versioned_module() -> None:
         encoding="utf-8"
     )
 
-    assert "from nemotron_ocr_v2.inference import pipeline_v2" in source
-    assert "from nemotron_ocr.inference import pipeline_v2" not in source
+    assert "from nemotron_ocr.inference import pipeline_v2" in source
     assert "Local Nemotron OCR v2 requires the `nemotron_ocr_v2` package." in source

--- a/nemo_retriever/tests/test_slim_imports_no_triton.py
+++ b/nemo_retriever/tests/test_slim_imports_no_triton.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Ensure core pipeline / API imports never load ``tritonclient`` at import time.
+
+Remote-NIM and slim installs omit ``tritonclient``; gRPC code paths import it lazily.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+_SLIM_IMPORT_SCRIPT = r"""
+import builtins
+
+_real_import = builtins.__import__
+
+
+def _guard(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "tritonclient" or (
+        isinstance(name, str) and name.startswith("tritonclient.")
+    ):
+        raise ImportError("tritonclient import blocked (slim / API-only contract)")
+    return _real_import(name, globals, locals, fromlist, level)
+
+
+builtins.__import__ = _guard
+
+from nemo_retriever.api.util.nim import create_inference_client  # noqa: F401
+from nemo_retriever.graph_ingestor import GraphIngestor  # noqa: F401
+from nemo_retriever.pipeline import __main__ as _pipeline_main  # noqa: F401
+
+print("slim_imports_ok")
+"""
+
+
+def test_core_imports_do_not_require_tritonclient_at_import_time() -> None:
+    """Fresh interpreter: block tritonclient, then import hot paths used by remote pipeline."""
+    root = Path(__file__).resolve().parents[1]
+    src = root / "src"
+    env = os.environ.copy()
+    prev = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = str(src) + (os.pathsep + prev if prev else "")
+
+    proc = subprocess.run(
+        [sys.executable, "-c", _SLIM_IMPORT_SCRIPT],
+        cwd=str(root),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+    assert proc.returncode == 0, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}\n" f"exit={proc.returncode}"
+    assert "slim_imports_ok" in proc.stdout

--- a/nemo_retriever/uv.lock
+++ b/nemo_retriever/uv.lock
@@ -290,6 +290,15 @@ wheels = [
 ]
 
 [[package]]
+name = "audioread"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/4a/874ecf9b472f998130c2b5e145dcdb9f6131e84786111489103b66772143/audioread-3.1.0.tar.gz", hash = "sha256:1c4ab2f2972764c896a8ac61ac53e261c8d29f0c6ccd652f84e18f08a4cab190", size = 20082, upload-time = "2025-10-26T19:44:13.484Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/16/fbe8e1e185a45042f7cd3a282def5bb8d95bb69ab9e9ef6a5368aa17e426/audioread-3.1.0-py3-none-any.whl", hash = "sha256:b30d1df6c5d3de5dcef0fb0e256f6ea17bdcf5f979408df0297d8a408e2971b4", size = 23143, upload-time = "2025-10-26T19:44:12.016Z" },
+]
+
+[[package]]
 name = "authlib"
 version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -756,6 +765,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/55/f14deb95eaf4f30f07ef4b90a8590fc05d9e04df85ee379712f6fb6736d7/debugpy-1.8.20-cp312-cp312-win32.whl", hash = "sha256:4057ac68f892064e5f98209ab582abfee3b543fb55d2e87610ddc133a954d390", size = 5331372, upload-time = "2026-01-29T23:03:45.526Z" },
     { url = "https://files.pythonhosted.org/packages/a1/39/2bef246368bd42f9bd7cba99844542b74b84dacbdbea0833e610f384fee8/debugpy-1.8.20-cp312-cp312-win_amd64.whl", hash = "sha256:a1a8f851e7cf171330679ef6997e9c579ef6dd33c9098458bd9986a0f4ca52e3", size = 5372835, upload-time = "2026-01-29T23:03:47.245Z" },
     { url = "https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl", hash = "sha256:5be9bed9ae3be00665a06acaa48f8329d2b9632f15fd09f6a9a8c8d9907e54d7", size = 5337658, upload-time = "2026-01-29T23:04:17.404Z" },
+]
+
+[[package]]
+name = "decorator"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
 ]
 
 [[package]]
@@ -1304,9 +1322,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
     { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
     { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
-    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
     { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
     { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
     { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
     { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
@@ -1928,6 +1944,44 @@ wheels = [
 ]
 
 [[package]]
+name = "lazy-loader"
+version = "0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/ac/21a1f8aa3777f5658576777ea76bfb124b702c520bbe90edf4ae9915eafa/lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3", size = 15294, upload-time = "2026-03-06T15:45:09.054Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl", hash = "sha256:ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005", size = 8044, upload-time = "2026-03-06T15:45:07.668Z" },
+]
+
+[[package]]
+name = "librosa"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "audioread" },
+    { name = "decorator" },
+    { name = "joblib" },
+    { name = "lazy-loader" },
+    { name = "msgpack" },
+    { name = "numba", version = "0.61.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "numba", version = "0.65.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "pooch" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "soundfile" },
+    { name = "soxr" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/36/360b5aafa0238e29758729e9486c6ed92a6f37fa403b7875e06c115cdf4a/librosa-0.11.0.tar.gz", hash = "sha256:f5ed951ca189b375bbe2e33b2abd7e040ceeee302b9bbaeeffdfddb8d0ace908", size = 327001, upload-time = "2025-03-11T15:09:54.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/ba/c63c5786dfee4c3417094c4b00966e61e4a63efecee22cb7b4c0387dda83/librosa-0.11.0-py3-none-any.whl", hash = "sha256:0b6415c4fd68bff4c29288abe67c6d80b587e0e1e2cfb0aad23e4559504a7fa1", size = 260749, upload-time = "2025-03-11T15:09:52.982Z" },
+]
+
+[[package]]
 name = "litellm"
 version = "1.83.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1965,10 +2019,32 @@ wheels = [
 name = "llvmlite"
 version = "0.44.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "platform_machine == 's390x' and sys_platform == 'linux'",
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/89/6a/95a3d3610d5c75293d5dbbb2a76480d5d4eeba641557b69fe90af6c5b84e/llvmlite-0.44.0.tar.gz", hash = "sha256:07667d66a5d150abed9157ab6c0b9393c9356f229784a4385c02f99e94fc94d4", size = 171880, upload-time = "2025-01-20T11:14:41.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/da/8341fd3056419441286c8e26bf436923021005ece0bff5f41906476ae514/llvmlite-0.44.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0143a5ef336da14deaa8ec26c5449ad5b6a2b564df82fcef4be040b9cacfea9", size = 42361901, upload-time = "2025-01-20T11:13:46.711Z" },
     { url = "https://files.pythonhosted.org/packages/53/ad/d79349dc07b8a395a99153d7ce8b01d6fcdc9f8231355a5df55ded649b61/llvmlite-0.44.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d752f89e31b66db6f8da06df8b39f9b91e78c5feea1bf9e8c1fba1d1c24c065d", size = 41184247, upload-time = "2025-01-20T11:13:56.159Z" },
+]
+
+[[package]]
+name = "llvmlite"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine != 's390x' and sys_platform == 'win32'",
+    "platform_machine == 's390x' and sys_platform == 'win32'",
+    "platform_machine != 's390x' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "platform_machine == 's390x' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/88/a8952b6d5c21e74cbf158515b779666f692846502623e9e3c39d8e8ba25f/llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc", size = 193614, upload-time = "2026-03-31T18:29:53.497Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/48/4b7fe0e34c169fa2f12532916133e0b219d2823b540733651b34fdac509a/llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:306a265f408c259067257a732c8e159284334018b4083a9e35f67d19792b164f", size = 37232769, upload-time = "2026-03-31T18:28:43.735Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f5/d281ae0f79378a5a91f308ea9fdb9f9cc068fddd09629edc0725a5a8fde1/llvmlite-0.47.0-cp312-cp312-win_amd64.whl", hash = "sha256:f3079f25bdc24cd9d27c4b2b5e68f5f60c4fdb7e8ad5ee2b9b006007558f9df7", size = 38138692, upload-time = "2026-03-31T18:28:57.147Z" },
 ]
 
 [[package]]
@@ -2302,6 +2378,7 @@ wheels = [
 name = "nemo-retriever"
 source = { editable = "." }
 dependencies = [
+    { name = "backoff" },
     { name = "click" },
     { name = "debugpy" },
     { name = "fastapi" },
@@ -2340,7 +2417,6 @@ all = [
     { name = "addict" },
     { name = "albumentations" },
     { name = "apscheduler" },
-    { name = "backoff" },
     { name = "cairosvg" },
     { name = "datasets" },
     { name = "duckdb" },
@@ -2351,6 +2427,7 @@ all = [
     { name = "flashinfer-python", marker = "sys_platform == 'linux'" },
     { name = "glom" },
     { name = "langgraph" },
+    { name = "librosa" },
     { name = "litellm" },
     { name = "nemotron-graphic-elements-v1" },
     { name = "nemotron-ocr", marker = "sys_platform == 'linux'" },
@@ -2392,7 +2469,6 @@ local = [
     { name = "addict" },
     { name = "albumentations" },
     { name = "apscheduler" },
-    { name = "backoff" },
     { name = "easydict" },
     { name = "einops" },
     { name = "flashinfer-cubin", marker = "sys_platform == 'linux'" },
@@ -2420,6 +2496,7 @@ local = [
 ]
 multimedia = [
     { name = "cairosvg" },
+    { name = "librosa" },
     { name = "scipy" },
     { name = "soundfile" },
 ]
@@ -2436,7 +2513,7 @@ requires-dist = [
     { name = "addict", marker = "extra == 'local'" },
     { name = "albumentations", marker = "extra == 'local'", specifier = "==2.0.8" },
     { name = "apscheduler", marker = "extra == 'local'", specifier = ">=3.10" },
-    { name = "backoff", marker = "extra == 'local'" },
+    { name = "backoff" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2.2" },
     { name = "cairosvg", marker = "extra == 'multimedia'", specifier = ">=2.7.0" },
     { name = "click", specifier = ">=8.2.0" },
@@ -2457,6 +2534,7 @@ requires-dist = [
     { name = "lancedb" },
     { name = "langchain-nvidia-ai-endpoints", specifier = ">=0.3.0" },
     { name = "langgraph", marker = "extra == 'tabular'", specifier = ">=1.1.0" },
+    { name = "librosa", marker = "extra == 'multimedia'", specifier = ">=0.10.2" },
     { name = "litellm", marker = "extra == 'llm'", specifier = ">=1.40.0" },
     { name = "markitdown" },
     { name = "nemo-retriever", extras = ["benchmarks", "llm", "local", "multimedia", "tabular"], marker = "extra == 'all'" },
@@ -2675,14 +2753,40 @@ wheels = [
 name = "numba"
 version = "0.61.2"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine != 'aarch64' and platform_machine != 's390x' and platform_machine != 'x86_64' and sys_platform == 'linux'",
+    "platform_machine == 's390x' and sys_platform == 'linux'",
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "platform_machine == 'aarch64' and sys_platform == 'linux'",
+]
 dependencies = [
-    { name = "llvmlite", marker = "sys_platform == 'linux'" },
+    { name = "llvmlite", version = "0.44.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/a0/e21f57604304aa03ebb8e098429222722ad99176a4f979d34af1d1ee80da/numba-0.61.2.tar.gz", hash = "sha256:8750ee147940a6637b80ecf7f95062185ad8726c8c28a2295b8ec1160a196f7d", size = 2820615, upload-time = "2025-04-09T02:58:07.659Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/2d/e518df036feab381c23a624dac47f8445ac55686ec7f11083655eb707da3/numba-0.61.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b1bb509d01f23d70325d3a5a0e237cbc9544dd50e50588bc581ba860c213546", size = 3885928, upload-time = "2025-04-09T02:57:55.206Z" },
     { url = "https://files.pythonhosted.org/packages/10/0f/23cced68ead67b75d77cfcca3df4991d1855c897ee0ff3fe25a56ed82108/numba-0.61.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:48a53a3de8f8793526cbe330f2a39fe9a6638efcbf11bd63f3d2f9757ae345cd", size = 3577115, upload-time = "2025-04-09T02:57:56.818Z" },
+]
+
+[[package]]
+name = "numba"
+version = "0.65.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "platform_machine != 's390x' and sys_platform == 'win32'",
+    "platform_machine == 's390x' and sys_platform == 'win32'",
+    "platform_machine != 's390x' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "platform_machine == 's390x' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "llvmlite", version = "0.47.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/c5/db2ac3685833d626c0dcae6bd2330cd68433e1fd248d15f70998160d3ad7/numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23", size = 2765600, upload-time = "2026-04-24T02:02:56.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/bc/76f8f8c5cf9adee47fdb7bbb03be8900f76f902d451d7477cf12b845e1de/numba-0.65.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:ac3f1e77c352dd0ea9712732c2d8f9ca507717435eec5b5013bf138ac33c4a08", size = 2681371, upload-time = "2026-04-24T02:02:26.105Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9e/3c679b2ee078425b9e99a91e44f8d132a6830d8ccce5227bc5e9181aeed8/numba-0.65.1-cp312-cp312-win_amd64.whl", hash = "sha256:5971c632be2a2351500431f46213821dba8d02b18a9f7d02fd36bd2743e41a6a", size = 2750611, upload-time = "2026-04-24T02:02:31.477Z" },
 ]
 
 [[package]]
@@ -3431,6 +3535,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pooch"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/43/85ef45e8b36c6a48546af7b266592dc32d7f67837a6514d111bced6d7d75/pooch-1.9.0.tar.gz", hash = "sha256:de46729579b9857ffd3e741987a2f6d5e0e03219892c167c6578c0091fb511ed", size = 61788, upload-time = "2026-01-30T19:15:09.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2d/d4bf65e47cea8ff2c794a600c4fd1273a7902f268757c531e0ee9f18aa58/pooch-1.9.0-py3-none-any.whl", hash = "sha256:f265597baa9f760d25ceb29d0beb8186c243d6607b0f60b83ecf14078dbc703b", size = 67175, upload-time = "2026-01-30T19:15:08.36Z" },
 ]
 
 [[package]]
@@ -4440,6 +4558,23 @@ wheels = [
 ]
 
 [[package]]
+name = "soxr"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/11/27cebce4a108f77afea7c80545115536b45e3f11ebfb914f638fdd9ba847/soxr-1.1.0.tar.gz", hash = "sha256:9f228ae21c78fa9359ca98d8a5e8e91f30639e438e574133dace62c5b5309e44", size = 173067, upload-time = "2026-05-03T00:15:18.214Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/8a/f3da7973b5f1b05d2d7e94d5376b881dcbc05297900cae6c3d33d95b209b/soxr-1.1.0-cp312-abi3-macosx_10_14_x86_64.whl", hash = "sha256:e0e09fa633ce2e67df08b298afced4d184f6e753fc330f241022250f1d0d61da", size = 204124, upload-time = "2026-05-03T00:14:54.505Z" },
+    { url = "https://files.pythonhosted.org/packages/03/dc/200013a74641f8774664bbcd2346c695c05c2e300ea792adcb40a293eed0/soxr-1.1.0-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:d6a7ad82b8d5f3fcc04b1d2ca055562b96af571e1d4fa7c6c61d0fb509ac43b4", size = 165457, upload-time = "2026-05-03T00:14:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/88/2b/2e5eba817a762a2ec589ff165b8bc5955b25a0ad140045f7cd8e45410543/soxr-1.1.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf98c0d7b7d5ef5bf072fee8d3020e8b664f2d195933ea7bc5089267c2e22a06", size = 206529, upload-time = "2026-05-03T00:14:57.646Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/f1/0e55195893228609c9a08c3b13b7a83a46c3a992cd00d3304f0f320cfb07/soxr-1.1.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b033078e86f3c4a658e5697fac8995764fad9e799563616b630136b613167f1", size = 240413, upload-time = "2026-05-03T00:14:59.363Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4d/621e4150e4815246ad552d215a8a294a90143fedd19ee442cf82d3b3abc8/soxr-1.1.0-cp312-abi3-win_amd64.whl", hash = "sha256:6ae2a174bffea94e8ead857dad85999d3f49f091774dbad5b046c0417d7092f4", size = 174357, upload-time = "2026-05-03T00:15:00.724Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.49"
 source = { registry = "https://pypi.org/simple" }
@@ -5073,7 +5208,7 @@ dependencies = [
     { name = "model-hosting-container-standards", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux'" },
     { name = "msgspec", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux'" },
     { name = "ninja", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux'" },
-    { name = "numba", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux'" },
+    { name = "numba", version = "0.61.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux'" },
     { name = "nvidia-cutlass-dsl", marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux'" },
     { name = "openai", version = "2.24.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'aarch64' and platform_machine != 'x86_64' and sys_platform == 'linux'" },
@@ -5155,7 +5290,7 @@ dependencies = [
     { name = "model-hosting-container-standards", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "msgspec", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "ninja", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "numba", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "numba", version = "0.61.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "nvidia-cutlass-dsl", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "openai", version = "2.24.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
@@ -5326,7 +5461,7 @@ dependencies = [
     { name = "model-hosting-container-standards", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "msgspec", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "ninja", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numba", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "numba", version = "0.61.2", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "nvidia-cutlass-dsl", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "openai", version = "2.24.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },


### PR DESCRIPTION
## Description
Fix import failure that happens when using the base nrl library install and you try to run using urls. It fails on tritonclient import which is not required for the base path (urls only).

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
