### PR TITLE
Adding Agentic Retrieval as a new retrieveral mode

### DIFF
--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -156,6 +156,59 @@ When querying a table ingested with an explicit embedding model, pass the same
 captioned image rows emitted by ingest. Hits with missing or unknown content
 types are excluded while `--content-types` is active.
 
+### Agentic retrieval
+
+`--agentic` swaps the single dense pass for an LLM-driven ReAct loop: the agent
+issues several retrieval sub-queries, fuses the candidates, and selects a final
+ranking. It searches the same LanceDB table built by `retriever ingest`, so it is
+a drop-in alternative to standard retrieval — add `--agentic` and name the chat
+model the agent drives with `--agentic-llm-model` (required):
+
+```bash
+retriever query "how does the ingestion pipeline handle tables?" \
+  --agentic \
+  --agentic-llm-model nvidia/llama-3.3-nemotron-super-49b-v1.5
+
+# remote agent + embedding endpoints, fewer reasoning rounds
+retriever query "summarize the deployment options" \
+  --agentic \
+  --agentic-llm-model nvidia/llama-3.3-nemotron-super-49b-v1.5 \
+  --agentic-invoke-url http://localhost:9000/v1/chat/completions \
+  --embed-invoke-url http://localhost:8000/v1 \
+  --agentic-react-max-steps 5
+```
+
+Unlike the dense path (which returns text-enriched hits), agentic mode returns
+the agent's ranked document IDs as JSON, each annotated with the source that
+produced it (`final_results`, `rrf`, or `selection_agent`). It reuses the same
+`--top-k`, `--lancedb-uri`, `--table-name`, `--embed-invoke-url`, and
+`--embed-model-name` options as standard retrieval.
+
+**How it works.** Each agentic query runs `Query → ReActAgentOperator → (RRF
+fusion) → SelectionAgentOperator → ranked results`:
+
+- `ReActAgentOperator` runs the per-query ReAct loop; every `retrieve` tool call
+  delegates to the standard `Retriever`, so the agent searches the same vector
+  DB and embedding config as dense retrieval.
+- `RRFAggregatorOperator` fuses candidates from the loop's multiple searches with
+  reciprocal rank fusion.
+- `SelectionAgentOperator` runs a final LLM selection pass over the fused set and
+  emits the ranked document IDs.
+
+Agentic-only knobs (apply only with `--agentic`):
+
+- `--agentic-invoke-url` — OpenAI-compatible chat-completions endpoint for the
+  agent LLM; defaults to the operators' built-in endpoint when omitted.
+- `--agentic-reasoning-effort` (default `high`) — `reasoning_effort` forwarded on
+  agentic LLM calls.
+- `--agentic-backend-top-k` (default `20`) — candidates pulled from the vector DB
+  per retrieval call.
+- `--agentic-react-max-steps` (default `50`) — maximum ReAct loop iterations.
+- `--agentic-text-truncation` (default `0`) — max characters of each candidate
+  shown to the agent; `0` disables truncation.
+- `--agentic-temperature` (default `0.0`) — sampling temperature for agentic LLM
+  calls (`0.0` = greedy).
+
 <!-- --8<-- [end:quickstart] -->
 
 ## Common ingest options

--- a/nemo_retriever/src/nemo_retriever/cli/main.py
+++ b/nemo_retriever/src/nemo_retriever/cli/main.py
@@ -18,8 +18,9 @@ from nemo_retriever.cli.shared import (
     silence_noisy_libraries as _silence_noisy_libraries,
 )
 from nemo_retriever.cli.evidence import build_evidence_result
-from nemo_retriever.cli.query_workflow import query_documents
+from nemo_retriever.cli.query_workflow import agentic_query_documents, query_documents
 from nemo_retriever.query.options import (
+    QueryAgenticOptions,
     QueryEmbedOptions,
     QueryRerankOptions,
     QueryRequest,
@@ -204,6 +205,50 @@ def query_command(
         "--max-text-chars",
         help="('hits' format only) Truncate each hit's text to N chars (0 = metadata-only). Default: full text.",
     ),
+    agentic: bool = typer.Option(
+        False,
+        "--agentic",
+        help="Run an LLM-driven agentic (ReAct) retrieval loop instead of the default dense pass.",
+    ),
+    agentic_llm_model: str | None = typer.Option(
+        None,
+        "--agentic-llm-model",
+        help="Chat model the agent drives. Required when --agentic is set.",
+    ),
+    agentic_invoke_url: str | None = typer.Option(
+        None,
+        "--agentic-invoke-url",
+        help="OpenAI-compatible chat-completions endpoint for the agent LLM (agentic mode).",
+    ),
+    agentic_reasoning_effort: str | None = typer.Option(
+        "high",
+        "--agentic-reasoning-effort",
+        help="reasoning_effort forwarded on agentic LLM calls.",
+    ),
+    agentic_backend_top_k: int = typer.Option(
+        20,
+        "--agentic-backend-top-k",
+        min=1,
+        help="Backend retrieve-pool depth per agentic retrieval call.",
+    ),
+    agentic_react_max_steps: int = typer.Option(
+        50,
+        "--agentic-react-max-steps",
+        min=1,
+        help="Maximum ReAct loop iterations for the agentic query.",
+    ),
+    agentic_text_truncation: int = typer.Option(
+        0,
+        "--agentic-text-truncation",
+        min=0,
+        help="Max characters of each candidate shown to the agent; 0 disables truncation.",
+    ),
+    agentic_temperature: float = typer.Option(
+        0.0,
+        "--agentic-temperature",
+        min=0.0,
+        help="Sampling temperature for agentic LLM calls (0.0 = greedy).",
+    ),
 ) -> None:
     if output_format not in ("hits", "evidence"):
         typer.echo(f"Error: unknown --format {output_format!r} (use 'hits' or 'evidence').", err=True)
@@ -217,6 +262,51 @@ def query_command(
         embed_invoke_url = os.environ.get("EMBED_INVOKE_URL") or None
     rerank = rerank or bool(reranker_invoke_url) or bool(reranker_model_name) or bool(reranker_backend)
     _silence_noisy_libraries()
+    if agentic and not agentic_llm_model:
+        typer.echo("Error: --agentic requires --agentic-llm-model.", err=True)
+        raise typer.Exit(1)
+    if agentic:
+        request = QueryRequest(
+            query=query,
+            retrieval=QueryRetrievalOptions(
+                top_k=top_k,
+                candidate_k=candidate_k,
+                page_dedup=page_dedup,
+                content_types=content_types,
+            ),
+            embed=QueryEmbedOptions(
+                embed_invoke_url=embed_invoke_url,
+                embed_model_name=embed_model_name,
+            ),
+            rerank=QueryRerankOptions(
+                enabled=rerank,
+                reranker_invoke_url=reranker_invoke_url,
+                reranker_model_name=reranker_model_name,
+                reranker_backend=reranker_backend,
+            ),
+            storage=QueryStorageOptions(
+                lancedb_uri=lancedb_uri,
+                table_name=table_name,
+            ),
+            agentic=QueryAgenticOptions(
+                enabled=agentic,
+                llm_model=agentic_llm_model,
+                invoke_url=agentic_invoke_url,
+                reasoning_effort=agentic_reasoning_effort,
+                backend_top_k=agentic_backend_top_k,
+                react_max_steps=agentic_react_max_steps,
+                text_truncation=agentic_text_truncation,
+                temperature=agentic_temperature,
+            ),
+        )
+        try:
+            with _quiet_capture():
+                ranked = agentic_query_documents(request)
+        except _ROOT_CLI_ERRORS as exc:
+            typer.echo(f"Error: {exc}", err=True)
+            raise typer.Exit(1) from exc
+        typer.echo(json.dumps(ranked, indent=2, sort_keys=True, default=str))
+        return
 
     try:
         reranker_api_key = _api_key_from_env_option(reranker_api_key_env) if reranker_invoke_url else None

--- a/nemo_retriever/src/nemo_retriever/cli/query_workflow.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query_workflow.py
@@ -4,7 +4,10 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from nemo_retriever.query.options import QueryRequest
+from nemo_retriever.query.workflow import agentic_query_documents as run_agentic_query_documents
 from nemo_retriever.query.workflow import query_documents as run_query_documents
 from nemo_retriever.common.vdb.records import RetrievalHit
 
@@ -12,3 +15,8 @@ from nemo_retriever.common.vdb.records import RetrievalHit
 def query_documents(request: QueryRequest) -> list[RetrievalHit]:
     """Run the typed root query workflow."""
     return run_query_documents(request)
+
+
+def agentic_query_documents(request: QueryRequest) -> list[dict[str, Any]]:
+    """Run the typed root agentic (ReAct) query workflow."""
+    return run_agentic_query_documents(request)

--- a/nemo_retriever/src/nemo_retriever/operators/graph_ops/react_agent_operator.py
+++ b/nemo_retriever/src/nemo_retriever/operators/graph_ops/react_agent_operator.py
@@ -22,6 +22,20 @@ from nemo_retriever.models.nim.chat_completions import invoke_chat_completion_st
 
 logger = logging.getLogger(__name__)
 
+_LOG_PREVIEW_CHARS = 300
+_LOG_DOC_ID_LIMIT = 20
+
+
+def _preview_text(value: Any, *, limit: int = _LOG_PREVIEW_CHARS) -> str:
+    text = " ".join(str(value or "").split())
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "..."
+
+
+def _preview_doc_ids(docs: List[Dict[str, Any]], *, limit: int = _LOG_DOC_ID_LIMIT) -> List[str]:
+    return [str(doc.get("doc_id", "")) for doc in docs[:limit]]
+
 
 # ---------------------------------------------------------------------------
 # Prompt rendering  (verbatim content of 02_v1.j2, rendered via Python)
@@ -245,6 +259,7 @@ def _make_final_results_tool_spec(top_k: Optional[int]) -> Dict[str, Any]:
                     "doc_ids": {
                         "type": "array",
                         "items": {"type": "string"},
+                        "minItems": 1,
                         "description": (
                             "List of document IDs that are relevant to the user's query sorted descending "
                             "by their level of relevance to the user's query. I.e., the first document is "
@@ -396,6 +411,9 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
         api_key: Optional[str] = None,
         max_tokens: Optional[int] = None,
         parallel_tool_calls: bool = True,
+        reasoning_effort: Optional[str] = None,
+        backend_top_k: Optional[int] = None,
+        temperature: float = 0.0,
     ) -> None:
         super().__init__()
         self._invoke_url = invoke_url or self._NVIDIA_BUILD_ENDPOINT
@@ -411,6 +429,18 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
         self._api_key = api_key
         self._max_tokens = max_tokens
         self._parallel_tool_calls = parallel_tool_calls
+        self._reasoning_effort = reasoning_effort
+        self._backend_top_k = backend_top_k
+        self._temperature = temperature
+
+    def _build_extra_body(self) -> Optional[Dict[str, Any]]:
+        """Assemble per-call extra payload fields (parallel_tool_calls, reasoning_effort)."""
+        extra: Dict[str, Any] = {}
+        if not self._parallel_tool_calls:
+            extra["parallel_tool_calls"] = False
+        if self._reasoning_effort:
+            extra["reasoning_effort"] = self._reasoning_effort
+        return extra or None
 
     # ------------------------------------------------------------------
     # AbstractOperator interface
@@ -439,28 +469,32 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
             qid, qtxt = query_rows[0]
             rows.extend(self._run_single_query(qid, qtxt, api_key))
         else:
+            # Collect per-query results keyed by query_id, then re-emit in the ORIGINAL
+            # input order. as_completed() yields futures in nondeterministic completion
+            # order; emitting in that order would make downstream groupby(sort=False)
+            # output order depend on which query finished first. Re-ordering here keeps
+            # the operator output deterministic regardless of concurrency.
+            results_by_qid: Dict[str, List[Dict[str, Any]]] = {}
             with ThreadPoolExecutor(max_workers=min(self._num_concurrent, len(query_rows))) as executor:
                 futures = {
                     executor.submit(self._run_single_query, qid, qtxt, api_key): (qid, qtxt) for qid, qtxt in query_rows
                 }
                 for future in as_completed(futures):
+                    qid, qtxt = futures[future]
                     try:
-                        rows.extend(future.result())
+                        results_by_qid[qid] = future.result()
                     except TimeoutError as exc:
-                        qid, qtxt = futures[future]
                         logger.warning("ReActAgentOperator: query %r timed out: %s", qid, exc, exc_info=True)
                     except RuntimeError as exc:
-                        qid, qtxt = futures[future]
                         logger.warning("ReActAgentOperator: query %r retries exhausted: %s", qid, exc, exc_info=True)
                     except requests.RequestException as exc:
-                        qid, qtxt = futures[future]
                         logger.warning("ReActAgentOperator: query %r HTTP error: %s", qid, exc, exc_info=True)
                     except (json.JSONDecodeError, ValueError) as exc:
-                        qid, qtxt = futures[future]
                         logger.warning("ReActAgentOperator: query %r data error: %s", qid, exc, exc_info=True)
                     except Exception as exc:  # catches unexpected worker errors not covered above
-                        qid, qtxt = futures[future]
                         logger.warning("ReActAgentOperator: query %r failed: %s", qid, exc, exc_info=True)
+            for qid, _qtxt in query_rows:
+                rows.extend(results_by_qid.get(qid, []))
 
         if not rows:
             return pd.DataFrame(columns=["query_id", "query_text", "step_idx", "doc_id", "text", "rank"])
@@ -502,6 +536,15 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
         seen_doc_ids: set[str] = set()
         step_counter = 0
 
+        logger.info(
+            "ReActAgentOperator: query=%s start max_steps=%d retriever_top_k=%d target_top_k=%d query=%r",
+            query_id,
+            self._max_steps,
+            self._retriever_top_k,
+            self._target_top_k,
+            _preview_text(query_text),
+        )
+
         # ------ optional initial retrieval (with_results mode) ------
         if with_init_docs:
             init_docs = self._call_retriever(query_text, seen_doc_ids, api_key)
@@ -509,6 +552,13 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
             step_counter += 1
             for d in init_docs:
                 seen_doc_ids.add(d["doc_id"])
+            logger.info(
+                "ReActAgentOperator: query=%s initial_retrieve docs=%d seen=%d doc_ids=%s",
+                query_id,
+                len(init_docs),
+                len(seen_doc_ids),
+                _preview_doc_ids(init_docs),
+            )
 
             doc_content = _docs_to_message_content(init_docs)
             user_msg_content: List[Dict[str, Any]] = [
@@ -522,7 +572,7 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
 
         # ------ main ReAct loop ------
         for _step in range(self._max_steps):
-            logger.debug("query=%r loop_step=%d seen_docs=%d", query_id, _step, len(seen_doc_ids))
+            logger.info("ReActAgentOperator: query=%s step=%d begin seen_docs=%d", query_id, _step, len(seen_doc_ids))
             try:
                 response = invoke_chat_completion_step(
                     invoke_url=self._invoke_url,
@@ -531,8 +581,9 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
                     api_key=api_key,
                     tools=tools,
                     tool_choice="auto",
+                    temperature=self._temperature,
                     max_tokens=self._max_tokens,
-                    extra_body={"parallel_tool_calls": False} if not self._parallel_tool_calls else None,
+                    extra_body=self._build_extra_body(),
                 )
             except TimeoutError as exc:
                 logger.warning(
@@ -580,6 +631,26 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
             msg = choice["message"]
             finish_reason = choice.get("finish_reason")
             tool_calls = msg.get("tool_calls") or []
+            if msg.get("content"):
+                # Agent reasoning can quote document text/PII; keep content at DEBUG.
+                logger.debug(
+                    "ReActAgentOperator: query=%s step=%d assistant content=%r",
+                    query_id,
+                    _step,
+                    _preview_text(msg.get("content")),
+                )
+            usage = response.get("usage") or {}
+            logger.info(
+                "ReActAgentOperator: query=%s step=%d finish_reason=%s tool_calls=%s "
+                "prompt_tokens=%s completion_tokens=%s total_tokens=%s",
+                query_id,
+                _step,
+                finish_reason,
+                [((tc.get("function") or {}).get("name") or "") for tc in tool_calls],
+                usage.get("prompt_tokens"),
+                usage.get("completion_tokens"),
+                usage.get("total_tokens"),
+            )
 
             # Append assistant turn
             assistant_turn: Dict[str, Any] = {"role": "assistant"}
@@ -590,6 +661,11 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
             messages.append(assistant_turn)
 
             if finish_reason == "stop" or not tool_calls:
+                logger.info(
+                    "ReActAgentOperator: query=%s step=%d no tool call; requesting continuation",
+                    query_id,
+                    _step,
+                )
                 messages.append({"role": "user", "content": _AUTO_USER_MSG})
                 continue
 
@@ -609,20 +685,39 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
                     continue
 
                 if fn_name == "think":
-                    logger.debug("query=%r step=%d [think] %s", query_id, _step, str(fn_args.get("thought", ""))[:120])
+                    # Agent thoughts can quote document text/PII; keep content at DEBUG.
+                    logger.debug(
+                        "ReActAgentOperator: query=%s step=%d think=%r",
+                        query_id,
+                        _step,
+                        _preview_text(fn_args.get("thought")),
+                    )
                     tool_messages.append(
                         {"role": "tool", "tool_call_id": tc_id, "content": "Your thought has been logged."}
                     )
 
                 elif fn_name == "retrieve":
                     subquery = str(fn_args.get("query", query_text))
-                    logger.debug("query=%r step=%d [retrieve] subquery=%r", query_id, _step, subquery)
+                    logger.info(
+                        "ReActAgentOperator: query=%s step=%d retrieve subquery=%r seen_before=%d",
+                        query_id,
+                        _step,
+                        _preview_text(subquery),
+                        len(seen_doc_ids),
+                    )
                     retrieved = self._call_retriever(subquery, seen_doc_ids, api_key)
-                    logger.debug("query=%r step=%d [retrieve] got %d new docs", query_id, _step, len(retrieved))
                     retrieval_log.append(retrieved)
                     step_counter += 1
                     for d in retrieved:
                         seen_doc_ids.add(d["doc_id"])
+                    logger.info(
+                        "ReActAgentOperator: query=%s step=%d retrieve docs=%d seen_after=%d doc_ids=%s",
+                        query_id,
+                        _step,
+                        len(retrieved),
+                        len(seen_doc_ids),
+                        _preview_doc_ids(retrieved),
+                    )
                     doc_content = _docs_to_message_content(retrieved)
                     tool_content: List[Dict[str, Any]] = [
                         {"type": "text", "text": f"Retrieved {len(retrieved)} documents:"}
@@ -631,17 +726,39 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
 
                 elif fn_name == "final_results":
                     raw_ids: List[str] = fn_args.get("doc_ids", [])
-                    logger.debug("query=%r step=%d [final_results] doc_ids=%s", query_id, _step, raw_ids)
-                    if isinstance(raw_ids, list) and raw_ids:
-                        final_doc_ids = [str(d) for d in raw_ids]
-                    tool_messages.append(
-                        {
-                            "role": "tool",
-                            "tool_call_id": tc_id,
-                            "content": "The results have been successfully logged and the interaction ended.",
-                        }
+                    logger.info(
+                        "ReActAgentOperator: query=%s step=%d final_results search_successful=%s doc_ids=%s",
+                        query_id,
+                        _step,
+                        fn_args.get("search_successful"),
+                        raw_ids[:_LOG_DOC_ID_LIMIT] if isinstance(raw_ids, list) else raw_ids,
                     )
-                    loop_done = True
+                    # Message can quote document text/PII; keep content at DEBUG.
+                    logger.debug(
+                        "ReActAgentOperator: query=%s step=%d final_results message=%r",
+                        query_id,
+                        _step,
+                        _preview_text(fn_args.get("message")),
+                    )
+                    validation_error = self._validate_final_results_args(fn_args)
+                    if validation_error is None:
+                        final_doc_ids = list(raw_ids)
+                        tool_messages.append(
+                            {
+                                "role": "tool",
+                                "tool_call_id": tc_id,
+                                "content": "The results have been successfully logged and the interaction ended.",
+                            }
+                        )
+                        loop_done = True
+                    else:
+                        tool_messages.append(
+                            {
+                                "role": "tool",
+                                "tool_call_id": tc_id,
+                                "content": f"Error: {validation_error}",
+                            }
+                        )
 
                 else:
                     tool_messages.append(
@@ -652,6 +769,13 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
             if loop_done:
                 break
 
+        logger.info(
+            "ReActAgentOperator: query=%s done retrieval_steps=%d seen_docs=%d final_doc_ids=%s",
+            query_id,
+            len(retrieval_log),
+            len(seen_doc_ids),
+            final_doc_ids[:_LOG_DOC_ID_LIMIT] if final_doc_ids else [],
+        )
         return _build_output_rows(query_id, query_text, retrieval_log, final_doc_ids)
 
     def _call_retriever(
@@ -662,6 +786,11 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
     ) -> List[Dict[str, Any]]:
         """Call retriever_fn, over-fetching to ensure new results after dedup."""
         fetch_k = self._retriever_top_k + len(seen_doc_ids)
+        # Optional fixed ceiling on backend depth, matching Path A's --retriever-top-k
+        # cap. Once the agent has seen the whole capped pool, retrieves return no new
+        # docs, so the prompt stops growing (prevents context-window overflow).
+        if self._backend_top_k:
+            fetch_k = min(fetch_k, int(self._backend_top_k))
         try:
             raw = self._retriever_fn(query_text, fetch_k)
         except TimeoutError as exc:
@@ -678,18 +807,75 @@ class ReActAgentOperator(AbstractOperator, CPUOperator):
             logger.warning("ReActAgentOperator: retriever_fn failed for query %r: %s", query_text, exc, exc_info=True)
             return []
 
-        # Filter already-seen and normalise keys
+        # Walk the ranked results, normalising keys and de-duplicating within the
+        # batch. Already-seen docs are always re-presented as short stubs, matching
+        # Path A's retrieve_with_guarantees, and do not count toward top_k.
         results: List[Dict[str, Any]] = []
+        batch_doc_ids: set[str] = set()
+        new_count = 0
         for item in raw:
             doc_id = str(item.get("doc_id", item.get("id", "")))
-            text = str(item.get("text", ""))
+            if not doc_id or doc_id in batch_doc_ids:
+                continue
             score = float(item.get("score", 0.0))
-            if doc_id and doc_id not in seen_doc_ids:
-                results.append({"doc_id": doc_id, "text": text, "score": score})
-            if len(results) >= self._retriever_top_k:
+            if doc_id in seen_doc_ids:
+                batch_doc_ids.add(doc_id)
+                results.append(
+                    {
+                        "doc_id": doc_id,
+                        "text": (
+                            "This document was retrieved before. See the earlier retrieval "
+                            f"results for its content (id: {doc_id})."
+                        ),
+                        "score": score,
+                    }
+                )
+                continue
+            batch_doc_ids.add(doc_id)
+            results.append(
+                {
+                    "doc_id": doc_id,
+                    "text": str(item.get("text", "")),
+                    "score": score,
+                }
+            )
+            new_count += 1
+            if new_count >= self._retriever_top_k:
                 break
 
         return results
+
+    def _validate_final_results_args(self, fn_args: Dict[str, Any]) -> Optional[str]:
+        """Validate final_results tool args outside the prompt/schema."""
+        message = fn_args.get("message")
+        if not isinstance(message, str):
+            return f"`message` must be a string. Got `{type(message)}` type."
+
+        doc_ids = fn_args.get("doc_ids")
+        if not isinstance(doc_ids, list):
+            return f"`doc_ids` must be a list. Got `{type(doc_ids)}` type."
+        if len(doc_ids) == 0:
+            return "`doc_ids` cannot be empty. You must choose at least one relevant document."
+        if not all(isinstance(doc_id, str) for doc_id in doc_ids):
+            return "Items in `doc_ids` must be of type string (i.e., python's `str` type)."
+        if not all(doc_id.strip() for doc_id in doc_ids):
+            return "Items in `doc_ids` must be non-empty (no blank or whitespace-only IDs)."
+
+        search_successful = fn_args.get("search_successful")
+        if not isinstance(search_successful, str):
+            return f"`search_successful` must be a string. Got `{type(search_successful)}` type."
+        if search_successful not in {"true", "false", "partial"}:
+            return (
+                f"`search_successful` must be one of `true`, `false`, or `partial`. Got `{search_successful}` instead."
+            )
+
+        if self._enforce_top_k and len(doc_ids) != self._target_top_k:
+            return (
+                f"`doc_ids` must contain exactly {self._target_top_k} documents. "
+                f"But got {len(doc_ids)} document IDs instead."
+            )
+
+        return None
 
     def _resolve_api_key(self) -> Optional[str]:
         api_key = self._api_key
@@ -742,13 +928,41 @@ def _build_output_rows(
                     "step_idx": step_idx,
                     "doc_id": doc.get("doc_id", ""),
                     "text": doc.get("text", ""),
+                    "has_valid_final_results": final_doc_ids is not None,
+                    "is_final_result": False,
                     "rank": rank,
                 }
             )
 
     # If final_results was called, also emit those as a synthetic final step
-    # (step_idx = len(retrieval_log)) so RRF can optionally weight it.
-    # These are already covered by the existing steps, so we skip deduplication
-    # here — RRF will naturally up-weight docs that appeared in final_results
-    # because they were retrieved in earlier steps.
+    # (step_idx = len(retrieval_log)) so RRF can weight the agent's final
+    # judgment in addition to the raw retrieval history.
+    if final_doc_ids:
+        first_doc_by_id: Dict[str, Dict[str, Any]] = {}
+        for step_docs in retrieval_log:
+            for doc in step_docs:
+                doc_id = str(doc.get("doc_id", ""))
+                if doc_id and doc_id not in first_doc_by_id:
+                    first_doc_by_id[doc_id] = doc
+
+        emitted: set[str] = set()
+        final_step_idx = len(retrieval_log)
+        for rank, doc_id in enumerate(final_doc_ids, 1):
+            doc_id = str(doc_id)
+            if not doc_id or doc_id in emitted:
+                continue
+            emitted.add(doc_id)
+            doc = first_doc_by_id.get(doc_id, {})
+            rows.append(
+                {
+                    "query_id": query_id,
+                    "query_text": query_text,
+                    "step_idx": final_step_idx,
+                    "doc_id": doc_id,
+                    "text": doc.get("text", ""),
+                    "has_valid_final_results": True,
+                    "is_final_result": True,
+                    "rank": rank,
+                }
+            )
     return rows

--- a/nemo_retriever/src/nemo_retriever/operators/graph_ops/rrf_aggregator_operator.py
+++ b/nemo_retriever/src/nemo_retriever/operators/graph_ops/rrf_aggregator_operator.py
@@ -102,6 +102,12 @@ class RRFAggregatorOperator(AbstractOperator, CPUOperator):
 
             rrf_scores: Dict[str, float] = defaultdict(float)
             first_text: Dict[str, str] = {}
+            react_final_rank: Dict[str, int] = {}
+            has_valid_final_results = (
+                bool(qgroup.get("has_valid_final_results", False).astype(bool).any())
+                if "has_valid_final_results" in qgroup.columns
+                else False
+            )
 
             # Process each step's ranked list
             for _step_idx, sgroup in qgroup.groupby("step_idx", sort=True):
@@ -112,6 +118,10 @@ class RRFAggregatorOperator(AbstractOperator, CPUOperator):
                     rrf_scores[doc_id] += 1.0 / (rank + k)
                     if doc_id not in first_text:
                         first_text[doc_id] = str(row["text"])
+                    if bool(row.get("is_final_result", False)):
+                        previous = react_final_rank.get(doc_id)
+                        if previous is None or rank < previous:
+                            react_final_rank[doc_id] = rank
 
             for doc_id, score in sorted(rrf_scores.items(), key=lambda kv: kv[1], reverse=True):
                 rows.append(
@@ -121,11 +131,23 @@ class RRFAggregatorOperator(AbstractOperator, CPUOperator):
                         "doc_id": doc_id,
                         "rrf_score": score,
                         "text": first_text.get(doc_id, ""),
+                        "has_valid_final_results": has_valid_final_results,
+                        "react_final_rank": react_final_rank.get(doc_id),
                     }
                 )
 
         if not rows:
-            return pd.DataFrame(columns=["query_id", "query_text", "doc_id", "rrf_score", "text"])
+            return pd.DataFrame(
+                columns=[
+                    "query_id",
+                    "query_text",
+                    "doc_id",
+                    "rrf_score",
+                    "text",
+                    "has_valid_final_results",
+                    "react_final_rank",
+                ]
+            )
 
         return pd.DataFrame(rows)
 

--- a/nemo_retriever/src/nemo_retriever/operators/graph_ops/selection_agent_operator.py
+++ b/nemo_retriever/src/nemo_retriever/operators/graph_ops/selection_agent_operator.py
@@ -21,6 +21,17 @@ from nemo_retriever.models.nim.chat_completions import invoke_chat_completion_st
 
 logger = logging.getLogger(__name__)
 
+_LOG_PREVIEW_CHARS = 300
+_LOG_DOC_ID_LIMIT = 20
+
+
+def _preview_text(value: Any, *, limit: int = _LOG_PREVIEW_CHARS) -> str:
+    text = " ".join(str(value or "").split())
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "..."
+
+
 # ---------------------------------------------------------------------------
 # Prompt rendering  (verbatim content of 01_v0.j2, rendered via Python)
 # ---------------------------------------------------------------------------
@@ -188,8 +199,12 @@ class SelectionAgentOperator(AbstractOperator, CPUOperator):
         text_truncation: int = 2000,
         parallel_tool_calls: bool = True,
         base_url: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
+        temperature: float = 0.0,
     ) -> None:
         super().__init__()
+        self._reasoning_effort = reasoning_effort
+        self._temperature = temperature
         self._llm_model = llm_model
         self._top_k = top_k
         self._api_key = api_key
@@ -236,21 +251,71 @@ class SelectionAgentOperator(AbstractOperator, CPUOperator):
 
         for query_id, group in data.groupby("query_id", sort=False):
             query_text = str(group["query_text"].iloc[0])
-            docs = [{"id": str(row["doc_id"]), "text": str(row["text"])} for _, row in group.iterrows()]
-            result = self._select_documents(query_text, docs)
-            message = result.get("message", "")
-            for rank, doc_id in enumerate(result.get("doc_ids", []), 1):
+            ordered_group = group
+            if "rrf_score" in group.columns:
+                ordered_group = group.sort_values("rrf_score", ascending=False)
+            docs = [
+                {
+                    "id": str(row["doc_id"]),
+                    "text": str(row["text"]),
+                }
+                for _, row in ordered_group.iterrows()
+            ]
+            logger.info(
+                "SelectionAgentOperator: query=%s start candidates=%d unique_candidates=%d query=%r",
+                query_id,
+                len(docs),
+                len({doc["id"] for doc in docs}),
+                _preview_text(query_text),
+            )
+            preferred_doc_ids, message, result_source = self._preferred_doc_ids(ordered_group)
+            if preferred_doc_ids is None:
+                result = self._select_documents(query_text, docs)
+                message = result.get("message", "")
+                doc_ids = list(result.get("doc_ids", []))
+                result_source = "selection_agent"
+            else:
+                doc_ids = preferred_doc_ids
+            if not doc_ids:
+                if preferred_doc_ids is None:
+                    doc_ids = ordered_group["doc_id"].astype(str).drop_duplicates().head(int(self._top_k)).tolist()
+                    message = (
+                        f"{message} Falling back to top {len(doc_ids)} RRF-ranked candidates."
+                        if message
+                        else f"Falling back to top {len(doc_ids)} RRF-ranked candidates."
+                    )
+                    result_source = "candidate_ranking"
+                    logger.warning(
+                        "SelectionAgentOperator: query=%s selection failed; "
+                        "falling back to candidate ranking doc_ids=%s",
+                        query_id,
+                        doc_ids[:_LOG_DOC_ID_LIMIT],
+                    )
+            logger.info(
+                "SelectionAgentOperator: query=%s result_source=%s selected=%s",
+                query_id,
+                result_source,
+                doc_ids[:_LOG_DOC_ID_LIMIT],
+            )
+            # Message can quote document text/PII; keep content at DEBUG.
+            logger.debug(
+                "SelectionAgentOperator: query=%s message=%r",
+                query_id,
+                _preview_text(message),
+            )
+            for rank, doc_id in enumerate(doc_ids, 1):
                 rows.append(
                     {
                         "query_id": query_id,
                         "doc_id": doc_id,
                         "rank": rank,
                         "message": message,
+                        "result_source": result_source,
                     }
                 )
 
         if not rows:
-            return pd.DataFrame(columns=["query_id", "doc_id", "rank", "message"])
+            return pd.DataFrame(columns=["query_id", "doc_id", "rank", "message", "result_source"])
 
         return pd.DataFrame(rows)
 
@@ -334,6 +399,38 @@ class SelectionAgentOperator(AbstractOperator, CPUOperator):
             },
         ]
 
+    def _preferred_doc_ids(self, ordered_group: pd.DataFrame) -> tuple[List[str] | None, str, str]:
+        """Apply retrieval-bench-style source priority before invoking selection."""
+        doc_ids = self._react_final_doc_ids(ordered_group)
+        if doc_ids is not None:
+            return doc_ids, "Using ReAct final_results.", "final_results"
+
+        if "rrf_score" in ordered_group.columns:
+            doc_ids = ordered_group["doc_id"].astype(str).drop_duplicates().head(int(self._top_k)).tolist()
+            if doc_ids:
+                return doc_ids, "Using RRF ranking.", "rrf"
+
+        return None, "", ""
+
+    def _react_final_doc_ids(self, ordered_group: pd.DataFrame) -> List[str] | None:
+        if "has_valid_final_results" in ordered_group.columns and not bool(
+            ordered_group["has_valid_final_results"].astype(bool).any()
+        ):
+            return None
+        if "react_final_rank" not in ordered_group.columns:
+            return None
+        final_rows = ordered_group[ordered_group["react_final_rank"].notna()].copy()
+        if final_rows.empty:
+            return [] if "has_valid_final_results" in ordered_group.columns else None
+        final_rows["react_final_rank"] = final_rows["react_final_rank"].astype(int)
+        doc_ids: List[str] = []
+        for doc_id in final_rows.sort_values("react_final_rank")["doc_id"].astype(str):
+            if doc_id and doc_id not in doc_ids:
+                doc_ids.append(doc_id)
+            if len(doc_ids) >= int(self._top_k):
+                break
+        return doc_ids
+
     def _build_user_message(self, query_text: str, docs: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Format query + candidate documents as a multi-part user message."""
         content: List[Dict[str, Any]] = [
@@ -349,8 +446,11 @@ class SelectionAgentOperator(AbstractOperator, CPUOperator):
             content.append({"type": "text", "text": f"Doc ID: {doc_id}"})
             text = doc.get("text", "").strip()
             if text:
-                truncated = text[: self._text_truncation]
-                if len(text) > self._text_truncation:
+                if self._text_truncation > 0:
+                    truncated = text[: self._text_truncation]
+                else:
+                    truncated = text
+                if self._text_truncation > 0 and len(text) > self._text_truncation:
                     truncated += "..."
                 content.append({"type": "text", "text": f"Doc Text: {truncated}"})
         return {"role": "user", "content": content}
@@ -363,6 +463,12 @@ class SelectionAgentOperator(AbstractOperator, CPUOperator):
         """Run the agentic selection loop for a single query."""
         valid_ids = list(dict.fromkeys(d["id"] for d in docs))
         feasible_k = min(self._top_k, len(valid_ids))
+        logger.info(
+            "SelectionAgentOperator: selecting top_k=%d feasible_k=%d valid_doc_ids=%s",
+            self._top_k,
+            feasible_k,
+            valid_ids[:_LOG_DOC_ID_LIMIT],
+        )
 
         system_prompt = self._build_system_prompt(feasible_k)
         tools = self._build_tools(feasible_k, valid_ids)
@@ -377,8 +483,16 @@ class SelectionAgentOperator(AbstractOperator, CPUOperator):
         extra_body: Dict[str, Any] = {}
         if not self._parallel_tool_calls:
             extra_body["parallel_tool_calls"] = False
+        if self._reasoning_effort:
+            extra_body["reasoning_effort"] = self._reasoning_effort
 
         for _step in range(self._max_steps):
+            logger.info(
+                "SelectionAgentOperator: step=%d begin candidates=%d feasible_k=%d",
+                _step,
+                len(valid_ids),
+                feasible_k,
+            )
             try:
                 response = invoke_chat_completion_step(
                     invoke_url=self._invoke_url,
@@ -387,6 +501,7 @@ class SelectionAgentOperator(AbstractOperator, CPUOperator):
                     api_key=api_key,
                     tools=tools,
                     tool_choice="auto",
+                    temperature=self._temperature,
                     max_tokens=self._max_tokens,
                     extra_body=extra_body or None,
                 )
@@ -438,12 +553,25 @@ class SelectionAgentOperator(AbstractOperator, CPUOperator):
             assistant_turn: Dict[str, Any] = {"role": "assistant"}
             if msg.get("content"):
                 assistant_turn["content"] = msg["content"]
+                # Agent reasoning can quote document text/PII; keep content at DEBUG.
+                logger.debug(
+                    "SelectionAgentOperator: step=%d assistant content=%r",
+                    _step,
+                    _preview_text(msg.get("content")),
+                )
             tool_calls = msg.get("tool_calls") or []
+            logger.info(
+                "SelectionAgentOperator: step=%d finish_reason=%s tool_calls=%s",
+                _step,
+                finish_reason,
+                [((tc.get("function") or {}).get("name") or "") for tc in tool_calls],
+            )
             if tool_calls:
                 assistant_turn["tool_calls"] = tool_calls
             messages.append(assistant_turn)
 
             if finish_reason == "stop" or not tool_calls:
+                logger.info("SelectionAgentOperator: step=%d no tool call; asking for final selection", _step)
                 messages.append(
                     {
                         "role": "user",
@@ -468,6 +596,13 @@ class SelectionAgentOperator(AbstractOperator, CPUOperator):
                     continue
 
                 if fn.get("name") == "think":
+                    # Agent thoughts can quote document text/PII; keep content at DEBUG
+                    # (matches ReActAgentOperator's think logging).
+                    logger.debug(
+                        "SelectionAgentOperator: step=%d think=%r",
+                        _step,
+                        _preview_text(fn_args.get("thought")),
+                    )
                     tool_messages.append(
                         {"role": "tool", "tool_call_id": tc_id, "content": "Your thought has been logged."}
                     )
@@ -480,6 +615,18 @@ class SelectionAgentOperator(AbstractOperator, CPUOperator):
                         except json.JSONDecodeError:
                             raw_doc_ids = []
                     doc_ids = [d for d in raw_doc_ids if d in valid_id_set][:feasible_k]
+                    logger.info(
+                        "SelectionAgentOperator: step=%d log_selected_documents raw=%s accepted=%s",
+                        _step,
+                        raw_doc_ids[:_LOG_DOC_ID_LIMIT] if isinstance(raw_doc_ids, list) else raw_doc_ids,
+                        doc_ids[:_LOG_DOC_ID_LIMIT],
+                    )
+                    # Message can quote document text/PII; keep content at DEBUG.
+                    logger.debug(
+                        "SelectionAgentOperator: step=%d log_selected_documents message=%r",
+                        _step,
+                        _preview_text(fn_args.get("message")),
+                    )
                     if not doc_ids and raw_doc_ids:
                         logger.warning(
                             "SelectionAgentOperator: LLM returned %d doc_id(s) for query %r "

--- a/nemo_retriever/src/nemo_retriever/query/agentic.py
+++ b/nemo_retriever/src/nemo_retriever/query/agentic.py
@@ -1,0 +1,382 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Graph-backed agentic retrieval mode.
+
+The implementation is intentionally additive: it composes the existing graph
+operators and wraps :class:`nemo_retriever.retriever.Retriever` without changing
+the standard retrieval path.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+import pandas as pd
+
+from nemo_retriever.operators.abstract_operator import AbstractOperator
+from nemo_retriever.models import VL_EMBED_MODEL, VL_RERANK_MODEL
+from nemo_retriever.tools.recall.beir import VALID_BEIR_DOC_ID_FIELDS
+from nemo_retriever.tools.recall.beir import _extract_doc_id_from_hit as _beir_doc_id_from_hit
+from nemo_retriever.tools.recall.core import (
+    _hit_to_audio_segment_key,
+    _normalize_pdf_name,
+)
+from nemo_retriever.graph.retriever import Retriever
+
+logger = logging.getLogger(__name__)
+
+AGENTIC_RETRIEVER_TOP_K = 10
+AGENTIC_TARGET_TOP_K = 10
+AGENTIC_BACKEND_TOP_K = 20  # backend retrieve-pool depth. show-count stays AGENTIC_TARGET_TOP_K=10
+AGENTIC_SELECTION_TOP_K = 10
+AGENTIC_NUM_CONCURRENT = 1
+AGENTIC_TEXT_TRUNCATION = 0
+AGENTIC_PARALLEL_TOOL_CALLS = False
+AGENTIC_RRF_K = 60
+AGENTIC_REACT_MAX_STEPS = 50
+AGENTIC_TEMPERATURE = 0.0  # agent LLM sampling temperature (0.0 = greedy)
+
+
+class AgenticQueryInputOperator(AbstractOperator):
+    """Adapt ``Retriever(graph=...)`` input DataFrames to agentic query schema."""
+
+    def preprocess(self, data: Any, **kwargs: Any) -> pd.DataFrame:
+        _ = kwargs
+        if not isinstance(data, pd.DataFrame):
+            raise TypeError(f"AgenticQueryInputOperator expects a pd.DataFrame, got {type(data).__name__}.")
+        return data.copy()
+
+    def process(self, data: pd.DataFrame, **kwargs: Any) -> pd.DataFrame:
+        _ = kwargs
+        out = data.copy()
+        if "query_text" not in out.columns:
+            if "query" in out.columns:
+                out["query_text"] = out["query"].astype(str)
+            elif "text" in out.columns:
+                out["query_text"] = out["text"].astype(str)
+            else:
+                raise ValueError("Agentic query graph input requires 'query_text', 'query', or 'text'.")
+        if "query_id" not in out.columns:
+            out["query_id"] = [str(idx) for idx in range(len(out.index))]
+        return out[["query_id", "query_text"]]
+
+    def postprocess(self, data: pd.DataFrame, **kwargs: Any) -> pd.DataFrame:
+        _ = kwargs
+        return data
+
+
+class AgenticSelectionOutputOperator(AbstractOperator):
+    """Convert final agentic selection DataFrame to ``Retriever`` hit-list output."""
+
+    def preprocess(self, data: Any, **kwargs: Any) -> pd.DataFrame:
+        _ = kwargs
+        if not isinstance(data, pd.DataFrame):
+            raise TypeError(f"AgenticSelectionOutputOperator expects a pd.DataFrame, got {type(data).__name__}.")
+        return data.copy()
+
+    def process(self, data: pd.DataFrame, **kwargs: Any) -> list[list[dict[str, Any]]]:
+        _ = kwargs
+        if data.empty:
+            return []
+        required = {"query_id", "doc_id", "rank"}
+        missing = required - set(data.columns)
+        if missing:
+            raise ValueError(f"Agentic selection output missing required columns: {sorted(missing)}")
+
+        hits: list[list[dict[str, Any]]] = []
+        for _query_id, group in data.groupby("query_id", sort=False):
+            query_hits: list[dict[str, Any]] = []
+            for _, row in group.sort_values("rank").iterrows():
+                hit = row.to_dict()
+                doc_id = str(hit.get("doc_id", ""))
+                if doc_id and not hit.get("pdf_page"):
+                    hit["pdf_page"] = doc_id
+                query_hits.append(hit)
+            hits.append(query_hits)
+        return hits
+
+    def postprocess(self, data: list[list[dict[str, Any]]], **kwargs: Any) -> list[list[dict[str, Any]]]:
+        _ = kwargs
+        return data
+
+
+@dataclass(frozen=True)
+class AgenticRetrievalConfig:
+    """Configuration for graph-backed agentic retrieval."""
+
+    vdb_op: str = "lancedb"
+    vdb_kwargs: dict[str, Any] = field(default_factory=dict)
+    query_embedder: str = VL_EMBED_MODEL
+    embedding_endpoint: Optional[str] = None
+    embedding_api_key: str = ""
+    local_hf_batch_size: int = 32
+    local_query_embed_backend: str = "hf"
+    reranker: Optional[str] = None
+    reranker_endpoint: Optional[str] = None
+    reranker_api_key: str = ""
+    local_reranker_backend: str = "vllm"
+    embed_modality: str = "text"
+    llm_model: str = ""
+    invoke_url: Optional[str] = None
+    api_key: Optional[str] = None
+    react_max_steps: int = AGENTIC_REACT_MAX_STEPS
+    text_truncation: int = AGENTIC_TEXT_TRUNCATION
+    num_concurrent: int = AGENTIC_NUM_CONCURRENT
+    # Forwarded verbatim as the OpenAI `reasoning_effort` field on every LLM
+    # call. Defaults to Path A's validated setting.
+    reasoning_effort: Optional[str] = "high"
+    # Backend retrieve-pool depth, Distinct from the per-call show count (AGENTIC_TARGET_TOP_K).
+    backend_top_k: int = AGENTIC_BACKEND_TOP_K
+    # Sampling temperature sent on every agent LLM call (0.0 = greedy).
+    temperature: float = AGENTIC_TEMPERATURE
+    # Final number of documents the agent targets/selects and the pipeline returns.
+    # Drives the ReAct target, the RRF/selection cut, and the per-hop fetch depth
+    # (which is raised to at least this). Defaults to 10.
+    top_k: int = AGENTIC_TARGET_TOP_K
+
+    def __post_init__(self) -> None:
+        if self.llm_model is None or not str(self.llm_model).strip():
+            raise ValueError("Agentic retrieval requires a non-empty llm_model.")
+        if int(self.react_max_steps) < 1:
+            raise ValueError("react_max_steps must be >= 1.")
+        if int(self.text_truncation) < 0:
+            raise ValueError("text_truncation must be >= 0.")
+        if int(self.top_k) < 1:
+            raise ValueError("top_k must be >= 1.")
+
+
+class AgenticRetriever:
+    """Run graph-backed agentic retrieval over query IDs and query texts."""
+
+    def __init__(
+        self,
+        cfg: AgenticRetrievalConfig,
+        *,
+        match_mode: str = "pdf_page",
+        doc_id_field: str | None = None,
+    ) -> None:
+        self._cfg = cfg
+        self._match_mode = str(match_mode)
+        self._doc_id_field = str(doc_id_field) if doc_id_field else None
+        if self._doc_id_field is not None and self._doc_id_field not in VALID_BEIR_DOC_ID_FIELDS:
+            raise ValueError(f"Unsupported doc_id_field: {self._doc_id_field}")
+        self._retriever = Retriever(
+            vdb_kwargs={
+                "vdb_op": str(cfg.vdb_op),
+                "vdb_kwargs": dict(cfg.vdb_kwargs or {}),
+            },
+            embed_kwargs={
+                "model_name": str(cfg.query_embedder or VL_EMBED_MODEL),
+                "embed_model_name": str(cfg.query_embedder or VL_EMBED_MODEL),
+                "embedding_endpoint": cfg.embedding_endpoint,
+                "api_key": cfg.embedding_api_key,
+                "input_type": "query",
+                "local_ingest_embed_backend": str(cfg.local_query_embed_backend),
+                "inference_batch_size": int(cfg.local_hf_batch_size),
+                "embed_inference_batch_size": int(cfg.local_hf_batch_size),
+            },
+            top_k=AGENTIC_RETRIEVER_TOP_K,
+            rerank=bool(cfg.reranker),
+            rerank_kwargs={
+                "model_name": cfg.reranker or VL_RERANK_MODEL,
+                "invoke_url": cfg.reranker_endpoint,
+                "api_key": cfg.reranker_api_key,
+                "local_reranker_backend": str(cfg.local_reranker_backend),
+                "modality": str(cfg.embed_modality),
+            },
+        )
+        self._lock = threading.Lock()
+
+    def retrieve(self, query_ids: Sequence[str], query_texts: Sequence[str]) -> pd.DataFrame:
+        """Return selected ranked documents for each query.
+
+        The output schema matches ``SelectionAgentOperator``: ``query_id``,
+        ``doc_id``, ``rank``, and ``message``.
+        """
+
+        if len(query_ids) != len(query_texts):
+            raise ValueError("query_ids and query_texts must have the same length.")
+
+        from nemo_retriever.operators.graph_ops.react_agent_operator import ReActAgentOperator
+        from nemo_retriever.operators.graph_ops.rrf_aggregator_operator import RRFAggregatorOperator
+        from nemo_retriever.operators.graph_ops.selection_agent_operator import SelectionAgentOperator
+
+        # Honor the caller's requested top_k. The per-hop fetch is raised to at least
+        # the default pool depth so the agent always sees a full working set even for
+        # small top_k.
+        target_top_k = int(self._cfg.top_k)
+        per_hop_top_k = max(AGENTIC_RETRIEVER_TOP_K, target_top_k)
+
+        pipeline = (
+            AgenticQueryInputOperator()
+            >> ReActAgentOperator(
+                invoke_url=_none_if_empty(self._cfg.invoke_url),
+                llm_model=str(self._cfg.llm_model),
+                retriever_fn=self._retrieve_for_agent,
+                retriever_top_k=per_hop_top_k,
+                target_top_k=target_top_k,
+                user_msg_type="with_results",
+                max_steps=int(self._cfg.react_max_steps),
+                extended_relevance=True,
+                api_key=_none_if_empty(self._cfg.api_key),
+                parallel_tool_calls=AGENTIC_PARALLEL_TOOL_CALLS,
+                num_concurrent=int(self._cfg.num_concurrent),
+                reasoning_effort=self._cfg.reasoning_effort,
+                backend_top_k=self._cfg.backend_top_k,
+                temperature=float(self._cfg.temperature),
+            )
+            >> RRFAggregatorOperator(k=AGENTIC_RRF_K)
+            >> SelectionAgentOperator(
+                invoke_url=_none_if_empty(self._cfg.invoke_url),
+                llm_model=str(self._cfg.llm_model),
+                top_k=target_top_k,
+                api_key=_none_if_empty(self._cfg.api_key),
+                parallel_tool_calls=AGENTIC_PARALLEL_TOOL_CALLS,
+                extended_relevance=True,  # match Path A
+                text_truncation=int(self._cfg.text_truncation),
+                reasoning_effort=self._cfg.reasoning_effort,
+                temperature=float(self._cfg.temperature),
+            )
+            >> AgenticSelectionOutputOperator()
+        )
+        graph_retriever = Retriever(
+            graph=pipeline,
+            top_k=target_top_k,
+            embed_kwargs={"text_column": "query_text"},
+        )
+        raw_hits = graph_retriever.queries(
+            [str(query_text) for query_text in query_texts],
+            top_k=target_top_k,
+        )
+        return _raw_hits_to_agentic_result([str(query_id) for query_id in query_ids], raw_hits)
+
+    def _retrieve_for_agent(self, query_text: str, top_k: int) -> list[dict[str, Any]]:
+        """Retriever callback used by ``ReActAgentOperator``.
+
+        Retrieval is serialized across concurrent ReAct workers via ``self._lock``
+        because the shared ``Retriever`` is not assumed thread-safe. This caps the
+        retrieval hop at single-threaded throughput; it is intentional and not the
+        bottleneck, since per-query cost is dominated by the multi-step LLM calls,
+        which still run concurrently under ``num_concurrent > 1``.
+        """
+
+        with self._lock:
+            hits = self._retriever.query(str(query_text), top_k=int(top_k))
+
+        docs: list[dict[str, Any]] = []
+        doc_id_field = getattr(self, "_doc_id_field", None)
+        for hit in hits:
+            hit_dict = dict(hit)
+            doc_id = (
+                _beir_doc_id_from_hit(hit_dict, doc_id_field=doc_id_field)
+                if doc_id_field is not None
+                else _doc_id_for_match_mode(hit_dict, match_mode=self._match_mode)
+            )
+            if not doc_id:
+                continue
+            text = str(hit_dict.get("text", ""))
+            if int(self._cfg.text_truncation) > 0:
+                text = text[: int(self._cfg.text_truncation)]
+            docs.append(
+                {
+                    "doc_id": doc_id,
+                    "text": text,
+                    "score": _hit_score(hit_dict),
+                }
+            )
+            if len(docs) >= int(top_k):
+                break
+        return docs
+
+
+def _raw_hits_to_agentic_result(query_ids: Sequence[str], raw_hits: Sequence[Sequence[dict[str, Any]]]) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    # The agentic graph (AgenticQueryInputOperator) assigns POSITIONAL query_ids
+    # "0".."N-1" to its inputs, independent of the caller's real ids. Each hit
+    # therefore carries its positional index; map that back through `query_ids`
+    # to recover the caller's real id. This is robust to (a) ThreadPool
+    # completion-order reordering at num_concurrent>1, (b) queries that produced
+    # no rows (gaps don't shift anything), and (c) sharded offset ranges where the
+    # positional index != the caller's real id (e.g. query_ids=["1000".."1049"]).
+    # For a full sweep with sequential ids ("0".."N-1") this is a no-op vs the
+    # old positional zip.
+    n = len(query_ids)
+    for pos, hits in enumerate(raw_hits):
+        for rank, hit in enumerate(hits, start=1):
+            raw_qid = hit.get("query_id")
+            if raw_qid is not None and str(raw_qid).isdigit() and int(raw_qid) < n:
+                qid = str(query_ids[int(raw_qid)])
+            elif pos < n:
+                qid = str(query_ids[pos])
+            else:
+                qid = str(raw_qid) if raw_qid is not None else ""
+            rows.append(
+                {
+                    "query_id": qid,
+                    "doc_id": str(hit.get("doc_id") or hit.get("pdf_page") or ""),
+                    "rank": int(hit.get("rank", rank)),
+                    "message": str(hit.get("message", "")),
+                    "result_source": str(hit.get("result_source", "")),
+                }
+            )
+    if not rows:
+        return pd.DataFrame(columns=["query_id", "doc_id", "rank", "message", "result_source"])
+    return pd.DataFrame(rows)
+
+
+def _doc_id_for_match_mode(hit: dict[str, Any], *, match_mode: str) -> str:
+    if match_mode == "audio_segment":
+        return _hit_to_audio_segment_key(hit) or ""
+    if match_mode == "pdf_only":
+        return _doc_id_from_hit(hit)
+    return _pdf_page_from_hit(hit)
+
+
+def _pdf_page_from_hit(hit: dict[str, Any]) -> str:
+    pdf_page = hit.get("pdf_page")
+    if isinstance(pdf_page, str) and pdf_page.strip():
+        return pdf_page.strip()
+
+    source = hit.get("source") or hit.get("source_id") or hit.get("path")
+    page_number = hit.get("page_number")
+    if source and page_number is not None:
+        return f"{Path(str(source)).stem}_{page_number}"
+    return _doc_id_from_hit(hit)
+
+
+def _doc_id_from_hit(hit: dict[str, Any]) -> str:
+    for key in ("pdf_basename", "source_id", "path", "source", "doc_id"):
+        value = hit.get(key)
+        if isinstance(value, str) and value.strip():
+            return _normalize_pdf_name(Path(value).stem)
+    return ""
+
+
+def _hit_score(hit: dict[str, Any]) -> float:
+    for key in ("_rerank_score", "_score", "score"):
+        if key in hit:
+            try:
+                return float(hit[key])
+            except (TypeError, ValueError):
+                return 0.0
+    if "_distance" in hit:
+        try:
+            return -float(hit["_distance"])
+        except (TypeError, ValueError):
+            return 0.0
+    return 0.0
+
+
+def _none_if_empty(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    stripped = str(value).strip()
+    if not stripped or stripped.lower() in {"none", "null"}:
+        return None
+    return stripped

--- a/nemo_retriever/src/nemo_retriever/query/options.py
+++ b/nemo_retriever/src/nemo_retriever/query/options.py
@@ -41,9 +41,25 @@ class QueryStorageOptions:
 
 
 @dataclass(frozen=True)
+class QueryAgenticOptions:
+    """Options for the agentic (ReAct) retrieval strategy. Mirrors ``QueryRerankOptions``:
+    ``enabled`` switches the standard dense pass for an LLM-driven agent loop."""
+
+    enabled: bool = False
+    llm_model: str | None = None
+    invoke_url: str | None = None
+    reasoning_effort: str | None = "high"
+    backend_top_k: int = 20
+    react_max_steps: int = 50
+    text_truncation: int = 0
+    temperature: float = 0.0
+
+
+@dataclass(frozen=True)
 class QueryRequest:
     query: str
     retrieval: QueryRetrievalOptions = field(default_factory=QueryRetrievalOptions)
     embed: QueryEmbedOptions = field(default_factory=QueryEmbedOptions)
     rerank: QueryRerankOptions = field(default_factory=QueryRerankOptions)
     storage: QueryStorageOptions = field(default_factory=QueryStorageOptions)
+    agentic: QueryAgenticOptions = field(default_factory=QueryAgenticOptions)

--- a/nemo_retriever/src/nemo_retriever/query/workflow.py
+++ b/nemo_retriever/src/nemo_retriever/query/workflow.py
@@ -65,3 +65,62 @@ def query_documents(request: QueryRequest) -> list[RetrievalHit]:
         page_dedup=request.retrieval.page_dedup,
         content_types=request.retrieval.content_types,
     )
+
+
+def agentic_query_documents(request: QueryRequest) -> list[dict[str, Any]]:
+    """Run agentic (ReAct) retrieval for a single query and return the agent's
+    ranked document IDs.
+
+    Unlike the dense ``query_documents`` path (which returns enriched hits with
+    text), the agent operates at the document-ID granularity of the configured
+    index, so the result is the ranked ``doc_id`` list the agent selected,
+    annotated with the source that produced it (``final_results`` / ``rrf`` /
+    ``selection_agent``). The LanceDB ``uri``/``table_name``, embedding config,
+    and (when ``--rerank`` is enabled) reranker config are passed straight
+    through to the wrapped ``Retriever`` that backs the agent's ``retrieve``
+    tool. Reranking therefore applies per agent retrieval hop.
+    """
+    from nemo_retriever.query.agentic import AgenticRetrievalConfig, AgenticRetriever
+
+    api_key = resolve_remote_api_key()
+    cfg_kwargs: dict[str, Any] = {
+        "vdb_op": "lancedb",
+        "vdb_kwargs": {"uri": request.storage.lancedb_uri, "table_name": request.storage.table_name},
+        "top_k": int(request.retrieval.top_k),
+        "embedding_endpoint": request.embed.embed_invoke_url,
+        "embedding_api_key": api_key or "",
+        "llm_model": request.agentic.llm_model,
+        "invoke_url": request.agentic.invoke_url,
+        "api_key": api_key,
+        "reasoning_effort": request.agentic.reasoning_effort,
+        "backend_top_k": int(request.agentic.backend_top_k),
+        "react_max_steps": int(request.agentic.react_max_steps),
+        "text_truncation": int(request.agentic.text_truncation),
+        "temperature": float(request.agentic.temperature),
+    }
+    if request.embed.embed_model_name:
+        cfg_kwargs["query_embedder"] = request.embed.embed_model_name
+    if request.rerank.enabled:
+        # `reranker` doubles as the on/off gate (rerank=bool(cfg.reranker)) and the
+        # model name, so fall back to the default model when only --rerank is given.
+        cfg_kwargs["reranker"] = request.rerank.reranker_model_name or _LOCAL_VL_RERANK_MODEL
+        cfg_kwargs["reranker_endpoint"] = request.rerank.reranker_invoke_url
+        cfg_kwargs["reranker_api_key"] = resolve_remote_api_key(request.rerank.reranker_api_key) or ""
+        if request.rerank.reranker_backend:
+            cfg_kwargs["local_reranker_backend"] = request.rerank.reranker_backend
+
+    result = AgenticRetriever(AgenticRetrievalConfig(**cfg_kwargs)).retrieve(["0"], [str(request.query)])
+    if "rank" in result.columns:
+        result = result.sort_values("rank")
+    ranked: list[dict[str, Any]] = []
+    for _, row in result.iterrows():
+        ranked.append(
+            {
+                "rank": int(row.get("rank", len(ranked) + 1)),
+                "doc_id": str(row.get("doc_id", "")),
+                "result_source": str(row.get("result_source", "")),
+            }
+        )
+        if len(ranked) >= request.retrieval.top_k:
+            break
+    return ranked

--- a/nemo_retriever/tests/test_agentic_eval.py
+++ b/nemo_retriever/tests/test_agentic_eval.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+
+def _make_tool_call_response(fn_name: str, fn_args: dict, tc_id: str = "call_1") -> dict:
+    return {
+        "choices": [
+            {
+                "message": {
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": tc_id,
+                            "type": "function",
+                            "function": {"name": fn_name, "arguments": json.dumps(fn_args)},
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ]
+    }
+
+
+class FakeRetriever:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.graph = kwargs.get("graph")
+        self.top_k = int(kwargs.get("top_k", 10))
+
+    def query(self, query: str, *, top_k: int | None = None):
+        if self.graph is not None:
+            return self.queries([query], top_k=top_k)[0]
+        _ = query
+        hits = [
+            {
+                "source": "/tmp/doc.pdf",
+                "source_id": "/tmp/doc.pdf",
+                "page_number": 1,
+                "pdf_page": "doc_1",
+                "text": "matching document",
+                "_score": 0.9,
+            },
+            {
+                "source": "/tmp/other.pdf",
+                "source_id": "/tmp/other.pdf",
+                "page_number": 2,
+                "pdf_page": "other_2",
+                "text": "other document",
+                "_score": 0.1,
+            },
+        ]
+        return hits[:top_k]
+
+    def queries(self, queries, *, top_k: int | None = None):
+        if self.graph is None:
+            return [self.query(query, top_k=top_k) for query in queries]
+        limit = int(top_k) if top_k is not None else self.top_k
+        df = pd.DataFrame({"query_text": [str(query) for query in queries]})
+        graph = self.graph.resolve_for_local_execution()
+        raw_hits = graph.execute(df)[0]
+        return [list(hits)[:limit] for hits in raw_hits]
+
+
+@patch("nemo_retriever.operators.graph_ops.selection_agent_operator.invoke_chat_completion_step")
+@patch("nemo_retriever.operators.graph_ops.react_agent_operator.invoke_chat_completion_step")
+@patch("nemo_retriever.query.agentic.Retriever", FakeRetriever)
+def test_agentic_retriever_runs_graph_with_wrapped_retriever(mock_react_step, mock_selection_step):
+    from nemo_retriever.query.agentic import AgenticRetrievalConfig, AgenticRetriever
+
+    final_ids = ["doc_1"] + [f"extra_{i}" for i in range(9)]
+    mock_react_step.return_value = _make_tool_call_response(
+        "final_results",
+        {"doc_ids": final_ids, "message": "done", "search_successful": "true"},
+    )
+    mock_selection_step.return_value = _make_tool_call_response(
+        "log_selected_documents",
+        {"doc_ids": ["doc_1"], "message": "doc_1 is best"},
+    )
+
+    cfg = AgenticRetrievalConfig(llm_model="test-model", invoke_url="http://localhost/v1/chat/completions")
+    result = AgenticRetriever(cfg, match_mode="pdf_page").retrieve(["0"], ["find doc"])
+
+    assert list(result.columns) == ["query_id", "doc_id", "rank", "message", "result_source"]
+    assert result["query_id"].tolist() == ["0"] * 10
+    assert result["doc_id"].tolist()[0] == "doc_1"
+    assert result["rank"].tolist() == list(range(1, 11))
+
+
+@patch("nemo_retriever.operators.graph_ops.selection_agent_operator.invoke_chat_completion_step")
+@patch("nemo_retriever.operators.graph_ops.react_agent_operator.invoke_chat_completion_step")
+@patch("nemo_retriever.query.agentic.Retriever", FakeRetriever)
+def test_agentic_retriever_honors_top_k(mock_react_step, mock_selection_step):
+    """cfg.top_k drives the pipeline output count, not the hardcoded default of 10."""
+    from nemo_retriever.query.agentic import AgenticRetrievalConfig, AgenticRetriever
+
+    final_ids = ["doc_1"] + [f"extra_{i}" for i in range(4)]  # exactly 5
+    mock_react_step.return_value = _make_tool_call_response(
+        "final_results",
+        {"doc_ids": final_ids, "message": "done", "search_successful": "true"},
+    )
+    mock_selection_step.return_value = _make_tool_call_response(
+        "log_selected_documents",
+        {"doc_ids": ["doc_1"], "message": "doc_1 is best"},
+    )
+
+    cfg = AgenticRetrievalConfig(llm_model="test-model", invoke_url="http://localhost/v1/chat/completions", top_k=5)
+    result = AgenticRetriever(cfg, match_mode="pdf_page").retrieve(["0"], ["find doc"])
+
+    assert result["rank"].tolist() == list(range(1, 6))  # 5 rows, honoring top_k=5
+
+
+def test_agentic_config_requires_llm_model():
+    from nemo_retriever.query.agentic import AgenticRetrievalConfig
+
+    with pytest.raises(ValueError, match="llm_model"):
+        AgenticRetrievalConfig(llm_model="")
+    # None must not slip through as the literal string "None".
+    with pytest.raises(ValueError, match="llm_model"):
+        AgenticRetrievalConfig(llm_model=None)
+
+
+def test_agentic_config_rejects_nonpositive_top_k():
+    from nemo_retriever.query.agentic import AgenticRetrievalConfig
+
+    with pytest.raises(ValueError, match="top_k"):
+        AgenticRetrievalConfig(llm_model="m", top_k=0)

--- a/nemo_retriever/tests/test_agentic_operators.py
+++ b/nemo_retriever/tests/test_agentic_operators.py
@@ -75,6 +75,17 @@ class TestRRFAggregatorOperator:
         result = op.run(self._make_input())
         assert set(result.columns) >= {"query_id", "query_text", "doc_id", "rrf_score", "text"}
 
+    def test_carries_react_final_rank(self):
+        from nemo_retriever.operators.graph_ops.rrf_aggregator_operator import RRFAggregatorOperator
+
+        df = self._make_input()
+        df["is_final_result"] = [False, False, True, False, False, False]
+        op = RRFAggregatorOperator(k=60)
+        result = op.run(df)
+
+        q1 = result[result["query_id"] == "q1"].set_index("doc_id")
+        assert int(q1.loc["d1", "react_final_rank"]) == 1
+
     def test_missing_column_raises(self):
         from nemo_retriever.operators.graph_ops.rrf_aggregator_operator import RRFAggregatorOperator
 
@@ -181,10 +192,11 @@ class TestSelectionAgentOperator:
         )
         result = op.run(self._make_input())
 
-        assert list(result.columns) == ["query_id", "doc_id", "rank", "message"]
+        assert set(result.columns) >= {"query_id", "doc_id", "rank", "message", "result_source"}
         assert result["query_id"].tolist() == ["q1", "q1"]
         assert result["doc_id"].tolist() == ["d1", "d2"]
         assert result["rank"].tolist() == [1, 2]
+        assert result["result_source"].tolist() == ["selection_agent", "selection_agent"]
 
     @patch("nemo_retriever.operators.graph_ops.selection_agent_operator.invoke_chat_completion_step")
     def test_think_then_select(self, mock_step):
@@ -227,6 +239,82 @@ class TestSelectionAgentOperator:
         op.run(self._make_input())
 
         assert "RELEVANCE_DEFINITION" in captured_prompts[0]
+
+    @patch("nemo_retriever.operators.graph_ops.selection_agent_operator.invoke_chat_completion_step")
+    def test_final_results_policy_skips_selection_agent(self, mock_step):
+        from nemo_retriever.operators.graph_ops.selection_agent_operator import SelectionAgentOperator
+
+        op = SelectionAgentOperator(
+            llm_model="test-model",
+            invoke_url="http://localhost/v1/chat/completions",
+            top_k=2,
+        )
+        df = pd.DataFrame(
+            {
+                "query_id": ["q1", "q1", "q1"],
+                "query_text": ["What causes inflation?"] * 3,
+                "doc_id": ["d1", "d2", "d3"],
+                "text": ["doc one", "doc two", "doc three"],
+                "rrf_score": [0.1, 0.9, 0.8],
+                "react_final_rank": [2, None, 1],
+            }
+        )
+        result = op.run(df)
+
+        assert result["doc_id"].tolist() == ["d3", "d1"]
+        assert result["result_source"].tolist() == ["final_results", "final_results"]
+        mock_step.assert_not_called()
+
+    @patch("nemo_retriever.operators.graph_ops.selection_agent_operator.invoke_chat_completion_step")
+    def test_result_policy_uses_rrf_before_selection_when_no_final_results(self, mock_step):
+        from nemo_retriever.operators.graph_ops.selection_agent_operator import SelectionAgentOperator
+
+        op = SelectionAgentOperator(
+            llm_model="test-model",
+            invoke_url="http://localhost/v1/chat/completions",
+            top_k=2,
+        )
+        df = pd.DataFrame(
+            {
+                "query_id": ["q1", "q1", "q1"],
+                "query_text": ["What causes inflation?"] * 3,
+                "doc_id": ["d1", "d2", "d3"],
+                "text": ["doc one", "doc two", "doc three"],
+                "rrf_score": [0.1, 0.9, 0.8],
+                "react_final_rank": [None, None, None],
+            }
+        )
+        result = op.run(df)
+
+        assert result["doc_id"].tolist() == ["d2", "d3"]
+        assert result["result_source"].tolist() == ["rrf", "rrf"]
+        mock_step.assert_not_called()
+
+    @patch("nemo_retriever.operators.graph_ops.selection_agent_operator.invoke_chat_completion_step")
+    def test_empty_final_results_is_not_valid_and_falls_back_to_rrf(self, mock_step):
+        from nemo_retriever.operators.graph_ops.selection_agent_operator import SelectionAgentOperator
+
+        op = SelectionAgentOperator(
+            llm_model="test-model",
+            invoke_url="http://localhost/v1/chat/completions",
+            top_k=2,
+        )
+        df = pd.DataFrame(
+            {
+                "query_id": ["q1", "q1"],
+                "query_text": ["What causes inflation?"] * 2,
+                "doc_id": ["d1", "d2"],
+                "text": ["doc one", "doc two"],
+                "rrf_score": [0.9, 0.8],
+                "has_valid_final_results": [False, False],
+                "react_final_rank": [None, None],
+            }
+        )
+        result = op.run(df)
+
+        assert result["doc_id"].tolist() == ["d1", "d2"]
+        assert result["result_source"].tolist() == ["rrf", "rrf"]
+        mock_step.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -305,6 +393,67 @@ class TestReActAgentOperator:
         assert retriever.call_count >= 1
         assert 0 in result["step_idx"].values
 
+    def test_backend_top_k_caps_fetch_depth_and_replays_seen_docs(self):
+        from nemo_retriever.operators.graph_ops.react_agent_operator import ReActAgentOperator
+
+        calls = []
+        docs = [
+            {"doc_id": "d1", "text": "already seen", "score": 0.9},
+            {"doc_id": "d2", "text": "new two", "score": 0.8},
+            {"doc_id": "d3", "text": "new three", "score": 0.7},
+            {"doc_id": "d4", "text": "outside backend cap", "score": 0.6},
+        ]
+
+        def retriever_fn(query_text, top_k):
+            calls.append((query_text, top_k))
+            return docs[:top_k]
+
+        op = ReActAgentOperator(
+            invoke_url="http://localhost/v1/chat/completions",
+            llm_model="test-model",
+            retriever_fn=retriever_fn,
+            retriever_top_k=2,
+            backend_top_k=3,
+        )
+
+        result = op._call_retriever("inflation", {"d1"}, api_key=None)
+
+        assert calls == [("inflation", 3)]
+        assert [doc["doc_id"] for doc in result] == ["d1", "d2", "d3"]
+        assert "retrieved before" in result[0]["text"]
+        assert result[1]["text"] == "new two"
+
+    @pytest.mark.parametrize(
+        ("fn_args", "target_top_k", "enforce_top_k"),
+        [
+            ({"doc_ids": [1], "message": "bad id type", "search_successful": "true"}, 1, False),
+            ({"doc_ids": [], "message": "empty", "search_successful": "false"}, 1, False),
+            ({"doc_ids": [""], "message": "empty-string id", "search_successful": "true"}, 1, False),
+            ({"doc_ids": ["  "], "message": "whitespace id", "search_successful": "true"}, 1, False),
+            ({"doc_ids": ["d1"], "message": "wrong count", "search_successful": "true"}, 2, True),
+            ({"doc_ids": ["d1"], "message": "bad status", "search_successful": "yes"}, 1, False),
+        ],
+    )
+    @patch("nemo_retriever.operators.graph_ops.react_agent_operator.invoke_chat_completion_step")
+    def test_invalid_final_results_are_rejected(self, mock_step, fn_args, target_top_k, enforce_top_k):
+        from nemo_retriever.operators.graph_ops.react_agent_operator import ReActAgentOperator
+
+        mock_step.return_value = _make_tool_call_response("final_results", fn_args)
+        retriever = MagicMock(return_value=[{"doc_id": "d1", "text": "monetary policy"}])
+
+        op = ReActAgentOperator(
+            invoke_url="http://localhost/v1/chat/completions",
+            llm_model="test-model",
+            retriever_fn=retriever,
+            user_msg_type="with_results",
+            target_top_k=target_top_k,
+            enforce_top_k=enforce_top_k,
+        )
+        result = op.run(self._make_input())
+
+        assert not result["is_final_result"].astype(bool).any()
+        assert not result["has_valid_final_results"].astype(bool).any()
+
     @patch("nemo_retriever.operators.graph_ops.react_agent_operator.invoke_chat_completion_step")
     def test_output_row_structure(self, mock_step):
         from nemo_retriever.operators.graph_ops.react_agent_operator import ReActAgentOperator
@@ -321,12 +470,42 @@ class TestReActAgentOperator:
             llm_model="test-model",
             retriever_fn=self._make_retriever(),
             user_msg_type="simple",
+            target_top_k=1,
         )
         result = op.run(self._make_input())
 
         assert (result["rank"] >= 1).all()
         assert result["step_idx"].dtype in (int, "int64")
         assert result["doc_id"].notna().all()
+
+    @patch("nemo_retriever.operators.graph_ops.react_agent_operator.invoke_chat_completion_step")
+    def test_no_final_results_falls_back_to_retrieval_log(self, mock_step):
+        from nemo_retriever.operators.graph_ops.react_agent_operator import ReActAgentOperator
+
+        mock_step.side_effect = [
+            _make_tool_call_response("retrieve", {"query": "inflation monetary policy"}),
+            _make_tool_call_response("think", {"thought": "still reasoning"}),
+        ]
+        retriever = MagicMock(
+            return_value=[
+                {"doc_id": "d1", "text": "monetary policy"},
+                {"doc_id": "d2", "text": "supply chains"},
+            ]
+        )
+
+        op = ReActAgentOperator(
+            invoke_url="http://localhost/v1/chat/completions",
+            llm_model="test-model",
+            retriever_fn=retriever,
+            user_msg_type="simple",
+            target_top_k=2,
+            max_steps=2,
+        )
+        result = op.run(self._make_input())
+
+        assert result["doc_id"].tolist() == ["d1", "d2"]
+        assert result["rank"].tolist() == [1, 2]
+        assert retriever.call_count == 1
 
     @patch("nemo_retriever.operators.graph_ops.selection_agent_operator.invoke_chat_completion_step")
     @patch("nemo_retriever.operators.graph_ops.react_agent_operator.invoke_chat_completion_step")
@@ -345,7 +524,7 @@ class TestReActAgentOperator:
         mock_react_step.side_effect = [
             _make_tool_call_response("retrieve", {"query": "inflation"}),
             _make_tool_call_response(
-                "final_results", {"doc_ids": ["d1", "d2"], "message": "ok", "search_successful": "true"}
+                "final_results", {"doc_ids": ["d1"], "message": "ok", "search_successful": "true"}
             ),
         ]
         # Selection: immediately log_selected_documents
@@ -375,7 +554,7 @@ class TestReActAgentOperator:
         query_df = pd.DataFrame({"query_id": ["q1"], "query_text": ["What causes inflation?"]})
         result = InprocessExecutor(pipeline).ingest(query_df)
 
-        assert list(result.columns) == ["query_id", "doc_id", "rank", "message"]
+        assert set(result.columns) >= {"query_id", "doc_id", "rank", "message", "result_source"}
         assert result["query_id"].tolist() == ["q1"]
         assert result["rank"].tolist() == [1]
 
@@ -569,10 +748,9 @@ class TestSelectionAgentPreprocess:
 
 class TestSelectionAgentMaxSteps:
     @patch("nemo_retriever.operators.graph_ops.selection_agent_operator.invoke_chat_completion_step")
-    def test_max_steps_exhausted_returns_empty(self, mock_step):
+    def test_rrf_candidates_skip_selection_agent(self, mock_step):
         from nemo_retriever.operators.graph_ops.selection_agent_operator import SelectionAgentOperator
 
-        # LLM only ever calls think — never log_selected_documents
         mock_step.return_value = _make_tool_call_response("think", {"thought": "still thinking..."})
 
         op = SelectionAgentOperator(
@@ -583,14 +761,17 @@ class TestSelectionAgentMaxSteps:
         )
         df = pd.DataFrame(
             {
-                "query_id": ["q1", "q1"],
-                "query_text": ["What causes inflation?"] * 2,
-                "doc_id": ["d1", "d2"],
-                "text": ["doc one", "doc two"],
+                "query_id": ["q1", "q1", "q1"],
+                "query_text": ["What causes inflation?"] * 3,
+                "doc_id": ["d1", "d2", "d3"],
+                "text": ["doc one", "doc two", "doc three"],
+                "rrf_score": [0.2, 0.9, 0.5],
             }
         )
         result = op.run(df)
 
-        assert len(result) == 0
-        assert list(result.columns) == ["query_id", "doc_id", "rank", "message"]
-        assert mock_step.call_count == 3
+        assert result["doc_id"].tolist() == ["d2", "d3"]
+        assert result["rank"].tolist() == [1, 2]
+        assert result["message"].tolist() == ["Using RRF ranking."] * 2
+        assert result["result_source"].tolist() == ["rrf", "rrf"]
+        mock_step.assert_not_called()

--- a/nemo_retriever/tests/test_root_query_cli.py
+++ b/nemo_retriever/tests/test_root_query_cli.py
@@ -12,7 +12,6 @@ from typer.testing import CliRunner
 
 import nemo_retriever.query.workflow as query_core
 
-
 RUNNER = CliRunner()
 cli_main = importlib.import_module("nemo_retriever.cli.main")
 
@@ -332,6 +331,136 @@ def test_root_query_reports_os_errors(monkeypatch) -> None:
 
     assert result.exit_code == 1
     assert "Error: database unavailable" in result.output
+
+
+def test_root_query_agentic_passes_config_and_prints_ranked(monkeypatch) -> None:
+    """`--agentic` wires the LanceDB/embed/LLM options into AgenticRetrievalConfig
+    and prints the agent's ranked doc_ids (sorted by rank, truncated to --top-k)."""
+    import pandas as pd
+
+    import nemo_retriever.query.agentic as agentic_retrieval
+
+    config_calls: list[dict[str, Any]] = []
+    retrieve_calls: list[tuple[Any, Any]] = []
+
+    class FakeConfig:
+        def __init__(self, **kwargs: Any) -> None:
+            config_calls.append(kwargs)
+
+    class FakeAgenticRetriever:
+        def __init__(self, cfg: Any) -> None:
+            self.cfg = cfg
+
+        def retrieve(self, query_ids: Any, query_texts: Any) -> Any:
+            retrieve_calls.append((query_ids, query_texts))
+            # Deliberately out of rank order to exercise the sort.
+            return pd.DataFrame(
+                [
+                    {"query_id": "0", "doc_id": "b.pdf", "rank": 2, "result_source": "rrf"},
+                    {"query_id": "0", "doc_id": "a.pdf", "rank": 1, "result_source": "final_results"},
+                    {"query_id": "0", "doc_id": "c.pdf", "rank": 3, "result_source": "rrf"},
+                ]
+            )
+
+    monkeypatch.setattr(agentic_retrieval, "AgenticRetrievalConfig", FakeConfig)
+    monkeypatch.setattr(agentic_retrieval, "AgenticRetriever", FakeAgenticRetriever)
+
+    result = RUNNER.invoke(
+        cli_main.app,
+        [
+            "query",
+            "how does ingest work?",
+            "--agentic",
+            "--agentic-llm-model",
+            "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+            "--top-k",
+            "2",
+            "--lancedb-uri",
+            "/tmp/lancedb",
+            "--table-name",
+            "docs",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert retrieve_calls == [(["0"], ["how does ingest work?"])]
+    cfg = config_calls[0]
+    assert cfg["vdb_op"] == "lancedb"
+    assert cfg["vdb_kwargs"] == {"uri": "/tmp/lancedb", "table_name": "docs"}
+    assert cfg["llm_model"] == "nvidia/llama-3.3-nemotron-super-49b-v1.5"
+    # --top-k is honored end-to-end: plumbed into the agentic config (drives the
+    # ReAct target / RRF / selection cut), not just applied as a post-filter.
+    assert cfg["top_k"] == 2
+    # Sorted by rank and truncated to --top-k=2.
+    assert json.loads(result.output) == [
+        {"rank": 1, "doc_id": "a.pdf", "result_source": "final_results"},
+        {"rank": 2, "doc_id": "b.pdf", "result_source": "rrf"},
+    ]
+
+
+def test_root_query_agentic_requires_llm_model() -> None:
+    """Agentic mode is inert without a chat model to drive the loop."""
+    result = RUNNER.invoke(cli_main.app, ["query", "hello", "--agentic"])
+
+    assert result.exit_code == 1
+    assert "requires --agentic-llm-model" in result.output
+
+
+def test_root_query_agentic_plumbs_rerank_into_config(monkeypatch) -> None:
+    """`--rerank` with `--agentic` wires the reranker config into AgenticRetrievalConfig
+    (reranker model + endpoint + backend), so the agent's retrieval backend reranks."""
+    import pandas as pd
+
+    import nemo_retriever.query.agentic as agentic_retrieval
+
+    config_calls: list[dict[str, Any]] = []
+
+    class FakeConfig:
+        def __init__(self, **kwargs: Any) -> None:
+            config_calls.append(kwargs)
+
+    class FakeAgenticRetriever:
+        def __init__(self, cfg: Any) -> None:
+            self.cfg = cfg
+
+        def retrieve(self, query_ids: Any, query_texts: Any) -> Any:
+            return pd.DataFrame([{"query_id": "0", "doc_id": "a.pdf", "rank": 1, "result_source": "rrf"}])
+
+    monkeypatch.setattr(agentic_retrieval, "AgenticRetrievalConfig", FakeConfig)
+    monkeypatch.setattr(agentic_retrieval, "AgenticRetriever", FakeAgenticRetriever)
+
+    base = ["query", "q", "--agentic", "--agentic-llm-model", "m"]
+
+    # 1. Explicit reranker model + endpoint + backend flow through.
+    result = RUNNER.invoke(
+        cli_main.app,
+        base
+        + [
+            "--reranker-model-name",
+            "my-rerank",
+            "--reranker-invoke-url",
+            "http://rr/v1/rerank",
+            "--reranker-backend",
+            "hf",
+        ],
+    )
+    assert result.exit_code == 0
+    cfg = config_calls[-1]
+    assert cfg["reranker"] == "my-rerank"
+    assert cfg["reranker_endpoint"] == "http://rr/v1/rerank"
+    assert cfg["local_reranker_backend"] == "hf"
+
+    # 2. --rerank with no model name falls back to the default rerank model (gate stays on).
+    config_calls.clear()
+    result = RUNNER.invoke(cli_main.app, base + ["--rerank"])
+    assert result.exit_code == 0
+    assert config_calls[-1]["reranker"] == query_core._LOCAL_VL_RERANK_MODEL
+
+    # 3. No rerank flags => no reranker key => backend rerank stays off (cfg default None).
+    config_calls.clear()
+    result = RUNNER.invoke(cli_main.app, base)
+    assert result.exit_code == 0
+    assert "reranker" not in config_calls[-1]
 
 
 def test_root_query_passes_hybrid_into_vdb_kwargs(monkeypatch) -> None:


### PR DESCRIPTION
# Agentic retrieval mode for `retriever query`

## Summary
Adds an **LLM-driven agentic retrieval strategy** as an opt-in alternative to the
single dense-retrieval pass on `retriever query`. **Additive** — the standard
retrieval path and outputs are unchanged; agentic mode reuses the existing
`Retriever`/vector DB and is enabled via `--agentic`.

## What's new
- **Agentic retrieval** — `ReActAgentOperator` runs a per-query ReAct loop (issues
  retrieval sub-queries, accumulates candidates across steps, decides when to stop)
  → `RRFAggregatorOperator` fuses across steps (RRF, k=60) → `SelectionAgentOperator`
  applies a source-priority chain (`final_results → RRF → selection → candidate_ranking`)
  and carries `result_source` through to the caller.
- **CLI flags** on `retriever query` — `--agentic`, `--agentic-llm-model`,
  `--agentic-invoke-url`, `--agentic-react-max-steps` (50), `--agentic-backend-top-k`
  (20), `--agentic-text-truncation` (0 = none), `--agentic-reasoning-effort` (high),
  `--agentic-temperature` (0.0). Existing `--rerank`/`--reranker-*` flags are plumbed
  through to the agent's retrieval backend (rerank applies per agent retrieval hop).
- **Docs & tests** — "Agentic retrieval" section in `docs/cli/README.md`;
  `test_agentic_eval.py`, `test_agentic_operators.py`, and `--agentic` CLI tests in
  `test_root_query_cli.py`.

## Results — ViDoRe v3
Benchmarked against the reference agentic pipeline (`retrieval-bench`) under an
**identical, controlled setup** so the comparison isolates the retrieval
framework: same page-level image+text index (`llama-nemotron-embed-vl-1b-v2`
embedder), same agent LLM (`llama-3.3-nemotron-super-49b-v1.5`), same agent
settings (`reasoning_effort=high`, retriever pool depth 20, target top-k 10,
max 50 ReAct steps), full query sets. The retrieval substrate is shared, so the
numbers reflect the agent framework only.

| Domain | recall@10 (ref / this PR) | nDCG@10 (ref / this PR) |
|---|---|---|
| computer_science | 0.7431 / 0.7234 | 0.7396 / 0.7182 |
| energy | 0.6975 / 0.6612 | 0.6369 / 0.6274 |
| finance_en | 0.6406 / 0.6134 | 0.6109 / 0.5951 |
| finance_fr | 0.4750 / 0.4491 | 0.4182 / 0.4008 |
| hr | 0.5775 / 0.5583 | 0.5631 / 0.5523 |
| industrial | 0.4695 / 0.4636 | 0.4543 / 0.4615 |
| pharmaceuticals | 0.6724 / 0.6711 | 0.6449 / 0.6439 |
| physics | 0.4560 / 0.4353 | 0.4373 / 0.4133 |
| **Macro avg** | **0.5914 / 0.5719** | **0.5632 / 0.5516** |

  ▎ Both runs share the same index, embedder, agent LLM, reasoning_effort, and top-k; the only setting not pinned is agent-LLM sampling temperature (this PR uses greedy 0.0; the reference uses its endpoint default).

The graph-operator implementation tracks the reference pipeline across all eight
domains on a shared substrate.

## Scope
- No changes to the standard retrieval path or shared modules; opt-in via `--agentic`.
- Metric/log format follows existing pipeline conventions.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
