### PR TITLE
fix retriever to work with graph and handle cpu env

### DIFF
--- a/.github/workflows/integration-test-library-mode.yml
+++ b/.github/workflows/integration-test-library-mode.yml
@@ -69,12 +69,4 @@ jobs:
           python -m nemo_retriever.examples.graph_pipeline ./data \
             --run-mode inprocess \
             --input-type pdf \
-            --api-key "${{ secrets.NVIDIA_BUILD_API_KEY }}" \
-            --page-elements-invoke-url "$PAGE_ELEMENTS_INVOKE_URL" \
-            --ocr-invoke-url "$OCR_INVOKE_URL" \
-            --use-graphic-elements \
-            --graphic-elements-invoke-url "$GRAPHIC_ELEMENTS_INVOKE_URL" \
-            --use-table-structure \
-            --table-structure-invoke-url "$TABLE_STRUCTURE_INVOKE_URL" \
-            --embed-invoke-url "$EMBED_INVOKE_URL" \
-            --embed-model-name "$EMBED_MODEL_NAME"
+            --api-key "${{ secrets.NVIDIA_BUILD_API_KEY }}"

--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -198,5 +198,7 @@ where = ["src"]
 "nemo_retriever.service" = ["retriever-service.yaml"]
 
 [tool.pytest.ini_options]
-# So ``from tests import …`` resolves to ``nemo_retriever/tests`` when pytest rootdir is this project.
-pythonpath = ["."]
+# ``src`` exposes the ``nemo_retriever`` package (src layout). ``.`` keeps ``from tests import …``
+# working when pytest rootdir is this project. Editable install (``pip install -e .``) is still
+# recommended for scripts and non-pytest entry points.
+pythonpath = ["src", "."]

--- a/nemo_retriever/retriever.md
+++ b/nemo_retriever/retriever.md
@@ -1,0 +1,150 @@
+# NeMo Retriever: `Retriever` class
+
+The high-level **`Retriever`** runs **query → embed → vector search → optional rerank** through a small **operator graph** (see `nemo_retriever.retriever`). Configuration is grouped into three dicts that map to Pydantic / operator constructors.
+
+## Constructor surface
+
+| Parameter | Purpose |
+|-----------|---------|
+| **`run_mode`** | `"local"` (default): archetype batch embed (HTTP URL → CPU operator, else local model). `"service"`: **always** CPU HTTP embed; you must set an embedding URL in **`embed_kwargs`**. |
+| **`top_k`** | Default number of hits per query (retrieval; rerank may use `refine_factor` to retrieve more candidates first). |
+| **`rerank`** | If `True`, append **`NemotronRerankActor`** after **`RetrieveVdbOperator`**. |
+| **`graph`** | Optional custom `Graph`. When set, **`embed_kwargs` / `vdb_kwargs` are not used to build the default graph**—you supply a fully wired pipeline. |
+| **`embed_kwargs`** | Passed to **`EmbedParams`** (merged over library defaults). Controls model, endpoints, `input_type` (default `"query"`), batch sizes, `runtime` (device, HF cache), etc. |
+| **`vdb_kwargs`** | Passed to **`RetrieveVdbOperator`**. Either nested `{"vdb_op": "lancedb", "vdb_kwargs": {"uri": "...", "table_name": "..."}}` or, for convenience, a **flat** Lance-only dict `{"uri": "...", "table_name": "..."}` is coerced to `vdb_op="lancedb"`. |
+| **`rerank_kwargs`** | Forwarded to **`NemotronRerankActor`** (merged over defaults). Common keys: `model_name`, `invoke_url`, `api_key`, `batch_size`, `max_length`, `score_column`, `local_reranker_backend`. **`refine_factor`** (default `4`) multiplies `top_k` for retrieval when **`rerank`** is true; it is **not** passed to the actor. |
+
+### Default pipeline
+
+```text
+_BatchEmbedActor >> RetrieveVdbOperator [>> NemotronRerankActor if rerank]
+```
+
+`RetrieveVdbOperator.preprocess` accepts an embedded **pandas `DataFrame`** from the embed step and converts it to query vectors before calling `VDB.retrieval`.
+
+---
+
+## Runnable snippets
+
+Set `PYTHONPATH` to the `nemo_retriever` source tree (or use an installed wheel). Examples assume LanceDB already populated (e.g. after ingest).
+
+### 1) Minimal local retrieval (default VL embed model, local backend)
+
+```python
+from nemo_retriever.retriever import Retriever
+
+r = Retriever(
+    vdb_kwargs={"uri": "./kb", "table_name": "nv-ingest"},
+    embed_kwargs={
+        "local_ingest_embed_backend": "hf",
+        "runtime": {"hf_cache_dir": "~/.cache/huggingface"},
+    },
+    top_k=5,
+)
+hits = r.query("What is in this corpus?")
+print(hits[0]["text"][:200])
+```
+
+### 2) Remote HTTP embeddings (CPU batch embed)
+
+```python
+import os
+from nemo_retriever.retriever import Retriever
+
+r = Retriever(
+    vdb_kwargs={"vdb_op": "lancedb", "vdb_kwargs": {"uri": "./kb", "table_name": "nv-ingest"}},
+    embed_kwargs={
+        "model_name": "nvidia/llama-nemotron-embed-1b-v2",
+        "embed_invoke_url": os.environ["NIM_EMBED_URL"],  # OpenAI-compatible /v1
+        "api_key": os.environ.get("NVIDIA_API_KEY", ""),
+    },
+)
+print(r.query("hello")[0].keys())
+```
+
+### 3) `run_mode="service"` (force CPU URL embed)
+
+Same as (2) but **`run_mode="service"`** requires a non-empty HTTP embedding URL in **`embed_kwargs`**; local GPU embed is not used for queries.
+
+```python
+from nemo_retriever.retriever import Retriever
+
+r = Retriever(
+    run_mode="service",
+    embed_kwargs={
+        "embed_invoke_url": "https://integrate.api.nvidia.com/v1",
+        "api_key": "...",
+    },
+    vdb_kwargs={"uri": "./kb", "table_name": "nv-ingest"},
+)
+```
+
+### 4) Reranking
+
+```python
+from nemo_retriever.retriever import Retriever
+
+r = Retriever(
+    vdb_kwargs={"uri": "./kb", "table_name": "nv-ingest"},
+    rerank=True,
+    rerank_kwargs={
+        "invoke_url": "http://localhost:8015",
+        "model_name": "nvidia/llama-nemotron-rerank-1b-v2",
+        "refine_factor": 4,
+    },
+    top_k=5,
+)
+hits = r.query("detailed question")
+assert "_rerank_score" in hits[0]
+```
+
+### 5) Per-call overrides
+
+```python
+hits = r.query(
+    "q",
+    top_k=3,
+    vdb_kwargs={"where": "content_type = 'text'"},
+    embed_kwargs={"model_name": "nvidia/llama-nemotron-embed-1b-v2"},
+)
+```
+
+### 6) Batch queries
+
+```python
+batch = r.queries(["q1", "q2"], top_k=5)
+assert len(batch) == 2
+```
+
+### 7) Structured `RetrievalResult` (RAG)
+
+```python
+res = r.retrieve("What is RAG?", top_k=4)
+print(res.chunks[0][:80], res.metadata[0])
+```
+
+### 8) Custom `graph`
+
+Build any linear `Graph` whose first operator accepts a `DataFrame` whose text column matches **`EmbedParams.text_column`** (default `"text"`), and whose **last** node returns `list[list[dict]]` (or a rerank `DataFrame` when **`rerank=True`** on a default-style tail—prefer matching the default contract).
+
+```python
+from nemo_retriever.graph.pipeline_graph import Graph
+from nemo_retriever.retriever import Retriever
+
+# my_graph: Graph = embed_op >> retrieve_op  # your operators
+r = Retriever(graph=my_graph, top_k=5)
+```
+
+---
+
+## gRPC embedding
+
+The graph embed path targets **HTTP** (OpenAI-style) batch embedding. **`RecallConfig`** gRPC-only embedding previously used a separate client; with the graph **`Retriever`**, configure an **HTTP** embedding endpoint instead.
+
+---
+
+## Related types
+
+- **`EmbedParams`**: `nemo_retriever.params.EmbedParams`
+- **`RetrieveVdbOperator`**: `nemo_retriever.vdb.operators.RetrieveVdbOperator`
+- **`NemotronRerankActor`**: `nemo_retriever.rerank.rerank.NemotronRerankActor`

--- a/nemo_retriever/src/nemo_retriever/evaluation/live_retrieval.py
+++ b/nemo_retriever/src/nemo_retriever/evaluation/live_retrieval.py
@@ -43,7 +43,9 @@ class LiveRetrievalOperator(EvalOperator):
 
     Example:
         >>> from nemo_retriever.retriever import Retriever  # doctest: +SKIP
-        >>> retriever = Retriever(vdb_kwargs={"uri": "./kb", "table_name": "nv-ingest"})  # doctest: +SKIP
+        >>> retriever = Retriever(  # doctest: +SKIP
+        ...     vdb_kwargs={"vdb_op": "lancedb", "vdb_kwargs": {"uri": "./kb", "table_name": "nv-ingest"}}
+        ... )  # doctest: +SKIP
         >>> op = LiveRetrievalOperator(retriever, top_k=5)  # doctest: +SKIP
         >>> import pandas as pd  # doctest: +SKIP
         >>> df = pd.DataFrame({"query": ["What is RAG?"]})  # doctest: +SKIP

--- a/nemo_retriever/src/nemo_retriever/export.py
+++ b/nemo_retriever/src/nemo_retriever/export.py
@@ -139,11 +139,13 @@ def query_lancedb(
     from nemo_retriever.retriever import Retriever
 
     retriever = Retriever(
-        vdb="lancedb",
-        vdb_kwargs={"uri": lancedb_uri, "table_name": lancedb_table},
-        embedder=embedder,
+        vdb_kwargs={
+            "vdb_op": "lancedb",
+            "vdb_kwargs": {"uri": lancedb_uri, "table_name": lancedb_table},
+        },
+        embed_kwargs={"model_name": embedder, "embed_model_name": embedder},
         top_k=top_k,
-        reranker=False,
+        rerank=False,
     )
 
     use_fullpage = page_index is not None

--- a/nemo_retriever/src/nemo_retriever/harness/portal/app.py
+++ b/nemo_retriever/src/nemo_retriever/harness/portal/app.py
@@ -857,9 +857,11 @@ async def run_retrieval_query(run_id: int, req: RetrievalQueryRequest):
         from nemo_retriever.retriever import Retriever
 
         retriever = Retriever(
-            vdb="lancedb",
-            vdb_kwargs={"uri": uri, "table_name": LANCEDB_TABLE},
-            embedder=embed_model,
+            vdb_kwargs={
+                "vdb_op": "lancedb",
+                "vdb_kwargs": {"uri": uri, "table_name": LANCEDB_TABLE},
+            },
+            embed_kwargs={"model_name": embed_model, "embed_model_name": embed_model},
             top_k=req.top_k,
         )
         hits = retriever.query(req.query)

--- a/nemo_retriever/src/nemo_retriever/llm/__init__.py
+++ b/nemo_retriever/src/nemo_retriever/llm/__init__.py
@@ -17,7 +17,7 @@ Credentials
 -----------
 Per-component API keys (``api_key``) and base URLs (``api_base``) are
 passed directly on ``LiteLLMClient.from_kwargs`` / ``LLMJudge.from_kwargs``
-or on ``Retriever(embedding_api_key=..., embedding_endpoint=...)``.  When
+or via ``Retriever(embed_kwargs={"api_key": ..., "embedding_endpoint": ...})``.  When
 ``api_key`` is left ``None`` the shared ``_ParamsModel`` validator
 resolves ``NVIDIA_API_KEY`` / ``NGC_API_KEY`` from the environment.  This
 keeps the common single-provider path a one-liner while still allowing

--- a/nemo_retriever/src/nemo_retriever/ocr/cpu_ocrv2.py
+++ b/nemo_retriever/src/nemo_retriever/ocr/cpu_ocrv2.py
@@ -19,11 +19,12 @@ from nemo_retriever.ocr.shared import ocr_page_elements
 class OCRV2CPUActor(AbstractOperator, CPUOperator):
     """CPU-only variant of :class:`OCRV2Actor`.
 
-    Defaults to the build.nvidia.com endpoint for ``nemotron-ocr-v2``.
+    Defaults to the build.nvidia.com endpoint for ``nemotron-ocr-v1`` (same hosted
+    path as :class:`~nemo_retriever.ocr.cpu_ocr.OCRCPUActor`).
     No local GPU model is loaded.
     """
 
-    DEFAULT_INVOKE_URL = "https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-ocr-v2"
+    DEFAULT_INVOKE_URL = "https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-ocr-v1"
 
     def __init__(self, **ocr_kwargs: Any) -> None:
         super().__init__(**ocr_kwargs)

--- a/nemo_retriever/src/nemo_retriever/recall/beir.py
+++ b/nemo_retriever/src/nemo_retriever/recall/beir.py
@@ -713,30 +713,49 @@ def evaluate_lancedb_beir(
         doc_id_field=cfg.doc_id_field,
     )
     ks = tuple(sorted({int(k) for k in cfg.ks if int(k) > 0}))
+    from nemo_retriever.params.models import ModelRuntimeParams
+
+    embed_kwargs: dict[str, Any] = {
+        "model_name": str(cfg.embedding_model),
+        "embed_model_name": str(cfg.embedding_model),
+        "local_ingest_embed_backend": str(cfg.local_query_embed_backend),
+        "inference_batch_size": int(cfg.local_hf_batch_size),
+        "embed_inference_batch_size": int(cfg.local_hf_batch_size),
+    }
+    if cfg.embedding_http_endpoint:
+        embed_kwargs["embedding_endpoint"] = cfg.embedding_http_endpoint
+        embed_kwargs["embed_invoke_url"] = cfg.embedding_http_endpoint
+    if (cfg.embedding_api_key or "").strip():
+        embed_kwargs["api_key"] = (cfg.embedding_api_key or "").strip()
+    if cfg.local_hf_device or cfg.local_hf_cache_dir:
+        embed_kwargs["runtime"] = ModelRuntimeParams(
+            device=cfg.local_hf_device,
+            hf_cache_dir=str(cfg.local_hf_cache_dir) if cfg.local_hf_cache_dir else None,
+        )
+
+    rerank_kw = {
+        "model_name": str(cfg.reranker_model_name),
+        "invoke_url": (cfg.reranker_endpoint or "").strip() or None,
+        "api_key": (cfg.reranker_api_key or "").strip(),
+        "batch_size": int(cfg.reranker_batch_size),
+        "local_reranker_backend": str(cfg.local_reranker_backend),
+    }
+
     retriever = Retriever(
-        vdb="lancedb",
         vdb_kwargs={
-            "uri": str(cfg.lancedb_uri),
-            "table_name": str(cfg.lancedb_table),
-            "hybrid": bool(cfg.hybrid),
-            "nprobes": int(cfg.nprobes),
-            "refine_factor": int(cfg.refine_factor),
+            "vdb_op": "lancedb",
+            "vdb_kwargs": {
+                "uri": str(cfg.lancedb_uri),
+                "table_name": str(cfg.lancedb_table),
+                "hybrid": bool(cfg.hybrid),
+                "nprobes": int(cfg.nprobes),
+                "refine_factor": int(cfg.refine_factor),
+            },
         },
-        embedder=str(cfg.embedding_model),
-        embedding_endpoint=cfg.embedding_http_endpoint,
-        embedding_api_key=(cfg.embedding_api_key or "").strip(),
-        embedding_use_grpc=False if cfg.embedding_http_endpoint else None,
+        embed_kwargs=embed_kwargs,
         top_k=max(ks),
-        local_hf_device=cfg.local_hf_device,
-        local_hf_cache_dir=Path(cfg.local_hf_cache_dir) if cfg.local_hf_cache_dir else None,
-        local_hf_batch_size=int(cfg.local_hf_batch_size),
-        reranker=bool(cfg.reranker),
-        reranker_model_name=str(cfg.reranker_model_name),
-        reranker_endpoint=cfg.reranker_endpoint,
-        reranker_api_key=(cfg.reranker_api_key or "").strip(),
-        reranker_batch_size=int(cfg.reranker_batch_size),
-        local_reranker_backend=str(cfg.local_reranker_backend),
-        local_query_embed_backend=str(cfg.local_query_embed_backend),
+        rerank=bool(cfg.reranker),
+        rerank_kwargs=rerank_kw,
     )
     raw_hits = retriever.queries(dataset.queries)
     run = build_beir_run_from_hits(dataset.query_ids, raw_hits, doc_id_field=cfg.doc_id_field)

--- a/nemo_retriever/src/nemo_retriever/recall/core.py
+++ b/nemo_retriever/src/nemo_retriever/recall/core.py
@@ -470,28 +470,50 @@ def retrieve_and_score(
 
     queries = df_query["query"].astype(str).tolist()
     gold = df_query["golden_answer"].astype(str).tolist()
-    vdb_kwargs = dict(cfg.vdb_kwargs or {})
+    vdb_inner = dict(cfg.vdb_kwargs or {})
     query_embedder = str(cfg.query_embedder or VL_EMBED_MODEL)
     embedding_endpoint, embedding_use_grpc = _resolve_embedding_endpoint(cfg)
+    if embedding_use_grpc:
+        raise ValueError(
+            "RecallConfig gRPC query embedding is not supported with the graph-based Retriever. "
+            "Use embedding_http_endpoint or an http(s) embedding_endpoint."
+        )
+
+    from nemo_retriever.params.models import ModelRuntimeParams
+
+    embed_kwargs: dict[str, Any] = {
+        "model_name": query_embedder,
+        "embed_model_name": query_embedder,
+        "inference_batch_size": int(cfg.local_hf_batch_size),
+        "embed_inference_batch_size": int(cfg.local_hf_batch_size),
+        "local_ingest_embed_backend": str(cfg.local_query_embed_backend),
+        "embed_modality": str(cfg.embed_modality),
+    }
+    if embedding_endpoint:
+        embed_kwargs["embedding_endpoint"] = embedding_endpoint
+        embed_kwargs["embed_invoke_url"] = embedding_endpoint
+    if (cfg.embedding_api_key or "").strip():
+        embed_kwargs["api_key"] = (cfg.embedding_api_key or "").strip()
+    if cfg.local_hf_device or cfg.local_hf_cache_dir:
+        embed_kwargs["runtime"] = ModelRuntimeParams(
+            device=str(cfg.local_hf_device) if cfg.local_hf_device else None,
+            hf_cache_dir=str(cfg.local_hf_cache_dir) if cfg.local_hf_cache_dir else None,
+        )
+
+    rerank_kw: dict[str, Any] = {
+        "model_name": str(cfg.reranker or VL_RERANK_MODEL),
+        "invoke_url": (cfg.reranker_endpoint or "").strip() or None,
+        "api_key": (cfg.reranker_api_key or "").strip(),
+        "batch_size": int(cfg.reranker_batch_size),
+        "local_reranker_backend": str(cfg.local_reranker_backend),
+    }
+
     retriever = Retriever(
-        vdb=str(cfg.vdb_op),
-        vdb_kwargs=vdb_kwargs,
-        embedder=query_embedder,
-        embedding_endpoint=embedding_endpoint,
-        embedding_api_key=cfg.embedding_api_key,
-        embedding_use_grpc=embedding_use_grpc,
+        vdb_kwargs={"vdb_op": str(cfg.vdb_op), "vdb_kwargs": vdb_inner},
+        embed_kwargs=embed_kwargs,
         top_k=cfg.top_k,
-        local_hf_device=cfg.local_hf_device,
-        local_hf_cache_dir=cfg.local_hf_cache_dir,
-        local_hf_batch_size=int(cfg.local_hf_batch_size),
-        local_query_embed_backend=cfg.local_query_embed_backend,
-        reranker=bool(cfg.reranker),
-        reranker_model_name=cfg.reranker or VL_RERANK_MODEL,
-        reranker_endpoint=cfg.reranker_endpoint,
-        reranker_api_key=cfg.reranker_api_key,
-        reranker_batch_size=cfg.reranker_batch_size,
-        local_reranker_backend=cfg.local_reranker_backend,
-        rerank_modality=cfg.embed_modality,
+        rerank=bool(cfg.reranker),
+        rerank_kwargs=rerank_kw,
     )
     start = time.time()
     raw_hits = retriever.queries(queries)

--- a/nemo_retriever/src/nemo_retriever/retriever.py
+++ b/nemo_retriever/src/nemo_retriever/retriever.py
@@ -1,24 +1,26 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2024-26, NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence
 
-from tqdm import tqdm
+import pandas as pd
 
-import nemo_retriever.vdb as vdb_pkg
 from nemo_retriever.model import VL_EMBED_MODEL, VL_RERANK_MODEL
+from nemo_retriever.retriever_graph_utils import (
+    filter_retrieval_kwargs,
+    rerank_long_dataframe_to_hits,
+)
+from nemo_retriever.vdb.operators import RetrieveVdbOperator
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    import pandas as pd
-
     from nemo_retriever.llm.types import (
         AnswerJudge,
         AnswerResult,
@@ -26,507 +28,221 @@ if TYPE_CHECKING:
         RetrievalResult,
     )
 
-_KEEP_KEYS = frozenset(
-    {
-        "text",
-        "metadata",
-        "source",
-        "page_number",
-        "pdf_page",
-        "pdf_basename",
-        "source_id",
-        "path",
-        "stored_image_uri",
-        "content_type",
-        "bbox_xyxy_norm",
+
+def _coerce_vdb_init(user: dict[str, Any]) -> dict[str, Any]:
+    """Normalize ``vdb_kwargs`` into :class:`RetrieveVdbOperator` constructor kwargs."""
+    u = dict(user or {})
+    if "vdb" in u or "vdb_op" in u:
+        return u
+    return {"vdb_op": "lancedb", "vdb_kwargs": u}
+
+
+def _default_rerank_actor_kwargs() -> dict[str, Any]:
+    return {
+        "model_name": VL_RERANK_MODEL,
+        "query_column": "query",
+        "text_column": "text",
+        "score_column": "rerank_score",
+        "max_length": 10240,
+        "batch_size": 32,
+        "sort_results": False,
+        "api_key": "",
     }
-)
 
 
 @dataclass
 class Retriever:
-    """VDB-agnostic query helper over vector databases.
+    """Graph-based query helper: batch embed → VDB retrieve [→ Nemotron rerank].
 
-    Run modes
-    ---------
-    ``run_mode="local"`` (default)
-        Embed queries locally (NIM endpoint or HuggingFace model) and
-        search a local LanceDB directory.  All processing happens in
-        this process.
+    Configuration is passed through ``embed_kwargs`` (:class:`~nemo_retriever.params.EmbedParams`),
+    ``vdb_kwargs`` (constructor kwargs for :class:`~nemo_retriever.vdb.operators.RetrieveVdbOperator`),
+    and optional ``rerank_kwargs`` for :class:`~nemo_retriever.rerank.rerank.NemotronRerankActor`.
 
-    ``run_mode="service"``
-        Delegate embedding and vector search to a running
-        nemo-retriever service via ``POST /v1/query``.  Set
-        ``service_url`` to the base URL of the service (e.g.
-        ``"http://localhost:7670"``).  When ``reranker`` is enabled,
-        the service's ``POST /v1/rerank`` endpoint is called to
-        re-score and sort results.
-
-    Example — service mode::
-
-        retriever = Retriever(
-            run_mode="service",
-            service_url="http://localhost:7670",
-        )
-        results = retriever.query("What is machine learning?")
-
-    Retrieval pipeline (local mode)
-    -------------------------------
-    1. Embed query strings with a local query embedder, or with a configured
-       embedding endpoint.
-    2. Search the configured vector database.
-    3. Optionally rerank the results with ``nvidia/llama-nemotron-rerank-1b-v2``
-       (NIM/vLLM endpoint or local HuggingFace model).
-
-    Reranking
-    ---------
-    Set ``reranker`` to a model name (e.g.
-    ``"nvidia/llama-nemotron-rerank-1b-v2"``) to enable post-retrieval
-    reranking.  Results are re-sorted by the cross-encoder score and a
-    ``"_rerank_score"`` key is added to each hit dict.
-
-    Use ``reranker_endpoint`` to delegate to a running vLLM (>=0.14) or NIM
-    server instead of loading the model locally::
-
-        retriever = Retriever(
-            vdb="lancedb",
-            vdb_kwargs={"uri": "./kb", "table_name": "nv-ingest"},
-            reranker="nvidia/llama-nemotron-rerank-1b-v2",
-            reranker_endpoint="http://localhost:8000",
-        )
-        results = retriever.query("What is machine learning?")
-
-    LanceDB SQL filters
-    --------------------
-    Pass a Lance / DataFusion predicate via ``where`` (or ``_filter``) in
-    ``vdb_kwargs``, or per call to ``query`` / ``queries``, to pre-filter
-    vector search (see ``LanceDB.retrieval`` in ``nemo_retriever.vdb.lancedb``).
+    See ``retriever.md`` for examples.
     """
 
-    # Run-mode selection ---------------------------------------------------
     run_mode: Literal["local", "service"] = "local"
-    """``'local'`` for direct LanceDB + NIM/HF embedding; ``'service'`` to
-    delegate to a running nemo-retriever service."""
-    service_url: Optional[str] = None
-    """Base URL of the nemo-retriever service (e.g. ``http://localhost:7670``).
-    Required when ``run_mode='service'``."""
-    service_api_token: Optional[str] = None
-    """Optional bearer token for authenticating with the service."""
+    """``local`` uses archetype batch embed resolution; ``service`` forces CPU HTTP embed."""
 
-    # Local-mode settings --------------------------------------------------
-    vdb: Any = "lancedb"
-    vdb_kwargs: dict[str, Any] = field(default_factory=dict)
-    embedder: str = VL_EMBED_MODEL
     top_k: int = 10
-    embedding_endpoint: Optional[str] = None
-    """Optional query embedding endpoint. If unset, query embedding uses local HuggingFace."""
-    embedding_http_endpoint: Optional[str] = None
-    """Back-compat HTTP query embedding endpoint alias."""
-    embedding_grpc_endpoint: Optional[str] = None
-    """Back-compat gRPC query embedding endpoint alias."""
-    embedding_api_key: str = ""
-    """Bearer token/API key for the query embedding endpoint."""
-    embedding_use_grpc: Optional[bool] = None
-    """Whether the query embedding endpoint is gRPC. If unset, infer from the endpoint string."""
-    local_hf_device: Optional[str] = None
-    local_hf_cache_dir: Optional[Path] = None
-    local_hf_batch_size: int = 32
-    #: When embedding queries locally (no HTTP endpoint): ``"hf"`` (default) uses
-    #: HuggingFace; ``"vllm"`` uses vLLM (same model as ingest).
-    local_query_embed_backend: str = "hf"
-    # Reranking -----------------------------------------------------------
-    reranker: Optional[bool] = False
-    """True to enable reranking with the default model, will use the reranker_model_name as hf model"""
-    reranker_model_name: Optional[str] = VL_RERANK_MODEL
-    """HuggingFace model ID for local reranking (e.g. 'nvidia/llama-nemotron-rerank-1b-v2')."""
-    reranker_endpoint: Optional[str] = None
-    """Base URL of a vLLM / NIM ranking endpoint. Appends ``/v1/ranking`` unless already using ``/reranking``."""
-    reranker_api_key: str = ""
-    """Bearer token for the remote rerank endpoint."""
-    reranker_max_length: int = 10240
-    """Tokenizer truncation length for local reranking (max 8 192)."""
-    reranker_batch_size: int = 32
-    """GPU micro-batch size for local reranking."""
-    reranker_refine_factor: int = 4
-    """Number of candidates to rerank = top_k * reranker_refine_factor.
-    Set to 1 to rerank only the top_k results."""
-    rerank_modality: str = "text"
-    """Reranking modality, typically matches embed_modality. Set to 'text_image'
-    to enable multimodal reranking with images."""
-    local_reranker_backend: str = "vllm"
-    """Backend for local VL reranking: ``"vllm"`` (default) or ``"hf"``."""
-    reranker_gpu_memory_utilization: float = 0.5
-    """Fraction of GPU memory for the vLLM reranker engine."""
-    # Internal cache for the local rerank model (not part of the public API).
-    _reranker_model: Any = field(default=None, init=False, repr=False, compare=False)
-    # Internal cache for local text embedders, keyed by model name.
-    _embedder_cache: dict = field(default_factory=dict, init=False, repr=False, compare=False)
-    # Internal cache for the VDB retrieval operator.
-    _retrieve_operator: Any = field(default=None, init=False, repr=False, compare=False)
+    rerank: bool = False
+    """When ``True``, append :class:`~nemo_retriever.rerank.rerank.NemotronRerankActor` after retrieval."""
+
+    graph: Any = None
+    """Custom :class:`~nemo_retriever.graph.pipeline_graph.Graph`. When set, ``embed_kwargs`` /
+    ``vdb_kwargs`` default-graph fields are ignored for construction (you still pass execute kwargs)."""
+
+    embed_kwargs: dict[str, Any] = field(default_factory=dict)
+    vdb_kwargs: dict[str, Any] = field(default_factory=dict)
+    rerank_kwargs: dict[str, Any] = field(default_factory=dict)
+
+    _cached_graph: Any = field(default=None, init=False, repr=False, compare=False)
+    _cache_key: Any = field(default=None, init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
-        from nemo_retriever.model import (
-            _LOCAL_QUERY_BACKENDS,
-            _LOCAL_RERANKER_BACKENDS,
-            normalize_backend,
-        )
+        if self.run_mode not in ("local", "service"):
+            raise ValueError("run_mode must be 'local' or 'service'")
 
-        self.local_query_embed_backend = normalize_backend(
-            self.local_query_embed_backend,
-            _LOCAL_QUERY_BACKENDS,
-            field_name="local_query_embed_backend",
-            default="hf",
-        )
-        self.local_reranker_backend = normalize_backend(
-            self.local_reranker_backend,
-            _LOCAL_RERANKER_BACKENDS,
-            field_name="local_reranker_backend",
-            default="vllm",
-        )
+    def _merge_embed_params(self, extra: Optional[dict[str, Any]] = None) -> Any:
+        from nemo_retriever.model import _LOCAL_INGEST_EMBED_BACKENDS, normalize_backend
+        from nemo_retriever.params import EmbedParams
 
-    def _get_local_embedder(self, model_name: str) -> Any:
-        """Lazily load and cache the local embedder for *model_name*."""
-        from nemo_retriever.model import (
-            create_local_query_embedder,
-            resolve_embed_model,
-        )
-
-        resolved = resolve_embed_model(model_name)
-        backend_raw = self.local_query_embed_backend
-        cache_key: tuple[str, str] = (resolved, backend_raw)
-
-        if cache_key not in self._embedder_cache:
-            cache_dir = str(self.local_hf_cache_dir) if self.local_hf_cache_dir else None
-            dev = str(self.local_hf_device) if self.local_hf_device else None
-            self._embedder_cache[cache_key] = create_local_query_embedder(
-                resolved,
-                backend=backend_raw,
-                device=dev,
-                hf_cache_dir=cache_dir,
-            )
-        return self._embedder_cache[cache_key]
-
-    def _embed_queries_local(self, query_texts: list[str], *, model_name: str) -> list[list[float]]:
-        embedder = self._get_local_embedder(model_name)
-        vectors = embedder.embed_queries(query_texts, batch_size=int(self.local_hf_batch_size))
-        return vectors.detach().to("cpu").tolist()
-
-    def _embed_queries_local_hf(self, query_texts: list[str], *, model_name: Optional[str] = None) -> list[list[float]]:
-        """Compatibility wrapper for the local-HF default query embedding path."""
-        return self._embed_queries_local(query_texts, model_name=str(model_name or self.embedder))
-
-    def _resolve_embedding_endpoint(self) -> tuple[str | None, bool | None]:
-        http_ep = (self.embedding_http_endpoint or "").strip()
-        grpc_ep = (self.embedding_grpc_endpoint or "").strip()
-        endpoint = (self.embedding_endpoint or "").strip()
-        if http_ep:
-            return http_ep, False
-        if grpc_ep:
-            return grpc_ep, True
-        if self.embedding_use_grpc is not None:
-            return (endpoint, bool(self.embedding_use_grpc)) if endpoint else (None, None)
-        if not endpoint:
-            return None, None
-        return endpoint, not endpoint.lower().startswith("http")
-
-    def _embed_queries_remote(self, query_texts: list[str], *, model_name: Optional[str] = None) -> list[list[float]]:
-        endpoint, use_grpc = self._resolve_embedding_endpoint()
-        if endpoint is None or use_grpc is None:
-            raise ValueError("Remote query embedding requires embedding_endpoint.")
-
-        from nemo_retriever.api.util.nim import infer_microservice
-
-        embeddings = infer_microservice(
-            query_texts,
-            model_name=str(model_name or self.embedder),
-            embedding_endpoint=endpoint,
-            nvidia_api_key=(self.embedding_api_key or "").strip(),
-            grpc=bool(use_grpc),
-            input_type="query",
-        )
-        vectors: list[list[float]] = []
-        for embedding in embeddings:
-            tolist = getattr(embedding, "tolist", None)
-            values = tolist() if callable(tolist) else embedding
-            vectors.append(list(values))
-        return vectors
-
-    def _embed_queries(self, query_texts: list[str], *, model_name: Optional[str] = None) -> list[list[float]]:
-        endpoint, _use_grpc = self._resolve_embedding_endpoint()
-        if endpoint is not None:
-            return self._embed_queries_remote(query_texts, model_name=model_name)
-        return self._embed_queries_local_hf(query_texts, model_name=model_name)
-
-    def _get_retrieve_operator(self) -> Any:
-        """Lazily construct the VDB retrieval operator for this Retriever."""
-        if self._retrieve_operator is None:
-            operator_kwargs: dict[str, Any] = {"vdb_kwargs": dict(self.vdb_kwargs or {})}
-            if isinstance(self.vdb, str):
-                operator_kwargs["vdb_op"] = self.vdb
-            else:
-                operator_kwargs["vdb"] = self.vdb
-            self._retrieve_operator = vdb_pkg.RetrieveVdbOperator(**operator_kwargs)
-        return self._retrieve_operator
-
-    # ------------------------------------------------------------------
-    # Reranking helpers
-    # ------------------------------------------------------------------
-
-    def _get_reranker_model(self) -> Any:
-        """Lazily load and cache the local reranker model (text-only or VL)."""
-        if self._reranker_model is None and self.reranker:
-            from nemo_retriever.model import create_local_reranker
-
-            cache_dir = str(self.local_hf_cache_dir) if self.local_hf_cache_dir else None
-            self._reranker_model = create_local_reranker(
-                model_name=self.reranker_model_name,
-                device=self.local_hf_device,
-                hf_cache_dir=cache_dir,
-                backend=self.local_reranker_backend,
-                gpu_memory_utilization=self.reranker_gpu_memory_utilization,
-            )
-        return self._reranker_model
-
-    def _rerank_results(
-        self,
-        query_texts: list[str],
-        results: list[list[dict[str, Any]]],
-        *,
-        top_k: int,
-    ) -> list[list[dict[str, Any]]]:
-        """Rerank each per-query result list using the configured reranker."""
-        from nemo_retriever.rerank import rerank_hits
-
-        reranker_endpoint = (self.reranker_endpoint or "").strip() or None
-        model = None if reranker_endpoint else self._get_reranker_model()
-
-        reranked: list[list[dict[str, Any]]] = []
-        for query, hits in tqdm(zip(query_texts, results), desc="Reranking", unit="query", total=len(query_texts)):
-            reranked.append(
-                rerank_hits(
-                    query,
-                    hits,
-                    model=model,
-                    invoke_url=reranker_endpoint,
-                    model_name=str(self.reranker_model_name),
-                    api_key=(self.reranker_api_key or "").strip(),
-                    max_length=int(self.reranker_max_length),
-                    batch_size=int(self.reranker_batch_size),
-                    top_n=int(top_k),
-                    modality=self.rerank_modality,
-                )
-            )
-        return reranked
-
-    # ------------------------------------------------------------------
-    # Service-mode helpers
-    # ------------------------------------------------------------------
-
-    def _validate_service_config(self) -> str:
-        """Return the normalized service base URL, or raise."""
-        url = (self.service_url or "").strip().rstrip("/")
-        if not url:
-            raise ValueError(
-                "service_url is required when run_mode='service'. "
-                "Set it to the base URL of the nemo-retriever service "
-                "(e.g. 'http://localhost:7670')."
-            )
-        if not url.lower().startswith("http"):
-            raise ValueError(f"service_url must be an HTTP(S) URL, got: {url!r}")
-        return url
-
-    def _service_headers(self) -> dict[str, str]:
-        """Build HTTP headers for service requests (auth + content-type)."""
-        headers: dict[str, str] = {"Content-Type": "application/json"}
-        token = (self.service_api_token or "").strip()
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
-        return headers
-
-    def _service_post(self, url: str, payload: dict[str, Any]) -> dict[str, Any]:
-        """POST JSON to a service endpoint with standard error handling."""
-        import httpx
-
-        base_url = self._validate_service_config()
-        full_url = f"{base_url}{url}"
-
-        try:
-            with httpx.Client(timeout=httpx.Timeout(300.0, connect=30.0)) as client:
-                resp = client.post(full_url, json=payload, headers=self._service_headers())
-        except httpx.ConnectError as exc:
-            raise ConnectionError(
-                f"Failed to connect to the nemo-retriever service at {base_url!r}: " f"{type(exc).__name__}: {exc}"
-            ) from exc
-        except httpx.TimeoutException as exc:
-            raise TimeoutError(
-                f"Request to nemo-retriever service timed out ({base_url!r}): " f"{type(exc).__name__}: {exc}"
-            ) from exc
-        except httpx.HTTPError as exc:
-            raise RuntimeError(
-                f"HTTP error communicating with nemo-retriever service ({base_url!r}): " f"{type(exc).__name__}: {exc}"
-            ) from exc
-
-        if resp.status_code != 200:
-            detail = ""
-            try:
-                detail = resp.json().get("detail", resp.text)
-            except Exception:
-                detail = resp.text
-            raise RuntimeError(f"Service request to {url} failed with HTTP {resp.status_code}: {detail}")
-
-        return resp.json()
-
-    def _queries_via_service(
-        self,
-        query_texts: list[str],
-        *,
-        lancedb_uri: Optional[str] = None,
-        lancedb_table: Optional[str] = None,
-    ) -> list[list[dict[str, Any]]]:
-        """Delegate retrieval to the nemo-retriever service ``POST /v1/query``."""
-        payload: dict[str, Any] = {
-            "query": query_texts if len(query_texts) > 1 else query_texts[0],
-            "top_k": self.top_k if not self.reranker else self.top_k * self.reranker_refine_factor,
-            "hybrid": self.hybrid,
+        base: dict[str, Any] = {
+            "model_name": VL_EMBED_MODEL,
+            "embed_model_name": VL_EMBED_MODEL,
+            "input_type": "query",
+            "text_column": "text",
+            "inference_batch_size": 32,
+            "embed_inference_batch_size": 32,
         }
-        if lancedb_uri is not None:
-            payload["lancedb_uri"] = lancedb_uri
-        if lancedb_table is not None:
-            payload["lancedb_table"] = lancedb_table
+        merged = {**base, **dict(self.embed_kwargs or {}), **dict(extra or {})}
+        if "local_ingest_embed_backend" in merged and merged["local_ingest_embed_backend"] is not None:
+            merged["local_ingest_embed_backend"] = normalize_backend(
+                str(merged["local_ingest_embed_backend"]),
+                _LOCAL_INGEST_EMBED_BACKENDS,
+                field_name="local_ingest_embed_backend",
+                default="vllm",
+            )
+        params = EmbedParams.model_validate(merged)
+        if self.run_mode == "service":
+            url = (params.embedding_endpoint or params.embed_invoke_url or "").strip()
+            if not url:
+                raise ValueError(
+                    "run_mode='service' requires a non-empty HTTP embedding URL. "
+                    "Set ``embedding_endpoint`` or ``embed_invoke_url`` inside ``embed_kwargs``."
+                )
+        return params
 
-        logger.debug("Service query: %d queries", len(query_texts))
-        body = self._service_post("/v1/query", payload)
+    def _merge_rerank_actor_kwargs(self) -> dict[str, Any]:
+        return {**_default_rerank_actor_kwargs(), **dict(self.rerank_kwargs or {})}
 
-        all_results: list[list[dict[str, Any]]] = []
-        for result_set in body.get("results", []):
-            hits: list[dict[str, Any]] = []
-            for hit in result_set.get("hits", []):
-                row: dict[str, Any] = {}
-                for key in _KEEP_KEYS:
-                    if key in hit:
-                        row[key] = hit[key]
-                hits.append(row)
-            all_results.append(hits)
+    def _refine_factor(self) -> int:
+        if not self.rerank:
+            return 1
+        return int(self._merge_rerank_actor_kwargs().get("refine_factor", 4))
 
-        return all_results
+    def _build_default_graph(self, *, embed_extra: Optional[dict[str, Any]] = None) -> Any:
+        from nemo_retriever.rerank.rerank import NemotronRerankActor
+        from nemo_retriever.text_embed.cpu_operator import _BatchEmbedCPUActor
+        from nemo_retriever.text_embed.operators import _BatchEmbedActor
 
-    def _rerank_via_service(
+        embed_params = self._merge_embed_params(embed_extra)
+        if self.run_mode == "service":
+            embed_op = _BatchEmbedCPUActor(params=embed_params)
+        else:
+            embed_op = _BatchEmbedActor(params=embed_params)
+
+        vdb_init = _coerce_vdb_init(self.vdb_kwargs)
+        retrieve = RetrieveVdbOperator(
+            explode_for_rerank=self.rerank,
+            **vdb_init,
+        )
+
+        chain = embed_op >> retrieve
+        if self.rerank:
+            rk = self._merge_rerank_actor_kwargs()
+            rk.pop("refine_factor", None)
+            chain = chain >> NemotronRerankActor(**rk)
+
+        return chain
+
+    def _get_graph(self, *, embed_extra: Optional[dict[str, Any]] = None) -> Any:
+        if self.graph is not None:
+            return self.graph
+
+        key = (
+            self.run_mode,
+            self.rerank,
+            json.dumps(self.vdb_kwargs, sort_keys=True, default=str),
+            json.dumps(self.embed_kwargs, sort_keys=True, default=str),
+            json.dumps(self.rerank_kwargs, sort_keys=True, default=str),
+            json.dumps(embed_extra or {}, sort_keys=True, default=str),
+        )
+        if self._cached_graph is not None and self._cache_key == key:
+            return self._cached_graph
+        g = self._build_default_graph(embed_extra=embed_extra)
+        self._cached_graph = g
+        self._cache_key = key
+        return g
+
+    def _execute_queries_graph(
         self,
         query_texts: list[str],
-        results: list[list[dict[str, Any]]],
+        *,
+        effective_top_k: int,
+        retrieval_top_k: int,
+        vdb_call_kwargs: Optional[dict[str, Any]],
+        embed_extra: Optional[dict[str, Any]],
     ) -> list[list[dict[str, Any]]]:
-        """Rerank each per-query result list via ``POST /v1/rerank``."""
-        reranked: list[list[dict[str, Any]]] = []
-        for query_text, hits in zip(query_texts, results):
-            if not hits:
-                reranked.append([])
-                continue
+        embed_params = self._merge_embed_params(embed_extra)
+        text_col = str(embed_params.text_column)
+        df = pd.DataFrame({text_col: query_texts})
 
-            payload: dict[str, Any] = {
-                "query": query_text,
-                "passages": hits,
-                "top_n": self.top_k,
-            }
-            if self.reranker_model_name:
-                payload["model_name"] = self.reranker_model_name
+        graph = self._get_graph(embed_extra=embed_extra)
+        if not callable(getattr(graph, "resolve_for_local_execution", None)):
+            raise TypeError("graph must provide resolve_for_local_execution() (e.g. pipeline_graph.Graph)")
 
-            logger.debug("Service rerank: query=%r, %d passages", query_text[:80], len(hits))
-            body = self._service_post("/v1/rerank", payload)
+        exec_kwargs: dict[str, Any] = {
+            **filter_retrieval_kwargs(dict(vdb_call_kwargs or {})),
+            "top_k": int(retrieval_top_k),
+            "query_texts": query_texts,
+        }
+        resolved = graph.resolve_for_local_execution()
+        leaves = resolved.execute(df, **exec_kwargs)
+        if len(leaves) != 1:
+            raise RuntimeError(
+                f"Retriever query graph must yield exactly one leaf output; got {len(leaves)}. "
+                "Use a linear graph or adjust your custom ``graph``."
+            )
+        out = leaves[0]
 
-            ranked_hits: list[dict[str, Any]] = []
-            for hit in body.get("results", []):
-                row: dict[str, Any] = {"_rerank_score": hit.get("rerank_score", 0.0)}
-                for key in _KEEP_KEYS:
-                    if key in hit:
-                        row[key] = hit[key]
-                ranked_hits.append(row)
-            reranked.append(ranked_hits)
-
-        return reranked
-
-    # ------------------------------------------------------------------
-    # Public query API
-    # ------------------------------------------------------------------
+        if isinstance(out, pd.DataFrame):
+            if not self.rerank:
+                raise TypeError(
+                    "Graph returned a DataFrame but ``rerank`` is False; expected list[list[dict]] from retrieval."
+                )
+            rk = self._merge_rerank_actor_kwargs()
+            score_col = str(rk.get("score_column", "rerank_score"))
+            return rerank_long_dataframe_to_hits(
+                out, query_texts=query_texts, top_k=int(effective_top_k), score_column=score_col
+            )
+        if not isinstance(out, list):
+            raise TypeError(f"Unexpected query graph output type: {type(out).__name__}")
+        return out
 
     def query(
         self,
         query: str,
         *,
         top_k: Optional[int] = None,
-        embedder: Optional[str] = None,
         vdb_kwargs: Optional[dict[str, Any]] = None,
+        embed_kwargs: Optional[dict[str, Any]] = None,
     ) -> list[dict[str, Any]]:
-        """Run retrieval for a single query string.
-
-        Args:
-            query: The natural-language query.
-            top_k: Per-call override of ``self.top_k``; passed as a local
-                value so the instance attribute is never mutated.
-            embedder: Per-call query embedding model override.
-            vdb_kwargs: Per-call VDB retrieval kwargs. These override
-                instance-level ``self.vdb_kwargs`` for this call.
-        """
-        return self.queries([query], top_k=top_k, embedder=embedder, vdb_kwargs=vdb_kwargs)[0]
+        return self.queries([query], top_k=top_k, vdb_kwargs=vdb_kwargs, embed_kwargs=embed_kwargs)[0]
 
     def queries(
         self,
         queries: Sequence[str],
         *,
         top_k: Optional[int] = None,
-        embedder: Optional[str] = None,
         vdb_kwargs: Optional[dict[str, Any]] = None,
+        embed_kwargs: Optional[dict[str, Any]] = None,
     ) -> list[list[dict[str, Any]]]:
-        """Run retrieval for multiple query strings.
-
-        When ``run_mode='local'``:
-            Embeds locally, searches the configured VDB directly, and
-            optionally reranks with the configured reranker.
-
-        When ``run_mode='service'``:
-            Delegates embedding and vector search to the nemo-retriever
-            service at ``service_url``.  When ``reranker`` is set the
-            service's ``/v1/rerank`` endpoint is called to re-score and
-            sort the results; each hit gains a ``"_rerank_score"`` key.
-
-        If ``reranker`` is set on this instance (local mode) the initial
-        vector-search results are re-scored with
-        ``nvidia/llama-nemotron-rerank-1b-v2`` (or the configured endpoint)
-        and returned sorted by cross-encoder score.  Each hit gains a
-        ``"_rerank_score"`` key.
-
-        The ``top_k`` kwarg is threaded through the search + rerank stack
-        as a local value so concurrent callers never race on ``self.top_k``.
-        """
         query_texts = [str(q) for q in queries]
         if not query_texts:
             return []
 
-        if self.run_mode == "service":
-            results = self._queries_via_service(query_texts)
-            if self.reranker:
-                results = self._rerank_via_service(query_texts, results)
-            return results
-
         effective_top_k = int(top_k) if top_k is not None else int(self.top_k)
-        retrieval_top_k = effective_top_k
-        if self.reranker:
-            retrieval_top_k = effective_top_k * int(self.reranker_refine_factor)
+        refine = self._refine_factor()
+        retrieval_top_k = effective_top_k * refine if self.rerank else effective_top_k
 
-        resolved_embedder = str(embedder or self.embedder)
-        vectors = self._embed_queries(query_texts, model_name=resolved_embedder)
-
-        retrieval_kwargs = dict(vdb_kwargs or {})
-        retrieval_kwargs["top_k"] = int(retrieval_top_k)
-        results = self._get_retrieve_operator().process(vectors, **retrieval_kwargs)
-
-        if self.reranker:
-            results = self._rerank_results(query_texts, results, top_k=effective_top_k)
-
-        return results
-
-    # ------------------------------------------------------------------
-    # Live RAG API (structured retrieval + generation)
-    # ------------------------------------------------------------------
+        return self._execute_queries_graph(
+            query_texts,
+            effective_top_k=effective_top_k,
+            retrieval_top_k=retrieval_top_k,
+            vdb_call_kwargs=vdb_kwargs,
+            embed_extra=embed_kwargs,
+        )
 
     def retrieve(
         self,
@@ -534,35 +250,11 @@ class Retriever:
         top_k: Optional[int] = None,
         *,
         vdb_kwargs: Optional[dict[str, Any]] = None,
+        embed_kwargs: Optional[dict[str, Any]] = None,
     ) -> "RetrievalResult":
-        """Run retrieval for a single query and return a structured result.
-
-        Thin adapter over :meth:`query` that reshapes the raw VDB hits
-        into a :class:`~nemo_retriever.llm.RetrievalResult` with ``chunks``
-        (the retrieved text, in rank order) and aligned ``metadata``
-        (source, page_number, etc.).  Satisfies the
-        :class:`~nemo_retriever.llm.RetrieverStrategy` Protocol.
-
-        Args:
-            query: The natural-language query.
-            top_k: Per-call override of ``self.top_k``; passed as a local
-                value so the instance attribute is never mutated.
-            vdb_kwargs: Per-call VDB retrieval kwargs.
-
-        Returns:
-            A :class:`~nemo_retriever.llm.RetrievalResult` whose ``chunks``
-            and ``metadata`` lists have the same length.
-
-        Example:
-            >>> retriever = Retriever(vdb_kwargs={"uri": "./kb", "table_name": "nv-ingest"})
-            >>> result = retriever.retrieve("What is RAG?", top_k=3)
-            >>> import itertools
-            >>> "".join(itertools.islice(result.chunks[0], 40))  # doctest: +SKIP
-            'Retrieval augmented generation combines...'
-        """
         from nemo_retriever.llm.types import RetrievalResult
 
-        hits = self.query(query, top_k=top_k, vdb_kwargs=vdb_kwargs)
+        hits = self.query(query, top_k=top_k, vdb_kwargs=vdb_kwargs, embed_kwargs=embed_kwargs)
 
         chunks: list[str] = []
         metadata: list[dict[str, Any]] = []
@@ -577,32 +269,15 @@ class Retriever:
         *,
         top_k: Optional[int] = None,
         vdb_kwargs: Optional[dict[str, Any]] = None,
+        embed_kwargs: Optional[dict[str, Any]] = None,
     ) -> list["RetrievalResult"]:
-        """Run retrieval for a batch of queries in one VDB call.
-
-        Funnels the whole query list through :meth:`queries`, which delegates
-        embedding and backend-specific search to the configured VDB.
-
-        Args:
-            queries: Iterable of natural-language query strings.  Order
-                is preserved in the returned list.
-            top_k: Per-call override of ``self.top_k``; passed as a local
-                value so the instance attribute is never mutated.
-            vdb_kwargs: Per-call VDB retrieval kwargs.
-
-        Returns:
-            A list of :class:`~nemo_retriever.llm.RetrievalResult`,
-            aligned one-to-one with ``queries``.  Empty input returns an
-            empty list.
-        """
-
         from nemo_retriever.llm.types import RetrievalResult
 
         query_texts = [str(q) for q in queries]
         if not query_texts:
             return []
 
-        hits_per_query = self.queries(query_texts, top_k=top_k, vdb_kwargs=vdb_kwargs)
+        hits_per_query = self.queries(query_texts, top_k=top_k, vdb_kwargs=vdb_kwargs, embed_kwargs=embed_kwargs)
 
         results: list[RetrievalResult] = []
         for hits in hits_per_query:
@@ -620,64 +295,14 @@ class Retriever:
         reference: Optional[str] = None,
         top_k: Optional[int] = None,
         vdb_kwargs: Optional[dict[str, Any]] = None,
+        embed_kwargs: Optional[dict[str, Any]] = None,
     ) -> "AnswerResult":
-        """Run live RAG for a single query and optionally score the answer.
-
-        Performs ``retrieve -> llm.generate`` and, when a ``reference`` answer
-        (for token-level scoring) and/or a ``judge`` (for LLM-as-judge
-        scoring) are supplied, fans those out concurrently on a small thread
-        pool so the judge network call and the local token-F1 computation do
-        not serialize.
-
-        Scoring tiers that can be populated on the returned
-        :class:`~nemo_retriever.llm.AnswerResult`:
-
-          * Tier 1 -- ``answer_in_context`` (requires ``reference``)
-          * Tier 2 -- ``token_f1``, ``exact_match`` (requires ``reference``)
-          * Tier 3 -- ``judge_score``, ``judge_reasoning`` (requires ``judge``
-            and ``reference``); also populates ``failure_mode``
-
-        When generation fails the returned result has ``error`` populated
-        and all scoring/judge fields remain ``None`` -- scoring is skipped
-        to avoid misleading metrics on an empty answer.
-
-        Args:
-            query: Natural-language question.
-            llm: Any object satisfying the
-                :class:`~nemo_retriever.llm.LLMClient` Protocol (typically
-                :class:`~nemo_retriever.llm.LiteLLMClient`).
-            judge: Optional LLM-as-judge.  Requires ``reference``.
-            reference: Ground-truth answer for token-F1 and judge scoring.
-            top_k: Per-call override of ``self.top_k``.
-            vdb_kwargs: Per-call VDB retrieval kwargs.
-
-        Returns:
-            An :class:`~nemo_retriever.llm.AnswerResult` carrying the
-            generated answer, the retrieved context, and any scoring
-            artefacts that were requested.
-
-        Raises:
-            ValueError: If ``judge`` is supplied without ``reference``.
-
-        Example:
-            >>> from nemo_retriever.llm import LiteLLMClient
-            >>> retriever = Retriever(vdb_kwargs={"uri": "./kb", "table_name": "nv-ingest"})
-            >>> llm = LiteLLMClient.from_kwargs(
-            ...     model="nvidia_nim/meta/llama-3.3-70b-instruct",
-            ... )
-            >>> result = retriever.answer(  # doctest: +SKIP
-            ...     "What did Q4 revenue look like?",
-            ...     llm=llm,
-            ... )
-            >>> result.answer  # doctest: +SKIP
-            'Revenue grew 12% YoY to $4.2B...'
-        """
         from nemo_retriever.llm.types import AnswerResult
 
         if judge is not None and reference is None:
             raise ValueError("judge requires reference")
 
-        retrieved = self.retrieve(query, top_k=top_k, vdb_kwargs=vdb_kwargs)
+        retrieved = self.retrieve(query, top_k=top_k, vdb_kwargs=vdb_kwargs, embed_kwargs=embed_kwargs)
 
         gen = llm.generate(query, retrieved.chunks)
 
@@ -715,14 +340,6 @@ class Retriever:
         judge: Optional["AnswerJudge"],
         gen_error: Optional[str],
     ) -> None:
-        """Populate scoring tiers on ``result`` in-place.
-
-        Runs Tier-1 + Tier-2 (pure CPU, sub-millisecond) alongside the Tier-3
-        judge API call (network-bound) on a two-worker thread pool so the
-        judge latency is not extended by scoring.  After both complete,
-        ``failure_mode`` is derived from the combined signals via
-        :func:`~nemo_retriever.evaluation.scoring.classify_failure`.
-        """
         from concurrent.futures import ThreadPoolExecutor
 
         from nemo_retriever.evaluation.scoring import (
@@ -766,47 +383,10 @@ class Retriever:
             )
 
     def pipeline(self, *, top_k: Optional[int] = None) -> "RetrieverPipelineBuilder":
-        """Return a fluent builder for a batch live-RAG operator graph.
-
-        The builder composes existing evaluation operators -- live retrieval
-        (via :class:`~nemo_retriever.evaluation.live_retrieval.LiveRetrievalOperator`),
-        :class:`~nemo_retriever.evaluation.generation.QAGenerationOperator`,
-        :class:`~nemo_retriever.evaluation.scoring_operator.ScoringOperator`,
-        and :class:`~nemo_retriever.evaluation.judging.JudgingOperator` --
-        using the existing ``>>`` chaining from
-        :mod:`nemo_retriever.graph.pipeline_graph`.  No new graph primitives
-        are introduced; this method is sugar for building and executing that
-        graph against a list of queries.
-
-        Steps are optional and independent.  Call only the ones you want, in
-        any order (retrieval always runs first since it is the source).
-
-        Args:
-            top_k: Override ``self.top_k`` for retrieval within this
-                pipeline.  Defaults to the instance attribute.
-
-        Returns:
-            A :class:`RetrieverPipelineBuilder` whose ``.run(queries)`` method
-            executes the composed graph and returns a ``pandas.DataFrame``.
-
-        Example:
-            >>> from nemo_retriever.llm import LiteLLMClient, LLMJudge
-            >>> retriever = Retriever(vdb_kwargs={"uri": "./kb", "table_name": "nv-ingest"})
-            >>> llm = LiteLLMClient.from_kwargs(model="nvidia_nim/meta/llama-3.3-70b-instruct")
-            >>> judge = LLMJudge.from_kwargs(model="nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1")
-            >>> df = (  # doctest: +SKIP
-            ...     retriever.pipeline()
-            ...     .generate(llm)
-            ...     .score()
-            ...     .judge(judge)
-            ...     .run(queries=["What is RAG?"], reference=["Retrieval-augmented generation..."])
-            ... )
-        """
         effective_top_k = int(top_k) if top_k is not None else int(self.top_k)
         return RetrieverPipelineBuilder(self, top_k=effective_top_k)
 
     def generate_sql(self, query: str) -> str:
-        """Generate a SQL query for a given natural language query."""
         from nemo_retriever.tabular_data.retrieval import generate_sql
 
         return generate_sql(query)

--- a/nemo_retriever/src/nemo_retriever/retriever_graph_utils.py
+++ b/nemo_retriever/src/nemo_retriever/retriever_graph_utils.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for :class:`~nemo_retriever.retriever.Retriever` graph execution."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+_RESERVED_RETRIEVE_KWARGS = frozenset({"query_texts", "refine_factor"})
+
+
+def filter_retrieval_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Drop keys reserved for graph coordination (not forwarded to ``VDB.retrieval``)."""
+    return {k: v for k, v in kwargs.items() if k not in _RESERVED_RETRIEVE_KWARGS}
+
+
+def hits_lists_to_rerank_dataframe(
+    query_texts: list[str],
+    hits_per_query: list[list[dict[str, Any]]],
+) -> pd.DataFrame:
+    """One row per (query, hit) with payload to rebuild hits after reranking."""
+    rows: list[dict[str, Any]] = []
+    for q, hits in zip(query_texts, hits_per_query):
+        for h in hits:
+            rows.append({"query": q, "text": str(h.get("text", "")), "_hit": dict(h)})
+    return pd.DataFrame(rows)
+
+
+def rerank_long_dataframe_to_hits(
+    df: pd.DataFrame,
+    *,
+    query_texts: list[str],
+    top_k: int,
+    score_column: str = "rerank_score",
+) -> list[list[dict[str, Any]]]:
+    """Group long rerank output by query (preserving *query_texts* order), take top_k per query."""
+    if df.empty:
+        return [[] for _ in query_texts]
+    if score_column not in df.columns:
+        raise ValueError(f"Rerank output missing score column {score_column!r}; columns={list(df.columns)}")
+
+    work = df.copy()
+    # Per-query score ordering (global sort in NemotronRerank is disabled for multi-query batches).
+    work["_q_order"] = work["query"].map({q: i for i, q in enumerate(query_texts)}).fillna(len(query_texts))
+    work = work.sort_values(["_q_order", score_column], ascending=[True, False]).drop(columns=["_q_order"])
+
+    out: list[list[dict[str, Any]]] = []
+    for q in query_texts:
+        sub = work[work["query"] == q]
+        picked: list[dict[str, Any]] = []
+        for _, row in sub.head(int(top_k)).iterrows():
+            hit = dict(row["_hit"])
+            score = row[score_column]
+            if isinstance(score, (int, float)):
+                hit["_rerank_score"] = float(score)
+            picked.append(hit)
+        out.append(picked)
+    return out

--- a/nemo_retriever/src/nemo_retriever/tabular_data/dev_tools/debug_ingest.py
+++ b/nemo_retriever/src/nemo_retriever/tabular_data/dev_tools/debug_ingest.py
@@ -103,15 +103,21 @@ def run_ingest() -> None:
 def run_retrieve() -> None:
     """Run the text-to-SQL agent against the previously ingested LanceDB."""
     lancedb_kwargs = VDB_PARAMS.vdb_kwargs
+    embed_url = EMBED_PARAMS.embed_invoke_url or ""
     retriever = Retriever(
-        vdb="lancedb",
         vdb_kwargs={
-            "uri": lancedb_kwargs["uri"],
-            "table_name": lancedb_kwargs["table_name"],
+            "vdb_op": "lancedb",
+            "vdb_kwargs": {
+                "uri": lancedb_kwargs["uri"],
+                "table_name": lancedb_kwargs["table_name"],
+            },
+        },
+        embed_kwargs={
+            "api_key": _NVIDIA_API_KEY,
+            "embed_invoke_url": embed_url,
+            "embedding_endpoint": embed_url,
         },
         top_k=15,
-        embedding_api_key=_NVIDIA_API_KEY,
-        embedding_http_endpoint=EMBED_PARAMS.embed_invoke_url,
     )
 
     question = "List aircraft codes"

--- a/nemo_retriever/src/nemo_retriever/tabular_data/retrieval/generate_sql.py
+++ b/nemo_retriever/src/nemo_retriever/tabular_data/retrieval/generate_sql.py
@@ -253,12 +253,19 @@ def get_sql_tool_response_top_k(
     """
     from nemo_retriever.retriever import Retriever
 
+    embed_kw: dict = {}
+    if embedding_http_endpoint:
+        embed_kw["embedding_endpoint"] = embedding_http_endpoint
+        embed_kw["embed_invoke_url"] = embedding_http_endpoint
+    if embedding_api_key:
+        embed_kw["api_key"] = embedding_api_key
+
     retriever = Retriever(
-        vdb="lancedb",
-        vdb_kwargs={"table_name": "nv-ingest-tabular"},
-        embedding_endpoint=embedding_http_endpoint or None,
-        embedding_api_key=embedding_api_key or "",
-        embedding_use_grpc=False if embedding_http_endpoint else None,
+        vdb_kwargs={
+            "vdb_op": "lancedb",
+            "vdb_kwargs": {"table_name": "nv-ingest-tabular"},
+        },
+        embed_kwargs=embed_kw,
         top_k=top_k,
     )
     hits = retriever.query(question)

--- a/nemo_retriever/src/nemo_retriever/text_embed/runtime.py
+++ b/nemo_retriever/src/nemo_retriever/text_embed/runtime.py
@@ -31,6 +31,7 @@ def _embed_group(
     output_column: str,
     resolved_model_name: str,
     nim_http_max_concurrent: int = 32,
+    input_type: str = "passage",
 ) -> pd.DataFrame:
     """Embed a single modality group via ``create_text_embeddings_for_df``."""
     embedder = None
@@ -66,7 +67,7 @@ def _embed_group(
         metadata_column="metadata",
         batch_size=int(effective_batch_size),
         encoding_format="float",
-        input_type="passage",
+        input_type=str(input_type),
         truncate="END",
         dimensions=None,
         embedding_nim_endpoint=endpoint or "http://localhost:8012/v1",
@@ -105,7 +106,8 @@ def embed_text_main_text_embed(
     has_embedding_column: str = "text_embeddings_1b_v2_has_embedding",
     embed_modality: str = "text",
     nim_http_max_concurrent: int = 32,
-    **_: Any,
+    input_type: str = "passage",
+    **_extras: Any,
 ) -> Any:
     """Embed graph batches while preserving the legacy output columns."""
     if not isinstance(batch_df, pd.DataFrame):
@@ -138,6 +140,7 @@ def embed_text_main_text_embed(
                 output_column=output_column,
                 resolved_model_name=resolved_model_name,
                 nim_http_max_concurrent=nim_http_max_concurrent,
+                input_type=input_type,
             )
         else:
             parts: List[pd.DataFrame] = []
@@ -157,6 +160,7 @@ def embed_text_main_text_embed(
                     output_column=output_column,
                     resolved_model_name=resolved_model_name,
                     nim_http_max_concurrent=nim_http_max_concurrent,
+                    input_type=input_type,
                 )
                 parts.append(part)
             out_df = pd.concat(parts).sort_index()

--- a/nemo_retriever/src/nemo_retriever/utils/benchmark/common.py
+++ b/nemo_retriever/src/nemo_retriever/utils/benchmark/common.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -46,9 +47,30 @@ def parse_csv_ints(value: str, *, name: str) -> List[int]:
     return sorted(set(out))
 
 
+def _dev_nemo_retriever_src_dir() -> Optional[str]:
+    """If ``nemo_retriever`` is imported from a source tree (not site-packages), return ``.../src`` for workers."""
+    import nemo_retriever
+
+    init_path = Path(nemo_retriever.__file__).resolve()
+    if "site-packages" in init_path.parts:
+        return None
+    src_dir = init_path.parent.parent
+    if src_dir.name == "src" and (src_dir / "nemo_retriever").is_dir():
+        return str(src_dir)
+    return None
+
+
 def maybe_init_ray(ray_address: Optional[str]) -> None:
-    if not ray.is_initialized():
-        ray.init(address=ray_address or "local", ignore_reinit_error=True)
+    if ray.is_initialized():
+        return
+    extra_src = _dev_nemo_retriever_src_dir()
+    runtime_env: dict[str, Any] | None = None
+    if extra_src:
+        merged = extra_src
+        if existing := os.environ.get("PYTHONPATH"):
+            merged = f"{extra_src}{os.pathsep}{existing}"
+        runtime_env = {"env_vars": {"PYTHONPATH": merged}}
+    ray.init(address=ray_address or "local", ignore_reinit_error=True, runtime_env=runtime_env)
 
 
 def read_pdf_bytes(pdf_path: Path) -> bytes:

--- a/nemo_retriever/src/nemo_retriever/vdb/operators.py
+++ b/nemo_retriever/src/nemo_retriever/vdb/operators.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pandas as pd
+
 from nemo_retriever.vdb.adt_vdb import VDB
 from nemo_retriever.vdb.factory import get_vdb_op_cls
 
@@ -33,6 +35,35 @@ def _construct_vdb(
         raise ValueError("Either vdb or vdb_op is required.")
 
     return vdb if vdb is not None else get_vdb_op_cls(str(vdb_op))(**dict(vdb_kwargs or {}))
+
+
+def query_vectors_from_embedded_dataframe(df: pd.DataFrame) -> list[list[float]]:
+    """Extract one query vector per row from batch-embed output (metadata or payload columns)."""
+    vectors: list[list[float]] = []
+    for _, row in df.iterrows():
+        vec: list[float] | None = None
+        md = row.get("metadata")
+        if isinstance(md, dict):
+            emb = md.get("embedding")
+            if isinstance(emb, list) and emb:
+                vec = [float(x) for x in emb]
+        if vec is None:
+            for col in df.columns:
+                if col == "metadata":
+                    continue
+                val = row.get(col)
+                if isinstance(val, dict):
+                    inner = val.get("embedding")
+                    if isinstance(inner, list) and inner:
+                        vec = [float(x) for x in inner]
+                        break
+        if vec is None:
+            raise ValueError(
+                "Expected query embeddings in each row's metadata['embedding'] or a payload column "
+                f"with key 'embedding'; columns={list(df.columns)}"
+            )
+        vectors.append(vec)
+    return vectors
 
 
 class IngestVdbOperator(AbstractOperator):
@@ -95,20 +126,35 @@ class RetrieveVdbOperator(AbstractOperator):
         vdb: VDB | None = None,
         vdb_op: str | None = None,
         vdb_kwargs: dict[str, Any] | None = None,
+        explode_for_rerank: bool = False,
     ) -> None:
         merged = dict(vdb_kwargs or {})
         clean_kwargs, _sidecar = split_sidecar_from_vdb_kwargs(merged)
-        super().__init__(vdb=vdb, vdb_op=vdb_op, vdb_kwargs=clean_kwargs)
+        super().__init__(vdb=vdb, vdb_op=vdb_op, vdb_kwargs=clean_kwargs, explode_for_rerank=explode_for_rerank)
         self._vdb_kwargs = clean_kwargs
         self._retrieval_vdb_kwargs = clean_kwargs
         self._vdb = _construct_vdb(vdb=vdb, vdb_op=vdb_op, vdb_kwargs=clean_kwargs)
+        self._explode_for_rerank = bool(explode_for_rerank)
 
     def preprocess(self, data: Any, **kwargs: Any) -> Any:
+        if isinstance(data, pd.DataFrame):
+            return query_vectors_from_embedded_dataframe(data)
         return data
 
     def process(self, data: Any, **kwargs: Any) -> list[list[dict[str, Any]]]:
-        retrieval_kwargs = {**self._retrieval_vdb_kwargs, **kwargs}
+        from nemo_retriever.retriever_graph_utils import filter_retrieval_kwargs
+
+        retrieval_kwargs = {**self._retrieval_vdb_kwargs, **filter_retrieval_kwargs(kwargs)}
         return normalize_retrieval_results(self._vdb.retrieval(data, **retrieval_kwargs))
 
     def postprocess(self, data: Any, **kwargs: Any) -> Any:
-        return data
+        if not self._explode_for_rerank:
+            return data
+        query_texts = kwargs.get("query_texts")
+        if not query_texts:
+            return data
+        from nemo_retriever.retriever_graph_utils import hits_lists_to_rerank_dataframe
+
+        if not isinstance(data, list):
+            return data
+        return hits_lists_to_rerank_dataframe(list(query_texts), data)

--- a/nemo_retriever/tests/test_beir_evaluation.py
+++ b/nemo_retriever/tests/test_beir_evaluation.py
@@ -406,29 +406,35 @@ def test_evaluate_lancedb_beir_uses_loader_and_retriever(monkeypatch) -> None:
     class _FakeRetriever:
         def __init__(self, **kwargs):
             expected_kwargs = {
-                "vdb": "lancedb",
                 "vdb_kwargs": {
-                    "uri": "/tmp/lancedb",
-                    "table_name": "nv-ingest",
-                    "hybrid": False,
-                    "nprobes": 0,
-                    "refine_factor": 10,
+                    "vdb_op": "lancedb",
+                    "vdb_kwargs": {
+                        "uri": "/tmp/lancedb",
+                        "table_name": "nv-ingest",
+                        "hybrid": False,
+                        "nprobes": 0,
+                        "refine_factor": 10,
+                    },
                 },
-                "embedder": "embedder",
-                "embedding_endpoint": "http://embed.example/v1",
-                "embedding_api_key": "secret",
-                "embedding_use_grpc": False,
+                "embed_kwargs": {
+                    "model_name": "embedder",
+                    "embed_model_name": "embedder",
+                    "local_ingest_embed_backend": "hf",
+                    "inference_batch_size": 32,
+                    "embed_inference_batch_size": 32,
+                    "embedding_endpoint": "http://embed.example/v1",
+                    "embed_invoke_url": "http://embed.example/v1",
+                    "api_key": "secret",
+                },
                 "top_k": 10,
-                "local_hf_device": None,
-                "local_hf_cache_dir": None,
-                "local_hf_batch_size": 32,
-                "local_query_embed_backend": "hf",
-                "reranker": False,
-                "reranker_model_name": "nvidia/llama-nemotron-rerank-1b-v2",
-                "reranker_endpoint": None,
-                "reranker_api_key": "",
-                "reranker_batch_size": 32,
-                "local_reranker_backend": "vllm",
+                "rerank": False,
+                "rerank_kwargs": {
+                    "model_name": "nvidia/llama-nemotron-rerank-1b-v2",
+                    "invoke_url": None,
+                    "api_key": "",
+                    "batch_size": 32,
+                    "local_reranker_backend": "vllm",
+                },
             }
             missing_keys = set(expected_kwargs) - set(kwargs)
             assert not missing_keys
@@ -458,5 +464,5 @@ def test_evaluate_lancedb_beir_uses_loader_and_retriever(monkeypatch) -> None:
     assert metrics["ndcg@10"] == 1.0
     assert metrics["recall@5"] == 1.0
     assert "embed_use_vllm" not in retriever_instances[0].kwargs
-    assert retriever_instances[0].kwargs.get("local_query_embed_backend") == "hf"
-    assert retriever_instances[0].kwargs.get("local_reranker_backend") == "vllm"
+    assert retriever_instances[0].kwargs["embed_kwargs"].get("local_ingest_embed_backend") == "hf"
+    assert retriever_instances[0].kwargs["rerank_kwargs"].get("local_reranker_backend") == "vllm"

--- a/nemo_retriever/tests/test_evaluation_retrievers.py
+++ b/nemo_retriever/tests/test_evaluation_retrievers.py
@@ -204,11 +204,13 @@ def test_query_lancedb_constructs_vdb_backed_retriever(monkeypatch) -> None:
     )
 
     assert captured_kwargs == {
-        "vdb": "lancedb",
-        "vdb_kwargs": {"uri": "/tmp/lancedb", "table_name": "nv-ingest"},
-        "embedder": "embedder",
+        "vdb_kwargs": {
+            "vdb_op": "lancedb",
+            "vdb_kwargs": {"uri": "/tmp/lancedb", "table_name": "nv-ingest"},
+        },
+        "embed_kwargs": {"model_name": "embedder", "embed_model_name": "embedder"},
         "top_k": 7,
-        "reranker": False,
+        "rerank": False,
     }
     assert all_results["What is the range of the 767?"]["chunks"] == ["range chunk"]
     assert meta["collection_name"] == "nv-ingest"

--- a/nemo_retriever/tests/test_retriever_queries.py
+++ b/nemo_retriever/tests/test_retriever_queries.py
@@ -2,14 +2,17 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for the VDB-backed Retriever query surface."""
+"""Unit tests for the graph-based :class:`~nemo_retriever.retriever.Retriever` query surface."""
 
 from __future__ import annotations
 
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
+
+from nemo_retriever.retriever import Retriever
 
 
 def _make_hits(n: int, base_score: float = 0.5) -> list[dict[str, Any]]:
@@ -25,322 +28,129 @@ def _make_hits(n: int, base_score: float = 0.5) -> list[dict[str, Any]]:
     ]
 
 
-def _make_retriever(**overrides: Any):
-    from nemo_retriever.retriever import Retriever
-
-    defaults = dict(
-        reranker=None,
-        top_k=5,
-        vdb="fake",
-        embedder="embedder",
-        vdb_kwargs={"collection_name": "docs", "model_name": "embedder"},
-    )
+def _make_retriever(**overrides: Any) -> Retriever:
+    defaults: dict[str, Any] = {
+        "rerank": False,
+        "top_k": 5,
+        "vdb_kwargs": {"vdb_op": "lancedb", "vdb_kwargs": {"uri": "/tmp/r", "table_name": "t"}},
+        "embed_kwargs": {"model_name": "embedder", "embed_model_name": "embedder"},
+    }
     defaults.update(overrides)
     return Retriever(**defaults)
 
 
-class _FakeRetrieveVdbOperator:
-    instances: list["_FakeRetrieveVdbOperator"] = []
-    next_result: list[list[dict[str, Any]]] = [[{"text": "retrieved", "source": "doc.pdf", "page_number": 1}]]
+def _install_mock_graph(monkeypatch: pytest.MonkeyPatch, hits: list[list[dict[str, Any]]]) -> MagicMock:
+    """Avoid constructing real LanceDB / embed operators."""
+    resolved = MagicMock()
+    # :meth:`Graph.execute` returns one entry per graph leaf; retrieval output is ``list[list[dict]]``.
+    resolved.execute.return_value = [hits]
 
-    def __init__(self, **kwargs: Any) -> None:
-        self.constructor_kwargs = kwargs
-        self.process_calls: list[tuple[Any, dict[str, Any]]] = []
-        self.__class__.instances.append(self)
+    graph = MagicMock()
+    graph.resolve_for_local_execution.return_value = resolved
 
-    def process(self, data: Any, **kwargs: Any) -> list[list[dict[str, Any]]]:
-        self.process_calls.append((data, kwargs))
-        return self.__class__.next_result
+    monkeypatch.setattr(Retriever, "_build_default_graph", lambda self: graph)
 
+    # bypass instance cache from other tests
+    def fresh_get(self: Retriever, *, embed_extra: Any = None) -> MagicMock:
+        graph.resolve_for_local_execution.return_value = resolved
+        return graph
 
-@pytest.fixture(autouse=True)
-def _reset_fake_operator() -> None:
-    _FakeRetrieveVdbOperator.instances = []
-    _FakeRetrieveVdbOperator.next_result = [[{"text": "retrieved", "source": "doc.pdf", "page_number": 1}]]
+    monkeypatch.setattr(Retriever, "_get_graph", fresh_get)
+    return resolved
 
 
-class TestQueriesVdbDelegation:
-    def test_empty_queries_returns_empty_without_operator(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import nemo_retriever.vdb as vdb_pkg
-
-        monkeypatch.setattr(vdb_pkg, "RetrieveVdbOperator", MagicMock())
+class TestQueriesGraphExecution:
+    def test_empty_queries_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_get = MagicMock()
+        monkeypatch.setattr(Retriever, "_get_graph", mock_get)
         assert _make_retriever().queries([]) == []
-        vdb_pkg.RetrieveVdbOperator.assert_not_called()
+        mock_get.assert_not_called()
 
-    def test_queries_use_instance_top_k_when_not_overridden(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import nemo_retriever.vdb as vdb_pkg
-
-        monkeypatch.setattr(vdb_pkg, "RetrieveVdbOperator", _FakeRetrieveVdbOperator)
+    def test_queries_thread_top_k_and_vdb_kwargs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        hit = [[{"text": "retrieved", "source": "doc.pdf", "page_number": 1}]]
+        resolved = _install_mock_graph(monkeypatch, hit)
         retriever = _make_retriever(top_k=11)
-        with patch.object(retriever, "_embed_queries_local_hf", return_value=[[0.1, 0.2]]):
-            retriever.queries(["q"])
+        out = retriever.queries(["q"], vdb_kwargs={"where": "x"})
+        assert out == hit
+        resolved.execute.assert_called_once()
+        _args, kw = resolved.execute.call_args
+        assert kw["top_k"] == 11
+        assert kw["query_texts"] == ["q"]
+        assert kw["where"] == "x"
+        df = _args[0]
+        assert isinstance(df, pd.DataFrame)
+        assert list(df.columns) == ["text"]
+        assert df["text"].tolist() == ["q"]
 
-        operator = _FakeRetrieveVdbOperator.instances[0]
-        assert operator.process_calls[0][1]["top_k"] == 11
+    def test_merge_embed_params_per_call_overrides(self) -> None:
+        r = _make_retriever(embed_kwargs={"model_name": "base", "embed_model_name": "base"})
+        p = r._merge_embed_params({"model_name": "call"})
+        assert p.model_name == "call"
 
-    def test_queries_accept_prebuilt_vdb(self) -> None:
-        from nemo_retriever.retriever import Retriever
+    def test_rerank_inflates_retrieval_top_k(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        resolved = _install_mock_graph(monkeypatch, [[{"text": "x"}]])
+        retriever = _make_retriever(top_k=3, rerank=True, rerank_kwargs={"refine_factor": 4})
+        retriever._cached_graph = None
+        retriever._cache_key = None
+        retriever.queries(["q"])
+        assert resolved.execute.call_args.kwargs["top_k"] == 12
 
-        class FakeVDB:
-            def __init__(self) -> None:
-                self.calls: list[tuple[Any, dict[str, Any]]] = []
-
-            def retrieval(self, vectors: list[list[float]], **kwargs: Any) -> list[list[dict[str, Any]]]:
-                self.calls.append((vectors, kwargs))
-                return [
-                    [
-                        {
-                            "text": "direct hit",
-                            "source": "doc-a.pdf",
-                            "content_metadata": {"page_number": 2},
-                        }
-                    ]
-                ]
-
-        vdb = FakeVDB()
-        retriever = Retriever(
-            vdb=vdb,
-            embedder="embedder",
-            vdb_kwargs={"collection_name": "docs", "model_name": "embedder"},
-            top_k=4,
-        )
-
-        with patch.object(retriever, "_embed_queries_local_hf", return_value=[[0.1, 0.2]]) as mock_embed:
-            result = retriever.queries(["q"], vdb_kwargs={"_filter": "content_type == 'text'"})
-
-        mock_embed.assert_called_once_with(["q"], model_name="embedder")
-        assert vdb.calls == [
-            (
-                [[0.1, 0.2]],
-                {
-                    "collection_name": "docs",
-                    "model_name": "embedder",
-                    "_filter": "content_type == 'text'",
-                    "top_k": 4,
-                },
-            )
-        ]
-        assert result[0][0]["text"] == "direct hit"
-        assert result[0][0]["pdf_page"] == "doc-a_2"
-
-    def test_queries_accept_embedder_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import nemo_retriever.vdb as vdb_pkg
-        from nemo_retriever.retriever import Retriever
-
-        monkeypatch.setattr(vdb_pkg, "RetrieveVdbOperator", _FakeRetrieveVdbOperator)
-
-        retriever = Retriever(vdb="lancedb", embedder="instance-embedder", vdb_kwargs={"uri": "/tmp/lancedb"}, top_k=6)
-        with patch.object(retriever, "_embed_queries_local_hf", return_value=[[0.1, 0.2]]) as mock_embed:
-            result = retriever.queries(["q"], embedder="call-embedder", vdb_kwargs={"table_name": "nv-ingest"})
-
-        mock_embed.assert_called_once_with(["q"], model_name="call-embedder")
-        operator = _FakeRetrieveVdbOperator.instances[0]
-        assert operator.constructor_kwargs == {
-            "vdb_op": "lancedb",
-            "vdb_kwargs": {"uri": "/tmp/lancedb"},
-        }
-        assert operator.process_calls == [
-            (
-                [[0.1, 0.2]],
-                {"table_name": "nv-ingest", "top_k": 6},
-            )
-        ]
-        assert result == _FakeRetrieveVdbOperator.next_result
-
-    def test_queries_use_remote_embedding_endpoint_when_configured(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import nemo_retriever.vdb as vdb_pkg
-
-        monkeypatch.setattr(vdb_pkg, "RetrieveVdbOperator", _FakeRetrieveVdbOperator)
-        retriever = _make_retriever(
-            embedding_endpoint="http://embed.example/v1",
-            embedding_api_key="secret",
-            embedding_use_grpc=False,
-        )
-
-        with (
-            patch("nemo_retriever.api.util.nim.infer_microservice", return_value=[[0.5, 0.6]]) as mock_embed,
-            patch.object(retriever, "_embed_queries_local_hf") as mock_local_embed,
-        ):
-            retriever.queries(["q"], embedder="query-model")
-
-        mock_embed.assert_called_once_with(
-            ["q"],
-            model_name="query-model",
-            embedding_endpoint="http://embed.example/v1",
-            nvidia_api_key="secret",
-            grpc=False,
-            input_type="query",
-        )
-        mock_local_embed.assert_not_called()
-        operator = _FakeRetrieveVdbOperator.instances[0]
-        assert operator.process_calls == [([[0.5, 0.6]], {"top_k": 5})]
-
-    def test_queries_reuse_retrieve_operator(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import nemo_retriever.vdb as vdb_pkg
-
-        monkeypatch.setattr(vdb_pkg, "RetrieveVdbOperator", _FakeRetrieveVdbOperator)
+    def test_query_delegates_to_queries(self) -> None:
         retriever = _make_retriever()
-
-        with patch.object(retriever, "_embed_queries_local_hf", side_effect=[[[0.1, 0.2]], [[0.3, 0.4]]]):
-            retriever.queries(["q1"], vdb_kwargs={"refine_factor": 50})
-            retriever.queries(["q2"], vdb_kwargs={"refine_factor": 21})
-
-        assert len(_FakeRetrieveVdbOperator.instances) == 1
-        operator = _FakeRetrieveVdbOperator.instances[0]
-        assert operator.process_calls == [
-            ([[0.1, 0.2]], {"refine_factor": 50, "top_k": 5}),
-            ([[0.3, 0.4]], {"refine_factor": 21, "top_k": 5}),
-        ]
-
-    def test_reranker_requests_fanout_and_reranks_to_requested_top_k(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import nemo_retriever.vdb as vdb_pkg
-
-        monkeypatch.setattr(vdb_pkg, "RetrieveVdbOperator", _FakeRetrieveVdbOperator)
-        initial = [_make_hits(12)]
-        reranked = [_make_hits(3)]
-        _FakeRetrieveVdbOperator.next_result = initial
-        retriever = _make_retriever(
-            top_k=3,
-            reranker="nvidia/llama-nemotron-rerank-1b-v2",
-            reranker_refine_factor=4,
-        )
-
-        with (
-            patch.object(retriever, "_embed_queries_local_hf", return_value=[[0.1, 0.2]]),
-            patch.object(retriever, "_rerank_results", return_value=reranked) as mock_rerank,
-        ):
-            result = retriever.queries(["q"])
-
-        operator = _FakeRetrieveVdbOperator.instances[0]
-        assert operator.process_calls[0][1]["top_k"] == 12
-        mock_rerank.assert_called_once_with(["q"], initial, top_k=3)
-        assert result is reranked
-
-
-class TestQuerySingleConvenience:
-    def test_query_delegates_to_queries_and_returns_first_element(self) -> None:
-        retriever = _make_retriever()
-        expected = _make_hits(5)
-        with patch.object(retriever, "queries", return_value=[expected]) as mock_queries:
-            result = retriever.query("find something", top_k=4, vdb_kwargs={"collection_name": "docs"})
-
-        mock_queries.assert_called_once_with(
-            ["find something"], top_k=4, embedder=None, vdb_kwargs={"collection_name": "docs"}
-        )
+        expected = _make_hits(2)
+        with patch.object(retriever, "queries", return_value=[expected]) as mock_q:
+            result = retriever.query("find", top_k=4, vdb_kwargs={"uri": "x"})
+        mock_q.assert_called_once_with(["find"], top_k=4, vdb_kwargs={"uri": "x"}, embed_kwargs=None)
         assert result is expected
 
 
-class TestQueriesWithEndpointReranking:
-    def test_reranked_results_are_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import nemo_retriever.vdb as vdb_pkg
-
-        monkeypatch.setattr(vdb_pkg, "RetrieveVdbOperator", _FakeRetrieveVdbOperator)
-        initial = [_make_hits(8)]
-        reranked = [_make_hits(2)]
-        _FakeRetrieveVdbOperator.next_result = initial
-        retriever = _make_retriever(
-            reranker="nvidia/llama-nemotron-rerank-1b-v2",
-            reranker_endpoint="http://rerank.example.com",
-            top_k=2,
-        )
-
-        with (
-            patch.object(retriever, "_embed_queries_local_hf", return_value=[[0.1, 0.2]]),
-            patch.object(retriever, "_rerank_results", return_value=reranked),
-        ):
-            out = retriever.queries(["q"])
-
-        assert out is reranked
-
-    def test_rerank_results_uses_endpoint_not_local_model(self) -> None:
-        retriever = _make_retriever(
-            reranker="nvidia/llama-nemotron-rerank-1b-v2",
-            reranker_endpoint="http://rerank.example.com",
-            top_k=3,
-        )
-        fake_hits = _make_hits(4)
-
-        mock_resp = MagicMock()
-        mock_resp.raise_for_status = MagicMock()
-        mock_resp.json.return_value = {
-            "results": [{"index": i, "relevance_score": float(len(fake_hits) - i)} for i in range(len(fake_hits))]
-        }
-
-        with patch("requests.post", return_value=mock_resp) as mock_post:
-            out = retriever._rerank_results(["q"], [fake_hits], top_k=retriever.top_k)
-
-        mock_post.assert_called()
-        scores = [h["_rerank_score"] for h in out[0]]
-        assert scores == sorted(scores, reverse=True)
-
-
-class TestQueriesWithLocalReranking:
-    def test_rerank_results_with_local_model(self) -> None:
-        retriever = _make_retriever(reranker="nvidia/llama-nemotron-rerank-1b-v2")
-        hits = _make_hits(4)
-        fake_model = MagicMock()
-        fake_model.score.return_value = [0.1, 0.9, 0.5, 0.3]
-
-        with patch.object(retriever, "_get_reranker_model", return_value=fake_model):
-            out = retriever._rerank_results(["q"], [hits], top_k=retriever.top_k)
-
-        scores = [h["_rerank_score"] for h in out[0]]
-        assert scores == sorted(scores, reverse=True)
-        assert max(scores) == 0.9
-
-    def test_rerank_results_respects_top_k(self) -> None:
-        retriever = _make_retriever(reranker="nvidia/llama-nemotron-rerank-1b-v2", top_k=2)
-        hits = _make_hits(4)
-        fake_model = MagicMock()
-        fake_model.score.return_value = [0.1, 0.9, 0.5, 0.3]
-
-        with patch.object(retriever, "_get_reranker_model", return_value=fake_model):
-            out = retriever._rerank_results(["q"], [hits], top_k=retriever.top_k)
-
-        assert len(out[0]) == 2
-
-    def test_rerank_results_multiple_queries(self) -> None:
-        retriever = _make_retriever(reranker="nvidia/llama-nemotron-rerank-1b-v2", top_k=2)
-        hits_a = _make_hits(2)
-        hits_b = _make_hits(2)
-        fake_model = MagicMock()
-        fake_model.score.side_effect = [[0.2, 0.8], [0.6, 0.4]]
-
-        with patch.object(retriever, "_get_reranker_model", return_value=fake_model):
-            out = retriever._rerank_results(["q1", "q2"], [hits_a, hits_b], top_k=retriever.top_k)
-
-        assert len(out) == 2
-        for per_query in out:
-            scores = [h["_rerank_score"] for h in per_query]
-            assert scores == sorted(scores, reverse=True)
-
-
 class TestRetrieverDefaults:
-    def test_default_vdb_is_lancedb(self) -> None:
-        from nemo_retriever.retriever import Retriever
+    def test_default_top_k(self) -> None:
+        assert Retriever().top_k == 10
 
-        retriever = Retriever()
-        assert retriever.vdb == "lancedb"
-        assert retriever.vdb_kwargs == {}
+    def test_rerank_disabled_by_default(self) -> None:
+        assert Retriever().rerank is False
 
-    def test_default_reranker_is_nemotron_model(self) -> None:
-        from nemo_retriever.retriever import Retriever
-
-        retriever = Retriever()
-        assert retriever.reranker_model_name == "nvidia/llama-nemotron-rerank-vl-1b-v2"
-
-    def test_reranker_can_be_disabled(self) -> None:
-        retriever = _make_retriever(reranker=None)
-        assert retriever.reranker is None
-
-    def test_reranker_model_not_initialized_at_construction(self) -> None:
-        from nemo_retriever.retriever import Retriever
-
-        retriever = Retriever()
-        assert retriever._reranker_model is None
-        assert retriever._retrieve_operator is None
-
-    def test_retriever_alias_is_retriever_class(self) -> None:
-        from nemo_retriever.retriever import Retriever, retriever
+    def test_retriever_alias_is_class(self) -> None:
+        from nemo_retriever.retriever import retriever
 
         assert retriever is Retriever
+
+
+class TestRunModeServiceRequiresHttpEmbed:
+    def test_service_mode_errors_without_url(self) -> None:
+        with pytest.raises(ValueError, match="run_mode='service'"):
+            Retriever(run_mode="service", embed_kwargs={})._merge_embed_params()
+
+
+class TestRetrieveVdbOperatorPreprocess:
+    def test_dataframe_to_vectors(self) -> None:
+        from nemo_retriever.vdb.operators import RetrieveVdbOperator
+
+        df = pd.DataFrame(
+            {
+                "text": ["a"],
+                "metadata": [{"embedding": [0.1, 0.2]}],
+            }
+        )
+        op = RetrieveVdbOperator(vdb_op="lancedb", vdb_kwargs={"uri": "/tmp", "table_name": "t"})
+        vec = op.preprocess(df)
+        assert vec == [[0.1, 0.2]]
+
+
+class TestRerankLongDataframe:
+    def test_groups_by_query_order(self) -> None:
+        from nemo_retriever.retriever_graph_utils import rerank_long_dataframe_to_hits
+
+        df = pd.DataFrame(
+            [
+                {"query": "q1", "text": "b", "_hit": {"text": "b"}, "rerank_score": 0.5},
+                {"query": "q1", "text": "a", "_hit": {"text": "a"}, "rerank_score": 0.9},
+                {"query": "q2", "text": "c", "_hit": {"text": "c"}, "rerank_score": 0.3},
+            ]
+        )
+        out = rerank_long_dataframe_to_hits(df, query_texts=["q1", "q2"], top_k=1, score_column="rerank_score")
+        assert len(out) == 2
+        assert out[0][0]["text"] == "a"
+        assert out[0][0]["_rerank_score"] == 0.9
+        assert out[1][0]["text"] == "c"


### PR DESCRIPTION
## Description
This PR refactors the retriever to use graphs instead of hard coded functions. This allows the graph to execute the correct operators dependent on the available system. Now retrieval in a CPU only environment should work correctly.


## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
