### PR TITLE
Surface remote NIM stage errors

### DIFF
--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -55,6 +55,8 @@ For advanced scenarios, you might want to use library mode with self-hosted NIM 
 You can set custom endpoints for each NIM. 
 For examples of `*_ENDPOINT` variables, refer to [Environment variables](environment-config.md) and the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md).
 
+When you explicitly configure remote NIM endpoints in Python library mode, graph ingestion raises a `GraphIngestionError` if a stage reports row-level connection or inference errors. This makes unreachable services visible to callers instead of returning a DataFrame that looks successful. To intentionally keep partial results with row-level error payloads, pass `error_policy="collect"` to `GraphIngestor` or `create_ingestor`.
+
 
 
 

--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -200,3 +200,7 @@ where = ["src"]
 [tool.pytest.ini_options]
 # So ``from tests import …`` resolves to ``nemo_retriever/tests`` when pytest rootdir is this project.
 pythonpath = ["."]
+addopts = "-m 'not integration'"
+markers = [
+  "integration: mark a test as an integration test",
+]

--- a/nemo_retriever/src/nemo_retriever/__init__.py
+++ b/nemo_retriever/src/nemo_retriever/__init__.py
@@ -21,7 +21,15 @@ for _finder in sys.meta_path:
 
 from .retriever import retriever as _retriever_cls
 
-__all__ = ["__version__", "create_ingestor", "get_version", "get_version_info", "ingestor", "retriever"]
+__all__ = [
+    "__version__",
+    "create_ingestor",
+    "get_version",
+    "get_version_info",
+    "GraphIngestionError",
+    "ingestor",
+    "retriever",
+]
 
 retriever = _retriever_cls()
 
@@ -43,4 +51,8 @@ def __getattr__(name: str):
         from .ingestor import ingestor
 
         return ingestor
+    if name == "GraphIngestionError":
+        from .graph_ingestor import GraphIngestionError
+
+        return GraphIngestionError
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/nemo_retriever/src/nemo_retriever/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/graph_ingestor.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import json
 import os
 import sys
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Union
 
 from nemo_retriever.graph import InprocessExecutor, RayDataExecutor
 from nemo_retriever.graph.ingestor_runtime import batch_tuning_to_node_overrides, build_graph
@@ -58,15 +58,10 @@ from nemo_retriever.utils.ray_resource_hueristics import gather_cluster_resource
 
 
 _ERROR_FIELD_KEYS = ("error", "errors", "exception", "traceback", "failed")
-_REMOTE_EXTRACT_ENDPOINT_FIELDS = (
-    "invoke_url",
-    "page_elements_invoke_url",
-    "ocr_invoke_url",
-    "graphic_elements_invoke_url",
-    "table_structure_invoke_url",
-    "nemotron_parse_invoke_url",
-)
 _REMOTE_EMBED_ENDPOINT_FIELDS = ("embedding_endpoint", "embed_invoke_url")
+_DEFAULT_PAGE_ELEMENTS_COLUMN = "page_elements_v3"
+_DEFAULT_EMBED_COLUMN = "text_embeddings_1b_v2"
+_ERROR_MESSAGE_LIMIT = 256
 
 
 class GraphIngestionError(RuntimeError):
@@ -101,7 +96,7 @@ def _summarize_error_payload(error: Any) -> str:
         parts = []
         stage = error.get("stage")
         err_type = error.get("type") or error.get("error_type")
-        message = error.get("message") or error.get("detail")
+        message = _sanitize_error_text(error.get("message") or error.get("detail"))
         if stage:
             parts.append(str(stage))
         if err_type:
@@ -110,7 +105,20 @@ def _summarize_error_payload(error: Any) -> str:
             parts.append(str(message))
         if parts:
             return ": ".join(parts)
-    return str(error)
+    return _sanitize_error_text(error) or type(error).__name__
+
+
+def _sanitize_error_text(value: Any, *, limit: int = _ERROR_MESSAGE_LIMIT) -> str | None:
+    if value is None:
+        return None
+    text = str(value).encode("ascii", errors="ignore").decode("ascii")
+    text = " ".join(ch if ch.isprintable() else " " for ch in text).split()
+    text = " ".join(text)
+    if not text:
+        return None
+    if len(text) > limit:
+        return text[:limit].rstrip() + "..."
+    return text
 
 
 def _resolve_api_key(params: Any) -> Any:
@@ -555,7 +563,7 @@ class GraphIngestor(ingestor):
         return None
 
     @classmethod
-    def _iter_stage_errors_from_value(cls, value: Any, *, path: str = "") -> Any:
+    def _iter_stage_errors_from_value(cls, value: Any, *, path: str = "") -> Iterator[dict[str, Any]]:
         if isinstance(value, dict):
             for key in _ERROR_FIELD_KEYS:
                 if key in value and cls._is_populated_error_field(key, value.get(key)):
@@ -580,14 +588,15 @@ class GraphIngestor(ingestor):
                 yield from cls._iter_stage_errors_from_value(parsed, path=path)
 
     @classmethod
-    def _stage_error_records(cls, batch: Any) -> list[dict[str, Any]]:
-        columns = getattr(batch, "columns", None)
-        if columns is None:
+    def _stage_error_records(cls, batch: Any, *, columns: Iterable[str] | None = None) -> list[dict[str, Any]]:
+        available_columns = getattr(batch, "columns", None)
+        if available_columns is None:
             return []
+        target_columns = list(available_columns) if columns is None else [c for c in columns if c in available_columns]
 
         records: list[dict[str, Any]] = []
         for row_index, row in batch.iterrows():
-            for column in columns:
+            for column in target_columns:
                 for record in cls._iter_stage_errors_from_value(row[column]):
                     records.append(
                         {
@@ -624,18 +633,32 @@ class GraphIngestor(ingestor):
     def _params_has_configured_field(cls, params: Any, fields: tuple[str, ...]) -> bool:
         return any(cls._is_configured(cls._param_value(params, field)) for field in fields)
 
-    def _has_explicit_remote_nim_endpoint(self) -> bool:
-        return (
-            self._params_has_configured_field(self._extract_params, _REMOTE_EXTRACT_ENDPOINT_FIELDS)
-            or self._params_has_configured_field(self._embed_params, _REMOTE_EMBED_ENDPOINT_FIELDS)
-            or self._params_has_configured_field(self._caption_params, ("endpoint_url",))
-            or self._params_has_configured_field(self._asr_params, ("audio_endpoints",))
-        )
+    def _remote_stage_error_columns(self) -> set[str]:
+        columns: set[str] = set()
+
+        if self._params_has_configured_field(self._extract_params, ("page_elements_invoke_url",)):
+            columns.add(self._param_value(self._extract_params, "output_column") or _DEFAULT_PAGE_ELEMENTS_COLUMN)
+        if self._params_has_configured_field(self._extract_params, ("ocr_invoke_url",)):
+            columns.add("ocr")
+        if self._params_has_configured_field(self._extract_params, ("table_structure_invoke_url",)):
+            columns.add("table_structure_ocr_v1")
+        if self._params_has_configured_field(self._extract_params, ("graphic_elements_invoke_url",)):
+            columns.add("graphic_elements_ocr_v1")
+        if self._params_has_configured_field(self._extract_params, ("invoke_url", "nemotron_parse_invoke_url")):
+            columns.add("nemotron_parse_v1_2")
+
+        if self._params_has_configured_field(self._embed_params, _REMOTE_EMBED_ENDPOINT_FIELDS):
+            columns.add(self._param_value(self._embed_params, "output_column") or _DEFAULT_EMBED_COLUMN)
+
+        return columns
 
     def _raise_for_stage_errors(self, result: Any) -> None:
-        if self._error_policy == "collect" or not self._has_explicit_remote_nim_endpoint():
+        if self._error_policy == "collect":
             return
-        records = self._stage_error_records(result)
+        remote_columns = self._remote_stage_error_columns()
+        if not remote_columns:
+            return
+        records = self._stage_error_records(result, columns=remote_columns)
         if records:
             raise GraphIngestionError(records)
 

--- a/nemo_retriever/src/nemo_retriever/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/graph_ingestor.py
@@ -56,6 +56,62 @@ from nemo_retriever.utils.remote_auth import collect_remote_auth_runtime_env, re
 from nemo_retriever.utils.ray_resource_hueristics import gather_cluster_resources
 
 
+_ERROR_FIELD_KEYS = ("error", "errors", "exception", "traceback", "failed")
+_REMOTE_EXTRACT_ENDPOINT_FIELDS = (
+    "invoke_url",
+    "page_elements_invoke_url",
+    "ocr_invoke_url",
+    "graphic_elements_invoke_url",
+    "table_structure_invoke_url",
+    "nemotron_parse_invoke_url",
+)
+_REMOTE_EMBED_ENDPOINT_FIELDS = ("embedding_endpoint", "embed_invoke_url")
+
+
+class GraphIngestionError(RuntimeError):
+    """Raised when graph ingestion stages report structured row-level errors."""
+
+    def __init__(self, records: list[dict[str, Any]]) -> None:
+        self.records = records
+        super().__init__(_format_stage_error_message(records))
+
+
+def _format_stage_error_message(records: list[dict[str, Any]]) -> str:
+    limit = 5
+    details = []
+    for record in records[:limit]:
+        details.append(
+            "row {row_index}, column {column}, path {path}: {summary}".format(
+                row_index=record.get("row_index"),
+                column=record.get("column"),
+                path=record.get("path"),
+                summary=_summarize_error_payload(record.get("error")),
+            )
+        )
+    more = "" if len(records) <= limit else f" ({len(records) - limit} more)"
+    return (
+        "Graph ingestion detected row-level errors from an explicitly configured remote NIM endpoint"
+        f"{more}. " + "; ".join(details)
+    )
+
+
+def _summarize_error_payload(error: Any) -> str:
+    if isinstance(error, dict):
+        parts = []
+        stage = error.get("stage")
+        err_type = error.get("type") or error.get("error_type")
+        message = error.get("message") or error.get("detail")
+        if stage:
+            parts.append(str(stage))
+        if err_type:
+            parts.append(str(err_type))
+        if message:
+            parts.append(str(message))
+        if parts:
+            return ": ".join(parts)
+    return str(error)
+
+
 def _resolve_api_key(params: Any) -> Any:
     """Auto-resolve api_key from NVIDIA_API_KEY / NGC_API_KEY if not explicitly set."""
     if params is None:
@@ -109,6 +165,10 @@ class GraphIngestor(ingestor):
         ``RayDataExecutor.__init__`` (``num_gpus``, ``batch_size``, etc.).
     show_progress
         Show a tqdm progress bar when running in inprocess mode.
+    error_policy
+        ``"raise"`` raises when explicitly configured remote NIM stages report
+        row-level errors. ``"collect"`` returns partial results with the stage
+        error payloads preserved.
     """
 
     RUN_MODE = "graph"
@@ -127,10 +187,13 @@ class GraphIngestor(ingestor):
         num_gpus: float = 0,
         node_overrides: Optional[Dict[str, Dict[str, Any]]] = None,
         show_progress: bool = True,
+        error_policy: str = "raise",
     ) -> None:
         super().__init__(documents=documents)
         if run_mode not in {"batch", "inprocess"}:
             raise ValueError(f"run_mode must be 'batch' or 'inprocess', got {run_mode!r}")
+        if error_policy not in {"raise", "collect"}:
+            raise ValueError(f"error_policy must be 'raise' or 'collect', got {error_policy!r}")
         self._run_mode = run_mode
         self._ray_address = ray_address
         self._ray_log_to_driver = ray_log_to_driver
@@ -141,6 +204,7 @@ class GraphIngestor(ingestor):
         self._num_gpus = num_gpus
         self._node_overrides: Dict[str, Dict[str, Any]] = node_overrides or {}
         self._show_progress = show_progress
+        self._error_policy = error_policy
         self._rd_dataset: Any = None
 
         # Pipeline configuration accumulated by fluent methods
@@ -443,6 +507,7 @@ class GraphIngestor(ingestor):
             self._rd_dataset = None
             result = executor.ingest(self._documents)
 
+        self._raise_for_stage_errors(result)
         return result
 
     # ------------------------------------------------------------------
@@ -450,39 +515,113 @@ class GraphIngestor(ingestor):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _has_error(v: Any) -> bool:
-        def _is_populated_error_field(key: str, value: Any) -> bool:
-            if value is None:
-                return False
-            if key == "failed" and isinstance(value, bool):
-                return value
-            if isinstance(value, str):
-                return bool(value.strip())
-            if isinstance(value, (list, tuple, set, dict)):
-                return len(value) > 0
-            return bool(value)
-
-        if v is None:
+    def _is_populated_error_field(key: str, value: Any) -> bool:
+        if value is None:
             return False
-        if isinstance(v, dict):
-            for k in ("error", "errors", "exception", "traceback", "failed"):
-                if k in v and _is_populated_error_field(k, v.get(k)):
-                    return True
-            return any(GraphIngestor._has_error(x) for x in v.values())
-        if isinstance(v, list):
-            return any(GraphIngestor._has_error(x) for x in v)
-        if isinstance(v, str):
-            s = v.strip()
-            if not s:
-                return False
-            if (s.startswith("{") and s.endswith("}")) or (s.startswith("[") and s.endswith("]")):
-                try:
-                    return GraphIngestor._has_error(json.loads(s))
-                except Exception:
-                    pass
-            low = s.lower()
-            return any(tok in low for tok in ("error", "exception", "traceback", "failed"))
-        return False
+        if key == "failed" and isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return bool(value.strip())
+        if isinstance(value, (list, tuple, set, dict)):
+            return len(value) > 0
+        return bool(value)
+
+    @staticmethod
+    def _jsonish(value: str) -> Any:
+        s = value.strip()
+        if not s:
+            return None
+        if (s.startswith("{") and s.endswith("}")) or (s.startswith("[") and s.endswith("]")):
+            try:
+                return json.loads(s)
+            except Exception:
+                return None
+        return None
+
+    @classmethod
+    def _iter_stage_errors_from_value(cls, value: Any, *, path: str = "") -> Any:
+        if isinstance(value, dict):
+            for key in _ERROR_FIELD_KEYS:
+                if key in value and cls._is_populated_error_field(key, value.get(key)):
+                    yield {
+                        "path": f"{path}.{key}" if path else key,
+                        "error": value.get(key),
+                    }
+            for key, child in value.items():
+                if key in _ERROR_FIELD_KEYS and cls._is_populated_error_field(key, child):
+                    continue
+                child_path = f"{path}.{key}" if path else str(key)
+                yield from cls._iter_stage_errors_from_value(child, path=child_path)
+            return
+        if isinstance(value, (list, tuple)):
+            for i, child in enumerate(value):
+                child_path = f"{path}[{i}]" if path else f"[{i}]"
+                yield from cls._iter_stage_errors_from_value(child, path=child_path)
+            return
+        if isinstance(value, str):
+            parsed = cls._jsonish(value)
+            if parsed is not None:
+                yield from cls._iter_stage_errors_from_value(parsed, path=path)
+
+    @classmethod
+    def _stage_error_records(cls, batch: Any) -> list[dict[str, Any]]:
+        columns = getattr(batch, "columns", None)
+        if columns is None:
+            return []
+
+        records: list[dict[str, Any]] = []
+        for row_index, row in batch.iterrows():
+            for column in columns:
+                for record in cls._iter_stage_errors_from_value(row[column]):
+                    records.append(
+                        {
+                            "row_index": row_index,
+                            "column": column,
+                            **record,
+                        }
+                    )
+        return records
+
+    @staticmethod
+    def _has_error(v: Any) -> bool:
+        return any(GraphIngestor._iter_stage_errors_from_value(v))
+
+    @staticmethod
+    def _param_value(params: Any, field: str) -> Any:
+        if params is None:
+            return None
+        if isinstance(params, dict):
+            return params.get(field)
+        return getattr(params, field, None)
+
+    @classmethod
+    def _is_configured(cls, value: Any) -> bool:
+        if value is None:
+            return False
+        if isinstance(value, str):
+            return bool(value.strip())
+        if isinstance(value, (list, tuple, set)):
+            return any(cls._is_configured(v) for v in value)
+        return bool(value)
+
+    @classmethod
+    def _params_has_configured_field(cls, params: Any, fields: tuple[str, ...]) -> bool:
+        return any(cls._is_configured(cls._param_value(params, field)) for field in fields)
+
+    def _has_explicit_remote_nim_endpoint(self) -> bool:
+        return (
+            self._params_has_configured_field(self._extract_params, _REMOTE_EXTRACT_ENDPOINT_FIELDS)
+            or self._params_has_configured_field(self._embed_params, _REMOTE_EMBED_ENDPOINT_FIELDS)
+            or self._params_has_configured_field(self._caption_params, ("endpoint_url",))
+            or self._params_has_configured_field(self._asr_params, ("audio_endpoints",))
+        )
+
+    def _raise_for_stage_errors(self, result: Any) -> None:
+        if self._error_policy == "collect" or not self._has_explicit_remote_nim_endpoint():
+            return
+        records = self._stage_error_records(result)
+        if records:
+            raise GraphIngestionError(records)
 
     @staticmethod
     def extract_error_rows(batch: Any) -> Any:
@@ -491,21 +630,11 @@ class GraphIngestor(ingestor):
         columns = getattr(batch, "columns", None)
         if columns is None:
             return batch
-        error_candidate_columns = (
-            "error",
-            "errors",
-            "exception",
-            "traceback",
-            "metadata",
-            "source",
-            "embedding",
-        )
-        cols = [c for c in error_candidate_columns if c in columns]
-        if not cols:
+        if len(columns) == 0:
             return batch.iloc[0:0]
 
-        mask = batch[cols[0]].apply(GraphIngestor._has_error).astype(bool)
-        for c in cols[1:]:
+        mask = batch[columns[0]].apply(GraphIngestor._has_error).astype(bool)
+        for c in columns[1:]:
             mask = mask | batch[c].apply(GraphIngestor._has_error).astype(bool)
         return batch[mask]
 
@@ -513,6 +642,8 @@ class GraphIngestor(ingestor):
         target = dataset if dataset is not None else self._rd_dataset
         if target is None:
             raise RuntimeError("No Ray Dataset available to inspect for errors.")
+        if getattr(target, "columns", None) is not None:
+            return self.extract_error_rows(target)
         return target.map_batches(self.extract_error_rows, batch_format="pandas")
 
     def get_dataset(self) -> Any:

--- a/nemo_retriever/src/nemo_retriever/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/graph_ingestor.py
@@ -111,7 +111,7 @@ def _sanitize_error_text(value: Any, *, limit: int = _ERROR_MESSAGE_LIMIT) -> st
     if value is None:
         return None
     text = str(value).encode("ascii", errors="ignore").decode("ascii")
-    text = " ".join(ch if ch.isprintable() else " " for ch in text).split()
+    text = "".join(ch if ch.isprintable() else " " for ch in text).split()
     text = " ".join(text)
     if not text:
         return None
@@ -675,10 +675,12 @@ class GraphIngestor(ingestor):
         return batch[mask]
 
     def get_error_rows(self, dataset: Any = None) -> Any:
+        import pandas as pd
+
         target = dataset if dataset is not None else self._rd_dataset
         if target is None:
             raise RuntimeError("No Ray Dataset available to inspect for errors.")
-        if getattr(target, "columns", None) is not None:
+        if isinstance(target, pd.DataFrame):
             return self.extract_error_rows(target)
         return target.map_batches(self.extract_error_rows, batch_format="pandas")
 

--- a/nemo_retriever/src/nemo_retriever/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/graph_ingestor.py
@@ -26,7 +26,6 @@ Usage::
 
 from __future__ import annotations
 
-import json
 import os
 import sys
 from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Union
@@ -550,18 +549,6 @@ class GraphIngestor(ingestor):
             return len(value) > 0
         return bool(value)
 
-    @staticmethod
-    def _jsonish(value: str) -> Any:
-        s = value.strip()
-        if not s:
-            return None
-        if (s.startswith("{") and s.endswith("}")) or (s.startswith("[") and s.endswith("]")):
-            try:
-                return json.loads(s)
-            except Exception:
-                return None
-        return None
-
     @classmethod
     def _iter_stage_errors_from_value(cls, value: Any, *, path: str = "") -> Iterator[dict[str, Any]]:
         if isinstance(value, dict):
@@ -582,10 +569,6 @@ class GraphIngestor(ingestor):
                 child_path = f"{path}[{i}]" if path else f"[{i}]"
                 yield from cls._iter_stage_errors_from_value(child, path=child_path)
             return
-        if isinstance(value, str):
-            parsed = cls._jsonish(value)
-            if parsed is not None:
-                yield from cls._iter_stage_errors_from_value(parsed, path=path)
 
     @classmethod
     def _stage_error_records(cls, batch: Any, *, columns: Iterable[str] | None = None) -> list[dict[str, Any]]:

--- a/nemo_retriever/src/nemo_retriever/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/graph_ingestor.py
@@ -589,22 +589,36 @@ class GraphIngestor(ingestor):
 
     @classmethod
     def _stage_error_records(cls, batch: Any, *, columns: Iterable[str] | None = None) -> list[dict[str, Any]]:
-        available_columns = getattr(batch, "columns", None)
-        if available_columns is None:
+        iter_batches = getattr(batch, "iter_batches", None)
+        if getattr(batch, "columns", None) is None and not callable(iter_batches):
             return []
-        target_columns = list(available_columns) if columns is None else [c for c in columns if c in available_columns]
+        requested_columns = list(columns) if columns is not None else None
+
+        if callable(iter_batches):
+            batches = iter_batches(batch_format="pandas")
+        else:
+            batches = (batch,)
 
         records: list[dict[str, Any]] = []
-        for row_index, row in batch.iterrows():
-            for column in target_columns:
-                for record in cls._iter_stage_errors_from_value(row[column]):
-                    records.append(
-                        {
-                            "row_index": row_index,
-                            "column": column,
-                            **record,
-                        }
-                    )
+        for batch_df in batches:
+            available_columns = getattr(batch_df, "columns", None)
+            if available_columns is None:
+                continue
+            target_columns = (
+                list(available_columns)
+                if requested_columns is None
+                else [c for c in requested_columns if c in available_columns]
+            )
+            for row_index, row in batch_df.iterrows():
+                for column in target_columns:
+                    for record in cls._iter_stage_errors_from_value(row[column]):
+                        records.append(
+                            {
+                                "row_index": row_index,
+                                "column": column,
+                                **record,
+                            }
+                        )
         return records
 
     @staticmethod

--- a/nemo_retriever/src/nemo_retriever/ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor.py
@@ -79,6 +79,7 @@ def create_ingestor(
         ray_log_to_driver=parsed.ray_log_to_driver,
         debug=parsed.debug,
         allow_no_gpu=parsed.allow_no_gpu,
+        error_policy=parsed.error_policy,
     )
 
 

--- a/nemo_retriever/src/nemo_retriever/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/params/models.py
@@ -106,6 +106,7 @@ class IngestorCreateParams(_ParamsModel):
     base_url: str = "http://localhost:7670"
     allow_no_gpu: bool = False
     api_key: Optional[str] = None
+    error_policy: Literal["raise", "collect"] = "raise"
     # service run mode: maximum number of concurrent page uploads.  Lower
     # values (e.g. 2-4) reduce burst pressure on Kubernetes NodePort /
     # kube-proxy paths that otherwise reset connections under heavy load.

--- a/nemo_retriever/tests/test_ingest_interface.py
+++ b/nemo_retriever/tests/test_ingest_interface.py
@@ -270,6 +270,27 @@ def test_graph_ingestion_error_sanitizes_remote_message_fields() -> None:
     assert sensitive_tail not in raw_rendered
 
 
+def test_graph_ingestion_error_preserves_readable_remote_message_text() -> None:
+    err = GraphIngestionError(
+        [
+            {
+                "row_index": 0,
+                "column": "page_elements_v3",
+                "path": "error",
+                "error": {
+                    "stage": "remote_inference",
+                    "type": "ConnectionError",
+                    "message": "connection\nrefused",
+                },
+            }
+        ]
+    )
+
+    rendered = str(err)
+    assert "connection refused" in rendered
+    assert "c o n n e c t i o n" not in rendered
+
+
 def test_get_error_rows_accepts_inprocess_dataframe_stage_error_columns() -> None:
     ingestor = GraphIngestor(run_mode="inprocess")
     df = pd.DataFrame(
@@ -290,6 +311,39 @@ def test_get_error_rows_accepts_inprocess_dataframe_stage_error_columns() -> Non
     )
 
     errors = ingestor.get_error_rows(df)
+
+    assert len(errors) == 1
+    assert errors.iloc[0]["text"] == "first page"
+
+
+def test_get_error_rows_maps_batch_dataset_with_columns_property() -> None:
+    class RayLikeDataset:
+        columns = ["page_elements_v3", "text"]
+
+        def __getitem__(self, key: str):
+            raise AssertionError(f"expected map_batches path, got pandas access for {key}")
+
+        def map_batches(self, fn, *, batch_format: str):
+            assert batch_format == "pandas"
+            batch = pd.DataFrame(
+                {
+                    "page_elements_v3": [
+                        {
+                            "timing": None,
+                            "error": {
+                                "stage": "remote_inference",
+                                "type": "ConnectionError",
+                                "message": "connection refused",
+                            },
+                        },
+                        {"timing": None, "error": None},
+                    ],
+                    "text": ["first page", "second page"],
+                }
+            )
+            return fn(batch)
+
+    errors = GraphIngestor(run_mode="batch").get_error_rows(RayLikeDataset())
 
     assert len(errors) == 1
     assert errors.iloc[0]["text"] == "first page"

--- a/nemo_retriever/tests/test_ingest_interface.py
+++ b/nemo_retriever/tests/test_ingest_interface.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 
 from nemo_retriever.graph_ingestor import GraphIngestor
@@ -10,6 +11,7 @@ from nemo_retriever.params import (
     EmbedParams,
     ExtractParams,
     HtmlChunkParams,
+    RemoteRetryParams,
     TextChunkParams,
 )
 
@@ -32,6 +34,12 @@ def test_create_ingestor_parses_kwargs_and_returns_graph_ingestor() -> None:
     assert isinstance(ingestor, GraphIngestor)
     assert ingestor._run_mode == "inprocess"
     assert ingestor._documents == ["doc.pdf"]
+
+
+def test_create_ingestor_passes_error_policy_to_graph_ingestor() -> None:
+    ingestor = create_ingestor(run_mode="inprocess", error_policy="collect")
+    assert isinstance(ingestor, GraphIngestor)
+    assert ingestor._error_policy == "collect"
 
 
 def test_create_ingestor_rejects_unknown_kwargs() -> None:
@@ -96,3 +104,82 @@ def test_typed_shortcuts_preserve_legacy_no_default_chunking() -> None:
     txt_ingestor = GraphIngestor(run_mode="inprocess").extract_txt(custom)
     assert txt_ingestor._split_config["text"] is None
     assert txt_ingestor._text_params is custom
+
+
+def test_graph_ingestor_raises_for_explicit_remote_stage_errors() -> None:
+    ingestor = GraphIngestor(
+        run_mode="inprocess",
+        documents=["data/test.pdf"],
+        show_progress=False,
+    ).extract(
+        page_elements_invoke_url="http://127.0.0.1:1/v1/nonexistent",
+        extract_text=False,
+        extract_images=True,
+        extract_tables=False,
+        extract_charts=False,
+        extract_infographics=False,
+        inference_batch_size=1,
+        remote_retry=RemoteRetryParams(
+            remote_max_pool_workers=1,
+            remote_max_retries=1,
+            remote_max_429_retries=1,
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="page_elements_v3"):
+        ingestor.ingest()
+
+
+def test_graph_ingestor_collect_policy_returns_explicit_remote_stage_errors() -> None:
+    result = (
+        GraphIngestor(
+            run_mode="inprocess",
+            documents=["data/test.pdf"],
+            show_progress=False,
+            error_policy="collect",
+        )
+        .extract(
+            page_elements_invoke_url="http://127.0.0.1:1/v1/nonexistent",
+            extract_text=False,
+            extract_images=True,
+            extract_tables=False,
+            extract_charts=False,
+            extract_infographics=False,
+            inference_batch_size=1,
+            remote_retry=RemoteRetryParams(
+                remote_max_pool_workers=1,
+                remote_max_retries=1,
+                remote_max_429_retries=1,
+            ),
+        )
+        .ingest()
+    )
+
+    assert "page_elements_v3" in result.columns
+    payload = result.iloc[0]["page_elements_v3"]
+    assert payload["error"]["type"] == "ConnectionError"
+
+
+def test_get_error_rows_accepts_inprocess_dataframe_stage_error_columns() -> None:
+    ingestor = GraphIngestor(run_mode="inprocess")
+    df = pd.DataFrame(
+        {
+            "table_structure_ocr_v1": [
+                {
+                    "timing": None,
+                    "error": {
+                        "stage": "remote_inference",
+                        "type": "ConnectionError",
+                        "message": "connection refused",
+                    },
+                },
+                {"timing": None, "error": None},
+            ],
+            "text": ["first page", "second page"],
+        }
+    )
+
+    errors = ingestor.get_error_rows(df)
+
+    assert len(errors) == 1
+    assert errors.iloc[0]["text"] == "first page"

--- a/nemo_retriever/tests/test_ingest_interface.py
+++ b/nemo_retriever/tests/test_ingest_interface.py
@@ -1,7 +1,8 @@
 import pandas as pd
 import pytest
 
-from nemo_retriever.graph_ingestor import GraphIngestor
+import nemo_retriever
+from nemo_retriever.graph_ingestor import GraphIngestionError, GraphIngestor
 from nemo_retriever.ingestor import IngestorCreateParams, _merge_params, create_ingestor
 from nemo_retriever.params import (
     ASRParams,
@@ -40,6 +41,11 @@ def test_create_ingestor_passes_error_policy_to_graph_ingestor() -> None:
     ingestor = create_ingestor(run_mode="inprocess", error_policy="collect")
     assert isinstance(ingestor, GraphIngestor)
     assert ingestor._error_policy == "collect"
+
+
+def test_graph_ingestion_error_is_exported_from_top_level_package() -> None:
+    assert "GraphIngestionError" in nemo_retriever.__all__
+    assert nemo_retriever.GraphIngestionError is GraphIngestionError
 
 
 def test_create_ingestor_rejects_unknown_kwargs() -> None:
@@ -106,6 +112,7 @@ def test_typed_shortcuts_preserve_legacy_no_default_chunking() -> None:
     assert txt_ingestor._text_params is custom
 
 
+@pytest.mark.integration
 def test_graph_ingestor_raises_for_explicit_remote_stage_errors() -> None:
     ingestor = GraphIngestor(
         run_mode="inprocess",
@@ -130,6 +137,7 @@ def test_graph_ingestor_raises_for_explicit_remote_stage_errors() -> None:
         ingestor.ingest()
 
 
+@pytest.mark.integration
 def test_graph_ingestor_collect_policy_returns_explicit_remote_stage_errors() -> None:
     result = (
         GraphIngestor(
@@ -158,6 +166,71 @@ def test_graph_ingestor_collect_policy_returns_explicit_remote_stage_errors() ->
     assert "page_elements_v3" in result.columns
     payload = result.iloc[0]["page_elements_v3"]
     assert payload["error"]["type"] == "ConnectionError"
+
+
+def test_strict_remote_error_policy_ignores_unrelated_error_columns() -> None:
+    ingestor = GraphIngestor(run_mode="inprocess").extract(
+        page_elements_invoke_url="http://remote.example/v1/page-elements",
+        extract_text=False,
+        extract_images=True,
+        extract_tables=False,
+        extract_charts=False,
+        extract_infographics=False,
+    )
+    result = pd.DataFrame(
+        {
+            "page_elements_v3": [{"detections": [], "error": None}],
+            "metadata": [
+                {
+                    "error": {
+                        "stage": "local_postprocess",
+                        "type": "ValueError",
+                        "message": "local stage failed",
+                    }
+                }
+            ],
+        }
+    )
+
+    ingestor._raise_for_stage_errors(result)
+
+
+def test_graph_ingestion_error_sanitizes_remote_message_fields() -> None:
+    sensitive_tail = "TAIL_SHOULD_NOT_APPEAR"
+    long_message = "π" + ("x" * 600) + sensitive_tail
+
+    err = GraphIngestionError(
+        [
+            {
+                "row_index": 0,
+                "column": "page_elements_v3",
+                "path": "error",
+                "error": {
+                    "stage": "remote_inference",
+                    "type": "BadRequest",
+                    "message": long_message,
+                },
+            }
+        ]
+    )
+
+    rendered = str(err)
+    assert "π" not in rendered
+    assert sensitive_tail not in rendered
+
+    raw_string_err = GraphIngestionError(
+        [
+            {
+                "row_index": 0,
+                "column": "text_embeddings_1b_v2",
+                "path": "error",
+                "error": long_message,
+            }
+        ]
+    )
+    raw_rendered = str(raw_string_err)
+    assert "π" not in raw_rendered
+    assert sensitive_tail not in raw_rendered
 
 
 def test_get_error_rows_accepts_inprocess_dataframe_stage_error_columns() -> None:

--- a/nemo_retriever/tests/test_ingest_interface.py
+++ b/nemo_retriever/tests/test_ingest_interface.py
@@ -195,6 +195,43 @@ def test_strict_remote_error_policy_ignores_unrelated_error_columns() -> None:
     ingestor._raise_for_stage_errors(result)
 
 
+def test_strict_remote_error_policy_accepts_batch_dataset_rows() -> None:
+    class RayLikeDataset:
+        columns = ["page_elements_v3", "metadata"]
+
+        def iter_batches(self, *, batch_format: str):
+            assert batch_format == "pandas"
+            yield pd.DataFrame(
+                {
+                    "page_elements_v3": [
+                        {
+                            "timing": None,
+                            "error": {
+                                "stage": "remote_inference",
+                                "type": "ConnectionError",
+                                "message": "connection refused",
+                            },
+                        }
+                    ],
+                    "metadata": [{"source": "test.pdf"}],
+                }
+            )
+
+    ingestor = GraphIngestor(run_mode="batch").extract(
+        page_elements_invoke_url="http://remote.example/v1/page-elements",
+        extract_text=False,
+        extract_images=True,
+        extract_tables=False,
+        extract_charts=False,
+        extract_infographics=False,
+    )
+
+    with pytest.raises(GraphIngestionError, match="page_elements_v3") as exc_info:
+        ingestor._raise_for_stage_errors(RayLikeDataset())
+
+    assert exc_info.value.records[0]["row_index"] == 0
+
+
 def test_graph_ingestion_error_sanitizes_remote_message_fields() -> None:
     sensitive_tail = "TAIL_SHOULD_NOT_APPEAR"
     long_message = "π" + ("x" * 600) + sensitive_tail


### PR DESCRIPTION
## Description

This PR makes graph ingestion fail visibly when a caller explicitly configures a remote NIM endpoint and that endpoint reports row-level connection or inference errors.

Previously, stages such as page-elements caught remote transport failures and stored them in payload columns like `page_elements_v3.error`, while `GraphIngestor(...).ingest()` returned the DataFrame as if ingestion had succeeded. That made unreachable explicit endpoints hard to detect in Python library mode.

Changes:
- Adds `GraphIngestionError`, raised after graph execution when explicit remote NIM-backed stages report structured row-level errors.
- Adds `error_policy="collect"` to `GraphIngestor` and `create_ingestor` for callers that intentionally want partial results with row-level error payloads.
- Centralizes stage error detection across result columns instead of patching only page-elements.
- Allows `get_error_rows()` to inspect in-process pandas DataFrames as well as Ray datasets.
- Documents strict vs. collect behavior for Python library mode.

Validation:
- `uv run --project nemo_retriever --extra dev pytest nemo_retriever/tests/test_ingest_interface.py nemo_retriever/tests/test_params_models.py nemo_retriever/tests/test_graph_pipeline_cli.py -q`
- `git diff --check`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file. N/A: this PR does not adjust docker-compose environment variables.
