### PR TITLE
[codex] Fix Nemotron OCR v2 local import

### DIFF
--- a/nemo_retriever/src/nemo_retriever/model/local/nemotron_ocr_v2.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/nemotron_ocr_v2.py
@@ -38,7 +38,7 @@ class NemotronOCRV2(BaseModel):
         super().__init__()
         configure_global_hf_cache_base()
         try:
-            from nemotron_ocr.inference import pipeline_v2 as _nemotron_ocr_pipeline_v2  # local-only import
+            from nemotron_ocr_v2.inference import pipeline_v2 as _nemotron_ocr_pipeline_v2  # local-only import
         except ImportError as exc:
             raise ImportError(
                 "Local Nemotron OCR v2 requires the `nemotron_ocr_v2` package. "

--- a/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
+++ b/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
@@ -4,7 +4,10 @@
 
 from __future__ import annotations
 
+import importlib
+import sys
 import tomllib
+import types
 from pathlib import Path
 
 
@@ -19,8 +22,11 @@ def test_local_extra_depends_on_versioned_ocr_v2_nightly() -> None:
     uv_sources = uv_tool["sources"]
 
     assert "nemotron-ocr>=1.0.2.dev0,<1.0.2a0; sys_platform == 'linux'" in local_deps
+    assert "nemotron-ocr-v2>=2.0.0.dev0,<2.0.0a0; sys_platform == 'linux'" in local_deps
     assert "nemotron-ocr" in uv_tool["no-build-package"]
+    assert "nemotron-ocr-v2" in uv_tool["no-build-package"]
     assert uv_sources["nemotron-ocr"] == {"index": "test-pypi"}
+    assert uv_sources["nemotron-ocr-v2"] == {"index": "test-pypi"}
 
 
 def test_local_ocr_v2_wrapper_imports_versioned_module() -> None:
@@ -28,5 +34,50 @@ def test_local_ocr_v2_wrapper_imports_versioned_module() -> None:
         encoding="utf-8"
     )
 
-    assert "from nemotron_ocr.inference import pipeline_v2" in source
+    assert "from nemotron_ocr_v2.inference import pipeline_v2" in source
     assert "Local Nemotron OCR v2 requires the `nemotron_ocr_v2` package." in source
+
+
+def test_local_ocr_v2_wrapper_initializes_from_versioned_namespace(monkeypatch) -> None:
+    class FakeTensor:
+        pass
+
+    class FakeModule:
+        pass
+
+    torch_stub = types.ModuleType("torch")
+    torch_stub.__path__ = []
+    torch_nn_stub = types.ModuleType("torch.nn")
+    torch_nn_stub.Module = FakeModule
+    torch_stub.Tensor = FakeTensor
+    torch_stub.nn = torch_nn_stub
+    torch_stub.float16 = object()
+    monkeypatch.setitem(sys.modules, "torch", torch_stub)
+    monkeypatch.setitem(sys.modules, "torch.nn", torch_nn_stub)
+
+    constructed_with: list[str | None] = []
+
+    class FakeUpstreamNemotronOCRV2:
+        def __init__(self, model_dir: str | None = None) -> None:
+            constructed_with.append(model_dir)
+
+    pipeline_v2 = types.ModuleType("nemotron_ocr_v2.inference.pipeline_v2")
+    pipeline_v2.NemotronOCRV2 = FakeUpstreamNemotronOCRV2
+    pipeline_v2.hf_hub_download = lambda *args, **kwargs: ""
+
+    inference_pkg = types.ModuleType("nemotron_ocr_v2.inference")
+    inference_pkg.pipeline_v2 = pipeline_v2
+
+    ocr_v2_pkg = types.ModuleType("nemotron_ocr_v2")
+    ocr_v2_pkg.inference = inference_pkg
+
+    monkeypatch.setitem(sys.modules, "nemotron_ocr_v2", ocr_v2_pkg)
+    monkeypatch.setitem(sys.modules, "nemotron_ocr_v2.inference", inference_pkg)
+    monkeypatch.setitem(sys.modules, "nemotron_ocr_v2.inference.pipeline_v2", pipeline_v2)
+    monkeypatch.delitem(sys.modules, "nemo_retriever.model.local.nemotron_ocr_v2", raising=False)
+
+    wrapper_module = importlib.import_module("nemo_retriever.model.local.nemotron_ocr_v2")
+    wrapper = wrapper_module.NemotronOCRV2(model_dir="/models/ocr-v2")
+
+    assert isinstance(wrapper._model, FakeUpstreamNemotronOCRV2)
+    assert constructed_with == ["/models/ocr-v2"]


### PR DESCRIPTION
## Description
Fix local Nemotron OCR v2 initialization so the SDK imports `pipeline_v2` from the installed OCR v2 package namespace, `nemotron_ocr_v2.inference.pipeline_v2`, instead of the legacy OCR v1 namespace.

Root cause: `nemo_retriever.model.local.nemotron_ocr_v2.NemotronOCRV2` imported `pipeline_v2` from `nemotron_ocr.inference`, but `nemotron-ocr-v2` exposes the module under `nemotron_ocr_v2.inference.pipeline_v2`. With both OCR packages installed, the v2 namespace imported successfully while the wrapper raised an ImportError from the v1 package.

This PR updates the import and adds regression coverage that stubs the upstream v2 package namespace and verifies `NemotronOCRV2` initializes from it. It also extends the nightly dependency check to assert the local extra declares and sources `nemotron-ocr-v2`.

Validation:
- `.venv/bin/python -m pytest tests/test_nemotron_ocr_v2_nightly.py -q`
- `git diff --check`
- Reproduced the original failure before the fix.
- After the fix, the minimal OCR v2 script imports `nemotron_ocr_v2.inference.pipeline_v2` and reaches model loading; with `HF_HUB_OFFLINE=1`, it stops at the expected local cache miss instead of the old v1 namespace import error.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file. (N/A)
