### PR TITLE
Unblock Docker and pre-commit CI checks

### DIFF
--- a/.github/workflows/reusable-docker-build-and-test.yml
+++ b/.github/workflows/reusable-docker-build-and-test.yml
@@ -214,15 +214,14 @@ jobs:
             COV_ARGS=""
           fi
 
-          # Use pip (not uv): the service image runs as user `nemo`, which cannot execute
-          # binaries under /root/.local/bin because /root is not traversable (mode 0700).
+          # Use uv so pyproject uv sources are honored for nightly Nemotron packages.
           if [ "${{ inputs.test-selection }}" = "full" ]; then
-            CMD="source /opt/retriever_runtime/bin/activate; pip install -e \"./nemo_retriever[all,dev]\" && pip install pytest && python -m pytest nemo_retriever/tests"
+            CMD="source /opt/retriever_runtime/bin/activate; uv pip install -e \"./nemo_retriever[all,dev]\" && uv pip install pytest && python -m pytest nemo_retriever/tests"
           else
             N="${{ inputs.random-count }}"
             CMD="set -euo pipefail; \
               source /opt/retriever_runtime/bin/activate; \
-              pip install -e \"./nemo_retriever[all,dev]\" && pip install pytest; \
+              uv pip install -e \"./nemo_retriever[all,dev]\" && uv pip install pytest; \
               python -m pytest --collect-only -q $TEST_PATHS | grep '::' | shuf -n \"$N\" > /tmp/selected-tests.txt; \
               python -m pytest -rs -m \"$MARKERS\" $COV_ARGS \$(cat /tmp/selected-tests.txt)"
           fi

--- a/.github/workflows/reusable-docker-build-and-test.yml
+++ b/.github/workflows/reusable-docker-build-and-test.yml
@@ -216,7 +216,7 @@ jobs:
 
           # Use uv so pyproject uv sources are honored for nightly Nemotron packages.
           if [ "${{ inputs.test-selection }}" = "full" ]; then
-            CMD="source /opt/retriever_runtime/bin/activate; uv pip install -e \"./nemo_retriever[all,dev]\" && uv pip install pytest && python -m pytest nemo_retriever/tests"
+            CMD="set -euo pipefail; source /opt/retriever_runtime/bin/activate; uv pip install -e \"./nemo_retriever[all,dev]\" && uv pip install pytest && python -m pytest -m \"$MARKERS\" $COV_ARGS nemo_retriever/tests"
           else
             N="${{ inputs.random-count }}"
             CMD="set -euo pipefail; \

--- a/.github/workflows/reusable-docker-build-and-test.yml
+++ b/.github/workflows/reusable-docker-build-and-test.yml
@@ -209,19 +209,19 @@ jobs:
           fi
 
           if [ "${{ inputs.coverage }}" = "true" ]; then
-            COV_ARGS="--cov-report term --cov-report xml:/tmp/coverage.xml"
+            COV_ARGS="--cov=nemo_retriever/src/nemo_retriever --cov-report term --cov-report xml:/tmp/coverage.xml"
           else
             COV_ARGS=""
           fi
 
           # Use uv so pyproject uv sources are honored for nightly Nemotron packages.
           if [ "${{ inputs.test-selection }}" = "full" ]; then
-            CMD="set -euo pipefail; source /opt/retriever_runtime/bin/activate; uv pip install -e \"./nemo_retriever[all,dev]\" && uv pip install pytest && python -m pytest -m \"$MARKERS\" $COV_ARGS nemo_retriever/tests"
+            CMD="set -euo pipefail; source /opt/retriever_runtime/bin/activate; uv pip install -e \"./nemo_retriever[all,dev]\" && uv pip install pytest pytest-cov && python -m pytest -m \"$MARKERS\" $COV_ARGS nemo_retriever/tests"
           else
             N="${{ inputs.random-count }}"
             CMD="set -euo pipefail; \
               source /opt/retriever_runtime/bin/activate; \
-              uv pip install -e \"./nemo_retriever[all,dev]\" && uv pip install pytest; \
+              uv pip install -e \"./nemo_retriever[all,dev]\" && uv pip install pytest pytest-cov; \
               python -m pytest --collect-only -q $TEST_PATHS | grep '::' | shuf -n \"$N\" > /tmp/selected-tests.txt; \
               python -m pytest -rs -m \"$MARKERS\" $COV_ARGS \$(cat /tmp/selected-tests.txt)"
           fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,8 @@ repos:
         name: validate deployment configs
         entry: python ci/scripts/validate_deployment_configs.py
         language: system
+        # Temporarily manual-only: the Helm values path is currently absent.
+        stages: [manual]
         files: (docker-compose\.yaml|helm/values\.yaml)
         pass_filenames: false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,9 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
 ENV PATH=/root/.local/bin:$PATH
 ENV UV_LINK_MODE=copy
+# Keep uv-managed Python outside /root so the non-root service user can execute
+# venv console-script interpreters.
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv python install 3.12 \
@@ -145,7 +148,7 @@ ENV NEMO_RETRIEVER_SERVICE_CONFIG=/etc/nemo-retriever/retriever-service.yaml
 
 ENV PATH=/opt/retriever_runtime/bin:$PATH
 
-RUN chmod -R a+rX /root/.local \
+RUN chmod -R a+rX /root/.local /opt/uv \
     && groupadd -r nemo && useradd -r -g nemo -d /workspace -s /sbin/nologin nemo \
     && mkdir -p /etc/nemo-retriever /var/lib/nemo-retriever \
     && cp /workspace/nemo_retriever/src/nemo_retriever/service/retriever-service.yaml \

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,9 +63,9 @@ RUN sed -i 's/# deb-src/deb-src/' /etc/apt/sources.list \
        done \
     && apt-get clean
 
+ENV UV_INSTALL_DIR=/usr/local/bin
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
-ENV PATH=/root/.local/bin:$PATH
 ENV UV_LINK_MODE=copy
 # Keep uv-managed Python outside /root so the non-root service user can execute
 # venv console-script interpreters.
@@ -112,7 +112,7 @@ ENV PYTHONUNBUFFERED=1
 
 # Activate venv by default so CLI and python see nemo_retriever; mount over /workspace for dev.
 ENV VIRTUAL_ENV=/opt/retriever_runtime
-ENV PATH=/opt/retriever_runtime/bin:/root/.local/bin:$PATH
+ENV PATH=/opt/retriever_runtime/bin:$PATH
 
 # Editable install: at runtime, -v host_repo:/workspace overrides these dirs so dev changes apply.
 SHELL ["/bin/bash", "-c"]
@@ -148,7 +148,8 @@ ENV NEMO_RETRIEVER_SERVICE_CONFIG=/etc/nemo-retriever/retriever-service.yaml
 
 ENV PATH=/opt/retriever_runtime/bin:$PATH
 
-RUN chmod -R a+rX /root/.local /opt/uv \
+RUN chmod a+rx /usr/local/bin/uv /usr/local/bin/uvx \
+    && chmod -R a+rX /opt/uv \
     && groupadd -r nemo && useradd -r -g nemo -d /workspace -s /sbin/nologin nemo \
     && mkdir -p /etc/nemo-retriever /var/lib/nemo-retriever \
     && cp /workspace/nemo_retriever/src/nemo_retriever/service/retriever-service.yaml \


### PR DESCRIPTION
## Description
General CI unblocker for the current Docker build/test and pre-commit failures.

This PR addresses a chain of CI failures:
- The service image ran as non-root `nemo`, but `/opt/retriever_runtime/bin/pip` resolved its interpreter through uv-managed CPython under `/root/.local/share/uv`, causing `bad interpreter: Permission denied`.
- The Docker test workflow temporarily used plain `pip`, which bypassed uv's `pyproject.toml` source configuration and failed to resolve nightly Nemotron packages such as `nemotron-ocr>=1.0.2.dev0,<1.0.2a0`.
- The `full` Docker test path did not pass `$MARKERS` or `$COV_ARGS`, so `coverage: true` full runs did not write `/tmp/coverage.xml`.
- Once coverage args were applied, pytest failed with `unrecognized arguments: --cov-report --cov-report` because `pytest-cov` was not installed in the container test env.
- The `validate-deployment-configs` pre-commit hook is currently known-broken because it expects the old root `helm/values.yaml` path.

Changes:
- Install the `uv` executable into `/usr/local/bin`, which is traversable by the non-root service user.
- Keep uv-managed Python installs under `/opt/uv/python` via `UV_PYTHON_INSTALL_DIR`.
- Make `/opt/uv` and the `uv`/`uvx` binaries executable for `nemo` in the service stage.
- Switch Docker test installs back to `uv pip install` so uv-specific package sources are honored.
- Apply `$MARKERS` and `$COV_ARGS` to both `full` and `random` Docker test selections.
- Install `pytest-cov` for Docker test runs and target coverage at `nemo_retriever/src/nemo_retriever`.
- Keep the known-broken `validate-deployment-configs` hook disabled in the merged pre-commit config until the hook is updated for the current Helm layout.
- Merge the latest `upstream/main` into this PR branch.

Validation:
- Reproduced the original `pip --version` bad-interpreter failure in the pre-fix service image.
- Rebuilt the real service target with `docker buildx build --platform linux/amd64 --load --target service ...`.
- Verified inside the built service image as `nemo` that `uv --version` and venv `pip --version` both run, and the venv Python resolves to `/opt/uv/python/cpython-3.12.13-linux-x86_64-gnu/bin/python3.12`.
- Verified `uv pip install --dry-run -e "./nemo_retriever[all,dev]"` resolves successfully and selects nightly `nemotron-ocr==1.0.2.dev20260508042302`.
- Reproduced the pytest coverage parser failure with only `pytest` installed.
- Verified a focused Docker pytest-cov smoke run accepts the coverage args and writes `/tmp/coverage.xml`.
- Verified `.github/workflows/reusable-docker-build-and-test.yml` and `.pre-commit-config.yaml` parse as YAML after merging upstream.
- Verified `pre-commit validate-config .pre-commit-config.yaml` passes after merging upstream.
- Verified there are no unresolved merge conflicts or conflict markers after merging `upstream/main`.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file. (N/A; no docker-compose environment variables changed.)
