### PR TITLE
Update Nemotron OCR v2 nightly packaging

### DIFF
--- a/.github/workflows/huggingface-nightly.yml
+++ b/.github/workflows/huggingface-nightly.yml
@@ -149,17 +149,9 @@ jobs:
         ocr:
           - id: nemotron-ocr-v1
             url: https://huggingface.co/nvidia/nemotron-ocr-v1
-            project_name: ""
-            expected_project_name: nemotron-ocr
-            package_rename: ""
-            expected_package: nemotron_ocr
             nightly_base_version: "1.0.2"
           - id: nemotron-ocr-v2
             url: https://huggingface.co/nvidia/nemotron-ocr-v2
-            project_name: ""
-            expected_project_name: nemotron-ocr
-            package_rename: ""
-            expected_package: nemotron_ocr
             nightly_base_version: "2.0.0"
     container:
       image: ${{ matrix.platform.cuda_image }}
@@ -243,16 +235,6 @@ jobs:
             arch_env_arg="--build-env ARCH=arm64"
           fi
 
-          project_name_args=()
-          if [[ -n "${{ matrix.ocr.project_name }}" ]]; then
-            project_name_args+=(--project-name "${{ matrix.ocr.project_name }}")
-          fi
-
-          package_rename_args=()
-          if [[ -n "${{ matrix.ocr.package_rename }}" ]]; then
-            package_rename_args+=(--rename-python-package "${{ matrix.ocr.package_rename }}")
-          fi
-
           python --version
           python ci/scripts/nightly_build_publish.py \
             --repo-id "${{ matrix.ocr.id }}" \
@@ -261,8 +243,6 @@ jobs:
             --dist-dir "dist-out" \
             --project-subdir "nemotron-ocr" \
             --nightly-base-version "${{ matrix.ocr.nightly_base_version }}" \
-            "${project_name_args[@]}" \
-            "${package_rename_args[@]}" \
             --hatch-force-platform-wheel \
             --auditwheel-repair \
             --auditwheel-exclude libtorch_cpu.so \
@@ -298,8 +278,8 @@ jobs:
               raise SystemExit(f"No wheel found in {dist_dir}")
 
           py_tag = f"cpython-{sys.version_info.major}{sys.version_info.minor}"
-          expected_project = "${{ matrix.ocr.expected_project_name }}"
-          expected_package = "${{ matrix.ocr.expected_package }}"
+          expected_project = "nemotron-ocr"
+          expected_package = "nemotron_ocr"
           expected_version_prefix = "${{ matrix.ocr.nightly_base_version }}.dev"
           matches = []
           for wheel in wheels:
@@ -315,8 +295,8 @@ jobs:
                   )
               if not any(name.startswith(f"{expected_package}/") for name in names):
                   raise SystemExit(f"Built wheel is missing {expected_package} package")
-              if expected_package != "nemotron_ocr" and any(name.startswith("nemotron_ocr/") for name in names):
-                  raise SystemExit("Built wheel still contains the unversioned nemotron_ocr package")
+              if any(name.startswith("nemotron_ocr_v2/") for name in names):
+                  raise SystemExit("Built wheel still contains the patched nemotron_ocr_v2 package")
               for name in names:
                   if "nemotron_ocr_cpp/_nemotron_ocr_cpp." in name:
                       matches.append((wheel.name, name))

--- a/.github/workflows/huggingface-nightly.yml
+++ b/.github/workflows/huggingface-nightly.yml
@@ -156,10 +156,10 @@ jobs:
             nightly_base_version: "1.0.2"
           - id: nemotron-ocr-v2
             url: https://huggingface.co/nvidia/nemotron-ocr-v2
-            project_name: nemotron-ocr-v2
-            expected_project_name: nemotron-ocr-v2
-            package_rename: nemotron_ocr=nemotron_ocr_v2
-            expected_package: nemotron_ocr_v2
+            project_name: ""
+            expected_project_name: nemotron-ocr
+            package_rename: ""
+            expected_package: nemotron_ocr
             nightly_base_version: "2.0.0"
     container:
       image: ${{ matrix.platform.cuda_image }}

--- a/ci/scripts/nightly_build_publish.py
+++ b/ci/scripts/nightly_build_publish.py
@@ -733,8 +733,7 @@ def main() -> int:
         "--rename-python-package",
         action="append",
         default=[],
-        help="Rename a Python import package before building, as OLD=NEW "
-        "(repeatable).",
+        help="Rename a Python import package before building, as OLD=NEW " "(repeatable).",
     )
     ap.add_argument(
         "--build-env",

--- a/ci/scripts/nightly_build_publish.py
+++ b/ci/scripts/nightly_build_publish.py
@@ -727,14 +727,14 @@ def main() -> int:
         "--project-name",
         default=None,
         help="Patch the source Python project/distribution name before building "
-        "(e.g. publish a source tree declaring 'nemotron-ocr' as 'nemotron-ocr-v2').",
+        "(e.g. publish a source tree under an alternate distribution name).",
     )
     ap.add_argument(
         "--rename-python-package",
         action="append",
         default=[],
         help="Rename a Python import package before building, as OLD=NEW "
-        "(e.g. nemotron_ocr=nemotron_ocr_v2; repeatable).",
+        "(repeatable).",
     )
     ap.add_argument(
         "--build-env",

--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -96,7 +96,7 @@ local = [
   "nemotron-graphic-elements-v1>=0.dev0",
   "nemotron-table-structure-v1>=0.dev0",
   # Stay on the 2.0.0 OCR dev train and exclude older PyPI finals.
-  "nemotron-ocr>=2.0.0.dev0,<2.0.0a0; sys_platform == 'linux'",
+  "nemotron-ocr>=2.0.0.dev0,<2.0.0a0; sys_platform == 'linux' and (platform_machine == 'x86_64' or platform_machine == 'aarch64')",
   "nvidia-ml-py",
   "apscheduler>=3.10",
   "psutil>=5.9.0",

--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [tool.uv]
 managed = true
 package = true
-no-build-package = ["nemotron-ocr", "nemotron-ocr-v2"]
+no-build-package = ["nemotron-ocr"]
 # fastparquet 2026.3.0 has no wheel for Linux x86_64 (manylinux); constrain to last version that does.
 override-dependencies = [
   "fastparquet>=2024.11.0,<2026",
@@ -95,10 +95,8 @@ local = [
   "nemotron-page-elements-v3>=0.dev0",
   "nemotron-graphic-elements-v1>=0.dev0",
   "nemotron-table-structure-v1>=0.dev0",
-  # Stay on the 1.0.2 OCR dev train and exclude older PyPI finals.
-  "nemotron-ocr>=1.0.2.dev0,<1.0.2a0; sys_platform == 'linux'",
-  # Stay on the 2.0.0 OCR v2 dev train and exclude older PyPI finals.
-  "nemotron-ocr-v2>=2.0.0.dev0,<2.0.0a0; sys_platform == 'linux'",
+  # Stay on the 2.0.0 OCR dev train and exclude older PyPI finals.
+  "nemotron-ocr>=2.0.0.dev0,<2.0.0a0; sys_platform == 'linux'",
   "nvidia-ml-py",
   "apscheduler>=3.10",
   "psutil>=5.9.0",
@@ -166,7 +164,6 @@ nemotron-page-elements-v3 = { index = "test-pypi" }
 nemotron-graphic-elements-v1 = { index = "test-pypi" }
 nemotron-table-structure-v1 = { index = "test-pypi" }
 nemotron-ocr = { index = "test-pypi" }
-nemotron-ocr-v2 = { index = "test-pypi" }
 # On Linux, resolve torch/torchvision from the CUDA wheel index.
 # On Mac, fall through to PyPI to get CPU wheels.
 torch = [

--- a/nemo_retriever/src/nemo_retriever/model/local/nemotron_ocr_v2.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/nemotron_ocr_v2.py
@@ -33,11 +33,20 @@ class NemotronOCRV2(BaseModel):
     - v2_multi
     """
 
+    _VALID_LANG_SELECTORS: frozenset[str] = frozenset({"v1", "v2_english", "v2_multi"})
+
     def __init__(
         self,
         model_dir: Optional[str] = None,
         lang: str = "v2_multi",
     ) -> None:
+        if lang not in self._VALID_LANG_SELECTORS:
+            raise ValueError(
+                f"Invalid lang selector {lang!r}. "
+                f"Supported values: {sorted(self._VALID_LANG_SELECTORS)}. "
+                "Pass lang='v2_multi' for multilingual, 'v2_english' for English-only, "
+                "or 'v1' to run the v1 model through the v2 package."
+            )
         super().__init__()
         configure_global_hf_cache_base()
         try:

--- a/nemo_retriever/src/nemo_retriever/model/local/nemotron_ocr_v2.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/nemotron_ocr_v2.py
@@ -38,13 +38,13 @@ class NemotronOCRV2(BaseModel):
     def __init__(
         self,
         model_dir: Optional[str] = None,
-        lang: str = "v2_multi",
+        lang: str = "v2_english",
     ) -> None:
         if lang not in self._VALID_LANG_SELECTORS:
             raise ValueError(
                 f"Invalid lang selector {lang!r}. "
                 f"Supported values: {sorted(self._VALID_LANG_SELECTORS)}. "
-                "Pass lang='v2_multi' for multilingual, 'v2_english' for English-only, "
+                "Pass lang='v2_english' for English-only, 'v2_multi' for multilingual, "
                 "or 'v1' to run the v1 model through the v2 package."
             )
         super().__init__()

--- a/nemo_retriever/src/nemo_retriever/model/local/nemotron_ocr_v2.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/nemotron_ocr_v2.py
@@ -27,13 +27,16 @@ class NemotronOCRV2(BaseModel):
     - Text recognizer for transcription (pre-norm Transformer)
     - Relational model for layout and reading order analysis
 
-    Supports both English-only (v2_english) and multilingual variants
-    (v2_multilingual: EN, ZH, JA, KO, RU).
+    Supports the upstream ``lang`` selector:
+    - v1
+    - v2_english
+    - v2_multi
     """
 
     def __init__(
         self,
         model_dir: Optional[str] = None,
+        lang: str = "v2_multi",
     ) -> None:
         super().__init__()
         configure_global_hf_cache_base()
@@ -41,8 +44,8 @@ class NemotronOCRV2(BaseModel):
             from nemotron_ocr.inference import pipeline_v2 as _nemotron_ocr_pipeline_v2  # local-only import
         except ImportError as exc:
             raise ImportError(
-                "Local Nemotron OCR v2 requires the `nemotron_ocr_v2` package. "
-                "Install `nemotron-ocr-v2` from TestPyPI, or install from source via: "
+                "Local Nemotron OCR v2 requires the `nemotron_ocr` package. "
+                "Install `nemotron-ocr` 2.0 nightlies from TestPyPI, or install from source via: "
                 "git clone https://huggingface.co/nvidia/nemotron-ocr-v2 && "
                 "cd nemotron-ocr-v2/nemotron-ocr && pip install --no-build-isolation -v . "
                 "Alternatively, run with --ocr-invoke-url pointed at a v2 endpoint, "
@@ -53,9 +56,9 @@ class NemotronOCRV2(BaseModel):
         _NemotronOCRV2 = _nemotron_ocr_pipeline_v2.NemotronOCRV2
 
         if model_dir:
-            self._model = _NemotronOCRV2(model_dir=model_dir)
+            self._model = _NemotronOCRV2(model_dir=model_dir, lang=lang)
         else:
-            self._model = _NemotronOCRV2()
+            self._model = _NemotronOCRV2(lang=lang)
         self._enable_trt = os.getenv("RETRIEVER_ENABLE_TORCH_TRT", "").strip().lower() in {"1", "true", "yes", "on"}
         if self._enable_trt and self._model is not None:
             self._maybe_compile_submodules()

--- a/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
+++ b/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
@@ -4,12 +4,38 @@
 
 from __future__ import annotations
 
+import sys
 import tomllib
 from pathlib import Path
+from types import ModuleType
+
+import pytest
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = PROJECT_ROOT.parent
+
+
+def _install_ocr_import_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    torch_mod = ModuleType("torch")
+    nn_mod = ModuleType("torch.nn")
+
+    class _Module:
+        pass
+
+    nn_mod.Module = _Module
+    torch_mod.nn = nn_mod
+    torch_mod.Tensor = object
+    torch_mod.float16 = "float16"
+
+    pil_mod = ModuleType("PIL")
+    image_mod = ModuleType("PIL.Image")
+    pil_mod.Image = image_mod
+
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+    monkeypatch.setitem(sys.modules, "torch.nn", nn_mod)
+    monkeypatch.setitem(sys.modules, "PIL", pil_mod)
+    monkeypatch.setitem(sys.modules, "PIL.Image", image_mod)
 
 
 def test_local_extra_depends_on_ocr_2_nightly_only() -> None:
@@ -36,18 +62,27 @@ def test_local_ocr_v2_wrapper_uses_original_namespace_and_lang_selector() -> Non
     )
 
     assert "from nemotron_ocr.inference import pipeline_v2" in source
-    assert "lang: str = \"v2_multi\"" in source
+    assert 'lang: str = "v2_multi"' in source
     assert "_NemotronOCRV2(model_dir=model_dir, lang=lang)" in source
     assert "_NemotronOCRV2(lang=lang)" in source
     assert "nemotron_ocr_v2" not in source
     assert "nemotron-ocr-v2` from TestPyPI" not in source
 
 
+def test_local_ocr_v2_wrapper_rejects_invalid_lang_selector(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_ocr_import_stubs(monkeypatch)
+
+    from nemo_retriever.model.local.nemotron_ocr_v2 import NemotronOCRV2
+
+    with pytest.raises(ValueError, match=r"Invalid lang selector 'v3'"):
+        NemotronOCRV2(lang="v3")
+
+
 def test_huggingface_ocr_nightly_does_not_carry_namespace_patch_knobs() -> None:
     workflow = (REPO_ROOT / ".github" / "workflows" / "huggingface-nightly.yml").read_text(encoding="utf-8")
     v2_stanza = workflow.split("- id: nemotron-ocr-v2", 1)[1].split("container:", 1)[0]
 
-    assert "nightly_base_version: \"2.0.0\"" in v2_stanza
+    assert 'nightly_base_version: "2.0.0"' in v2_stanza
     assert "project_name:" not in workflow
     assert "package_rename:" not in workflow
     assert "expected_project_name:" not in workflow

--- a/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
+++ b/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
@@ -19,7 +19,10 @@ def test_local_extra_depends_on_ocr_2_nightly_only() -> None:
     uv_tool = pyproject["tool"]["uv"]
     uv_sources = uv_tool["sources"]
 
-    assert "nemotron-ocr>=2.0.0.dev0,<2.0.0a0; sys_platform == 'linux'" in local_deps
+    assert (
+        "nemotron-ocr>=2.0.0.dev0,<2.0.0a0; sys_platform == 'linux' "
+        "and (platform_machine == 'x86_64' or platform_machine == 'aarch64')"
+    ) in local_deps
     assert not any(dep.startswith("nemotron-ocr-v2") for dep in local_deps)
     assert "nemotron-ocr" in uv_tool["no-build-package"]
     assert "nemotron-ocr-v2" not in uv_tool["no-build-package"]

--- a/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
+++ b/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
@@ -38,6 +38,28 @@ def _install_ocr_import_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setitem(sys.modules, "PIL.Image", image_mod)
 
 
+def _install_upstream_ocr_v2_stub(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+    captured_kwargs: list[dict[str, object]] = []
+
+    class _NemotronOCRV2:
+        def __init__(self, **kwargs: object) -> None:
+            captured_kwargs.append(kwargs)
+
+    nemotron_ocr_mod = ModuleType("nemotron_ocr")
+    inference_mod = ModuleType("nemotron_ocr.inference")
+    pipeline_v2_mod = ModuleType("nemotron_ocr.inference.pipeline_v2")
+    pipeline_v2_mod.NemotronOCRV2 = _NemotronOCRV2
+    inference_mod.pipeline_v2 = pipeline_v2_mod
+    nemotron_ocr_mod.inference = inference_mod
+
+    monkeypatch.setitem(sys.modules, "nemotron_ocr", nemotron_ocr_mod)
+    monkeypatch.setitem(sys.modules, "nemotron_ocr.inference", inference_mod)
+    monkeypatch.setitem(sys.modules, "nemotron_ocr.inference.pipeline_v2", pipeline_v2_mod)
+    monkeypatch.delenv("RETRIEVER_ENABLE_TORCH_TRT", raising=False)
+
+    return captured_kwargs
+
+
 def test_local_extra_depends_on_ocr_2_nightly_only() -> None:
     pyproject = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
@@ -76,6 +98,21 @@ def test_local_ocr_v2_wrapper_rejects_invalid_lang_selector(monkeypatch: pytest.
 
     with pytest.raises(ValueError, match=r"Invalid lang selector 'v3'"):
         NemotronOCRV2(lang="v3")
+
+
+@pytest.mark.parametrize("selector", ["v1", "v2_english", "v2_multi"])
+def test_local_ocr_v2_wrapper_accepts_valid_lang_selectors(
+    monkeypatch: pytest.MonkeyPatch,
+    selector: str,
+) -> None:
+    _install_ocr_import_stubs(monkeypatch)
+    captured_kwargs = _install_upstream_ocr_v2_stub(monkeypatch)
+
+    from nemo_retriever.model.local.nemotron_ocr_v2 import NemotronOCRV2
+
+    NemotronOCRV2(lang=selector)
+
+    assert captured_kwargs == [{"lang": selector}]
 
 
 def test_huggingface_ocr_nightly_does_not_carry_namespace_patch_knobs() -> None:

--- a/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
+++ b/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
@@ -43,16 +43,14 @@ def test_local_ocr_v2_wrapper_uses_original_namespace_and_lang_selector() -> Non
     assert "nemotron-ocr-v2` from TestPyPI" not in source
 
 
-def test_huggingface_v2_nightly_publishes_to_ocr_project_without_namespace_rename() -> None:
+def test_huggingface_ocr_nightly_does_not_carry_namespace_patch_knobs() -> None:
     workflow = (REPO_ROOT / ".github" / "workflows" / "huggingface-nightly.yml").read_text(encoding="utf-8")
     v2_stanza = workflow.split("- id: nemotron-ocr-v2", 1)[1].split("container:", 1)[0]
 
-    assert "project_name: \"\"" in v2_stanza
-    assert "expected_project_name: nemotron-ocr\n" in v2_stanza
-    assert "package_rename: \"\"" in v2_stanza
-    assert "expected_package: nemotron_ocr\n" in v2_stanza
     assert "nightly_base_version: \"2.0.0\"" in v2_stanza
-    assert "project_name: nemotron-ocr-v2" not in v2_stanza
-    assert "expected_project_name: nemotron-ocr-v2" not in v2_stanza
-    assert "package_rename: nemotron_ocr=nemotron_ocr_v2" not in v2_stanza
-    assert "expected_package: nemotron_ocr_v2" not in v2_stanza
+    assert "project_name:" not in workflow
+    assert "package_rename:" not in workflow
+    assert "expected_project_name:" not in workflow
+    assert "expected_package:" not in workflow
+    assert "--project-name" not in workflow
+    assert "--rename-python-package" not in workflow

--- a/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
+++ b/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
@@ -79,7 +79,11 @@ def test_local_ocr_v2_wrapper_rejects_invalid_lang_selector(monkeypatch: pytest.
 
 
 def test_huggingface_ocr_nightly_does_not_carry_namespace_patch_knobs() -> None:
-    workflow = (REPO_ROOT / ".github" / "workflows" / "huggingface-nightly.yml").read_text(encoding="utf-8")
+    workflow_path = REPO_ROOT / ".github" / "workflows" / "huggingface-nightly.yml"
+    if not workflow_path.exists():
+        pytest.skip("Hugging Face nightly workflow is not available in this checkout")
+
+    workflow = workflow_path.read_text(encoding="utf-8")
     v2_stanza = workflow.split("- id: nemotron-ocr-v2", 1)[1].split("container:", 1)[0]
 
     assert 'nightly_base_version: "2.0.0"' in v2_stanza

--- a/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
+++ b/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
@@ -9,24 +9,47 @@ from pathlib import Path
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = PROJECT_ROOT.parent
 
 
-def test_local_extra_depends_on_versioned_ocr_v2_nightly() -> None:
+def test_local_extra_depends_on_ocr_2_nightly_only() -> None:
     pyproject = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     local_deps = pyproject["project"]["optional-dependencies"]["local"]
     uv_tool = pyproject["tool"]["uv"]
     uv_sources = uv_tool["sources"]
 
-    assert "nemotron-ocr>=1.0.2.dev0,<1.0.2a0; sys_platform == 'linux'" in local_deps
+    assert "nemotron-ocr>=2.0.0.dev0,<2.0.0a0; sys_platform == 'linux'" in local_deps
+    assert not any(dep.startswith("nemotron-ocr-v2") for dep in local_deps)
     assert "nemotron-ocr" in uv_tool["no-build-package"]
+    assert "nemotron-ocr-v2" not in uv_tool["no-build-package"]
     assert uv_sources["nemotron-ocr"] == {"index": "test-pypi"}
+    assert "nemotron-ocr-v2" not in uv_sources
 
 
-def test_local_ocr_v2_wrapper_imports_versioned_module() -> None:
+def test_local_ocr_v2_wrapper_uses_original_namespace_and_lang_selector() -> None:
     source = (PROJECT_ROOT / "src" / "nemo_retriever" / "model" / "local" / "nemotron_ocr_v2.py").read_text(
         encoding="utf-8"
     )
 
     assert "from nemotron_ocr.inference import pipeline_v2" in source
-    assert "Local Nemotron OCR v2 requires the `nemotron_ocr_v2` package." in source
+    assert "lang: str = \"v2_multi\"" in source
+    assert "_NemotronOCRV2(model_dir=model_dir, lang=lang)" in source
+    assert "_NemotronOCRV2(lang=lang)" in source
+    assert "nemotron_ocr_v2" not in source
+    assert "nemotron-ocr-v2` from TestPyPI" not in source
+
+
+def test_huggingface_v2_nightly_publishes_to_ocr_project_without_namespace_rename() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "huggingface-nightly.yml").read_text(encoding="utf-8")
+    v2_stanza = workflow.split("- id: nemotron-ocr-v2", 1)[1].split("container:", 1)[0]
+
+    assert "project_name: \"\"" in v2_stanza
+    assert "expected_project_name: nemotron-ocr\n" in v2_stanza
+    assert "package_rename: \"\"" in v2_stanza
+    assert "expected_package: nemotron_ocr\n" in v2_stanza
+    assert "nightly_base_version: \"2.0.0\"" in v2_stanza
+    assert "project_name: nemotron-ocr-v2" not in v2_stanza
+    assert "expected_project_name: nemotron-ocr-v2" not in v2_stanza
+    assert "package_rename: nemotron_ocr=nemotron_ocr_v2" not in v2_stanza
+    assert "expected_package: nemotron_ocr_v2" not in v2_stanza

--- a/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
+++ b/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
@@ -62,7 +62,7 @@ def test_local_ocr_v2_wrapper_uses_original_namespace_and_lang_selector() -> Non
     )
 
     assert "from nemotron_ocr.inference import pipeline_v2" in source
-    assert 'lang: str = "v2_multi"' in source
+    assert 'lang: str = "v2_english"' in source
     assert "_NemotronOCRV2(model_dir=model_dir, lang=lang)" in source
     assert "_NemotronOCRV2(lang=lang)" in source
     assert "nemotron_ocr_v2" not in source

--- a/nemo_retriever/uv.lock
+++ b/nemo_retriever/uv.lock
@@ -2430,8 +2430,7 @@ all = [
     { name = "librosa" },
     { name = "litellm" },
     { name = "nemotron-graphic-elements-v1" },
-    { name = "nemotron-ocr", marker = "sys_platform == 'linux'" },
-    { name = "nemotron-ocr-v2", marker = "sys_platform == 'linux'" },
+    { name = "nemotron-ocr", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemotron-page-elements-v3" },
     { name = "nemotron-table-structure-v1" },
     { name = "neo4j" },
@@ -2475,8 +2474,7 @@ local = [
     { name = "flashinfer-python", marker = "sys_platform == 'linux'" },
     { name = "glom" },
     { name = "nemotron-graphic-elements-v1" },
-    { name = "nemotron-ocr", marker = "sys_platform == 'linux'" },
-    { name = "nemotron-ocr-v2", marker = "sys_platform == 'linux'" },
+    { name = "nemotron-ocr", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemotron-page-elements-v3" },
     { name = "nemotron-table-structure-v1" },
     { name = "nvidia-ml-py" },
@@ -2539,8 +2537,7 @@ requires-dist = [
     { name = "markitdown" },
     { name = "nemo-retriever", extras = ["benchmarks", "llm", "local", "multimedia", "tabular"], marker = "extra == 'all'" },
     { name = "nemotron-graphic-elements-v1", marker = "extra == 'local'", specifier = ">=0.dev0", index = "https://test.pypi.org/simple/" },
-    { name = "nemotron-ocr", marker = "sys_platform == 'linux' and extra == 'local'", specifier = ">=1.0.2.dev0,<1.0.2a0", index = "https://test.pypi.org/simple/" },
-    { name = "nemotron-ocr-v2", marker = "sys_platform == 'linux' and extra == 'local'", specifier = ">=2.0.0.dev0,<2.0.0a0", index = "https://test.pypi.org/simple/" },
+    { name = "nemotron-ocr", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'local') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'local')", specifier = ">=2.0.0.dev0,<2.0.0a0", index = "https://test.pypi.org/simple/" },
     { name = "nemotron-page-elements-v3", marker = "extra == 'local'", specifier = ">=0.dev0", index = "https://test.pypi.org/simple/" },
     { name = "nemotron-table-structure-v1", marker = "extra == 'local'", specifier = ">=0.dev0", index = "https://test.pypi.org/simple/" },
     { name = "neo4j", marker = "extra == 'tabular'", specifier = ">=5.0" },
@@ -2605,39 +2602,20 @@ wheels = [
 
 [[package]]
 name = "nemotron-ocr"
-version = "1.0.2.dev20260501161212"
+version = "2.0.0.dev20260508175030"
 source = { registry = "https://test.pypi.org/simple/" }
 dependencies = [
-    { name = "huggingface-hub", marker = "sys_platform == 'linux'" },
-    { name = "pandas", marker = "sys_platform == 'linux'" },
-    { name = "pillow", marker = "sys_platform == 'linux'" },
-    { name = "scikit-learn", marker = "sys_platform == 'linux'" },
-    { name = "shapely", marker = "sys_platform == 'linux'" },
-    { name = "torch", version = "2.10.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux'" },
-    { name = "torchvision", version = "0.25.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux'" },
+    { name = "huggingface-hub", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pillow", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "shapely", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "torch", version = "2.10.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "torchvision", version = "0.25.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
-sdist = { url = "https://test-files.pythonhosted.org/packages/6b/66/91c14964e71b4996d637e2f7b5fb8a1d6667a8ae89bc342c0355e37c6f1e/nemotron_ocr-1.0.2.dev20260501161212.tar.gz", hash = "sha256:2d589546b168e8526eb3ee3c05c22112b972180d65e1204783b92cc7116655c4", size = 153233, upload-time = "2026-05-01T16:22:41.113Z" }
+sdist = { url = "https://test-files.pythonhosted.org/packages/26/5f/0a121fcd2cc2e2e8873b946e0cca4fb28b32778705f16e544694a3a2a105/nemotron_ocr-2.0.0.dev20260508175030.tar.gz", hash = "sha256:639e5181b5c5d4a928813de9f397af4628cb05cc660cf4b972e0ffc619b3e928", size = 155961, upload-time = "2026-05-08T18:01:04.331Z" }
 wheels = [
-    { url = "https://test-files.pythonhosted.org/packages/cd/26/75b37338788e039981781cec51edb56ed88809c807e50023cb0a2b5d953f/nemotron_ocr-1.0.2.dev20260501161212-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:f2b25279a9b1fb889aee0d673417f7dc12e66af4da527667eda557a7f76b7850", size = 36094403, upload-time = "2026-05-01T16:22:38.714Z" },
-    { url = "https://test-files.pythonhosted.org/packages/47/00/158545e4fd6168add3c244237b6ac5016ceb4f6e197f05586d9f696938f9/nemotron_ocr-1.0.2.dev20260501161212-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:384189507ab46e3e33c31cc973e580af3c0de3640e6ca6b3971b040233fd2f21", size = 36800021, upload-time = "2026-05-01T16:23:56.626Z" },
-]
-
-[[package]]
-name = "nemotron-ocr-v2"
-version = "2.0.0.dev20260505184508"
-source = { registry = "https://test.pypi.org/simple/" }
-dependencies = [
-    { name = "huggingface-hub", marker = "sys_platform == 'linux'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
-    { name = "pillow", marker = "sys_platform == 'linux'" },
-    { name = "shapely", marker = "sys_platform == 'linux'" },
-    { name = "torch", version = "2.10.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux'" },
-    { name = "torchvision", version = "0.25.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux'" },
-]
-sdist = { url = "https://test-files.pythonhosted.org/packages/51/97/d1043d34a0b14cd5eac4a1222f2005265155b7d23c8f054d86efac3989c2/nemotron_ocr_v2-2.0.0.dev20260505184508.tar.gz", hash = "sha256:72217882fab7bdfbb7cabe9f7b605ed70f99bae5c75c90e9a63ae4f69fb3fd77", size = 156182, upload-time = "2026-05-05T18:55:00.058Z" }
-wheels = [
-    { url = "https://test-files.pythonhosted.org/packages/3c/76/ef821cb3fdd4ad72219a048c8a8b3729637984a3ab779be7e927dc23445f/nemotron_ocr_v2-2.0.0.dev20260505184508-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4a0e0afda7bbfafca5e7fb1c7ac244cf4c3f034b93b1d047553eba186715865d", size = 36097960, upload-time = "2026-05-05T18:54:57.332Z" },
-    { url = "https://test-files.pythonhosted.org/packages/b3/97/08c741924833121f646739e1b9ddeac82e95fed0939dcc0993d13d1f19cc/nemotron_ocr_v2-2.0.0.dev20260505184508-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:77872a706a9c0ee236a0054222f78347ff043815de43a012f7e67ffe77bc5c58", size = 36802716, upload-time = "2026-05-05T18:56:38.832Z" },
+    { url = "https://test-files.pythonhosted.org/packages/fa/7b/98d461288d72aff10e084128fdabaf3410097c8113200449ba37d7a6e385/nemotron_ocr-2.0.0.dev20260508175030-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:1f6b7b8d1f9d3f327dd176035db43e0c6fb58a4c2f2879d969cfb779a20ec717", size = 36096949, upload-time = "2026-05-08T18:01:02.201Z" },
+    { url = "https://test-files.pythonhosted.org/packages/de/9b/5d111a0c665e7bbac52e86da16ccde0329b6469dd0ff79644b0185bdd988/nemotron_ocr-2.0.0.dev20260508175030-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:ef71916f024938bf685986a23af51cb044f303b1875f09373fcc227caf4881de", size = 36802428, upload-time = "2026-05-08T18:01:28.484Z" },
 ]
 
 [[package]]
@@ -4463,7 +4441,7 @@ name = "shapely"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
 wheels = [


### PR DESCRIPTION
## Description
- Updates the Hugging Face nightly OCR v2 build so v2 publishes as `nemotron-ocr` 2.0 nightlies with the original `nemotron_ocr` namespace.
- Removes the `nemotron-ocr-v2` project/package rename path from the nightly workflow and NRL local dependencies.
- Updates the local `NemotronOCRV2` wrapper to pass the upstream `lang` selector, defaulting to `v2_english`, and validates supported selectors at the wrapper boundary.
- Refreshes `nemo_retriever/uv.lock` to `nemotron-ocr==2.0.0.dev20260508175030` and removes `nemotron-ocr-v2`.
- Adds contract coverage for the new nightly packaging behavior.

Validation:
- `uv lock --no-cache -P nemotron-ocr`
- `uv run --extra dev pytest tests/test_nemotron_ocr_v2_nightly.py tests/test_ocr_version_selection.py`
- `uv lock --check`
- `git diff --check`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file. (N/A: no docker-compose or Helm changes.)
