### PR TITLE
Add agent MCP server for NeMo Retriever collections

### DIFF
--- a/docs/superpowers/specs/2026-05-08-nemo-retriever-agent-mcp-design.md
+++ b/docs/superpowers/specs/2026-05-08-nemo-retriever-agent-mcp-design.md
@@ -1,0 +1,333 @@
+# NeMo Retriever Agent MCP Design
+
+## Summary
+
+Build a dedicated MCP server that exposes a working NeMo Retriever installation
+to agents. The server lets an agent start with no vector database, create or use
+a collection, ingest local multimedia files into that collection, query the
+resulting evidence, and optionally rerank retrieved hits. Version 1 runs
+NeMo Retriever in-process through the Python API, while keeping the MCP tool
+contract neutral enough to support a future remote NeMo Retriever service
+backend.
+
+The MCP server is an evidence engine, not an answer-generation system. It
+returns retrieved chunks, scores, source locators, artifacts, and metadata so
+the calling agent model can reason over the evidence itself.
+
+## Goals
+
+- Expose NeMo Retriever extraction, embedding, VDB upload, retrieval, and
+  reranking to MCP-capable agents.
+- Let agents create, list, describe, query, and delete VDB-backed collections.
+- Start from an empty environment and populate collections entirely through MCP
+  usage.
+- Support local-path ingestion for PDFs, documents, images, text, HTML, audio,
+  and video where the installed NeMo Retriever runtime supports those formats.
+- Persist collections by default, with an explicit temporary collection option.
+- Use a job-based ingestion model internally, with a blocking convenience tool
+  for small or simple workflows.
+- Keep the agent-facing MCP contract backend-neutral so a future remote service
+  backend can replace the in-process backend without changing tool semantics.
+
+## Non-Goals
+
+- Fetching remote URLs, S3/GCS paths, or other network resources in v1.
+- Exposing arbitrary shell execution through MCP.
+- Building an agent orchestration loop or answer-generation tool.
+- Designing a distributed VDB scaling model beyond multiple named collections.
+- Guaranteeing GPU-backed full multimedia ingestion in normal unit test runs.
+
+## Architecture
+
+The MCP server is separate from the existing benchmark harness portal MCP. The
+harness MCP remains focused on benchmark runs and schedules; this server is a
+product-facing retrieval surface for agent workflows.
+
+Core components:
+
+- **MCP server**: FastMCP-based process that registers collection, ingestion,
+  retrieval, and reranking tools.
+- **Collection registry**: persistent SQLite store under a configured MCP data
+  root. It tracks collection metadata, backend configuration, job state, source
+  summaries, and queryability.
+- **Backend interface**: a stable internal interface implemented first by
+  `InProcessRetrieverBackend`. A later `ServiceRetrieverBackend` can map the
+  same operations to a deployed NeMo Retriever service.
+- **VDB storage**: v1 collections use LanceDB directories and tables under the
+  configured data root. `default` is a normal named collection, created lazily.
+- **Artifact storage**: optional per-collection storage for extracted images,
+  rendered pages, video frames, thumbnails, or other non-text evidence
+  artifacts.
+- **Job manager**: ingestion runs as jobs internally. Blocking tools submit a
+  job and wait for terminal state or timeout.
+- **Safety boundary**: local paths only, constrained to configured allowed
+  roots. The server resolves symlinks before validation.
+
+High-level flow:
+
+```text
+agent
+  -> create_collection("default")
+  -> ingest_local_paths("default", ["/allowed/docs"], wait=true)
+  -> InProcessRetrieverBackend
+  -> GraphIngestor extraction/embed/store pipeline
+  -> LanceDB collection
+  -> query_collection("default", "question")
+  -> Retriever query/rerank path
+  -> normalized multimedia evidence
+```
+
+## MCP Tool Surface
+
+The initial tools are intentionally small and evidence-focused:
+
+- `list_collections()`: list persistent and temporary collections.
+- `create_collection(name?, temporary=false, config?)`: create a named
+  collection, defaulting to `default` when `name` is omitted.
+- `describe_collection(name="default")`: return collection metadata, VDB
+  location, embedding config, source summaries, and recent jobs.
+- `delete_collection(name, delete_data=false)`: remove registry metadata and,
+  only when explicitly requested, delete collection data under the configured
+  collection root.
+- `start_ingestion(collection="default", paths, options?)`: validate local
+  paths, expand directories, create a job, and begin ingestion asynchronously.
+- `get_ingestion_status(job_id)`: return job status, counts, warnings, errors,
+  and queryability.
+- `ingest_local_paths(collection="default", paths, options?, wait=true,
+  timeout_s?)`: convenience wrapper around `start_ingestion` plus polling.
+- `query_collection(collection="default", query, top_k=10, filters?,
+  hybrid=false, rerank=false)`: retrieve normalized evidence hits.
+- `rerank_results(query, hits, top_n?)`: rerank provided evidence hits without
+  running a new VDB query.
+
+The v1 surface does not include `answer_question`. The caller can use the
+returned evidence in its own reasoning loop.
+
+## Collection And Storage Model
+
+Collections are modality-neutral workspaces. Each collection has:
+
+- name and optional aliases, including the conventional `default`;
+- persistent or temporary lifetime;
+- backend type and backend-specific configuration;
+- VDB location, table name, and embedding model/configuration;
+- artifact root;
+- creation and update timestamps;
+- ingestion jobs and source summaries;
+- queryable state.
+
+Recommended on-disk layout:
+
+```text
+<nemo-mcp-root>/
+  registry.sqlite
+  collections/
+    default/
+      lancedb/
+      artifacts/
+    quarterly-training/
+      lancedb/
+      artifacts/
+  tmp/
+    <temporary-collection-id>/
+      lancedb/
+      artifacts/
+```
+
+SQLite is preferred over loose JSON because the server needs durable job state,
+collection listings, source summaries, and status transitions. LanceDB remains
+responsible for vector storage.
+
+## Ingestion Design
+
+The backend accepts local files and directories only. It resolves every input
+path, checks it against configured allowed roots, expands directories and globs,
+and rejects unsupported paths before recording the job.
+
+Ingestion is internally job-based:
+
+1. Validate paths and collection.
+2. Record a queued job.
+3. Group files by media type.
+4. Run modality-specific NeMo Retriever pipelines.
+5. Embed extracted text representations.
+6. Optionally store artifacts.
+7. Upload embedded rows to the collection VDB.
+8. Update collection metadata and mark the collection queryable when at least
+   one upload succeeds.
+
+The recommended v1 execution shape is grouped sub-jobs by modality rather than
+a single opaque mixed-media run. Grouping makes status clearer and allows
+different options per media type:
+
+- PDFs, documents, and images use `GraphIngestor.extract(...)` or
+  `extract_image_files(...)` where appropriate.
+- Text uses `GraphIngestor.extract_txt(...)`.
+- HTML uses `GraphIngestor.extract_html(...)`.
+- Audio uses `GraphIngestor.extract_audio(...)`.
+- Video uses `GraphIngestor.extract_video(...)`.
+
+The job state model should include `queued`, `running`, `complete`, `failed`,
+and `partial`. Partial jobs are valid when some files ingest successfully and
+others fail or are skipped.
+
+Job status should expose source counts, accepted and skipped files, per-file
+errors, modality summaries, row count when available, artifact count when
+available, warnings, and whether the target collection is queryable.
+
+## Query And Rerank Design
+
+`query_collection` resolves the collection, constructs a `Retriever` with the
+collection's VDB settings and embedding configuration, runs semantic or hybrid
+retrieval, optionally reranks, and returns normalized evidence.
+
+Key rules:
+
+- Query embedding must use the same model and endpoint family used for
+  collection ingestion.
+- Hybrid search is available only when the collection was indexed for hybrid
+  retrieval.
+- Reranking can be requested inline with `query_collection(..., rerank=true)`
+  or separately through `rerank_results`.
+- Filters are supported conservatively. v1 may pass simple metadata filters to
+  backends that support them, but must not promise a cross-backend filter
+  language before that contract exists.
+- Raw metadata remains available as an escape hatch for advanced agents.
+
+The normalized evidence shape is modality-neutral and sparse:
+
+```json
+{
+  "text": "...",
+  "score": 0.82,
+  "source_path": "/allowed/docs/demo.mp4",
+  "media_type": "video",
+  "content_type": "transcript",
+  "locator": {
+    "page_number": null,
+    "timestamp_start_s": 42.0,
+    "timestamp_end_s": 55.5,
+    "frame_index": 18,
+    "bbox_xyxy_norm": [0.1, 0.2, 0.8, 0.6],
+    "chunk_id": "optional-backend-id"
+  },
+  "artifacts": {
+    "stored_image_uri": "optional-uri",
+    "thumbnail_uri": "optional-uri"
+  },
+  "metadata": {}
+}
+```
+
+PDFs and images tend to populate `page_number` and bounding boxes. Audio and
+video tend to populate timestamps, frame indices, transcript segment metadata,
+and extracted frame artifacts. Text and HTML may populate chunk IDs, headings,
+or offsets when available.
+
+## Backend Abstraction
+
+The MCP tools call a backend interface rather than importing pipeline details
+directly. A representative interface:
+
+```text
+RetrieverBackend
+  create_collection(...)
+  list_collections(...)
+  describe_collection(...)
+  delete_collection(...)
+  start_ingestion(...)
+  get_job_status(...)
+  query_collection(...)
+  rerank_results(...)
+```
+
+`InProcessRetrieverBackend` uses local NeMo Retriever Python APIs and local
+LanceDB. This is the v1 implementation.
+
+`ServiceRetrieverBackend` can later route the same operations to a running
+NeMo Retriever service. That path may require the service API to become more
+collection-aware than it is today, because the current service is oriented
+around configured LanceDB locations and tables. The backend abstraction lets the
+MCP contract lead while the service catches up.
+
+The agent-facing tool contract should describe retrieval capabilities and
+collection intent. LanceDB, local paths, in-process execution, Ray, and NIM
+details are backend facts, not MCP semantics.
+
+## Error Handling And Safety
+
+The MCP server returns structured errors with:
+
+- `code`;
+- `message`;
+- `retryable`;
+- optional `details`.
+
+Expected error codes include:
+
+- `PATH_OUTSIDE_ALLOWED_ROOT`
+- `PATH_NOT_FOUND`
+- `UNSUPPORTED_MEDIA_TYPE`
+- `COLLECTION_NOT_FOUND`
+- `COLLECTION_NOT_QUERYABLE`
+- `INGEST_JOB_FAILED`
+- `HYBRID_NOT_AVAILABLE`
+- `EMBEDDING_CONFIG_MISMATCH`
+- `VDB_NOT_FOUND`
+- `BACKEND_ERROR`
+
+Safety constraints:
+
+- All input paths must resolve under configured allowed roots.
+- Symlinks are resolved before validation.
+- URLs and cloud URIs are rejected in v1.
+- The MCP server does not execute shell commands for ingest/query.
+- Delete operations cannot remove data outside the configured MCP data root.
+- `delete_collection(..., delete_data=true)` is the only data removal path.
+- Resource guardrails should include max files, max total bytes, timeout, and
+  optional per-modality enablement.
+- Partial success is reported as `partial`; successful rows remain queryable.
+- Temporary collections are listable and explicitly cleanable. Automatic
+  cleanup can be a later policy.
+
+## Testing And Validation
+
+Unit tests should cover:
+
+- collection registry CRUD and persistence;
+- allowed-root path validation, including symlinks;
+- collection naming and lazy `default` creation;
+- temporary versus persistent layout;
+- job state transitions;
+- evidence-hit normalization across representative PDF, image, text, audio,
+  and video metadata;
+- structured error responses.
+
+Backend tests should use fake backend objects so MCP tool behavior can be
+tested without GPUs, Ray, NIM endpoints, or full LanceDB fixtures.
+
+Integration smoke tests should cover:
+
+- create collection;
+- ingest a small local fixture through the real in-process backend when the
+  environment supports it;
+- query the collection;
+- rerank retrieved hits when a reranker is configured;
+- list and describe the collection;
+- delete registry metadata and, in a separate explicit test, collection data.
+
+Normal CI should not require GPU-backed full multimedia extraction. Optional
+GPU/NIM smoke tests can run in suitable environments.
+
+## Success Criteria
+
+- An MCP-capable agent can start with no VDB, create or lazily use `default`,
+  ingest local allowed files, wait for completion, query the populated
+  collection, and receive normalized multimedia evidence.
+- Collections persist across MCP server restarts unless marked temporary.
+- The tool contract remains evidence-focused and does not include answer
+  generation.
+- The implementation can later route through a remote NeMo Retriever service
+  without changing the MCP tool names or core semantics.
+- Unsupported files and per-file failures are visible to the agent without
+  hiding successful ingested evidence.

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -8,6 +8,10 @@ This quick start guide shows how to run NeMo Retriever Library as a library all 
 
 You’ll set up a CUDA 13–compatible environment, install the library and its dependencies, and run GPU‑accelerated ingestion pipelines that convert PDFs, HTML, plain text, audio, or video into vector embeddings stored in LanceDB (on local disk), with Ray‑based scaling and built‑in recall benchmarking.
 
+## Documentation
+
+- **[Agent MCP server](docs/agent-mcp.md)** - Expose a local NeMo Retriever installation to MCP-capable agents for collection ingestion and evidence retrieval.
+
 ## Prerequisites
 
 Before starting, make sure your system meets the following requirements:

--- a/nemo_retriever/docs/agent-mcp.md
+++ b/nemo_retriever/docs/agent-mcp.md
@@ -40,15 +40,13 @@ Query and rerank tools return normalized evidence objects that agents can inspec
   "media_type": "video",
   "content_type": "transcript",
   "locator": {
-    "start_time": 192.4,
-    "end_time": 246.8
+    "timestamp_start_s": 192.4,
+    "timestamp_end_s": 246.8,
+    "frame_index": 18
   },
-  "artifacts": [
-    {
-      "type": "thumbnail",
-      "path": ".nemo-retriever-mcp/collections/default/artifacts/review-frame-192.jpg"
-    }
-  ],
+  "artifacts": {
+    "thumbnail_uri": ".nemo-retriever-mcp/collections/default/artifacts/review-frame-192.jpg"
+  },
   "metadata": {
     "collection": "default",
     "chunk_id": "review-mp4-transcript-0007",

--- a/nemo_retriever/docs/agent-mcp.md
+++ b/nemo_retriever/docs/agent-mcp.md
@@ -1,0 +1,64 @@
+# NeMo Retriever Agent MCP
+
+The NeMo Retriever agent MCP server exposes a local NeMo Retriever installation to MCP-capable agents. Agents can create collections, ingest local files from allowed roots, query the vector database, and receive normalized evidence for their own reasoning loop.
+
+The server returns evidence only and does not generate final answers.
+
+## Start The Server
+
+```bash
+retriever agent-mcp start \
+  --data-root .nemo-retriever-mcp \
+  --allowed-root /path/to/local/docs \
+  --host 127.0.0.1 \
+  --port 8099
+```
+
+Collections persist under `--data-root`. The default collection is named `default` and is created lazily when first needed.
+
+## Tools
+
+- `list_collections`
+- `create_collection`
+- `describe_collection`
+- `delete_collection`
+- `start_ingestion`
+- `get_ingestion_status`
+- `ingest_local_paths`
+- `query_collection`
+- `rerank_results`
+
+## Evidence Shape
+
+Query and rerank tools return normalized evidence objects that agents can inspect, cite, and reason over.
+
+```json
+{
+  "text": "The quarterly review starts at 00:03:12 and covers revenue growth by region.",
+  "score": 0.87,
+  "source_path": "/path/to/local/docs/review.mp4",
+  "media_type": "video",
+  "content_type": "transcript",
+  "locator": {
+    "start_time": 192.4,
+    "end_time": 246.8
+  },
+  "artifacts": [
+    {
+      "type": "thumbnail",
+      "path": ".nemo-retriever-mcp/collections/default/artifacts/review-frame-192.jpg"
+    }
+  ],
+  "metadata": {
+    "collection": "default",
+    "chunk_id": "review-mp4-transcript-0007",
+    "speaker": "Presenter"
+  }
+}
+```
+
+PDF and image evidence may populate page and bounding-box locator fields. Audio and video evidence may populate timestamps or frame information. Text and HTML evidence may include chunk metadata such as section, heading, or character offsets.
+
+## Safety
+
+Version 1 accepts local paths only. The server resolves every path before validation, requires at least one configured `--allowed-root`, and rejects remote URLs and cloud URIs.

--- a/nemo_retriever/src/nemo_retriever/__main__.py
+++ b/nemo_retriever/src/nemo_retriever/__main__.py
@@ -7,3 +7,6 @@ from __future__ import annotations
 from .adapters.cli.main import app, main
 
 __all__ = ["app", "main"]
+
+if __name__ == "__main__":
+    main()

--- a/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
+++ b/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import typer
 
+from nemo_retriever.agent_mcp.cli import app as agent_mcp_app
 from nemo_retriever.audio import app as audio_app
 from nemo_retriever.utils.benchmark import app as benchmark_app
 from nemo_retriever.chart import app as chart_app
@@ -36,6 +37,7 @@ app.add_typer(harness_app, name="harness")
 app.add_typer(vector_store_app, name="vector-store")
 app.add_typer(recall_app, name="recall")
 app.add_typer(service_app, name="service")
+app.add_typer(agent_mcp_app, name="agent-mcp")
 app.add_typer(txt_main.app, name="txt")
 app.add_typer(html_main.app, name="html")
 app.add_typer(pipeline_main.app, name="pipeline")

--- a/nemo_retriever/src/nemo_retriever/agent_mcp/__init__.py
+++ b/nemo_retriever/src/nemo_retriever/agent_mcp/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""MCP tools for exposing NeMo Retriever collections to agents."""
+
+from nemo_retriever.agent_mcp.models import (
+    AgentMcpError,
+    AgentMcpErrorCode,
+    CollectionRecord,
+    CollectionStatus,
+    EvidenceHit,
+    IngestJobRecord,
+    JobStatus,
+)
+
+__all__ = [
+    "AgentMcpError",
+    "AgentMcpErrorCode",
+    "CollectionRecord",
+    "CollectionStatus",
+    "EvidenceHit",
+    "IngestJobRecord",
+    "JobStatus",
+]

--- a/nemo_retriever/src/nemo_retriever/agent_mcp/backend.py
+++ b/nemo_retriever/src/nemo_retriever/agent_mcp/backend.py
@@ -236,12 +236,17 @@ class InProcessRetrieverBackend:
             )
 
         retriever = self.retriever_factory(
-            vdb=record.vdb_backend,
-            vdb_kwargs={"uri": record.vdb_uri, "table_name": record.vdb_table},
-            embedder=record.embedding_model,
-            embedding_endpoint=record.embedding_endpoint,
             top_k=top_k,
-            reranker=rerank,
+            rerank=rerank,
+            vdb_kwargs={
+                "vdb_op": record.vdb_backend,
+                "vdb_kwargs": {"uri": record.vdb_uri, "table_name": record.vdb_table},
+            },
+            embed_kwargs={
+                "model_name": record.embedding_model,
+                "embed_model_name": record.embedding_model,
+                "embedding_endpoint": record.embedding_endpoint,
+            },
         )
         call_vdb_kwargs = dict(filters) if filters else {}
         if hybrid:

--- a/nemo_retriever/src/nemo_retriever/agent_mcp/backend.py
+++ b/nemo_retriever/src/nemo_retriever/agent_mcp/backend.py
@@ -1,0 +1,270 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+from nemo_retriever.agent_mcp.evidence import normalize_hits
+from nemo_retriever.agent_mcp.models import AgentMcpError, AgentMcpErrorCode, CollectionRecord, EvidenceHit
+from nemo_retriever.agent_mcp.paths import PathPolicy
+from nemo_retriever.agent_mcp.registry import CollectionRegistry
+
+
+class RetrieverBackend(Protocol):
+    def create_collection(
+        self,
+        name: str = "default",
+        temporary: bool = False,
+        hybrid: bool = False,
+    ) -> CollectionRecord:
+        ...
+
+    def query_collection(
+        self,
+        collection: str = "default",
+        query: str = "",
+        top_k: int = 10,
+        hybrid: bool = False,
+        rerank: bool = False,
+        filters: dict[str, Any] | None = None,
+    ) -> list[EvidenceHit]:
+        ...
+
+    def rerank_results(
+        self,
+        query: str,
+        hits: list[EvidenceHit],
+        top_n: int | None = None,
+    ) -> list[EvidenceHit]:
+        ...
+
+
+class InProcessRetrieverBackend:
+    def __init__(
+        self,
+        registry: CollectionRegistry,
+        path_policy: PathPolicy,
+        retriever_factory: Callable[..., Any] | None = None,
+        ingestor_factory: Callable[..., Any] | None = None,
+        rerank_fn: Callable[..., list[dict[str, Any]]] | None = None,
+        reranker_model: Any | None = None,
+        reranker_endpoint: str | None = None,
+        reranker_model_name: str = "nvidia/llama-nemotron-rerank-1b-v2",
+        reranker_api_key: str = "",
+        reranker_max_length: int = 8192,
+        reranker_batch_size: int = 8,
+        rerank_modality: str = "text",
+        local_reranker_backend: str = "vllm",
+        local_hf_device: str | None = None,
+        local_hf_cache_dir: str | Path | None = None,
+        reranker_gpu_memory_utilization: float = 0.5,
+        max_workers: int = 2,
+    ) -> None:
+        self.registry = registry
+        self.path_policy = path_policy
+        self._retriever_factory = retriever_factory
+        self._ingestor_factory = ingestor_factory
+        self._rerank_fn = rerank_fn
+        self._custom_rerank_fn = rerank_fn is not None
+        self._reranker_model = reranker_model
+        self.reranker_endpoint = reranker_endpoint
+        self.reranker_model_name = reranker_model_name
+        self.reranker_api_key = reranker_api_key
+        self.reranker_max_length = reranker_max_length
+        self.reranker_batch_size = reranker_batch_size
+        self.rerank_modality = rerank_modality
+        self.local_reranker_backend = local_reranker_backend
+        self.local_hf_device = local_hf_device
+        self.local_hf_cache_dir = Path(local_hf_cache_dir) if local_hf_cache_dir else None
+        self.reranker_gpu_memory_utilization = reranker_gpu_memory_utilization
+        self.max_workers = max_workers
+
+    @property
+    def retriever_factory(self) -> Callable[..., Any]:
+        if self._retriever_factory is None:
+            from nemo_retriever.retriever import Retriever
+
+            self._retriever_factory = Retriever
+        return self._retriever_factory
+
+    @property
+    def ingestor_factory(self) -> Callable[..., Any]:
+        if self._ingestor_factory is None:
+            from nemo_retriever import create_ingestor
+
+            self._ingestor_factory = create_ingestor
+        return self._ingestor_factory
+
+    @property
+    def rerank_fn(self) -> Callable[..., list[dict[str, Any]]]:
+        if self._rerank_fn is None:
+            from nemo_retriever.rerank import rerank_hits
+
+            self._rerank_fn = rerank_hits
+        return self._rerank_fn
+
+    @property
+    def reranker_model(self) -> Any:
+        if self._reranker_model is None:
+            from nemo_retriever.model import create_local_reranker
+
+            cache_dir = str(self.local_hf_cache_dir) if self.local_hf_cache_dir else None
+            self._reranker_model = create_local_reranker(
+                model_name=self.reranker_model_name,
+                device=self.local_hf_device,
+                hf_cache_dir=cache_dir,
+                backend=self.local_reranker_backend,
+                gpu_memory_utilization=self.reranker_gpu_memory_utilization,
+            )
+        return self._reranker_model
+
+    def create_collection(
+        self,
+        name: str = "default",
+        temporary: bool = False,
+        hybrid: bool = False,
+    ) -> CollectionRecord:
+        return self.registry.create_collection(name=name, temporary=temporary, hybrid=hybrid)
+
+    def list_collections(self) -> list[CollectionRecord]:
+        return self.registry.list_collections()
+
+    def describe_collection(self, name: str = "default") -> dict[str, Any]:
+        record = self.registry.get_collection(name)
+        payload = record.model_dump(mode="json")
+        payload["recent_jobs"] = [
+            job.model_dump(mode="json")
+            for job in self.registry.list_jobs(name)[:10]
+        ]
+        return payload
+
+    def delete_collection(self, name: str, delete_data: bool = False) -> CollectionRecord:
+        record = self.registry.get_collection(name)
+        if delete_data:
+            self._delete_collection_root(record)
+        return self.registry.delete_collection(name)
+
+    def _delete_collection_root(self, record: CollectionRecord) -> None:
+        data_root = self.registry.data_root.expanduser().resolve()
+        root_path = Path(record.root_path).expanduser().resolve()
+        if root_path == data_root or data_root not in root_path.parents:
+            raise AgentMcpError(
+                AgentMcpErrorCode.PATH_OUTSIDE_ALLOWED_ROOT,
+                f"Collection root '{root_path}' is outside the registry data root.",
+                details={"collection": record.name, "root_path": str(root_path), "data_root": str(data_root)},
+            )
+        if root_path.exists():
+            shutil.rmtree(root_path)
+
+    def query_collection(
+        self,
+        collection: str = "default",
+        query: str = "",
+        top_k: int = 10,
+        hybrid: bool = False,
+        rerank: bool = False,
+        filters: dict[str, Any] | None = None,
+    ) -> list[EvidenceHit]:
+        record = self.registry.get_collection(collection)
+        if not record.queryable:
+            raise AgentMcpError(
+                AgentMcpErrorCode.COLLECTION_NOT_QUERYABLE,
+                f"Collection '{collection}' is not queryable.",
+                details={"collection": collection},
+            )
+        if hybrid and not record.hybrid:
+            raise AgentMcpError(
+                AgentMcpErrorCode.HYBRID_NOT_AVAILABLE,
+                f"Collection '{collection}' was not created with hybrid search enabled.",
+                details={"collection": collection},
+            )
+
+        retriever = self.retriever_factory(
+            vdb=record.vdb_backend,
+            vdb_kwargs={"uri": record.vdb_uri, "table_name": record.vdb_table},
+            embedder=record.embedding_model,
+            embedding_endpoint=record.embedding_endpoint,
+            top_k=top_k,
+            reranker=rerank,
+        )
+        call_vdb_kwargs = dict(filters) if filters else {}
+        if hybrid:
+            call_vdb_kwargs["hybrid"] = True
+        try:
+            raw_hits = retriever.query(
+                query,
+                top_k=top_k,
+                vdb_kwargs=call_vdb_kwargs or None,
+            )
+        except NotImplementedError as exc:
+            if not hybrid:
+                raise
+            raise AgentMcpError(
+                AgentMcpErrorCode.HYBRID_NOT_AVAILABLE,
+                f"Hybrid query is not available for collection '{collection}'.",
+                details={"collection": collection},
+            ) from exc
+        return normalize_hits(raw_hits)
+
+    def rerank_results(
+        self,
+        query: str,
+        hits: list[EvidenceHit],
+        top_n: int | None = None,
+    ) -> list[EvidenceHit]:
+        raw_hits = [self._hit_to_rerank_payload(hit) for hit in hits]
+        if self._custom_rerank_fn:
+            reranked = self.rerank_fn(query, raw_hits, top_n=top_n)
+        else:
+            endpoint = (self.reranker_endpoint or "").strip() or None
+            reranked = self.rerank_fn(
+                query,
+                raw_hits,
+                model=None if endpoint else self.reranker_model,
+                invoke_url=endpoint,
+                model_name=str(self.reranker_model_name),
+                api_key=(self.reranker_api_key or "").strip(),
+                max_length=int(self.reranker_max_length),
+                batch_size=int(self.reranker_batch_size),
+                top_n=top_n,
+                modality=self.rerank_modality,
+            )
+        return normalize_hits(reranked)
+
+    def _hit_to_rerank_payload(self, hit: EvidenceHit) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "text": hit.text,
+            "metadata": hit.metadata,
+        }
+        if hit.score is not None:
+            payload["score"] = hit.score
+        if hit.source_path:
+            payload["source_path"] = hit.source_path
+            payload["path"] = hit.source_path
+        if hit.content_type != "unknown":
+            payload["content_type"] = hit.content_type
+
+        locator = hit.locator
+        if locator.page_number is not None:
+            payload["page_number"] = locator.page_number
+        if locator.timestamp_start_s is not None:
+            payload["timestamp_start_s"] = locator.timestamp_start_s
+        if locator.timestamp_end_s is not None:
+            payload["timestamp_end_s"] = locator.timestamp_end_s
+        if locator.frame_index is not None:
+            payload["frame_index"] = locator.frame_index
+        if locator.chunk_id is not None:
+            payload["chunk_id"] = locator.chunk_id
+        if locator.bbox_xyxy_norm is not None:
+            payload["bbox_xyxy_norm"] = json.dumps(locator.bbox_xyxy_norm)
+
+        if hit.artifacts.stored_image_uri is not None:
+            payload["stored_image_uri"] = hit.artifacts.stored_image_uri
+        if hit.artifacts.thumbnail_uri is not None:
+            payload["thumbnail_uri"] = hit.artifacts.thumbnail_uri
+        return payload

--- a/nemo_retriever/src/nemo_retriever/agent_mcp/backend.py
+++ b/nemo_retriever/src/nemo_retriever/agent_mcp/backend.py
@@ -27,12 +27,21 @@ CANONICAL_MEDIA_ORDER = ("document", "image", "text", "html", "audio", "video")
 
 
 class RetrieverBackend(Protocol):
+    def list_collections(self) -> list[CollectionRecord]:
+        ...
+
     def create_collection(
         self,
         name: str = "default",
         temporary: bool = False,
         hybrid: bool = False,
     ) -> CollectionRecord:
+        ...
+
+    def describe_collection(self, name: str = "default") -> dict[str, Any]:
+        ...
+
+    def delete_collection(self, name: str, delete_data: bool = False) -> CollectionRecord:
         ...
 
     def query_collection(

--- a/nemo_retriever/src/nemo_retriever/agent_mcp/backend.py
+++ b/nemo_retriever/src/nemo_retriever/agent_mcp/backend.py
@@ -4,15 +4,26 @@
 
 from __future__ import annotations
 
+from concurrent.futures import Future, ThreadPoolExecutor
 import json
 import shutil
 from pathlib import Path
 from typing import Any, Callable, Protocol
 
 from nemo_retriever.agent_mcp.evidence import normalize_hits
-from nemo_retriever.agent_mcp.models import AgentMcpError, AgentMcpErrorCode, CollectionRecord, EvidenceHit
-from nemo_retriever.agent_mcp.paths import PathPolicy
+from nemo_retriever.agent_mcp.models import (
+    AgentMcpError,
+    AgentMcpErrorCode,
+    CollectionRecord,
+    EvidenceHit,
+    IngestJobRecord,
+    JobStatus,
+)
+from nemo_retriever.agent_mcp.paths import PathPolicy, expand_local_paths, group_paths_by_media_type
 from nemo_retriever.agent_mcp.registry import CollectionRegistry
+
+
+CANONICAL_MEDIA_ORDER = ("document", "image", "text", "html", "audio", "video")
 
 
 class RetrieverBackend(Protocol):
@@ -41,6 +52,29 @@ class RetrieverBackend(Protocol):
         hits: list[EvidenceHit],
         top_n: int | None = None,
     ) -> list[EvidenceHit]:
+        ...
+
+    def start_ingestion(
+        self,
+        collection: str,
+        paths: list[str | Path],
+        *,
+        run_mode: str = "inprocess",
+    ) -> IngestJobRecord:
+        ...
+
+    def ingest_local_paths(
+        self,
+        collection: str,
+        paths: list[str | Path],
+        *,
+        wait: bool = True,
+        timeout_s: float | None = None,
+        run_mode: str = "inprocess",
+    ) -> IngestJobRecord:
+        ...
+
+    def get_ingestion_status(self, job_id: str) -> IngestJobRecord:
         ...
 
 
@@ -83,6 +117,8 @@ class InProcessRetrieverBackend:
         self.local_hf_cache_dir = Path(local_hf_cache_dir) if local_hf_cache_dir else None
         self.reranker_gpu_memory_utilization = reranker_gpu_memory_utilization
         self.max_workers = max_workers
+        self._executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="agent-mcp-ingest")
+        self._futures: dict[str, Future[Any]] = {}
 
     @property
     def retriever_factory(self) -> Callable[..., Any]:
@@ -149,6 +185,9 @@ class InProcessRetrieverBackend:
             self._delete_collection_root(record)
         return self.registry.delete_collection(name)
 
+    def shutdown(self, wait: bool = True) -> None:
+        self._executor.shutdown(wait=wait)
+
     def _delete_collection_root(self, record: CollectionRecord) -> None:
         data_root = self.registry.data_root.expanduser().resolve()
         root_path = Path(record.root_path).expanduser().resolve()
@@ -210,6 +249,153 @@ class InProcessRetrieverBackend:
                 details={"collection": collection},
             ) from exc
         return normalize_hits(raw_hits)
+
+    def start_ingestion(
+        self,
+        collection: str,
+        paths: list[str | Path],
+        *,
+        run_mode: str = "inprocess",
+    ) -> IngestJobRecord:
+        self.registry.get_or_create_collection(collection)
+        expanded = expand_local_paths(paths, policy=self.path_policy)
+        job = self.registry.create_job(collection, source_count=len(expanded.files) + len(expanded.skipped))
+        if expanded.skipped:
+            job = self.registry.update_job(
+                job.job_id,
+                skipped_count=len(expanded.skipped),
+                warnings=list(expanded.skipped),
+            )
+        future = self._executor.submit(self._run_ingestion_job, job.job_id, collection, expanded.files, run_mode)
+        self._futures[job.job_id] = future
+        return job
+
+    def ingest_local_paths(
+        self,
+        collection: str,
+        paths: list[str | Path],
+        *,
+        wait: bool = True,
+        timeout_s: float | None = None,
+        run_mode: str = "inprocess",
+    ) -> IngestJobRecord:
+        job = self.start_ingestion(collection, paths, run_mode=run_mode)
+        if not wait:
+            return self.registry.get_job(job.job_id)
+
+        future = self._futures[job.job_id]
+        future.result(timeout=timeout_s)
+        return self.registry.get_job(job.job_id)
+
+    def get_ingestion_status(self, job_id: str) -> IngestJobRecord:
+        return self.registry.get_job(job_id)
+
+    def _run_ingestion_job(
+        self,
+        job_id: str,
+        collection: str,
+        files: list[Path],
+        run_mode: str,
+    ) -> None:
+        self.registry.update_job(job_id, status=JobStatus.RUNNING)
+        initial_record = self.registry.get_collection(collection)
+        accepted_count = 0
+        try:
+            grouped = group_paths_by_media_type(files)
+            ordered_media_types = [
+                media_type
+                for media_type in CANONICAL_MEDIA_ORDER
+                if media_type in grouped
+            ]
+            ordered_media_types.extend(sorted(set(grouped) - set(CANONICAL_MEDIA_ORDER)))
+
+            for media_type in ordered_media_types:
+                media_files = grouped[media_type]
+                overwrite = accepted_count == 0 and not initial_record.queryable
+                self._run_media_group(collection, media_type, media_files, run_mode, overwrite=overwrite)
+                accepted_count += len(media_files)
+
+            current_job = self.registry.get_job(job_id)
+            final_status = JobStatus.PARTIAL if current_job.skipped_count else JobStatus.COMPLETE
+            self.registry.update_job(
+                job_id,
+                status=final_status,
+                accepted_count=accepted_count,
+                row_count=accepted_count if accepted_count else None,
+            )
+            if accepted_count:
+                self.registry.mark_collection_queryable(collection, row_count=accepted_count)
+        except Exception as exc:
+            error = AgentMcpError(
+                AgentMcpErrorCode.BACKEND_ERROR,
+                f"Ingestion job '{job_id}' failed.",
+                details={"job_id": job_id, "collection": collection, "cause": str(exc)},
+            )
+            final_status = JobStatus.PARTIAL if accepted_count else JobStatus.FAILED
+            self.registry.update_job(
+                job_id,
+                status=final_status,
+                accepted_count=accepted_count,
+                row_count=accepted_count if accepted_count else None,
+                errors=[error.to_dict()],
+            )
+            if accepted_count:
+                self.registry.mark_collection_queryable(collection, row_count=accepted_count)
+            raise
+
+    def _run_media_group(
+        self,
+        collection: str,
+        media_type: str,
+        files: list[Path],
+        run_mode: str,
+        *,
+        overwrite: bool,
+    ) -> None:
+        record = self.registry.get_collection(collection)
+        ingestor = self.ingestor_factory(run_mode=run_mode)
+        ingestor = ingestor.files([str(path) for path in files])
+
+        extract_methods = {
+            "document": "extract",
+            "image": "extract_image_files",
+            "text": "extract_txt",
+            "html": "extract_html",
+            "audio": "extract_audio",
+            "video": "extract_video",
+        }
+        try:
+            extract_method = extract_methods[media_type]
+        except KeyError as exc:
+            raise AgentMcpError(
+                AgentMcpErrorCode.UNSUPPORTED_MEDIA_TYPE,
+                f"Unsupported media type '{media_type}'.",
+                details={"collection": collection, "media_type": media_type},
+            ) from exc
+
+        ingestor = getattr(ingestor, extract_method)()
+        ingestor = ingestor.embed(
+            model_name=record.embedding_model,
+            embedding_endpoint=record.embedding_endpoint,
+        )
+        if record.artifact_root:
+            ingestor = ingestor.store(storage_uri=record.artifact_root)
+        result = ingestor.ingest()
+        self._upload_records(record, result, overwrite=overwrite)
+
+    def _upload_records(self, record: CollectionRecord, result: Any, *, overwrite: bool) -> None:
+        from nemo_retriever.vdb import IngestVdbOperator
+
+        operator = IngestVdbOperator(
+            vdb_op=record.vdb_backend,
+            vdb_kwargs={
+                "uri": record.vdb_uri,
+                "table_name": record.vdb_table,
+                "hybrid": record.hybrid,
+                "overwrite": overwrite,
+            },
+        )
+        operator.process(result)
 
     def rerank_results(
         self,

--- a/nemo_retriever/src/nemo_retriever/agent_mcp/backend.py
+++ b/nemo_retriever/src/nemo_retriever/agent_mcp/backend.py
@@ -4,10 +4,11 @@
 
 from __future__ import annotations
 
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 import json
 import shutil
 from pathlib import Path
+from threading import Lock
 from typing import Any, Callable, Protocol
 
 from nemo_retriever.agent_mcp.evidence import normalize_hits
@@ -128,6 +129,8 @@ class InProcessRetrieverBackend:
         self.max_workers = max_workers
         self._executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="agent-mcp-ingest")
         self._futures: dict[str, Future[Any]] = {}
+        self._collection_locks_guard = Lock()
+        self._collection_locks: dict[str, Any] = {}
 
     @property
     def retriever_factory(self) -> Callable[..., Any]:
@@ -293,11 +296,22 @@ class InProcessRetrieverBackend:
             return self.registry.get_job(job.job_id)
 
         future = self._futures[job.job_id]
-        future.result(timeout=timeout_s)
+        try:
+            future.result(timeout=timeout_s)
+        except FutureTimeoutError:
+            return self.registry.get_job(job.job_id)
+        except Exception:
+            return self.registry.get_job(job.job_id)
         return self.registry.get_job(job.job_id)
 
     def get_ingestion_status(self, job_id: str) -> IngestJobRecord:
         return self.registry.get_job(job_id)
+
+    def _collection_lock(self, collection: str) -> Any:
+        with self._collection_locks_guard:
+            if collection not in self._collection_locks:
+                self._collection_locks[collection] = Lock()
+            return self._collection_locks[collection]
 
     def _run_ingestion_job(
         self,
@@ -306,51 +320,52 @@ class InProcessRetrieverBackend:
         files: list[Path],
         run_mode: str,
     ) -> None:
-        self.registry.update_job(job_id, status=JobStatus.RUNNING)
-        initial_record = self.registry.get_collection(collection)
-        accepted_count = 0
-        try:
-            grouped = group_paths_by_media_type(files)
-            ordered_media_types = [
-                media_type
-                for media_type in CANONICAL_MEDIA_ORDER
-                if media_type in grouped
-            ]
-            ordered_media_types.extend(sorted(set(grouped) - set(CANONICAL_MEDIA_ORDER)))
+        with self._collection_lock(collection):
+            self.registry.update_job(job_id, status=JobStatus.RUNNING)
+            initial_record = self.registry.get_collection(collection)
+            accepted_count = 0
+            try:
+                grouped = group_paths_by_media_type(files)
+                ordered_media_types = [
+                    media_type
+                    for media_type in CANONICAL_MEDIA_ORDER
+                    if media_type in grouped
+                ]
+                ordered_media_types.extend(sorted(set(grouped) - set(CANONICAL_MEDIA_ORDER)))
 
-            for media_type in ordered_media_types:
-                media_files = grouped[media_type]
-                overwrite = accepted_count == 0 and not initial_record.queryable
-                self._run_media_group(collection, media_type, media_files, run_mode, overwrite=overwrite)
-                accepted_count += len(media_files)
+                for media_type in ordered_media_types:
+                    media_files = grouped[media_type]
+                    overwrite = accepted_count == 0 and not initial_record.queryable
+                    self._run_media_group(collection, media_type, media_files, run_mode, overwrite=overwrite)
+                    accepted_count += len(media_files)
 
-            current_job = self.registry.get_job(job_id)
-            final_status = JobStatus.PARTIAL if current_job.skipped_count else JobStatus.COMPLETE
-            self.registry.update_job(
-                job_id,
-                status=final_status,
-                accepted_count=accepted_count,
-                row_count=accepted_count if accepted_count else None,
-            )
-            if accepted_count:
-                self.registry.mark_collection_queryable(collection, row_count=accepted_count)
-        except Exception as exc:
-            error = AgentMcpError(
-                AgentMcpErrorCode.BACKEND_ERROR,
-                f"Ingestion job '{job_id}' failed.",
-                details={"job_id": job_id, "collection": collection, "cause": str(exc)},
-            )
-            final_status = JobStatus.PARTIAL if accepted_count else JobStatus.FAILED
-            self.registry.update_job(
-                job_id,
-                status=final_status,
-                accepted_count=accepted_count,
-                row_count=accepted_count if accepted_count else None,
-                errors=[error.to_dict()],
-            )
-            if accepted_count:
-                self.registry.mark_collection_queryable(collection, row_count=accepted_count)
-            raise
+                current_job = self.registry.get_job(job_id)
+                final_status = JobStatus.PARTIAL if current_job.skipped_count else JobStatus.COMPLETE
+                self.registry.update_job(
+                    job_id,
+                    status=final_status,
+                    accepted_count=accepted_count,
+                    row_count=accepted_count if accepted_count else None,
+                )
+                if accepted_count:
+                    self.registry.mark_collection_queryable(collection, row_count=accepted_count)
+            except Exception as exc:
+                error = AgentMcpError(
+                    AgentMcpErrorCode.BACKEND_ERROR,
+                    f"Ingestion job '{job_id}' failed.",
+                    details={"job_id": job_id, "collection": collection, "cause": str(exc)},
+                )
+                final_status = JobStatus.PARTIAL if accepted_count else JobStatus.FAILED
+                self.registry.update_job(
+                    job_id,
+                    status=final_status,
+                    accepted_count=accepted_count,
+                    row_count=accepted_count if accepted_count else None,
+                    errors=[error.to_dict()],
+                )
+                if accepted_count:
+                    self.registry.mark_collection_queryable(collection, row_count=accepted_count)
+                raise
 
     def _run_media_group(
         self,

--- a/nemo_retriever/src/nemo_retriever/agent_mcp/cli.py
+++ b/nemo_retriever/src/nemo_retriever/agent_mcp/cli.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+import uvicorn
+
+from nemo_retriever.agent_mcp.server import build_asgi_app
+
+app = typer.Typer(help="Start the NeMo Retriever agent MCP server.")
+
+
+@app.command()
+def start(
+    data_root: Path = typer.Option(
+        Path(".nemo-retriever-mcp"),
+        "--data-root",
+        help="Directory for agent MCP registry and collection data.",
+    ),
+    allowed_root: list[Path] = typer.Option(
+        [],
+        "--allowed-root",
+        help="Local root path agents may ingest from. May be supplied multiple times.",
+    ),
+    host: str = typer.Option(
+        "127.0.0.1",
+        "--host",
+        help="Host interface for the agent MCP server.",
+    ),
+    port: int = typer.Option(
+        8099,
+        "--port",
+        help="Port for the agent MCP server.",
+    ),
+    log_level: str = typer.Option(
+        "info",
+        "--log-level",
+        help="Uvicorn log level.",
+    ),
+) -> None:
+    roots = allowed_root or [Path.cwd()]
+    application = build_asgi_app(data_root=data_root, allowed_roots=roots)
+    uvicorn.run(application, host=host, port=port, log_level=log_level)

--- a/nemo_retriever/src/nemo_retriever/agent_mcp/cli.py
+++ b/nemo_retriever/src/nemo_retriever/agent_mcp/cli.py
@@ -42,6 +42,7 @@ def start(
         help="Uvicorn log level.",
     ),
 ) -> None:
-    roots = allowed_root or [Path.cwd()]
-    application = build_asgi_app(data_root=data_root, allowed_roots=roots)
+    if not allowed_root:
+        raise typer.BadParameter("At least one --allowed-root is required.", param_hint="--allowed-root")
+    application = build_asgi_app(data_root=data_root, allowed_roots=allowed_root)
     uvicorn.run(application, host=host, port=port, log_level=log_level)

--- a/nemo_retriever/src/nemo_retriever/agent_mcp/evidence.py
+++ b/nemo_retriever/src/nemo_retriever/agent_mcp/evidence.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import ast
+import json
+import math
+from typing import Any, Iterable
+
+from nemo_retriever.agent_mcp.models import AgentMcpError, EvidenceArtifacts, EvidenceHit, Locator
+from nemo_retriever.agent_mcp.paths import media_type_for_path
+
+
+def _parse_mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    if not isinstance(value, str) or not value.strip():
+        return {}
+
+    for parser in (json.loads, ast.literal_eval):
+        try:
+            parsed = parser(value)
+        except (SyntaxError, ValueError, TypeError, json.JSONDecodeError):
+            continue
+        if isinstance(parsed, dict):
+            return dict(parsed)
+    return {}
+
+
+def _first_nonempty(*values: Any) -> str:
+    for value in values:
+        if value is None:
+            continue
+        stringified = str(value)
+        if stringified:
+            return stringified
+    return ""
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (OverflowError, TypeError, ValueError):
+        return None
+    if not math.isfinite(parsed):
+        return None
+    return parsed
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    try:
+        return int(value)
+    except (OverflowError, TypeError, ValueError):
+        return None
+
+
+def _score(hit: dict[str, Any]) -> float | None:
+    for key in ("_rerank_score", "rerank_score", "score", "_distance"):
+        if key in hit:
+            return _float_or_none(hit.get(key))
+    return None
+
+
+def _media_type(source_path: str) -> str:
+    if not source_path:
+        return "unknown"
+    try:
+        return media_type_for_path(source_path)
+    except AgentMcpError:
+        return "unknown"
+
+
+def _first_present(hit: dict[str, Any], metadata: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in hit:
+            return hit[key]
+        if key in metadata:
+            return metadata[key]
+    return None
+
+
+def _bbox_or_none(value: Any) -> list[float] | None:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            try:
+                value = ast.literal_eval(value)
+            except (SyntaxError, ValueError, TypeError):
+                return None
+
+    if isinstance(value, dict):
+        for nested_key in ("bbox_xyxy_norm", "bbox"):
+            if nested_key in value:
+                return _bbox_or_none(value[nested_key])
+        value = [value.get(key) for key in ("x1", "y1", "x2", "y2")]
+
+    if not isinstance(value, (list, tuple)):
+        return None
+
+    if len(value) != 4:
+        return None
+
+    bbox = [_float_or_none(item) for item in value]
+    if any(item is None for item in bbox):
+        return None
+    return [item for item in bbox if item is not None]
+
+
+def _locator(hit: dict[str, Any], metadata: dict[str, Any]) -> Locator:
+    timestamp_start = _first_present(hit, metadata, "timestamp_start_s", "segment_start_seconds")
+    timestamp_end = _first_present(hit, metadata, "timestamp_end_s", "segment_end_seconds")
+
+    return Locator(
+        page_number=_int_or_none(_first_present(hit, metadata, "page_number")),
+        timestamp_start_s=_float_or_none(timestamp_start),
+        timestamp_end_s=_float_or_none(timestamp_end),
+        frame_index=_int_or_none(_first_present(hit, metadata, "frame_index")),
+        bbox_xyxy_norm=_bbox_or_none(_first_present(hit, metadata, "bbox_xyxy_norm", "bbox")),
+        chunk_id=_first_nonempty(_first_present(hit, metadata, "chunk_id", "chunk")) or None,
+    )
+
+
+def normalize_hit(hit: dict[str, Any]) -> EvidenceHit:
+    metadata = _parse_mapping(hit.get("metadata"))
+    source = _parse_mapping(hit.get("source"))
+    source_path = _first_nonempty(
+        hit.get("source_path"),
+        hit.get("path"),
+        hit.get("source_id"),
+        source.get("source_id"),
+        source.get("source_name"),
+    )
+    output_metadata = dict(metadata)
+    output_metadata["_raw_hit_keys"] = sorted(hit)
+
+    return EvidenceHit(
+        text=_first_nonempty(hit.get("text")),
+        score=_score(hit),
+        source_path=source_path,
+        media_type=_media_type(source_path),
+        content_type=_first_nonempty(
+            hit.get("content_type"),
+            metadata.get("content_type"),
+            metadata.get("type"),
+            "unknown",
+        ),
+        locator=_locator(hit, metadata),
+        artifacts=EvidenceArtifacts(
+            stored_image_uri=_first_nonempty(hit.get("stored_image_uri"), metadata.get("stored_image_uri")) or None,
+            thumbnail_uri=_first_nonempty(hit.get("thumbnail_uri"), metadata.get("thumbnail_uri")) or None,
+        ),
+        metadata=output_metadata,
+    )
+
+
+def normalize_hits(hits: Iterable[dict[str, Any]]) -> list[EvidenceHit]:
+    return [normalize_hit(hit) for hit in hits]

--- a/nemo_retriever/src/nemo_retriever/agent_mcp/models.py
+++ b/nemo_retriever/src/nemo_retriever/agent_mcp/models.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class AgentMcpErrorCode(str, Enum):
+    PATH_OUTSIDE_ALLOWED_ROOT = "PATH_OUTSIDE_ALLOWED_ROOT"
+    PATH_NOT_FOUND = "PATH_NOT_FOUND"
+    UNSUPPORTED_MEDIA_TYPE = "UNSUPPORTED_MEDIA_TYPE"
+    COLLECTION_NOT_FOUND = "COLLECTION_NOT_FOUND"
+    COLLECTION_ALREADY_EXISTS = "COLLECTION_ALREADY_EXISTS"
+    COLLECTION_NOT_QUERYABLE = "COLLECTION_NOT_QUERYABLE"
+    INGEST_JOB_NOT_FOUND = "INGEST_JOB_NOT_FOUND"
+    INGEST_JOB_FAILED = "INGEST_JOB_FAILED"
+    HYBRID_NOT_AVAILABLE = "HYBRID_NOT_AVAILABLE"
+    EMBEDDING_CONFIG_MISMATCH = "EMBEDDING_CONFIG_MISMATCH"
+    VDB_NOT_FOUND = "VDB_NOT_FOUND"
+    BACKEND_ERROR = "BACKEND_ERROR"
+
+
+class AgentMcpError(Exception):
+    def __init__(
+        self,
+        code: AgentMcpErrorCode,
+        message: str,
+        *,
+        retryable: bool = False,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.retryable = bool(retryable)
+        self.details = dict(details or {})
+
+    def __str__(self) -> str:
+        return f"{self.code.value}: {self.message}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code.value,
+            "message": self.message,
+            "retryable": self.retryable,
+            "details": self.details,
+        }
+
+
+class CollectionStatus(str, Enum):
+    EMPTY = "empty"
+    INGESTING = "ingesting"
+    QUERYABLE = "queryable"
+    ERROR = "error"
+
+
+class JobStatus(str, Enum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETE = "complete"
+    FAILED = "failed"
+    PARTIAL = "partial"
+
+
+class Locator(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    page_number: int | None = None
+    timestamp_start_s: float | None = None
+    timestamp_end_s: float | None = None
+    frame_index: int | None = None
+    bbox_xyxy_norm: list[float] | None = None
+    chunk_id: str | None = None
+
+
+class EvidenceArtifacts(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    stored_image_uri: str | None = None
+    thumbnail_uri: str | None = None
+
+
+class EvidenceHit(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    text: str
+    score: float | None = None
+    source_path: str = ""
+    media_type: str = "unknown"
+    content_type: str = "unknown"
+    locator: Locator = Field(default_factory=Locator)
+    artifacts: EvidenceArtifacts = Field(default_factory=EvidenceArtifacts)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class CollectionRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    root_path: str
+    temporary: bool = False
+    backend: Literal["inprocess", "service"] = "inprocess"
+    vdb_backend: str = "lancedb"
+    vdb_uri: str | None = None
+    vdb_table: str = "nv-ingest"
+    artifact_root: str | None = None
+    embedding_model: str = "nvidia/llama-nemotron-embed-1b-v2"
+    embedding_endpoint: str | None = None
+    hybrid: bool = False
+    queryable: bool = False
+    status: CollectionStatus = CollectionStatus.EMPTY
+    created_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utc_now)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class IngestOptions(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    wait: bool = True
+    timeout_s: float | None = None
+    run_mode: Literal["inprocess", "batch"] = "inprocess"
+    hybrid: bool = False
+    store_artifacts: bool = True
+    max_files: int = 1000
+    max_total_bytes: int | None = None
+
+
+class IngestJobRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    job_id: str
+    collection: str
+    status: JobStatus = JobStatus.QUEUED
+    source_count: int = 0
+    accepted_count: int = 0
+    skipped_count: int = 0
+    row_count: int | None = None
+    artifact_count: int | None = None
+    warnings: list[dict[str, Any]] = Field(default_factory=list)
+    errors: list[dict[str, Any]] = Field(default_factory=list)
+    created_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utc_now)
+
+
+class QueryOptions(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    top_k: int = Field(default=10, ge=1, le=1000)
+    hybrid: bool = False
+    rerank: bool = False
+    filters: dict[str, Any] | None = None

--- a/nemo_retriever/src/nemo_retriever/agent_mcp/paths.py
+++ b/nemo_retriever/src/nemo_retriever/agent_mcp/paths.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator
+from urllib.parse import urlparse
+
+from nemo_retriever.agent_mcp.models import AgentMcpError, AgentMcpErrorCode
+
+EXTENSION_MEDIA_TYPES: dict[str, str] = {
+    ".pdf": "document",
+    ".docx": "document",
+    ".pptx": "document",
+    ".png": "image",
+    ".jpg": "image",
+    ".jpeg": "image",
+    ".webp": "image",
+    ".tif": "image",
+    ".tiff": "image",
+    ".txt": "text",
+    ".md": "text",
+    ".html": "html",
+    ".htm": "html",
+    ".mp3": "audio",
+    ".wav": "audio",
+    ".flac": "audio",
+    ".m4a": "audio",
+    ".mp4": "video",
+    ".mov": "video",
+    ".mkv": "video",
+    ".webm": "video",
+}
+
+_CLOUD_URI_PREFIXES = (
+    "s3://",
+    "gs://",
+    "az://",
+    "azure://",
+    "abfs://",
+    "abfss://",
+    "adl://",
+    "dbfs:/",
+)
+
+
+@dataclass(frozen=True)
+class PathPolicy:
+    allowed_roots: list[Path]
+    max_files: int = 1000
+    max_total_bytes: int | None = None
+
+    def resolved_roots(self) -> list[Path]:
+        return [root.expanduser().resolve() for root in self.allowed_roots]
+
+
+@dataclass
+class ExpandedPaths:
+    files: list[Path]
+    skipped: list[dict[str, str]]
+    total_bytes: int
+
+
+def _is_supported(path: Path) -> bool:
+    return path.suffix.lower() in EXTENSION_MEDIA_TYPES
+
+
+def _looks_like_uri(value: str) -> bool:
+    lower_value = value.lower()
+    if lower_value.startswith(_CLOUD_URI_PREFIXES):
+        return True
+
+    parsed = urlparse(value)
+    if not parsed.scheme:
+        return False
+    if len(parsed.scheme) == 1 and value[1:3] in {":/", ":\\"}:
+        return False
+    return True
+
+
+def _assert_allowed(path: Path, roots: list[Path]) -> Path:
+    resolved_path = path.expanduser().resolve()
+    for root in roots:
+        if resolved_path == root or root in resolved_path.parents:
+            return resolved_path
+
+    raise AgentMcpError(
+        AgentMcpErrorCode.PATH_OUTSIDE_ALLOWED_ROOT,
+        f"Path '{resolved_path}' is outside the allowed roots.",
+        details={"path": str(resolved_path), "allowed_roots": [str(root) for root in roots]},
+    )
+
+
+def _iter_candidates(path: Path) -> Iterator[Path]:
+    if path.is_dir():
+        yield from path.rglob("*")
+        return
+
+    yield path
+
+
+def expand_local_paths(inputs: Iterable[str | Path], *, policy: PathPolicy) -> ExpandedPaths:
+    roots = policy.resolved_roots()
+    files: set[Path] = set()
+    skipped_by_path: dict[Path, dict[str, str]] = {}
+    total_bytes = 0
+
+    for input_path in inputs:
+        if isinstance(input_path, str) and _looks_like_uri(input_path):
+            raise AgentMcpError(
+                AgentMcpErrorCode.PATH_NOT_FOUND,
+                f"Remote URI '{input_path}' is not a local path.",
+                details={"path": input_path},
+            )
+
+        resolved_path = _assert_allowed(Path(input_path), roots)
+        if not resolved_path.exists():
+            raise AgentMcpError(
+                AgentMcpErrorCode.PATH_NOT_FOUND,
+                f"Path '{resolved_path}' was not found.",
+                details={"path": str(resolved_path)},
+            )
+
+        for candidate in _iter_candidates(resolved_path):
+            if not candidate.exists():
+                raise AgentMcpError(
+                    AgentMcpErrorCode.PATH_NOT_FOUND,
+                    f"Path '{candidate}' was not found.",
+                    details={"path": str(candidate)},
+                )
+            if not candidate.is_file():
+                continue
+
+            resolved_file = _assert_allowed(candidate, roots)
+            if not _is_supported(resolved_file):
+                skipped_by_path[resolved_file] = {
+                    "path": str(resolved_file),
+                    "code": AgentMcpErrorCode.UNSUPPORTED_MEDIA_TYPE.value,
+                }
+                continue
+
+            if resolved_file in files:
+                continue
+
+            file_size = resolved_file.stat().st_size
+            if len(files) + 1 > policy.max_files:
+                raise AgentMcpError(
+                    AgentMcpErrorCode.BACKEND_ERROR,
+                    f"Expanded local paths exceed max_files={policy.max_files}.",
+                    details={"max_files": policy.max_files},
+                )
+            if policy.max_total_bytes is not None and total_bytes + file_size > policy.max_total_bytes:
+                raise AgentMcpError(
+                    AgentMcpErrorCode.BACKEND_ERROR,
+                    f"Expanded local paths exceed max_total_bytes={policy.max_total_bytes}.",
+                    details={"max_total_bytes": policy.max_total_bytes},
+                )
+
+            files.add(resolved_file)
+            total_bytes += file_size
+
+    return ExpandedPaths(
+        files=sorted(files),
+        skipped=[skipped_by_path[path] for path in sorted(skipped_by_path)],
+        total_bytes=total_bytes,
+    )
+
+
+def media_type_for_path(path: str | Path) -> str:
+    extension = Path(path).suffix.lower()
+    try:
+        return EXTENSION_MEDIA_TYPES[extension]
+    except KeyError as exc:
+        raise AgentMcpError(
+            AgentMcpErrorCode.UNSUPPORTED_MEDIA_TYPE,
+            f"Unsupported media type for path '{path}'.",
+            details={"path": str(path), "extension": extension},
+        ) from exc
+
+
+def group_paths_by_media_type(paths: Iterable[Path]) -> dict[str, list[Path]]:
+    grouped: dict[str, list[Path]] = {}
+    for path in paths:
+        grouped.setdefault(media_type_for_path(path), []).append(path)
+    return grouped

--- a/nemo_retriever/src/nemo_retriever/agent_mcp/registry.py
+++ b/nemo_retriever/src/nemo_retriever/agent_mcp/registry.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+from nemo_retriever.agent_mcp.models import (
+    AgentMcpError,
+    AgentMcpErrorCode,
+    CollectionRecord,
+    CollectionStatus,
+    IngestJobRecord,
+    JobStatus,
+    utc_now,
+)
+
+
+class CollectionRegistry:
+    def __init__(self, db_path: str | Path, *, data_root: str | Path) -> None:
+        self.db_path = Path(db_path)
+        self.data_root = Path(data_root)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.data_root.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path, timeout=30.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def _initialize(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS collections (
+                    name TEXT PRIMARY KEY,
+                    payload TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS jobs (
+                    job_id TEXT PRIMARY KEY,
+                    collection TEXT NOT NULL,
+                    payload TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+
+    def _validate_collection_name(self, name: str) -> None:
+        posix_path = PurePosixPath(name)
+        windows_path = PureWindowsPath(name)
+        unsafe_parts = {".", ".."}
+        if (
+            not name
+            or name in unsafe_parts
+            or any(part in unsafe_parts for part in posix_path.parts)
+            or any(part in unsafe_parts for part in windows_path.parts)
+            or posix_path.parts != (name,)
+            or windows_path.parts != (name,)
+            or windows_path.drive
+        ):
+            raise AgentMcpError(
+                AgentMcpErrorCode.PATH_OUTSIDE_ALLOWED_ROOT,
+                f"Collection name '{name}' is not a safe path component.",
+                details={"collection": name, "data_root": str(self.data_root)},
+            )
+
+    def _collection_paths(self, name: str, temporary: bool) -> tuple[Path, Path, Path]:
+        self._validate_collection_name(name)
+        namespace = "tmp" if temporary else "collections"
+        base = self.data_root / namespace / name
+        return base, base / "lancedb", base / "artifacts"
+
+    def create_collection(
+        self,
+        name: str = "default",
+        temporary: bool = False,
+        hybrid: bool = False,
+        metadata: dict | None = None,
+    ) -> CollectionRecord:
+        base, lancedb, artifacts = self._collection_paths(name, temporary)
+        lancedb.mkdir(parents=True, exist_ok=True)
+        artifacts.mkdir(parents=True, exist_ok=True)
+
+        record = CollectionRecord(
+            name=name,
+            root_path=str(base),
+            temporary=temporary,
+            vdb_uri=str(lancedb),
+            artifact_root=str(artifacts),
+            hybrid=hybrid,
+            metadata=dict(metadata or {}),
+        )
+        try:
+            with self._connect() as conn:
+                conn.execute(
+                    "INSERT INTO collections (name, payload, updated_at) VALUES (?, ?, ?)",
+                    (record.name, record.model_dump_json(), record.updated_at.isoformat()),
+                )
+        except sqlite3.IntegrityError as exc:
+            raise AgentMcpError(
+                AgentMcpErrorCode.COLLECTION_ALREADY_EXISTS,
+                f"Collection '{name}' already exists.",
+                details={"collection": name},
+            ) from exc
+        return record
+
+    def get_collection(self, name: str = "default") -> CollectionRecord:
+        self._validate_collection_name(name)
+        with self._connect() as conn:
+            row = conn.execute("SELECT payload FROM collections WHERE name = ?", (name,)).fetchone()
+        if row is None:
+            raise AgentMcpError(
+                AgentMcpErrorCode.COLLECTION_NOT_FOUND,
+                f"Collection '{name}' was not found.",
+                details={"collection": name},
+            )
+        return CollectionRecord.model_validate_json(row["payload"])
+
+    def get_or_create_collection(self, name: str = "default") -> CollectionRecord:
+        try:
+            return self.get_collection(name)
+        except AgentMcpError as exc:
+            if exc.code is not AgentMcpErrorCode.COLLECTION_NOT_FOUND:
+                raise
+        return self.create_collection(name)
+
+    def save_collection(self, record: CollectionRecord) -> CollectionRecord:
+        self._validate_collection_name(record.name)
+        updated = record.model_copy(update={"updated_at": utc_now()})
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "UPDATE collections SET payload = ?, updated_at = ? WHERE name = ?",
+                (updated.model_dump_json(), updated.updated_at.isoformat(), updated.name),
+            )
+        if cursor.rowcount == 0:
+            raise AgentMcpError(
+                AgentMcpErrorCode.COLLECTION_NOT_FOUND,
+                f"Collection '{record.name}' was not found.",
+                details={"collection": record.name},
+            )
+        return updated
+
+    def mark_collection_queryable(self, name: str, row_count: int | None = None) -> CollectionRecord:
+        record = self.get_collection(name)
+        metadata = dict(record.metadata)
+        if row_count is not None:
+            metadata["row_count"] = row_count
+        updated = record.model_copy(
+            update={
+                "queryable": True,
+                "status": CollectionStatus.QUERYABLE,
+                "metadata": metadata,
+            }
+        )
+        return self.save_collection(updated)
+
+    def list_collections(self) -> list[CollectionRecord]:
+        with self._connect() as conn:
+            rows = conn.execute("SELECT payload FROM collections ORDER BY name").fetchall()
+        return [CollectionRecord.model_validate_json(row["payload"]) for row in rows]
+
+    def delete_collection(self, name: str) -> CollectionRecord:
+        record = self.get_collection(name)
+        with self._connect() as conn:
+            conn.execute("DELETE FROM jobs WHERE collection = ?", (name,))
+            conn.execute("DELETE FROM collections WHERE name = ?", (name,))
+        return record
+
+    def create_job(self, collection: str, source_count: int = 0) -> IngestJobRecord:
+        self.get_collection(collection)
+        job = IngestJobRecord(job_id=str(uuid.uuid4()), collection=collection, source_count=source_count)
+        with self._connect() as conn:
+            conn.execute(
+                "INSERT INTO jobs (job_id, collection, payload, updated_at) VALUES (?, ?, ?, ?)",
+                (job.job_id, job.collection, job.model_dump_json(), job.updated_at.isoformat()),
+            )
+        return job
+
+    def get_job(self, job_id: str) -> IngestJobRecord:
+        with self._connect() as conn:
+            row = conn.execute("SELECT payload FROM jobs WHERE job_id = ?", (job_id,)).fetchone()
+        if row is None:
+            raise AgentMcpError(
+                AgentMcpErrorCode.INGEST_JOB_NOT_FOUND,
+                f"Ingest job '{job_id}' was not found.",
+                details={"job_id": job_id},
+            )
+        return IngestJobRecord.model_validate_json(row["payload"])
+
+    def update_job(self, job_id: str, **updates: object) -> IngestJobRecord:
+        job = self.get_job(job_id)
+        payload = job.model_dump()
+        payload.update(updates)
+        payload["updated_at"] = utc_now()
+        updated = IngestJobRecord.model_validate(payload)
+        if "collection" in updates:
+            self.get_collection(updated.collection)
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE jobs SET collection = ?, payload = ?, updated_at = ? WHERE job_id = ?",
+                (updated.collection, updated.model_dump_json(), updated.updated_at.isoformat(), updated.job_id),
+            )
+        return updated
+
+    def list_jobs(self, collection: str) -> list[IngestJobRecord]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT payload FROM jobs WHERE collection = ? ORDER BY updated_at DESC",
+                (collection,),
+            ).fetchall()
+        return [IngestJobRecord.model_validate_json(row["payload"]) for row in rows]

--- a/nemo_retriever/src/nemo_retriever/agent_mcp/server.py
+++ b/nemo_retriever/src/nemo_retriever/agent_mcp/server.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+from fastmcp import FastMCP
+
+from nemo_retriever.agent_mcp.backend import InProcessRetrieverBackend
+from nemo_retriever.agent_mcp.paths import PathPolicy
+from nemo_retriever.agent_mcp.registry import CollectionRegistry
+from nemo_retriever.agent_mcp.tools import AgentMcpToolService
+
+
+def create_mcp_server(service: AgentMcpToolService) -> FastMCP:
+    @asynccontextmanager
+    async def lifespan(_server: FastMCP) -> AsyncIterator[dict[str, Any]]:
+        try:
+            yield {}
+        finally:
+            shutdown = getattr(service.backend, "shutdown", None)
+            if callable(shutdown):
+                shutdown(wait=True)
+
+    mcp = FastMCP(
+        "NeMo Retriever Agent MCP",
+        instructions=(
+            "Expose NeMo Retriever collection, ingestion, query, and reranking tools "
+            "for agents. Tools return structured evidence and operational status, not "
+            "generated answers."
+        ),
+        lifespan=lifespan,
+    )
+
+    mcp.tool(
+        name="list_collections",
+        description="List retriever collections available to the agent.",
+    )(service.list_collections)
+    mcp.tool(
+        name="create_collection",
+        description="Create a retriever collection for local evidence ingestion.",
+    )(service.create_collection)
+    mcp.tool(
+        name="describe_collection",
+        description="Describe collection configuration, status, and recent ingestion jobs.",
+    )(service.describe_collection)
+    mcp.tool(
+        name="delete_collection",
+        description="Delete a retriever collection and optionally its stored data.",
+    )(service.delete_collection)
+    mcp.tool(
+        name="start_ingestion",
+        description="Start ingesting allowed local paths into a collection.",
+    )(service.start_ingestion)
+    mcp.tool(
+        name="get_ingestion_status",
+        description="Return the current status for an ingestion job.",
+    )(service.get_ingestion_status)
+    mcp.tool(
+        name="ingest_local_paths",
+        description="Ingest allowed local paths into a collection, optionally waiting for completion.",
+    )(service.ingest_local_paths)
+    mcp.tool(
+        name="query_collection",
+        description="Query a collection and return evidence hits for agent grounding.",
+    )(service.query_collection)
+    mcp.tool(
+        name="rerank_results",
+        description="Rerank evidence hits for a query and return the highest scoring evidence.",
+    )(service.rerank_results)
+
+    return mcp
+
+
+def create_default_service(
+    data_root: str | Path,
+    allowed_roots: list[str | Path],
+    registry_path: str | Path | None = None,
+) -> AgentMcpToolService:
+    root = Path(data_root)
+    registry = CollectionRegistry(registry_path or root / "registry.sqlite", data_root=root)
+    backend = InProcessRetrieverBackend(
+        registry=registry,
+        path_policy=PathPolicy(allowed_roots=[Path(path) for path in allowed_roots]),
+    )
+    return AgentMcpToolService(backend)
+
+
+def build_asgi_app(
+    data_root: str | Path,
+    allowed_roots: list[str | Path],
+    registry_path: str | Path | None = None,
+) -> Any:
+    service = create_default_service(data_root, allowed_roots, registry_path=registry_path)
+    return create_mcp_server(service).http_app(path="/")

--- a/nemo_retriever/src/nemo_retriever/agent_mcp/tools.py
+++ b/nemo_retriever/src/nemo_retriever/agent_mcp/tools.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from pydantic import BaseModel, ValidationError
+
+from nemo_retriever.agent_mcp.backend import RetrieverBackend
+from nemo_retriever.agent_mcp.models import AgentMcpError, AgentMcpErrorCode, EvidenceHit
+
+
+def _dump(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json", exclude_none=True)
+    if isinstance(value, list):
+        return [_dump(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _dump(item) for key, item in value.items()}
+    return value
+
+
+class AgentMcpToolService:
+    def __init__(self, backend: RetrieverBackend) -> None:
+        self.backend: RetrieverBackend = backend
+
+    def _call(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        try:
+            return _dump(fn(*args, **kwargs))
+        except AgentMcpError as exc:
+            return {"error": exc.to_dict()}
+
+    def list_collections(self) -> Any:
+        return self._call(self.backend.list_collections)
+
+    def create_collection(
+        self,
+        name: str = "default",
+        temporary: bool = False,
+        hybrid: bool = False,
+    ) -> Any:
+        return self._call(
+            self.backend.create_collection,
+            name=name,
+            temporary=temporary,
+            hybrid=hybrid,
+        )
+
+    def describe_collection(self, name: str = "default") -> Any:
+        return self._call(self.backend.describe_collection, name=name)
+
+    def delete_collection(self, name: str, delete_data: bool = False) -> Any:
+        return self._call(self.backend.delete_collection, name=name, delete_data=delete_data)
+
+    def start_ingestion(
+        self,
+        collection: str = "default",
+        paths: list[str] | None = None,
+        run_mode: str = "inprocess",
+    ) -> Any:
+        return self._call(
+            self.backend.start_ingestion,
+            collection=collection,
+            paths=paths or [],
+            run_mode=run_mode,
+        )
+
+    def get_ingestion_status(self, job_id: str) -> Any:
+        return self._call(self.backend.get_ingestion_status, job_id=job_id)
+
+    def ingest_local_paths(
+        self,
+        collection: str = "default",
+        paths: list[str] | None = None,
+        wait: bool = True,
+        timeout_s: float | None = None,
+        run_mode: str = "inprocess",
+    ) -> Any:
+        return self._call(
+            self.backend.ingest_local_paths,
+            collection=collection,
+            paths=paths or [],
+            wait=wait,
+            timeout_s=timeout_s,
+            run_mode=run_mode,
+        )
+
+    def query_collection(
+        self,
+        collection: str = "default",
+        query: str = "",
+        top_k: int = 10,
+        hybrid: bool = False,
+        rerank: bool = False,
+        filters: dict[str, Any] | None = None,
+    ) -> Any:
+        return self._call(
+            self.backend.query_collection,
+            collection=collection,
+            query=query,
+            top_k=top_k,
+            hybrid=hybrid,
+            rerank=rerank,
+            filters=filters,
+        )
+
+    def rerank_results(
+        self,
+        query: str,
+        hits: list[dict[str, Any]],
+        top_n: int | None = None,
+    ) -> Any:
+        def rerank_validated_hits() -> list[EvidenceHit]:
+            try:
+                validated_hits = [EvidenceHit.model_validate(hit) for hit in hits]
+            except ValidationError as exc:
+                raise AgentMcpError(
+                    AgentMcpErrorCode.BACKEND_ERROR,
+                    "Invalid rerank hit payload.",
+                    details={"errors": exc.errors()},
+                ) from exc
+            return self.backend.rerank_results(query=query, hits=validated_hits, top_n=top_n)
+
+        return self._call(rerank_validated_hits)

--- a/nemo_retriever/src/nemo_retriever/vdb/operators.py
+++ b/nemo_retriever/src/nemo_retriever/vdb/operators.py
@@ -37,6 +37,17 @@ def _construct_vdb(
     return vdb if vdb is not None else get_vdb_op_cls(str(vdb_op))(**dict(vdb_kwargs or {}))
 
 
+def _vector_or_none(value: Any) -> list[float] | None:
+    if isinstance(value, dict):
+        value = value.get("embedding")
+    if isinstance(value, (list, tuple)) and value:
+        try:
+            return [float(x) for x in value]
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
 def query_vectors_from_embedded_dataframe(df: pd.DataFrame) -> list[list[float]]:
     """Extract one query vector per row from batch-embed output (metadata or payload columns)."""
     vectors: list[list[float]] = []
@@ -44,23 +55,19 @@ def query_vectors_from_embedded_dataframe(df: pd.DataFrame) -> list[list[float]]
         vec: list[float] | None = None
         md = row.get("metadata")
         if isinstance(md, dict):
-            emb = md.get("embedding")
-            if isinstance(emb, list) and emb:
-                vec = [float(x) for x in emb]
+            vec = _vector_or_none(md)
         if vec is None:
             for col in df.columns:
                 if col == "metadata":
                     continue
                 val = row.get(col)
-                if isinstance(val, dict):
-                    inner = val.get("embedding")
-                    if isinstance(inner, list) and inner:
-                        vec = [float(x) for x in inner]
-                        break
+                vec = _vector_or_none(val)
+                if vec is not None:
+                    break
         if vec is None:
             raise ValueError(
-                "Expected query embeddings in each row's metadata['embedding'] or a payload column "
-                f"with key 'embedding'; columns={list(df.columns)}"
+                "Expected query embeddings in each row's metadata['embedding'], a payload column "
+                f"with key 'embedding', or a payload vector column; columns={list(df.columns)}"
             )
         vectors.append(vec)
     return vectors

--- a/nemo_retriever/tests/test_agent_mcp_backend.py
+++ b/nemo_retriever/tests/test_agent_mcp_backend.py
@@ -1,0 +1,235 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from nemo_retriever.agent_mcp.backend import InProcessRetrieverBackend
+from nemo_retriever.agent_mcp.models import AgentMcpError, AgentMcpErrorCode, EvidenceArtifacts, EvidenceHit, Locator
+from nemo_retriever.agent_mcp.paths import PathPolicy
+from nemo_retriever.agent_mcp.registry import CollectionRegistry
+
+
+class FakeRetriever:
+    constructor_kwargs: list[dict[str, Any]] = []
+    query_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.constructor_kwargs.append(kwargs)
+
+    def query(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+        self.query_calls.append((query, kwargs))
+        return [
+            {
+                "text": "A normalized answer.",
+                "_distance": "0.42",
+                "source": json.dumps({"source_id": "/tmp/source.pdf"}),
+                "metadata": json.dumps({"page_number": "3", "content_type": "text"}),
+            }
+        ]
+
+
+class HybridUnsupportedRetriever(FakeRetriever):
+    def query(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+        raise NotImplementedError("hybrid is not supported")
+
+
+def _backend(tmp_path: Path, **kwargs: Any) -> InProcessRetrieverBackend:
+    FakeRetriever.constructor_kwargs = []
+    FakeRetriever.query_calls = []
+    registry = CollectionRegistry(tmp_path / "registry.sqlite", data_root=tmp_path)
+    retriever_factory = kwargs.pop("retriever_factory", FakeRetriever)
+    return InProcessRetrieverBackend(
+        registry,
+        path_policy=PathPolicy(allowed_roots=[tmp_path]),
+        retriever_factory=retriever_factory,
+        **kwargs,
+    )
+
+
+def test_query_collection_uses_collection_embedding_and_vdb_config(tmp_path: Path) -> None:
+    backend = _backend(tmp_path)
+    record = backend.create_collection("docs")
+    record = backend.registry.mark_collection_queryable(record.name, row_count=1)
+
+    hits = backend.query_collection(collection="docs", query="what is here?", top_k=3)
+
+    assert hits[0].text == "A normalized answer."
+    assert hits[0].score == 0.42
+    assert hits[0].locator.page_number == 3
+
+    kwargs = FakeRetriever.constructor_kwargs[0]
+    assert kwargs["vdb"] == record.vdb_backend
+    assert kwargs["embedder"] == record.embedding_model
+    assert kwargs["vdb_kwargs"]["uri"] == record.vdb_uri
+    assert kwargs["vdb_kwargs"]["table_name"] == record.vdb_table
+    assert FakeRetriever.query_calls == [("what is here?", {"top_k": 3, "vdb_kwargs": None})]
+
+
+def test_query_rejects_unqueryable_collection(tmp_path: Path) -> None:
+    backend = _backend(tmp_path)
+    backend.create_collection("docs")
+
+    with pytest.raises(AgentMcpError) as exc:
+        backend.query_collection(collection="docs", query="not yet")
+
+    assert exc.value.code is AgentMcpErrorCode.COLLECTION_NOT_QUERYABLE
+
+
+def test_query_rejects_hybrid_when_collection_is_not_hybrid(tmp_path: Path) -> None:
+    backend = _backend(tmp_path)
+    backend.create_collection("docs", hybrid=False)
+    backend.registry.mark_collection_queryable("docs")
+
+    with pytest.raises(AgentMcpError) as exc:
+        backend.query_collection(collection="docs", query="hybrid please", hybrid=True)
+
+    assert exc.value.code is AgentMcpErrorCode.HYBRID_NOT_AVAILABLE
+
+
+def test_query_sets_reranker_flag_when_requested(tmp_path: Path) -> None:
+    backend = _backend(tmp_path)
+    backend.create_collection("docs")
+    backend.registry.mark_collection_queryable("docs")
+
+    backend.query_collection(collection="docs", query="rerank it", rerank=True)
+
+    assert FakeRetriever.constructor_kwargs[0]["reranker"] is True
+
+
+def test_query_forwards_hybrid_flag_for_hybrid_collection(tmp_path: Path) -> None:
+    backend = _backend(tmp_path)
+    backend.create_collection("docs", hybrid=True)
+    backend.registry.mark_collection_queryable("docs")
+
+    backend.query_collection(collection="docs", query="hybrid please", hybrid=True)
+
+    assert FakeRetriever.query_calls == [("hybrid please", {"top_k": 10, "vdb_kwargs": {"hybrid": True}})]
+
+
+def test_query_translates_hybrid_not_implemented(tmp_path: Path) -> None:
+    backend = _backend(tmp_path, retriever_factory=HybridUnsupportedRetriever)
+    backend.create_collection("docs", hybrid=True)
+    backend.registry.mark_collection_queryable("docs")
+
+    with pytest.raises(AgentMcpError) as exc:
+        backend.query_collection(collection="docs", query="hybrid please", hybrid=True)
+
+    assert exc.value.code is AgentMcpErrorCode.HYBRID_NOT_AVAILABLE
+
+
+def test_query_forwards_filters(tmp_path: Path) -> None:
+    backend = _backend(tmp_path)
+    backend.create_collection("docs")
+    backend.registry.mark_collection_queryable("docs")
+
+    backend.query_collection(collection="docs", query="filtered", filters={"tenant": "a"})
+
+    assert FakeRetriever.query_calls == [("filtered", {"top_k": 10, "vdb_kwargs": {"tenant": "a"}})]
+
+
+def test_standalone_rerank_results_uses_injected_reranker(tmp_path: Path) -> None:
+    rerank_calls = []
+
+    def fake_rerank(query: str, hits: list[dict[str, Any]], *, top_n: int | None = None) -> list[dict[str, Any]]:
+        rerank_calls.append((query, hits, top_n))
+        return [{**hits[0], "_rerank_score": 0.99}]
+
+    backend = _backend(tmp_path, rerank_fn=fake_rerank)
+    hit = EvidenceHit(text="candidate", score=0.1, source_path="/tmp/source.pdf")
+
+    reranked = backend.rerank_results("best one?", [hit], top_n=1)
+
+    assert rerank_calls[0][0] == "best one?"
+    assert rerank_calls[0][1][0]["text"] == "candidate"
+    assert rerank_calls[0][1][0]["source_path"] == "/tmp/source.pdf"
+    assert rerank_calls[0][1][0]["path"] == "/tmp/source.pdf"
+    assert rerank_calls[0][2] == 1
+    assert reranked[0].text == "candidate"
+    assert reranked[0].score == 0.99
+
+
+def test_default_standalone_rerank_uses_supplied_reranker_model(tmp_path: Path) -> None:
+    class FakeRerankerModel:
+        model_name = "nvidia/llama-nemotron-rerank-1b-v2"
+
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def score(
+            self,
+            query: str,
+            documents: list[str],
+            *,
+            max_length: int,
+            batch_size: int,
+        ) -> list[float]:
+            self.calls.append(
+                {
+                    "query": query,
+                    "documents": documents,
+                    "max_length": max_length,
+                    "batch_size": batch_size,
+                }
+            )
+            return [0.77]
+
+    model = FakeRerankerModel()
+    backend = _backend(tmp_path, reranker_model=model, reranker_max_length=128, reranker_batch_size=2)
+
+    reranked = backend.rerank_results("best one?", [EvidenceHit(text="candidate")], top_n=1)
+
+    assert model.calls == [
+        {
+            "query": "best one?",
+            "documents": ["candidate"],
+            "max_length": 128,
+            "batch_size": 2,
+        }
+    ]
+    assert reranked[0].score == 0.77
+
+
+def test_standalone_rerank_preserves_evidence_fields(tmp_path: Path) -> None:
+    def fake_rerank(query: str, hits: list[dict[str, Any]], *, top_n: int | None = None) -> list[dict[str, Any]]:
+        return [{**hits[0], "_rerank_score": 0.99}]
+
+    backend = _backend(tmp_path, rerank_fn=fake_rerank)
+    hit = EvidenceHit(
+        text="candidate",
+        score=0.1,
+        source_path="/tmp/source.pdf",
+        content_type="text",
+        locator=Locator(
+            page_number=7,
+            timestamp_start_s=1.25,
+            timestamp_end_s=2.5,
+            frame_index=3,
+            bbox_xyxy_norm=[0.1, 0.2, 0.8, 0.9],
+        ),
+        artifacts=EvidenceArtifacts(
+            stored_image_uri="file:///tmp/page.png",
+            thumbnail_uri="file:///tmp/thumb.png",
+        ),
+        metadata={"section": "intro"},
+    )
+
+    reranked = backend.rerank_results("best one?", [hit], top_n=1)
+
+    assert reranked[0].score == 0.99
+    assert reranked[0].source_path == "/tmp/source.pdf"
+    assert reranked[0].content_type == "text"
+    assert reranked[0].locator.page_number == 7
+    assert reranked[0].locator.timestamp_start_s == 1.25
+    assert reranked[0].locator.timestamp_end_s == 2.5
+    assert reranked[0].locator.frame_index == 3
+    assert reranked[0].locator.bbox_xyxy_norm == [0.1, 0.2, 0.8, 0.9]
+    assert reranked[0].artifacts.stored_image_uri == "file:///tmp/page.png"
+    assert reranked[0].artifacts.thumbnail_uri == "file:///tmp/thumb.png"
+    assert reranked[0].metadata["section"] == "intro"

--- a/nemo_retriever/tests/test_agent_mcp_backend.py
+++ b/nemo_retriever/tests/test_agent_mcp_backend.py
@@ -137,10 +137,11 @@ def test_query_collection_uses_collection_embedding_and_vdb_config(tmp_path: Pat
     assert hits[0].locator.page_number == 3
 
     kwargs = FakeRetriever.constructor_kwargs[0]
-    assert kwargs["vdb"] == record.vdb_backend
-    assert kwargs["embedder"] == record.embedding_model
-    assert kwargs["vdb_kwargs"]["uri"] == record.vdb_uri
-    assert kwargs["vdb_kwargs"]["table_name"] == record.vdb_table
+    assert kwargs["vdb_kwargs"]["vdb_op"] == record.vdb_backend
+    assert kwargs["vdb_kwargs"]["vdb_kwargs"]["uri"] == record.vdb_uri
+    assert kwargs["vdb_kwargs"]["vdb_kwargs"]["table_name"] == record.vdb_table
+    assert kwargs["embed_kwargs"]["model_name"] == record.embedding_model
+    assert kwargs["embed_kwargs"]["embed_model_name"] == record.embedding_model
     assert FakeRetriever.query_calls == [("what is here?", {"top_k": 3, "vdb_kwargs": None})]
 
 
@@ -344,7 +345,7 @@ def test_query_sets_reranker_flag_when_requested(tmp_path: Path) -> None:
 
     backend.query_collection(collection="docs", query="rerank it", rerank=True)
 
-    assert FakeRetriever.constructor_kwargs[0]["reranker"] is True
+    assert FakeRetriever.constructor_kwargs[0]["rerank"] is True
 
 
 def test_query_forwards_hybrid_flag_for_hybrid_collection(tmp_path: Path) -> None:

--- a/nemo_retriever/tests/test_agent_mcp_backend.py
+++ b/nemo_retriever/tests/test_agent_mcp_backend.py
@@ -11,7 +11,14 @@ from typing import Any
 import pytest
 
 from nemo_retriever.agent_mcp.backend import InProcessRetrieverBackend
-from nemo_retriever.agent_mcp.models import AgentMcpError, AgentMcpErrorCode, EvidenceArtifacts, EvidenceHit, Locator
+from nemo_retriever.agent_mcp.models import (
+    AgentMcpError,
+    AgentMcpErrorCode,
+    EvidenceArtifacts,
+    EvidenceHit,
+    JobStatus,
+    Locator,
+)
 from nemo_retriever.agent_mcp.paths import PathPolicy
 from nemo_retriever.agent_mcp.registry import CollectionRegistry
 
@@ -40,6 +47,63 @@ class HybridUnsupportedRetriever(FakeRetriever):
         raise NotImplementedError("hybrid is not supported")
 
 
+class FakeIngestor:
+    calls: list[tuple[str, Any]] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.constructor_kwargs = kwargs
+        self.current_files: list[str] = []
+        self.calls.append(("init", kwargs))
+
+    def files(self, files: list[str]) -> "FakeIngestor":
+        self.current_files = files
+        self.calls.append(("files", files))
+        return self
+
+    def extract(self) -> "FakeIngestor":
+        self.calls.append(("extract", list(self.current_files)))
+        return self
+
+    def extract_image_files(self) -> "FakeIngestor":
+        self.calls.append(("extract_image_files", list(self.current_files)))
+        return self
+
+    def extract_txt(self) -> "FakeIngestor":
+        self.calls.append(("extract_txt", list(self.current_files)))
+        return self
+
+    def extract_html(self) -> "FakeIngestor":
+        self.calls.append(("extract_html", list(self.current_files)))
+        return self
+
+    def extract_audio(self) -> "FakeIngestor":
+        self.calls.append(("extract_audio", list(self.current_files)))
+        return self
+
+    def extract_video(self) -> "FakeIngestor":
+        self.calls.append(("extract_video", list(self.current_files)))
+        return self
+
+    def embed(self, **kwargs: Any) -> "FakeIngestor":
+        self.calls.append(("embed", kwargs))
+        return self
+
+    def store(self, **kwargs: Any) -> "FakeIngestor":
+        self.calls.append(("store", kwargs))
+        return self
+
+    def ingest(self) -> list[dict[str, Any]]:
+        result = [{"path": path} for path in self.current_files]
+        self.calls.append(("ingest", result))
+        return result
+
+
+class FailingTextIngestor(FakeIngestor):
+    def extract_txt(self) -> "FakeIngestor":
+        self.calls.append(("extract_txt", list(self.current_files)))
+        raise RuntimeError("text extraction failed")
+
+
 def _backend(tmp_path: Path, **kwargs: Any) -> InProcessRetrieverBackend:
     FakeRetriever.constructor_kwargs = []
     FakeRetriever.query_calls = []
@@ -51,6 +115,13 @@ def _backend(tmp_path: Path, **kwargs: Any) -> InProcessRetrieverBackend:
         retriever_factory=retriever_factory,
         **kwargs,
     )
+
+
+def _ingest_backend(tmp_path: Path, **kwargs: Any) -> InProcessRetrieverBackend:
+    FakeIngestor.calls = []
+    backend = _backend(tmp_path, ingestor_factory=FakeIngestor, **kwargs)
+    backend._upload_records = lambda record, result, **kwargs: None
+    return backend
 
 
 def test_query_collection_uses_collection_embedding_and_vdb_config(tmp_path: Path) -> None:
@@ -70,6 +141,132 @@ def test_query_collection_uses_collection_embedding_and_vdb_config(tmp_path: Pat
     assert kwargs["vdb_kwargs"]["uri"] == record.vdb_uri
     assert kwargs["vdb_kwargs"]["table_name"] == record.vdb_table
     assert FakeRetriever.query_calls == [("what is here?", {"top_k": 3, "vdb_kwargs": None})]
+
+
+def test_ingest_local_paths_starts_job_and_marks_collection_queryable(tmp_path: Path) -> None:
+    backend = _ingest_backend(tmp_path)
+    doc = tmp_path / "manual.pdf"
+    doc.write_text("pdf-ish")
+
+    job = backend.ingest_local_paths("docs", [doc], wait=True)
+
+    assert job.status is JobStatus.COMPLETE
+    assert job.source_count == 1
+    assert job.accepted_count == 1
+    assert job.skipped_count == 0
+    assert backend.registry.get_collection("docs").queryable is True
+    assert ("extract", [str(doc.resolve())]) in FakeIngestor.calls
+
+
+def test_ingest_groups_media_types(tmp_path: Path) -> None:
+    backend = _ingest_backend(tmp_path)
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    txt = docs_dir / "notes.txt"
+    pdf = docs_dir / "paper.pdf"
+    mp4 = docs_dir / "clip.mp4"
+    for path in (mp4, txt, pdf):
+        path.write_text("content")
+
+    job = backend.ingest_local_paths("docs", [docs_dir], wait=True)
+
+    assert job.status is JobStatus.COMPLETE
+    assert job.accepted_count == 3
+    extraction_calls = [(name, value) for name, value in FakeIngestor.calls if name.startswith("extract")]
+    assert extraction_calls == [
+        ("extract", [str(pdf.resolve())]),
+        ("extract_txt", [str(txt.resolve())]),
+        ("extract_video", [str(mp4.resolve())]),
+    ]
+
+
+def test_ingest_uploads_first_media_group_with_overwrite_then_appends(tmp_path: Path) -> None:
+    backend = _ingest_backend(tmp_path)
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    for filename in ("paper.pdf", "notes.txt", "clip.mp4"):
+        (docs_dir / filename).write_text("content")
+    overwrite_flags: list[bool] = []
+
+    def fake_upload(record: Any, result: Any, *, overwrite: bool) -> None:
+        overwrite_flags.append(overwrite)
+
+    backend._upload_records = fake_upload
+
+    job = backend.ingest_local_paths("docs", [docs_dir], wait=True)
+
+    assert job.status is JobStatus.COMPLETE
+    assert overwrite_flags == [True, False, False]
+
+
+def test_ingest_appends_from_first_group_for_queryable_collection(tmp_path: Path) -> None:
+    backend = _ingest_backend(tmp_path)
+    backend.create_collection("docs")
+    backend.registry.mark_collection_queryable("docs", row_count=3)
+    doc = tmp_path / "manual.pdf"
+    doc.write_text("pdf-ish")
+    overwrite_flags: list[bool] = []
+
+    def fake_upload(record: Any, result: Any, *, overwrite: bool) -> None:
+        overwrite_flags.append(overwrite)
+
+    backend._upload_records = fake_upload
+
+    job = backend.ingest_local_paths("docs", [doc], wait=True)
+
+    assert job.status is JobStatus.COMPLETE
+    assert overwrite_flags == [False]
+
+
+def test_ingest_with_skipped_files_finishes_partial_with_warnings(tmp_path: Path) -> None:
+    backend = _ingest_backend(tmp_path)
+    doc = tmp_path / "manual.pdf"
+    unsupported = tmp_path / "notes.bin"
+    doc.write_text("pdf-ish")
+    unsupported.write_text("unsupported")
+
+    job = backend.ingest_local_paths("docs", [doc, unsupported], wait=True)
+
+    assert job.status is JobStatus.PARTIAL
+    assert job.accepted_count == 1
+    assert job.skipped_count == 1
+    assert job.warnings[0]["path"] == str(unsupported.resolve())
+    assert job.warnings[0]["code"] == AgentMcpErrorCode.UNSUPPORTED_MEDIA_TYPE.value
+    assert backend.registry.get_collection("docs").queryable is True
+
+
+def test_ingest_skipped_only_finishes_partial_without_marking_queryable(tmp_path: Path) -> None:
+    backend = _ingest_backend(tmp_path)
+    unsupported = tmp_path / "notes.bin"
+    unsupported.write_text("unsupported")
+
+    job = backend.ingest_local_paths("docs", [unsupported], wait=True)
+
+    assert job.status is JobStatus.PARTIAL
+    assert job.accepted_count == 0
+    assert job.skipped_count == 1
+    assert backend.registry.get_collection("docs").queryable is False
+    assert [name for name, _value in FakeIngestor.calls if name.startswith("extract")] == []
+
+
+def test_ingest_failure_after_success_finishes_partial_and_reraises(tmp_path: Path) -> None:
+    FakeIngestor.calls = []
+    backend = _backend(tmp_path, ingestor_factory=FailingTextIngestor)
+    backend._upload_records = lambda record, result, **kwargs: None
+    pdf = tmp_path / "paper.pdf"
+    txt = tmp_path / "notes.txt"
+    pdf.write_text("pdf-ish")
+    txt.write_text("text")
+
+    with pytest.raises(RuntimeError, match="text extraction failed"):
+        backend.ingest_local_paths("docs", [pdf, txt], wait=True)
+
+    job = backend.registry.list_jobs("docs")[0]
+    assert job.status is JobStatus.PARTIAL
+    assert job.accepted_count == 1
+    assert job.row_count == 1
+    assert job.errors[0]["code"] == AgentMcpErrorCode.BACKEND_ERROR.value
+    assert backend.registry.get_collection("docs").queryable is True
 
 
 def test_query_rejects_unqueryable_collection(tmp_path: Path) -> None:

--- a/nemo_retriever/tests/test_agent_mcp_backend.py
+++ b/nemo_retriever/tests/test_agent_mcp_backend.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from threading import Event
 from typing import Any
 
 import pytest
@@ -218,6 +219,35 @@ def test_ingest_appends_from_first_group_for_queryable_collection(tmp_path: Path
     assert overwrite_flags == [False]
 
 
+def test_concurrent_ingests_append_after_first_empty_collection_write(tmp_path: Path) -> None:
+    backend = _ingest_backend(tmp_path, max_workers=2)
+    first = tmp_path / "first.pdf"
+    second = tmp_path / "second.pdf"
+    first.write_text("first")
+    second.write_text("second")
+    upload_started = Event()
+    release_first_upload = Event()
+    overwrite_flags: list[bool] = []
+
+    def fake_upload(record: Any, result: Any, *, overwrite: bool) -> None:
+        overwrite_flags.append(overwrite)
+        if len(overwrite_flags) == 1:
+            upload_started.set()
+            release_first_upload.wait(timeout=5)
+
+    backend._upload_records = fake_upload
+
+    first_job = backend.start_ingestion("docs", [first])
+    assert upload_started.wait(timeout=5)
+    second_job = backend.start_ingestion("docs", [second])
+    release_first_upload.set()
+
+    backend._futures[first_job.job_id].result(timeout=5)
+    backend._futures[second_job.job_id].result(timeout=5)
+
+    assert overwrite_flags == [True, False]
+
+
 def test_ingest_with_skipped_files_finishes_partial_with_warnings(tmp_path: Path) -> None:
     backend = _ingest_backend(tmp_path)
     doc = tmp_path / "manual.pdf"
@@ -249,7 +279,7 @@ def test_ingest_skipped_only_finishes_partial_without_marking_queryable(tmp_path
     assert [name for name, _value in FakeIngestor.calls if name.startswith("extract")] == []
 
 
-def test_ingest_failure_after_success_finishes_partial_and_reraises(tmp_path: Path) -> None:
+def test_ingest_failure_after_success_returns_partial_job_status(tmp_path: Path) -> None:
     FakeIngestor.calls = []
     backend = _backend(tmp_path, ingestor_factory=FailingTextIngestor)
     backend._upload_records = lambda record, result, **kwargs: None
@@ -258,15 +288,32 @@ def test_ingest_failure_after_success_finishes_partial_and_reraises(tmp_path: Pa
     pdf.write_text("pdf-ish")
     txt.write_text("text")
 
-    with pytest.raises(RuntimeError, match="text extraction failed"):
-        backend.ingest_local_paths("docs", [pdf, txt], wait=True)
+    job = backend.ingest_local_paths("docs", [pdf, txt], wait=True)
 
-    job = backend.registry.list_jobs("docs")[0]
     assert job.status is JobStatus.PARTIAL
     assert job.accepted_count == 1
     assert job.row_count == 1
     assert job.errors[0]["code"] == AgentMcpErrorCode.BACKEND_ERROR.value
     assert backend.registry.get_collection("docs").queryable is True
+
+
+def test_ingest_wait_timeout_returns_current_job_status(tmp_path: Path) -> None:
+    backend = _ingest_backend(tmp_path)
+    doc = tmp_path / "manual.pdf"
+    doc.write_text("pdf-ish")
+    release_upload = Event()
+
+    def fake_upload(record: Any, result: Any, *, overwrite: bool) -> None:
+        release_upload.wait(timeout=5)
+
+    backend._upload_records = fake_upload
+
+    job = backend.ingest_local_paths("docs", [doc], wait=True, timeout_s=0.01)
+
+    assert job.status in {JobStatus.QUEUED, JobStatus.RUNNING}
+    release_upload.set()
+    backend._futures[job.job_id].result(timeout=5)
+    assert backend.get_ingestion_status(job.job_id).status is JobStatus.COMPLETE
 
 
 def test_query_rejects_unqueryable_collection(tmp_path: Path) -> None:

--- a/nemo_retriever/tests/test_agent_mcp_cli.py
+++ b/nemo_retriever/tests/test_agent_mcp_cli.py
@@ -32,6 +32,27 @@ def test_agent_mcp_help_runs_via_package_module(tmp_path: Path) -> None:
     assert "Start the NeMo Retriever agent MCP server" in result.stdout
 
 
+def test_agent_mcp_start_requires_allowed_root(tmp_path: Path) -> None:
+    with (
+        patch("nemo_retriever.agent_mcp.cli.build_asgi_app") as build_app,
+        patch("nemo_retriever.agent_mcp.cli.uvicorn.run") as run,
+    ):
+        result = CliRunner().invoke(
+            app,
+            [
+                "agent-mcp",
+                "start",
+                "--data-root",
+                str(tmp_path / "mcp"),
+            ],
+        )
+
+    assert result.exit_code != 0
+    assert "At least one --allowed-root is required" in result.output
+    build_app.assert_not_called()
+    run.assert_not_called()
+
+
 def test_agent_mcp_start_builds_app_and_runs_uvicorn(tmp_path: Path) -> None:
     application = object()
     data_root = tmp_path / "mcp"

--- a/nemo_retriever/tests/test_agent_mcp_cli.py
+++ b/nemo_retriever/tests/test_agent_mcp_cli.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from nemo_retriever.adapters.cli.main import app
+
+
+def test_agent_mcp_command_is_registered() -> None:
+    result = CliRunner().invoke(app, ["agent-mcp", "--help"])
+
+    assert result.exit_code == 0
+    assert "Start the NeMo Retriever agent MCP server" in result.output
+
+
+def test_agent_mcp_start_builds_app_and_runs_uvicorn(tmp_path: Path) -> None:
+    application = object()
+    data_root = tmp_path / "mcp"
+
+    with (
+        patch("nemo_retriever.agent_mcp.cli.build_asgi_app", return_value=application) as build_app,
+        patch("nemo_retriever.agent_mcp.cli.uvicorn.run") as run,
+    ):
+        result = CliRunner().invoke(
+            app,
+            [
+                "agent-mcp",
+                "start",
+                "--data-root",
+                str(data_root),
+                "--allowed-root",
+                str(tmp_path),
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "8099",
+            ],
+        )
+
+    assert result.exit_code == 0
+    build_app.assert_called_once_with(data_root=data_root, allowed_roots=[tmp_path])
+    run.assert_called_once_with(application, host="127.0.0.1", port=8099, log_level="info")

--- a/nemo_retriever/tests/test_agent_mcp_cli.py
+++ b/nemo_retriever/tests/test_agent_mcp_cli.py
@@ -2,6 +2,8 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -15,6 +17,19 @@ def test_agent_mcp_command_is_registered() -> None:
 
     assert result.exit_code == 0
     assert "Start the NeMo Retriever agent MCP server" in result.output
+
+
+def test_agent_mcp_help_runs_via_package_module(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "nemo_retriever", "agent-mcp", "--help"],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "Start the NeMo Retriever agent MCP server" in result.stdout
 
 
 def test_agent_mcp_start_builds_app_and_runs_uvicorn(tmp_path: Path) -> None:

--- a/nemo_retriever/tests/test_agent_mcp_evidence.py
+++ b/nemo_retriever/tests/test_agent_mcp_evidence.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+from nemo_retriever.agent_mcp.evidence import normalize_hit, normalize_hits
+
+
+def test_normalizes_document_hit_with_json_source_and_metadata() -> None:
+    hit = {
+        "text": "A policy document excerpt.",
+        "_distance": "0.42",
+        "source": json.dumps({"source_id": "/data/policy.pdf"}),
+        "metadata": json.dumps({"page_number": "7", "content_type": "text"}),
+    }
+
+    evidence = normalize_hit(hit)
+
+    assert evidence.text == "A policy document excerpt."
+    assert evidence.score == 0.42
+    assert evidence.source_path == "/data/policy.pdf"
+    assert evidence.media_type == "document"
+    assert evidence.content_type == "text"
+    assert evidence.locator.page_number == 7
+
+
+def test_normalizes_video_hit_with_artifact_and_locator_metadata() -> None:
+    hit = {
+        "text": "Speaker explains the demo.",
+        "_rerank_score": 0.91,
+        "path": "/data/demo.mp4",
+        "content_type": "transcript",
+        "stored_image_uri": "file:///artifacts/demo-frame.jpg",
+        "metadata": {
+            "segment_start_seconds": "12.5",
+            "segment_end_seconds": 15,
+            "frame_index": "30",
+        },
+    }
+
+    evidence = normalize_hit(hit)
+
+    assert evidence.score == 0.91
+    assert evidence.source_path == "/data/demo.mp4"
+    assert evidence.media_type == "video"
+    assert evidence.content_type == "transcript"
+    assert evidence.locator.timestamp_start_s == 12.5
+    assert evidence.locator.timestamp_end_s == 15.0
+    assert evidence.locator.frame_index == 30
+    assert evidence.artifacts.stored_image_uri == "file:///artifacts/demo-frame.jpg"
+
+
+def test_normalize_hits_preserves_order() -> None:
+    hits = [
+        {"text": "first", "source_path": "/data/first.pdf"},
+        {"text": "second", "source_path": "/data/second.mp4"},
+        {"text": "third", "source_path": "/data/third.png"},
+    ]
+
+    evidence = normalize_hits(hits)
+
+    assert [hit.text for hit in evidence] == ["first", "second", "third"]
+
+
+def test_malformed_numeric_values_normalize_to_none() -> None:
+    hit = {
+        "text": "bad numeric fields",
+        "_rerank_score": "nan",
+        "score": "0.9",
+        "metadata": {
+            "timestamp_start_s": "inf",
+            "timestamp_end_s": "1e309",
+            "page_number": float("inf"),
+            "frame_index": "nan",
+        },
+    }
+
+    evidence = normalize_hit(hit)
+
+    assert evidence.score is None
+    assert evidence.locator.timestamp_start_s is None
+    assert evidence.locator.timestamp_end_s is None
+    assert evidence.locator.page_number is None
+    assert evidence.locator.frame_index is None
+
+
+def test_string_bbox_normalizes_to_floats() -> None:
+    hit = {
+        "text": "bbox",
+        "metadata": {"bbox_xyxy_norm": "[0, 0.25, \"0.75\", 1]"},
+    }
+
+    evidence = normalize_hit(hit)
+
+    assert evidence.locator.bbox_xyxy_norm == [0.0, 0.25, 0.75, 1.0]
+
+
+def test_malformed_bbox_normalizes_to_none() -> None:
+    hit = {"text": "bad bbox", "metadata": {"bbox_xyxy_norm": ["bad"]}}
+
+    evidence = normalize_hit(hit)
+
+    assert evidence.locator.bbox_xyxy_norm is None
+
+
+def test_wrong_arity_bbox_normalizes_to_none() -> None:
+    short_bbox = normalize_hit({"text": "short bbox", "metadata": {"bbox_xyxy_norm": [0, 1]}})
+    long_string_bbox = normalize_hit({"text": "long bbox", "metadata": {"bbox_xyxy_norm": "[0, 0.25, 0.75, 1, 2]"}})
+
+    assert short_bbox.locator.bbox_xyxy_norm is None
+    assert long_string_bbox.locator.bbox_xyxy_norm is None

--- a/nemo_retriever/tests/test_agent_mcp_models.py
+++ b/nemo_retriever/tests/test_agent_mcp_models.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from nemo_retriever.agent_mcp.models import (
+    AgentMcpError,
+    AgentMcpErrorCode,
+    CollectionRecord,
+    CollectionStatus,
+    EvidenceHit,
+    IngestJobRecord,
+    JobStatus,
+    Locator,
+)
+
+
+def test_agent_mcp_error_serializes_actionable_payload() -> None:
+    err = AgentMcpError(
+        AgentMcpErrorCode.COLLECTION_NOT_FOUND,
+        "Collection 'docs' was not found.",
+        retryable=False,
+        details={"collection": "docs"},
+    )
+
+    assert err.to_dict() == {
+        "code": "COLLECTION_NOT_FOUND",
+        "message": "Collection 'docs' was not found.",
+        "retryable": False,
+        "details": {"collection": "docs"},
+    }
+    assert "COLLECTION_NOT_FOUND" in str(err)
+
+
+def test_collection_record_defaults_to_unqueryable_lancedb_collection() -> None:
+    record = CollectionRecord(name="default", root_path="/tmp/mcp/collections/default")
+
+    assert record.name == "default"
+    assert record.backend == "inprocess"
+    assert record.vdb_backend == "lancedb"
+    assert record.vdb_table == "nv-ingest"
+    assert record.status is CollectionStatus.EMPTY
+    assert record.queryable is False
+
+
+def test_ingest_job_record_tracks_partial_success() -> None:
+    job = IngestJobRecord(
+        job_id="job-1",
+        collection="default",
+        status=JobStatus.PARTIAL,
+        source_count=3,
+        accepted_count=2,
+        skipped_count=1,
+        errors=[{"path": "/tmp/bad.xyz", "code": "UNSUPPORTED_MEDIA_TYPE"}],
+    )
+
+    assert job.status is JobStatus.PARTIAL
+    assert job.accepted_count == 2
+    assert job.errors[0]["code"] == "UNSUPPORTED_MEDIA_TYPE"
+
+
+def test_evidence_hit_uses_sparse_locator_fields() -> None:
+    hit = EvidenceHit(
+        text="transcript text",
+        score=0.12,
+        source_path="/data/video.mp4",
+        media_type="video",
+        content_type="transcript",
+        locator=Locator(timestamp_start_s=4.0, timestamp_end_s=7.5),
+    )
+
+    payload = hit.model_dump(exclude_none=True)
+    assert payload["locator"] == {"timestamp_start_s": 4.0, "timestamp_end_s": 7.5}
+    assert "page_number" not in payload["locator"]

--- a/nemo_retriever/tests/test_agent_mcp_paths.py
+++ b/nemo_retriever/tests/test_agent_mcp_paths.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nemo_retriever.agent_mcp.models import AgentMcpError, AgentMcpErrorCode
+from nemo_retriever.agent_mcp.paths import (
+    PathPolicy,
+    expand_local_paths,
+    group_paths_by_media_type,
+    media_type_for_path,
+)
+
+
+def test_rejects_files_outside_allowed_root(tmp_path: Path) -> None:
+    allowed_root = tmp_path / "allowed"
+    outside_root = tmp_path / "outside"
+    allowed_root.mkdir()
+    outside_root.mkdir()
+    outside_file = outside_root / "escape.pdf"
+    outside_file.write_text("pdf", encoding="utf-8")
+
+    with pytest.raises(AgentMcpError) as exc:
+        expand_local_paths([outside_file], policy=PathPolicy(allowed_roots=[allowed_root]))
+
+    assert exc.value.code is AgentMcpErrorCode.PATH_OUTSIDE_ALLOWED_ROOT
+
+
+def test_missing_outside_allowed_root_is_rejected_before_not_found(tmp_path: Path) -> None:
+    allowed_root = tmp_path / "allowed"
+    allowed_root.mkdir()
+    missing_outside_file = tmp_path / "outside" / "missing.pdf"
+
+    with pytest.raises(AgentMcpError) as exc:
+        expand_local_paths([missing_outside_file], policy=PathPolicy(allowed_roots=[allowed_root]))
+
+    assert exc.value.code is AgentMcpErrorCode.PATH_OUTSIDE_ALLOWED_ROOT
+
+
+def test_resolves_symlinks_before_allowed_root_checks(tmp_path: Path) -> None:
+    allowed_root = tmp_path / "allowed"
+    outside_root = tmp_path / "outside"
+    allowed_root.mkdir()
+    outside_root.mkdir()
+    outside_file = outside_root / "escape.pdf"
+    outside_file.write_text("pdf", encoding="utf-8")
+    symlink = allowed_root / "linked.pdf"
+    symlink.symlink_to(outside_file)
+
+    with pytest.raises(AgentMcpError) as exc:
+        expand_local_paths([symlink], policy=PathPolicy(allowed_roots=[allowed_root]))
+
+    assert exc.value.code is AgentMcpErrorCode.PATH_OUTSIDE_ALLOWED_ROOT
+
+
+def test_expands_directory_collecting_supported_files_and_skipping_unsupported(tmp_path: Path) -> None:
+    root = tmp_path / "docs"
+    nested = root / "nested"
+    nested.mkdir(parents=True)
+    pdf = root / "manual.pdf"
+    png = nested / "diagram.png"
+    unsupported = root / "archive.zip"
+    pdf.write_text("pdf", encoding="utf-8")
+    png.write_bytes(b"png")
+    unsupported.write_bytes(b"zip")
+
+    expanded = expand_local_paths([root], policy=PathPolicy(allowed_roots=[root]))
+
+    assert expanded.files == sorted([pdf.resolve(), png.resolve()])
+    assert expanded.total_bytes == pdf.stat().st_size + png.stat().st_size
+    assert expanded.skipped == [
+        {
+            "path": str(unsupported.resolve()),
+            "code": AgentMcpErrorCode.UNSUPPORTED_MEDIA_TYPE.value,
+        }
+    ]
+
+
+def test_max_files_is_enforced_during_directory_expansion(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "docs"
+    root.mkdir()
+    first = root / "first.pdf"
+    second = root / "second.pdf"
+    third = root / "third.pdf"
+    for path in (first, second, third):
+        path.write_text("pdf", encoding="utf-8")
+    yielded: list[Path] = []
+    original_rglob = Path.rglob
+
+    def tracking_rglob(path: Path, pattern: str):
+        if path == root.resolve():
+            for candidate in (first.resolve(), second.resolve(), third.resolve()):
+                yielded.append(candidate)
+                yield candidate
+            return
+        yield from original_rglob(path, pattern)
+
+    monkeypatch.setattr(Path, "rglob", tracking_rglob)
+
+    with pytest.raises(AgentMcpError) as exc:
+        expand_local_paths([root], policy=PathPolicy(allowed_roots=[root], max_files=1))
+
+    assert exc.value.code is AgentMcpErrorCode.BACKEND_ERROR
+    assert yielded == [first.resolve(), second.resolve()]
+
+
+def test_rejects_remote_uri_strings_before_local_path_checks(tmp_path: Path) -> None:
+    with pytest.raises(AgentMcpError) as exc:
+        expand_local_paths(["https://example.com/doc.pdf"], policy=PathPolicy(allowed_roots=[tmp_path]))
+
+    assert exc.value.code is AgentMcpErrorCode.PATH_NOT_FOUND
+
+
+def test_groups_paths_by_media_type(tmp_path: Path) -> None:
+    paths = [
+        tmp_path / "doc.pdf",
+        tmp_path / "page.html",
+        tmp_path / "note.txt",
+        tmp_path / "audio.mp3",
+        tmp_path / "video.mp4",
+        tmp_path / "image.png",
+    ]
+
+    assert [media_type_for_path(path) for path in paths] == [
+        "document",
+        "html",
+        "text",
+        "audio",
+        "video",
+        "image",
+    ]
+    assert group_paths_by_media_type(paths) == {
+        "document": [paths[0]],
+        "html": [paths[1]],
+        "text": [paths[2]],
+        "audio": [paths[3]],
+        "video": [paths[4]],
+        "image": [paths[5]],
+    }

--- a/nemo_retriever/tests/test_agent_mcp_registry.py
+++ b/nemo_retriever/tests/test_agent_mcp_registry.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nemo_retriever.agent_mcp.models import AgentMcpError, AgentMcpErrorCode, CollectionStatus, JobStatus
+from nemo_retriever.agent_mcp.registry import CollectionRegistry
+
+
+def test_create_and_load_collection(tmp_path: Path) -> None:
+    registry = CollectionRegistry(tmp_path / "registry.sqlite", data_root=tmp_path)
+
+    record = registry.create_collection("docs", temporary=False, hybrid=True)
+    loaded = registry.get_collection("docs")
+
+    assert loaded.name == "docs"
+    assert loaded.root_path == record.root_path
+    assert loaded.vdb_uri.endswith("/collections/docs/lancedb")
+    assert loaded.artifact_root.endswith("/collections/docs/artifacts")
+    assert loaded.hybrid is True
+    assert loaded.queryable is False
+    assert loaded.status is CollectionStatus.EMPTY
+
+
+def test_default_collection_is_lazily_created(tmp_path: Path) -> None:
+    registry = CollectionRegistry(tmp_path / "registry.sqlite", data_root=tmp_path)
+
+    record = registry.get_or_create_collection("default")
+
+    assert record.name == "default"
+    assert registry.list_collections()[0].name == "default"
+
+
+def test_duplicate_collection_raises_structured_error(tmp_path: Path) -> None:
+    registry = CollectionRegistry(tmp_path / "registry.sqlite", data_root=tmp_path)
+    registry.create_collection("docs")
+
+    with pytest.raises(AgentMcpError) as exc:
+        registry.create_collection("docs")
+
+    assert exc.value.code is AgentMcpErrorCode.COLLECTION_ALREADY_EXISTS
+
+
+def test_path_like_collection_names_are_rejected_before_directories_are_created(tmp_path: Path) -> None:
+    registry = CollectionRegistry(tmp_path / "registry.sqlite", data_root=tmp_path)
+
+    invalid_names = [
+        ("../escape", tmp_path / "escape"),
+        (str(tmp_path / "absolute_escape"), tmp_path / "absolute_escape"),
+    ]
+
+    for collection_name, escaped_path in invalid_names:
+        with pytest.raises(AgentMcpError) as exc:
+            registry.create_collection(collection_name)
+
+        assert exc.value.code is AgentMcpErrorCode.PATH_OUTSIDE_ALLOWED_ROOT
+        assert not escaped_path.exists()
+
+    assert registry.list_collections() == []
+
+
+def test_parent_directory_collection_name_is_rejected_without_creating_data_root_artifacts(tmp_path: Path) -> None:
+    registry = CollectionRegistry(tmp_path / "registry.sqlite", data_root=tmp_path)
+
+    with pytest.raises(AgentMcpError) as exc:
+        registry.create_collection("..")
+
+    assert exc.value.code is AgentMcpErrorCode.PATH_OUTSIDE_ALLOWED_ROOT
+    assert not (tmp_path / "lancedb").exists()
+    assert not (tmp_path / "artifacts").exists()
+    assert registry.list_collections() == []
+
+
+def test_update_collection_queryable_state_persists(tmp_path: Path) -> None:
+    registry = CollectionRegistry(tmp_path / "registry.sqlite", data_root=tmp_path)
+    registry.create_collection("docs")
+
+    registry.mark_collection_queryable("docs", row_count=12)
+    loaded = registry.get_collection("docs")
+
+    assert loaded.queryable is True
+    assert loaded.status is CollectionStatus.QUERYABLE
+    assert loaded.metadata["row_count"] == 12
+
+
+def test_job_lifecycle_persists(tmp_path: Path) -> None:
+    registry = CollectionRegistry(tmp_path / "registry.sqlite", data_root=tmp_path)
+    registry.create_collection("docs")
+
+    job = registry.create_job("docs", source_count=3)
+    registry.update_job(job.job_id, status=JobStatus.RUNNING, accepted_count=1)
+    registry.update_job(job.job_id, status=JobStatus.PARTIAL, accepted_count=2, skipped_count=1)
+
+    loaded = registry.get_job(job.job_id)
+    jobs = registry.list_jobs("docs")
+
+    assert loaded.status is JobStatus.PARTIAL
+    assert loaded.accepted_count == 2
+    assert loaded.skipped_count == 1
+    assert jobs[0].job_id == job.job_id
+
+
+def test_update_job_collection_keeps_listing_index_consistent(tmp_path: Path) -> None:
+    registry = CollectionRegistry(tmp_path / "registry.sqlite", data_root=tmp_path)
+    registry.create_collection("docs")
+    registry.create_collection("other")
+
+    job = registry.create_job("docs")
+    registry.update_job(job.job_id, collection="other")
+
+    loaded = registry.get_job(job.job_id)
+    other_jobs = registry.list_jobs("other")
+    docs_jobs = registry.list_jobs("docs")
+
+    assert loaded.collection == "other"
+    assert [listed.job_id for listed in other_jobs] == [job.job_id]
+    assert job.job_id not in {listed.job_id for listed in docs_jobs}
+
+
+def test_update_job_rejects_unknown_collection_move(tmp_path: Path) -> None:
+    registry = CollectionRegistry(tmp_path / "registry.sqlite", data_root=tmp_path)
+    registry.create_collection("docs")
+
+    job = registry.create_job("docs")
+
+    with pytest.raises(AgentMcpError) as exc:
+        registry.update_job(job.job_id, collection="missing")
+
+    loaded = registry.get_job(job.job_id)
+    docs_jobs = registry.list_jobs("docs")
+
+    assert exc.value.code is AgentMcpErrorCode.COLLECTION_NOT_FOUND
+    assert loaded.collection == "docs"
+    assert [listed.job_id for listed in docs_jobs] == [job.job_id]
+
+
+def test_registry_records_reload_from_existing_database(tmp_path: Path) -> None:
+    db_path = tmp_path / "registry.sqlite"
+    registry = CollectionRegistry(db_path, data_root=tmp_path)
+    registry.create_collection("docs", hybrid=True)
+    registry.mark_collection_queryable("docs", row_count=4)
+    job = registry.create_job("docs", source_count=2)
+    registry.update_job(job.job_id, status=JobStatus.COMPLETE, accepted_count=2, row_count=4)
+
+    reloaded = CollectionRegistry(db_path, data_root=tmp_path)
+
+    collection = reloaded.get_collection("docs")
+    loaded_job = reloaded.get_job(job.job_id)
+
+    assert collection.hybrid is True
+    assert collection.queryable is True
+    assert collection.metadata["row_count"] == 4
+    assert loaded_job.status is JobStatus.COMPLETE
+    assert loaded_job.accepted_count == 2
+    assert reloaded.list_jobs("docs")[0].job_id == job.job_id

--- a/nemo_retriever/tests/test_agent_mcp_tools.py
+++ b/nemo_retriever/tests/test_agent_mcp_tools.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 import json
 from typing import Any
 
@@ -15,12 +17,15 @@ from nemo_retriever.agent_mcp.models import (
     IngestJobRecord,
     JobStatus,
 )
+from nemo_retriever.agent_mcp.server import create_default_service, create_mcp_server
 from nemo_retriever.agent_mcp.tools import AgentMcpToolService
 
 
 class FakeBackend:
     def __init__(self) -> None:
         self.rerank_seen_hits: list[EvidenceHit] = []
+        self.shutdown_called = False
+        self.shutdown_wait: bool | None = None
 
     def list_collections(self) -> list[CollectionRecord]:
         return [
@@ -119,6 +124,10 @@ class FakeBackend:
         self.rerank_seen_hits = hits
         return hits[:top_n]
 
+    def shutdown(self, wait: bool = True) -> None:
+        self.shutdown_called = True
+        self.shutdown_wait = wait
+
 
 class FailingBackend(FakeBackend):
     def list_collections(self) -> list[CollectionRecord]:
@@ -132,6 +141,29 @@ class FailingBackend(FakeBackend):
 
 def assert_json_serializable(value: Any) -> None:
     json.dumps(value)
+
+
+def registered_tool_names(server: Any) -> set[str]:
+    list_tools = getattr(server, "list_tools", None)
+    if callable(list_tools):
+        tools = list_tools()
+        if inspect.isawaitable(tools):
+            tools = asyncio.run(tools)
+        return {tool.name for tool in tools}
+
+    tool_manager = getattr(server, "_tool_manager", None)
+    if tool_manager is not None:
+        tools = getattr(tool_manager, "_tools", None)
+        if isinstance(tools, dict):
+            return set(tools.keys())
+
+    get_tools = getattr(server, "get_tools", None)
+    if callable(get_tools):
+        tools = get_tools()
+        if isinstance(tools, dict):
+            return set(tools.keys())
+
+    raise AssertionError("Could not inspect registered FastMCP tools.")
 
 
 def test_tool_service_returns_json_serializable_collection_payloads() -> None:
@@ -191,3 +223,49 @@ def test_tool_service_serializes_invalid_rerank_hit_payloads() -> None:
     assert payload["error"]["retryable"] is False
     assert "errors" in payload["error"]["details"]
     assert_json_serializable(payload)
+
+
+def test_create_mcp_server_registers_agent_tools() -> None:
+    server = create_mcp_server(AgentMcpToolService(FakeBackend()))
+
+    assert registered_tool_names(server) == {
+        "list_collections",
+        "create_collection",
+        "describe_collection",
+        "delete_collection",
+        "start_ingestion",
+        "get_ingestion_status",
+        "ingest_local_paths",
+        "query_collection",
+        "rerank_results",
+    }
+
+
+def test_mcp_server_lifespan_shuts_down_backend() -> None:
+    backend = FakeBackend()
+    service = AgentMcpToolService(backend)
+    server = create_mcp_server(service)
+    app = server.http_app(path="/")
+
+    async def run_lifespan() -> None:
+        async with app.router.lifespan_context(app):
+            pass
+
+    asyncio.run(run_lifespan())
+
+    assert backend.shutdown_called is True
+    assert backend.shutdown_wait is True
+
+
+def test_create_default_service_initializes_registry(tmp_path) -> None:
+    data_root = tmp_path / "data"
+    allowed_root = tmp_path / "allowed"
+
+    service = create_default_service(data_root, [allowed_root])
+
+    assert isinstance(service, AgentMcpToolService)
+    assert service.backend.registry.data_root == data_root
+    assert service.backend.registry.db_path == data_root / "registry.sqlite"
+    assert service.backend.path_policy.allowed_roots == [allowed_root]
+    assert data_root.exists()
+    assert (data_root / "registry.sqlite").exists()

--- a/nemo_retriever/tests/test_agent_mcp_tools.py
+++ b/nemo_retriever/tests/test_agent_mcp_tools.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from nemo_retriever.agent_mcp.models import (
+    AgentMcpError,
+    AgentMcpErrorCode,
+    CollectionRecord,
+    EvidenceHit,
+    IngestJobRecord,
+    JobStatus,
+)
+from nemo_retriever.agent_mcp.tools import AgentMcpToolService
+
+
+class FakeBackend:
+    def __init__(self) -> None:
+        self.rerank_seen_hits: list[EvidenceHit] = []
+
+    def list_collections(self) -> list[CollectionRecord]:
+        return [
+            CollectionRecord(name="docs", root_path="/tmp/docs", queryable=True),
+            CollectionRecord(name="scratch", root_path="/tmp/scratch"),
+        ]
+
+    def create_collection(
+        self,
+        name: str = "default",
+        temporary: bool = False,
+        hybrid: bool = False,
+    ) -> CollectionRecord:
+        return CollectionRecord(
+            name=name,
+            root_path=f"/tmp/{name}",
+            temporary=temporary,
+            hybrid=hybrid,
+        )
+
+    def describe_collection(self, name: str = "default") -> dict[str, Any]:
+        return {
+            "name": name,
+            "queryable": True,
+            "recent_jobs": [IngestJobRecord(job_id="job-1", collection=name, status=JobStatus.COMPLETE)],
+        }
+
+    def delete_collection(self, name: str, delete_data: bool = False) -> CollectionRecord:
+        return CollectionRecord(
+            name=name,
+            root_path=f"/tmp/{name}",
+            metadata={"delete_data": delete_data},
+        )
+
+    def start_ingestion(
+        self,
+        collection: str,
+        paths: list[str],
+        *,
+        run_mode: str = "inprocess",
+    ) -> IngestJobRecord:
+        return IngestJobRecord(
+            job_id="job-1",
+            collection=collection,
+            status=JobStatus.RUNNING,
+            source_count=len(paths),
+        )
+
+    def ingest_local_paths(
+        self,
+        collection: str,
+        paths: list[str],
+        *,
+        wait: bool = True,
+        timeout_s: float | None = None,
+        run_mode: str = "inprocess",
+    ) -> IngestJobRecord:
+        return IngestJobRecord(
+            job_id="job-1",
+            collection=collection,
+            status=JobStatus.COMPLETE,
+            source_count=len(paths),
+            accepted_count=len(paths),
+        )
+
+    def get_ingestion_status(self, job_id: str) -> IngestJobRecord:
+        return IngestJobRecord(job_id=job_id, collection="docs", status=JobStatus.COMPLETE)
+
+    def query_collection(
+        self,
+        collection: str = "default",
+        query: str = "",
+        top_k: int = 10,
+        hybrid: bool = False,
+        rerank: bool = False,
+        filters: dict[str, Any] | None = None,
+    ) -> list[EvidenceHit]:
+        return [
+            EvidenceHit(
+                text=f"{query} answer {index}",
+                score=1.0 / index,
+                source_path=f"/tmp/{collection}-{index}.txt",
+                media_type="text",
+                content_type="text",
+                metadata={"hybrid": hybrid, "rerank": rerank, "filters": filters},
+            )
+            for index in range(1, top_k + 1)
+        ]
+
+    def rerank_results(
+        self,
+        query: str,
+        hits: list[EvidenceHit],
+        top_n: int | None = None,
+    ) -> list[EvidenceHit]:
+        self.rerank_seen_hits = hits
+        return hits[:top_n]
+
+
+class FailingBackend(FakeBackend):
+    def list_collections(self) -> list[CollectionRecord]:
+        raise AgentMcpError(
+            AgentMcpErrorCode.BACKEND_ERROR,
+            "backend unavailable",
+            retryable=True,
+            details={"backend": "fake"},
+        )
+
+
+def assert_json_serializable(value: Any) -> None:
+    json.dumps(value)
+
+
+def test_tool_service_returns_json_serializable_collection_payloads() -> None:
+    service = AgentMcpToolService(FakeBackend())
+
+    payload = service.list_collections()
+
+    assert payload[0]["name"] == "docs"
+    assert payload[0]["queryable"] is True
+    assert payload[1]["name"] == "scratch"
+    assert payload[1]["queryable"] is False
+    assert_json_serializable(payload)
+
+
+def test_tool_service_ingest_and_query() -> None:
+    backend = FakeBackend()
+    service = AgentMcpToolService(backend)
+
+    job = service.ingest_local_paths(collection="docs", paths=["/tmp/a.pdf"])
+    hits = service.query_collection(collection="docs", query="hello", top_k=2, hybrid=True, rerank=True)
+    reranked = service.rerank_results("hello", hits, top_n=1)
+
+    assert job["status"] == "complete"
+    assert hits[0]["text"] == "hello answer 1"
+    assert hits[0]["metadata"] == {"hybrid": True, "rerank": True, "filters": None}
+    assert reranked == [hits[0]]
+    assert isinstance(backend.rerank_seen_hits[0], EvidenceHit)
+    assert backend.rerank_seen_hits[0].text == hits[0]["text"]
+    assert_json_serializable(job)
+    assert_json_serializable(hits)
+    assert_json_serializable(reranked)
+
+
+def test_tool_service_serializes_agent_mcp_errors() -> None:
+    service = AgentMcpToolService(FailingBackend())
+
+    payload = service.list_collections()
+
+    assert payload == {
+        "error": {
+            "code": "BACKEND_ERROR",
+            "message": "backend unavailable",
+            "retryable": True,
+            "details": {"backend": "fake"},
+        }
+    }
+    assert_json_serializable(payload)
+
+
+def test_tool_service_serializes_invalid_rerank_hit_payloads() -> None:
+    service = AgentMcpToolService(FakeBackend())
+
+    payload = service.rerank_results("hello", [{"score": 0.2}], top_n=1)
+
+    assert payload["error"]["code"] == "BACKEND_ERROR"
+    assert payload["error"]["message"] == "Invalid rerank hit payload."
+    assert payload["error"]["retryable"] is False
+    assert "errors" in payload["error"]["details"]
+    assert_json_serializable(payload)

--- a/nemo_retriever/tests/test_retriever_queries.py
+++ b/nemo_retriever/tests/test_retriever_queries.py
@@ -137,6 +137,21 @@ class TestRetrieveVdbOperatorPreprocess:
         vec = op.preprocess(df)
         assert vec == [[0.1, 0.2]]
 
+    def test_dataframe_to_vectors_from_payload_vector_column(self) -> None:
+        from nemo_retriever.vdb.operators import RetrieveVdbOperator
+
+        df = pd.DataFrame(
+            {
+                "text": ["a"],
+                "text_embeddings_1b_v2": [[0.1, 0.2]],
+                "text_embeddings_1b_v2_dim": [2],
+                "text_embeddings_1b_v2_has_embedding": [True],
+            }
+        )
+        op = RetrieveVdbOperator(vdb_op="lancedb", vdb_kwargs={"uri": "/tmp", "table_name": "t"})
+        vec = op.preprocess(df)
+        assert vec == [[0.1, 0.2]]
+
 
 class TestRerankLongDataframe:
     def test_groups_by_query_order(self) -> None:


### PR DESCRIPTION
## Description
Adds an agent-facing MCP server for local NeMo Retriever installations. The new surface lets MCP-capable agents create and manage collections, ingest local multimedia files from explicit allowed roots, query persistent VDB-backed collections, and rerank normalized evidence hits. The tools return evidence and status only; final answer generation remains with the calling agent model.

This includes:
- neutral Agent MCP models, collection registry, path validation, and evidence normalization
- in-process backend support for local ingestion jobs, query, and rerank
- JSON-safe tool service plus FastMCP server with lifecycle cleanup
- `retriever agent-mcp start` CLI and package-module help support
- Agent MCP docs and README link

Verification:
- `.venv/bin/python -m pytest tests/test_agent_mcp_models.py tests/test_agent_mcp_registry.py tests/test_agent_mcp_paths.py tests/test_agent_mcp_evidence.py tests/test_agent_mcp_backend.py tests/test_agent_mcp_tools.py tests/test_agent_mcp_cli.py -q` -> 58 passed
- `.venv/bin/python -m pytest tests/test_retriever_queries.py tests/test_ingest_interface.py -q` -> 26 passed
- `.venv/bin/python -m nemo_retriever agent-mcp --help` -> prints Agent MCP help

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
