### PR TITLE
Fix local query embedding regressions for recall evaluation and simplify beir pipeline command

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -52,37 +52,6 @@ jobs:
           python -c "import importlib.util; import sys; sys.exit(0 if importlib.util.find_spec('tritonclient') is None else 1)"
           python -m pytest tests/test_slim_imports_no_triton.py -q
 
-  # Hosted NIM ingest + Retriever query (CPU; requires NVIDIA_BUILD_API_KEY on the repo)
-  multimodal-ingest-retriever-integration:
-    name: Multimodal ingest + Retriever (integration)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    env:
-      NVIDIA_API_KEY: ${{ secrets.NVIDIA_BUILD_API_KEY }}
-
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - uses: astral-sh/setup-uv@v6
-
-      - name: Install nemo-retriever and run multimodal PDF integration test
-        working-directory: nemo_retriever
-        run: |
-          set -euo pipefail
-          uv venv .venv-integration
-          source .venv-integration/bin/activate
-          uv pip install -e ".[dev]"
-          uv pip install pytest
-          pytest tests/test_ingest_retrieve_multimodal_pdf_integration.py \
-            -m integration \
-            --override-ini="addopts=" \
-            -v
-
   # Docker build + test for x86_64 (single job so built image is available locally)
   docker-build-and-test:
     name: Build & Test Docker (amd64)
@@ -104,7 +73,6 @@ jobs:
     needs:
       - pre-commit
       - slim-import-contract
-      - multimodal-ingest-retriever-integration
       - docker-build-and-test
     runs-on: ubuntu-latest
     if: always()
@@ -113,7 +81,6 @@ jobs:
         run: |
           if [[ "${{ needs.pre-commit.result }}" != "success" ]] || \
              [[ "${{ needs.slim-import-contract.result }}" != "success" ]] || \
-             [[ "${{ needs.multimodal-ingest-retriever-integration.result }}" != "success" ]] || \
              [[ "${{ needs.docker-build-and-test.result }}" != "success" ]]; then
             echo "One or more required jobs failed"
             exit 1

--- a/nemo_retriever/src/nemo_retriever/model/__init__.py
+++ b/nemo_retriever/src/nemo_retriever/model/__init__.py
@@ -66,6 +66,7 @@ def create_local_embedder(
     dimensions: int | None = None,
     normalize: bool = True,
     max_length: int = 8192,
+    query_max_length: int = 128,
 ) -> Any:
     """Create the appropriate local embedding model (VL or non-VL).
 
@@ -127,6 +128,7 @@ def create_local_embedder(
             hf_cache_dir=hf_cache_dir,
             normalize=normalize,
             max_length=int(max_length),
+            query_max_length=int(query_max_length),
             model_id=model_id,
         )
 
@@ -174,6 +176,7 @@ def create_local_query_embedder(
     dimensions: int | None = None,
     normalize: bool = True,
     max_length: int = 8192,
+    query_max_length: int = 128,
 ) -> Any:
     """Create a local embedder for *query* vectors in retrieval (Retriever / recall).
 
@@ -194,6 +197,7 @@ def create_local_query_embedder(
         dimensions=dimensions,
         normalize=normalize,
         max_length=int(max_length),
+        query_max_length=int(query_max_length),
     )
 
 

--- a/nemo_retriever/src/nemo_retriever/model/local/llama_nemotron_embed_1b_v2_hf_embedder.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/llama_nemotron_embed_1b_v2_hf_embedder.py
@@ -10,6 +10,7 @@ evaluation) while document ingestion uses vLLM elsewhere.
 
 from __future__ import annotations
 
+import logging
 import warnings
 from dataclasses import dataclass
 from typing import List, Optional, Sequence
@@ -18,6 +19,8 @@ import torch
 
 from nemo_retriever.utils.hf_cache import configure_global_hf_cache_base
 from nemo_retriever.utils.hf_model_registry import get_hf_revision
+
+logger = logging.getLogger(__name__)
 
 
 def _l2_normalize(x: torch.Tensor, eps: float = 1e-12) -> torch.Tensor:
@@ -34,6 +37,8 @@ class LlamaNemotronEmbed1BV2HFEmbedder:
     hf_cache_dir: Optional[str] = None
     normalize: bool = True
     max_length: int = 8192
+    # Fixed query padding length. Queries longer than this are truncated; larger
+    # values preserve more text but increase query embedding cost.
     query_max_length: int = 128
     model_id: Optional[str] = None
 
@@ -134,6 +139,35 @@ class LlamaNemotronEmbed1BV2HFEmbedder:
             return torch.empty((0, 0), dtype=torch.float32)
         return self._embed_local(texts_list, batch_size=batch_size)
 
+    def _warn_if_queries_truncated(self, texts: Sequence[str], *, max_length: int) -> None:
+        self._ensure_loaded()
+        tokenizer = self._tokenizer
+        truncated = 0
+        for text in texts:
+            try:
+                encode = getattr(tokenizer, "encode", None)
+                if callable(encode):
+                    input_ids = encode(str(text), add_special_tokens=True, truncation=False)
+                else:
+                    encoded = tokenizer(str(text), add_special_tokens=True, truncation=False)
+                    input_ids = encoded.get("input_ids") if isinstance(encoded, dict) else getattr(encoded, "input_ids", None)
+            except Exception:  # noqa: BLE001 - best-effort warning only
+                return
+
+            if isinstance(input_ids, list):
+                length = len(input_ids[0]) if input_ids and isinstance(input_ids[0], list) else len(input_ids)
+                if length > max_length:
+                    truncated += 1
+
+        if truncated:
+            logger.warning(
+                "Truncating %d/%d HF query embeddings to query_max_length=%d tokens; "
+                "increase query_max_length if long queries lose recall.",
+                truncated,
+                len(texts),
+                max_length,
+            )
+
     def embed_queries(self, texts: Sequence[str], *, batch_size: int = 64) -> torch.Tensor:
         """Query strings; each line is prefixed with ``query:`` (same rules as vLLM embed_queries)."""
         texts_list = []
@@ -148,11 +182,13 @@ class LlamaNemotronEmbed1BV2HFEmbedder:
             return torch.empty((0, 0), dtype=torch.float32)
         # The Nemotron text embedder is sensitive to padding length. Use fixed
         # query padding so retrieval vectors do not change with batch grouping.
+        query_max_length = max(1, int(self.query_max_length))
+        self._warn_if_queries_truncated(texts_list, max_length=query_max_length)
         return self._embed_local(
             texts_list,
             batch_size=batch_size,
             padding="max_length",
-            max_length=max(1, int(self.query_max_length)),
+            max_length=query_max_length,
         )
 
     def unload(self) -> None:

--- a/nemo_retriever/src/nemo_retriever/model/local/llama_nemotron_embed_1b_v2_hf_embedder.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/llama_nemotron_embed_1b_v2_hf_embedder.py
@@ -164,7 +164,8 @@ class LlamaNemotronEmbed1BV2HFEmbedder:
         if truncated:
             logger.warning(
                 "Truncating %d/%d HF query embeddings to query_max_length=%d tokens; "
-                "increase query_max_length if long queries lose recall.",
+                "increase query_max_length (or --local-query-max-length in pipeline eval) "
+                "if long queries lose recall.",
                 truncated,
                 len(texts),
                 max_length,

--- a/nemo_retriever/src/nemo_retriever/model/local/llama_nemotron_embed_1b_v2_hf_embedder.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/llama_nemotron_embed_1b_v2_hf_embedder.py
@@ -150,7 +150,9 @@ class LlamaNemotronEmbed1BV2HFEmbedder:
                     input_ids = encode(str(text), add_special_tokens=True, truncation=False)
                 else:
                     encoded = tokenizer(str(text), add_special_tokens=True, truncation=False)
-                    input_ids = encoded.get("input_ids") if isinstance(encoded, dict) else getattr(encoded, "input_ids", None)
+                    input_ids = (
+                        encoded.get("input_ids") if isinstance(encoded, dict) else getattr(encoded, "input_ids", None)
+                    )
             except Exception:  # noqa: BLE001 - best-effort warning only
                 return
 

--- a/nemo_retriever/src/nemo_retriever/model/local/llama_nemotron_embed_1b_v2_hf_embedder.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/llama_nemotron_embed_1b_v2_hf_embedder.py
@@ -34,6 +34,7 @@ class LlamaNemotronEmbed1BV2HFEmbedder:
     hf_cache_dir: Optional[str] = None
     normalize: bool = True
     max_length: int = 8192
+    query_max_length: int = 128
     model_id: Optional[str] = None
 
     def __post_init__(self) -> None:
@@ -72,23 +73,27 @@ class LlamaNemotronEmbed1BV2HFEmbedder:
     def is_remote(self) -> bool:
         return False
 
-    def _embed_local(self, texts: List[str], *, batch_size: int) -> torch.Tensor:
+    def _embed_local(
+        self,
+        texts: List[str],
+        *,
+        batch_size: int,
+        padding: bool | str = True,
+        max_length: int | None = None,
+    ) -> torch.Tensor:
         self._ensure_loaded()
         dev = self._device
         bs = max(1, int(batch_size))
-        max_len = max(1, int(self.max_length))
+        max_len = max(1, int(max_length if max_length is not None else self.max_length))
 
         outs: List[torch.Tensor] = []
         with torch.inference_mode(), warnings.catch_warnings():
             warnings.filterwarnings("ignore", message="`input_embeds` is deprecated", category=FutureWarning)
-            # Tokenize per chunk (same as vLLM microbatches) so padding length matches
-            # within-batch max, not global max over all strings — bidirectional attention
-            # can otherwise shift vectors vs vLLM ingest / recall.
             for i in range(0, len(texts), bs):
                 chunk = texts[i : i + bs]
                 batch = self._tokenizer(
                     chunk,
-                    padding=True,
+                    padding=padding,
                     truncation=True,
                     max_length=max_len,
                     return_tensors="pt",
@@ -141,7 +146,14 @@ class LlamaNemotronEmbed1BV2HFEmbedder:
             texts_list.append(raw)
         if not texts_list:
             return torch.empty((0, 0), dtype=torch.float32)
-        return self._embed_local(texts_list, batch_size=batch_size)
+        # The Nemotron text embedder is sensitive to padding length. Use fixed
+        # query padding so retrieval vectors do not change with batch grouping.
+        return self._embed_local(
+            texts_list,
+            batch_size=batch_size,
+            padding="max_length",
+            max_length=max(1, int(self.query_max_length)),
+        )
 
     def unload(self) -> None:
         """Release GPU memory held by the HF model."""

--- a/nemo_retriever/src/nemo_retriever/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/params/models.py
@@ -368,6 +368,7 @@ class EmbedParams(_ParamsModel):
     local_ingest_embed_backend: str = (
         "vllm"  # "vllm" or "hf" — selects ingest-time embedder backend for both text and VL models
     )
+    query_max_length: int = 128
     dimensions: Optional[int] = None
 
     # Concurrent HTTP embedding requests per Ray batch (OpenAI-compatible NIM).

--- a/nemo_retriever/src/nemo_retriever/pipeline/__main__.py
+++ b/nemo_retriever/src/nemo_retriever/pipeline/__main__.py
@@ -632,7 +632,7 @@ def _run_evaluation(
     beir_dataset_name: Optional[str],
     beir_split: str,
     beir_query_language: Optional[str],
-    beir_doc_id_field: str,
+    beir_doc_id_field: Optional[str],
     beir_k: list[int],
     local_query_embed_backend: str = "hf",
 ) -> tuple[str, float, dict[str, float], Optional[int], bool]:
@@ -654,12 +654,20 @@ def _run_evaluation(
     if evaluation_mode == "beir":
         if str(vdb_op).strip().lower() != "lancedb":
             raise ValueError("--evaluation-mode=beir currently requires --vdb-op=lancedb")
-        if not beir_loader:
-            raise ValueError("--beir-loader is required when --evaluation-mode=beir")
-        if not beir_dataset_name:
-            raise ValueError("--beir-dataset-name is required when --evaluation-mode=beir")
+        from nemo_retriever.recall.beir import BeirConfig, evaluate_lancedb_beir, resolve_beir_dataset_options
 
-        from nemo_retriever.recall.beir import BeirConfig, evaluate_lancedb_beir
+        beir_options = resolve_beir_dataset_options(
+            dataset_name=beir_dataset_name,
+            loader=beir_loader,
+            doc_id_field=beir_doc_id_field,
+            ks=beir_k,
+        )
+        if not beir_options.loader:
+            raise ValueError("--beir-loader is required when --evaluation-mode=beir")
+        if not beir_options.dataset_name:
+            raise ValueError("--beir-dataset-name is required when --evaluation-mode=beir")
+        if not beir_options.doc_id_field:
+            raise ValueError("--beir-doc-id-field is required when --evaluation-mode=beir")
 
         lancedb_uri = str(eval_vdb_kwargs.get("uri") or eval_vdb_kwargs.get("lancedb_uri") or "lancedb")
         lancedb_table = str(eval_vdb_kwargs.get("table_name") or eval_vdb_kwargs.get("lancedb_table") or "nv-ingest")
@@ -668,12 +676,12 @@ def _run_evaluation(
             lancedb_uri=lancedb_uri,
             lancedb_table=lancedb_table,
             embedding_model=embed_model,
-            loader=str(beir_loader),
-            dataset_name=str(beir_dataset_name),
+            loader=str(beir_options.loader),
+            dataset_name=str(beir_options.dataset_name),
             split=str(beir_split),
             query_language=beir_query_language,
-            doc_id_field=str(beir_doc_id_field),
-            ks=tuple(beir_k) if beir_k else (1, 3, 5, 10),
+            doc_id_field=str(beir_options.doc_id_field),
+            ks=beir_options.ks,
             embedding_http_endpoint=embed_invoke_url,
             embedding_api_key=embed_remote_api_key or "",
             hybrid=bool(eval_vdb_kwargs.get("hybrid", False)),
@@ -1129,7 +1137,7 @@ def run(
     beir_dataset_name: Optional[str] = typer.Option(None, "--beir-dataset-name", rich_help_panel=_PANEL_EVAL),
     beir_split: str = typer.Option("test", "--beir-split", rich_help_panel=_PANEL_EVAL),
     beir_query_language: Optional[str] = typer.Option(None, "--beir-query-language", rich_help_panel=_PANEL_EVAL),
-    beir_doc_id_field: str = typer.Option("pdf_basename", "--beir-doc-id-field", rich_help_panel=_PANEL_EVAL),
+    beir_doc_id_field: Optional[str] = typer.Option(None, "--beir-doc-id-field", rich_help_panel=_PANEL_EVAL),
     beir_k: list[int] = typer.Option([], "--beir-k", rich_help_panel=_PANEL_EVAL),
     eval_config: Optional[Path] = typer.Option(
         None,

--- a/nemo_retriever/src/nemo_retriever/pipeline/__main__.py
+++ b/nemo_retriever/src/nemo_retriever/pipeline/__main__.py
@@ -1137,7 +1137,12 @@ def run(
     beir_dataset_name: Optional[str] = typer.Option(None, "--beir-dataset-name", rich_help_panel=_PANEL_EVAL),
     beir_split: str = typer.Option("test", "--beir-split", rich_help_panel=_PANEL_EVAL),
     beir_query_language: Optional[str] = typer.Option(None, "--beir-query-language", rich_help_panel=_PANEL_EVAL),
-    beir_doc_id_field: Optional[str] = typer.Option(None, "--beir-doc-id-field", rich_help_panel=_PANEL_EVAL),
+    beir_doc_id_field: Optional[str] = typer.Option(
+        None,
+        "--beir-doc-id-field",
+        help="BEIR document ID field. Defaults to the known dataset setting, or pdf_basename for custom datasets.",
+        rich_help_panel=_PANEL_EVAL,
+    ),
     beir_k: list[int] = typer.Option([], "--beir-k", rich_help_panel=_PANEL_EVAL),
     eval_config: Optional[Path] = typer.Option(
         None,

--- a/nemo_retriever/src/nemo_retriever/pipeline/__main__.py
+++ b/nemo_retriever/src/nemo_retriever/pipeline/__main__.py
@@ -628,6 +628,7 @@ def _run_evaluation(
     reranker_api_key: str,
     local_reranker_backend: str,
     local_hf_batch_size: int,
+    local_query_max_length: int,
     beir_loader: Optional[str],
     beir_dataset_name: Optional[str],
     beir_split: str,
@@ -693,6 +694,7 @@ def _run_evaluation(
             reranker_api_key=reranker_api_key,
             local_reranker_backend=local_reranker_backend,
             local_hf_batch_size=int(local_hf_batch_size),
+            local_query_max_length=int(local_query_max_length),
             local_query_embed_backend=local_query_embed_backend,
         )
         evaluation_start = time.perf_counter()
@@ -726,6 +728,7 @@ def _run_evaluation(
         reranker_api_key=reranker_api_key,
         local_reranker_backend=local_reranker_backend,
         local_hf_batch_size=int(local_hf_batch_size),
+        local_query_max_length=int(local_query_max_length),
         embed_modality=embed_modality,
         local_query_embed_backend=local_query_embed_backend,
     )
@@ -1133,6 +1136,13 @@ def run(
         help="Batch size for local HF query embedding during retrieval/reranking.",
         rich_help_panel=_PANEL_EVAL,
     ),
+    local_query_max_length: int = typer.Option(
+        128,
+        "--local-query-max-length",
+        min=1,
+        help="Fixed token length for local HF query embeddings; longer queries are truncated.",
+        rich_help_panel=_PANEL_EVAL,
+    ),
     beir_loader: Optional[str] = typer.Option(None, "--beir-loader", rich_help_panel=_PANEL_EVAL),
     beir_dataset_name: Optional[str] = typer.Option(None, "--beir-dataset-name", rich_help_panel=_PANEL_EVAL),
     beir_split: str = typer.Option("test", "--beir-split", rich_help_panel=_PANEL_EVAL),
@@ -1507,6 +1517,7 @@ def run(
             reranker_api_key=reranker_bearer,
             local_reranker_backend=local_reranker_backend,
             local_hf_batch_size=local_hf_batch_size,
+            local_query_max_length=local_query_max_length,
             beir_loader=beir_loader,
             beir_dataset_name=beir_dataset_name,
             beir_split=beir_split,

--- a/nemo_retriever/src/nemo_retriever/pipeline/__main__.py
+++ b/nemo_retriever/src/nemo_retriever/pipeline/__main__.py
@@ -667,8 +667,6 @@ def _run_evaluation(
             raise ValueError("--beir-loader is required when --evaluation-mode=beir")
         if not beir_options.dataset_name:
             raise ValueError("--beir-dataset-name is required when --evaluation-mode=beir")
-        if not beir_options.doc_id_field:
-            raise ValueError("--beir-doc-id-field is required when --evaluation-mode=beir")
 
         lancedb_uri = str(eval_vdb_kwargs.get("uri") or eval_vdb_kwargs.get("lancedb_uri") or "lancedb")
         lancedb_table = str(eval_vdb_kwargs.get("table_name") or eval_vdb_kwargs.get("lancedb_table") or "nv-ingest")

--- a/nemo_retriever/src/nemo_retriever/recall/beir.py
+++ b/nemo_retriever/src/nemo_retriever/recall/beir.py
@@ -30,6 +30,74 @@ BO10K_ANNOTATIONS_PATH = REPO_ROOT / "data" / "digital_corpora_10k_annotations.c
 EARNINGS_ANNOTATIONS_PATH = REPO_ROOT / "data" / "earnings_consulting_multimodal.csv"
 FINANCEBENCH_ANNOTATIONS_PATH = REPO_ROOT / "data" / "financebench_train.json"
 JP20_ANNOTATIONS_PATH = REPO_ROOT / "data" / "jp20_query_gt.csv"
+
+
+@dataclass(frozen=True)
+class BeirDatasetOptions:
+    loader: str | None = None
+    dataset_name: str | None = None
+    doc_id_field: str | None = None
+    ks: tuple[int, ...] = DEFAULT_BEIR_KS
+
+
+_FIRST_CLASS_BEIR_DATASETS: dict[str, BeirDatasetOptions] = {
+    "bo767": BeirDatasetOptions(
+        loader="bo767_csv",
+        dataset_name=str(BO767_ANNOTATIONS_PATH),
+        doc_id_field="pdf_page",
+    ),
+    "bo10k": BeirDatasetOptions(
+        loader="bo10k_csv",
+        dataset_name=str(BO10K_ANNOTATIONS_PATH),
+        doc_id_field="pdf_page",
+    ),
+    "jp20": BeirDatasetOptions(
+        loader="jp20_csv",
+        dataset_name=str(JP20_ANNOTATIONS_PATH),
+        doc_id_field="pdf_page",
+    ),
+    "earnings": BeirDatasetOptions(
+        loader="earnings_csv",
+        dataset_name=str(EARNINGS_ANNOTATIONS_PATH),
+        doc_id_field="pdf_page",
+    ),
+    "financebench": BeirDatasetOptions(
+        loader="financebench_json",
+        dataset_name=str(FINANCEBENCH_ANNOTATIONS_PATH),
+        doc_id_field="pdf_basename",
+    ),
+}
+
+
+def resolve_beir_dataset_options(
+    *,
+    dataset_name: str | None,
+    loader: str | None = None,
+    doc_id_field: str | None = None,
+    ks: Sequence[int] | None = None,
+) -> BeirDatasetOptions:
+    """Resolve shorthand first-class BEIR dataset names into concrete options."""
+    normalized_name = str(dataset_name).strip() if dataset_name is not None else None
+    defaults = None
+    if normalized_name:
+        lookup_key = normalized_name.lower()
+        defaults = _FIRST_CLASS_BEIR_DATASETS.get(lookup_key)
+        if defaults is None and lookup_key.startswith("vidore_v3_"):
+            defaults = BeirDatasetOptions(
+                loader="vidore_hf",
+                dataset_name=normalized_name,
+                doc_id_field="pdf_basename",
+            )
+
+    resolved_ks = tuple(int(k) for k in ks) if ks else (defaults.ks if defaults else DEFAULT_BEIR_KS)
+    return BeirDatasetOptions(
+        loader=loader or (defaults.loader if defaults else None),
+        dataset_name=(defaults.dataset_name if defaults else normalized_name),
+        doc_id_field=doc_id_field or (defaults.doc_id_field if defaults else None),
+        ks=resolved_ks,
+    )
+
+
 _ELEMENT_TYPE_ALIASES: dict[str, str] = {
     "caption": "image",
     "chart": "chart",

--- a/nemo_retriever/src/nemo_retriever/recall/beir.py
+++ b/nemo_retriever/src/nemo_retriever/recall/beir.py
@@ -34,6 +34,8 @@ JP20_ANNOTATIONS_PATH = REPO_ROOT / "data" / "jp20_query_gt.csv"
 
 @dataclass(frozen=True)
 class BeirDatasetOptions:
+    """Resolved BEIR dataset defaults: loader, dataset identifier/path, doc-id field, and metric cutoffs."""
+
     loader: str | None = None
     dataset_name: str | None = None
     doc_id_field: str | None = None

--- a/nemo_retriever/src/nemo_retriever/recall/beir.py
+++ b/nemo_retriever/src/nemo_retriever/recall/beir.py
@@ -162,6 +162,7 @@ class BeirConfig:
     local_hf_device: str | None = None
     local_hf_cache_dir: str | None = None
     local_hf_batch_size: int = 32
+    local_query_max_length: int = 128
     reranker: bool = False
     reranker_model_name: str = "nvidia/llama-nemotron-rerank-1b-v2"
     reranker_endpoint: str | None = None
@@ -791,6 +792,7 @@ def evaluate_lancedb_beir(
         "local_ingest_embed_backend": str(cfg.local_query_embed_backend),
         "inference_batch_size": int(cfg.local_hf_batch_size),
         "embed_inference_batch_size": int(cfg.local_hf_batch_size),
+        "query_max_length": int(cfg.local_query_max_length),
     }
     if cfg.embedding_http_endpoint:
         embed_kwargs["embedding_endpoint"] = cfg.embedding_http_endpoint

--- a/nemo_retriever/src/nemo_retriever/recall/beir.py
+++ b/nemo_retriever/src/nemo_retriever/recall/beir.py
@@ -90,10 +90,12 @@ def resolve_beir_dataset_options(
             )
 
     resolved_ks = tuple(int(k) for k in ks) if ks else (defaults.ks if defaults else DEFAULT_BEIR_KS)
+    # Preserve the historical CLI default for custom/non-first-class BEIR datasets.
+    resolved_doc_id_field = doc_id_field or (defaults.doc_id_field if defaults else "pdf_basename")
     return BeirDatasetOptions(
         loader=loader or (defaults.loader if defaults else None),
         dataset_name=(defaults.dataset_name if defaults else normalized_name),
-        doc_id_field=doc_id_field or (defaults.doc_id_field if defaults else None),
+        doc_id_field=resolved_doc_id_field,
         ks=resolved_ks,
     )
 

--- a/nemo_retriever/src/nemo_retriever/recall/core.py
+++ b/nemo_retriever/src/nemo_retriever/recall/core.py
@@ -35,6 +35,7 @@ class RecallConfig:
     local_hf_device: Optional[str] = None
     local_hf_cache_dir: Optional[str] = None
     local_hf_batch_size: int = 32
+    local_query_max_length: int = 128
     # When using local query embedding (no HTTP endpoint), select backend for *queries* only.
     # ``hf`` (default) uses the HF mean-pooled text embedder (see ``LlamaNemotronEmbed1BV2HFEmbedder``);
     # ``vllm`` uses :func:`~nemo_retriever.model.create_local_embedder`. Ignored when an
@@ -488,6 +489,7 @@ def retrieve_and_score(
         "embed_inference_batch_size": int(cfg.local_hf_batch_size),
         "local_ingest_embed_backend": str(cfg.local_query_embed_backend),
         "embed_modality": str(cfg.embed_modality),
+        "query_max_length": int(cfg.local_query_max_length),
     }
     if embedding_endpoint:
         embed_kwargs["embedding_endpoint"] = embedding_endpoint

--- a/nemo_retriever/src/nemo_retriever/text_embed/gpu_operator.py
+++ b/nemo_retriever/src/nemo_retriever/text_embed/gpu_operator.py
@@ -52,6 +52,7 @@ class _BatchEmbedActor(AbstractOperator, GPUOperator):
             dimensions=self._kwargs.get("dimensions"),
             normalize=bool(self._kwargs.get("normalize", True)),
             max_length=int(self._kwargs.get("max_length", 8192)),
+            query_max_length=int(self._kwargs.get("query_max_length", 128)),
         )
 
     def preprocess(self, data: Any, **kwargs: Any) -> Any:

--- a/nemo_retriever/src/nemo_retriever/text_embed/processor.py
+++ b/nemo_retriever/src/nemo_retriever/text_embed/processor.py
@@ -111,6 +111,7 @@ def maybe_inject_local_hf_embedder(task_config: Dict[str, Any], transform_config
         gpu_memory_utilization=float(task_config.get("gpu_memory_utilization", 0.45)),
         enforce_eager=_to_bool(task_config.get("enforce_eager"), default=False),
         dimensions=task_config.get("dimensions"),
+        query_max_length=int(task_config.get("query_max_length", 128)),
     )
 
     prefix = f"{transform_config.input_type}: " if getattr(transform_config, "input_type", None) else ""

--- a/nemo_retriever/src/nemo_retriever/text_embed/runtime.py
+++ b/nemo_retriever/src/nemo_retriever/text_embed/runtime.py
@@ -44,7 +44,7 @@ def _embed_group(
             skip_prefix = hasattr(model, "embed_queries")
 
             def embedder(texts: Sequence[str]) -> Sequence[Sequence[float]]:  # noqa
-                if str(input_type).strip().lower() == "query" and hasattr(model, "embed_queries"):
+                if str(input_type).strip().lower() == "query" and skip_prefix:
                     vectors = model.embed_queries(texts, batch_size=int(inference_batch_size))
                 else:
                     batch = texts if skip_prefix else [f"passage: {text}" for text in texts]

--- a/nemo_retriever/src/nemo_retriever/text_embed/runtime.py
+++ b/nemo_retriever/src/nemo_retriever/text_embed/runtime.py
@@ -44,8 +44,11 @@ def _embed_group(
             skip_prefix = hasattr(model, "embed_queries")
 
             def embedder(texts: Sequence[str]) -> Sequence[Sequence[float]]:  # noqa
-                batch = texts if skip_prefix else [f"passage: {text}" for text in texts]
-                vectors = model.embed(batch, batch_size=int(inference_batch_size))
+                if str(input_type).strip().lower() == "query" and hasattr(model, "embed_queries"):
+                    vectors = model.embed_queries(texts, batch_size=int(inference_batch_size))
+                else:
+                    batch = texts if skip_prefix else [f"passage: {text}" for text in texts]
+                    vectors = model.embed(batch, batch_size=int(inference_batch_size))
                 tolist = getattr(vectors, "tolist", None)
                 if callable(tolist):
                     return tolist()

--- a/nemo_retriever/src/nemo_retriever/vdb/operators.py
+++ b/nemo_retriever/src/nemo_retriever/vdb/operators.py
@@ -45,7 +45,10 @@ def _coerce_embedding_vector(value: Any) -> list[float] | None:
         if callable(tolist):
             value = tolist()
     if isinstance(value, list) and value:
-        return [float(x) for x in value]
+        try:
+            return [float(x) for x in value]
+        except (TypeError, ValueError):
+            return None
     return None
 
 

--- a/nemo_retriever/src/nemo_retriever/vdb/operators.py
+++ b/nemo_retriever/src/nemo_retriever/vdb/operators.py
@@ -52,6 +52,11 @@ def _coerce_embedding_vector(value: Any) -> list[float] | None:
     return None
 
 
+def _is_direct_embedding_column(column_name: object) -> bool:
+    name = str(column_name).strip().lower()
+    return "embedding" in name or name == "vector" or name.endswith("_vector")
+
+
 def query_vectors_from_embedded_dataframe(df: pd.DataFrame) -> list[list[float]]:
     """Extract one query vector per row from batch-embed output (metadata or payload columns)."""
     vectors: list[list[float]] = []
@@ -64,7 +69,9 @@ def query_vectors_from_embedded_dataframe(df: pd.DataFrame) -> list[list[float]]
             for col in df.columns:
                 if col == "metadata":
                     continue
-                vec = _coerce_embedding_vector(row.get(col))
+                val = row.get(col)
+                if isinstance(val, dict) or _is_direct_embedding_column(col):
+                    vec = _coerce_embedding_vector(val)
                 if vec is not None:
                     break
         if vec is None:

--- a/nemo_retriever/src/nemo_retriever/vdb/operators.py
+++ b/nemo_retriever/src/nemo_retriever/vdb/operators.py
@@ -37,6 +37,18 @@ def _construct_vdb(
     return vdb if vdb is not None else get_vdb_op_cls(str(vdb_op))(**dict(vdb_kwargs or {}))
 
 
+def _coerce_embedding_vector(value: Any) -> list[float] | None:
+    if isinstance(value, dict):
+        value = value.get("embedding")
+    if not isinstance(value, list):
+        tolist = getattr(value, "tolist", None)
+        if callable(tolist):
+            value = tolist()
+    if isinstance(value, list) and value:
+        return [float(x) for x in value]
+    return None
+
+
 def query_vectors_from_embedded_dataframe(df: pd.DataFrame) -> list[list[float]]:
     """Extract one query vector per row from batch-embed output (metadata or payload columns)."""
     vectors: list[list[float]] = []
@@ -44,19 +56,14 @@ def query_vectors_from_embedded_dataframe(df: pd.DataFrame) -> list[list[float]]
         vec: list[float] | None = None
         md = row.get("metadata")
         if isinstance(md, dict):
-            emb = md.get("embedding")
-            if isinstance(emb, list) and emb:
-                vec = [float(x) for x in emb]
+            vec = _coerce_embedding_vector(md)
         if vec is None:
             for col in df.columns:
                 if col == "metadata":
                     continue
-                val = row.get(col)
-                if isinstance(val, dict):
-                    inner = val.get("embedding")
-                    if isinstance(inner, list) and inner:
-                        vec = [float(x) for x in inner]
-                        break
+                vec = _coerce_embedding_vector(row.get(col))
+                if vec is not None:
+                    break
         if vec is None:
             raise ValueError(
                 "Expected query embeddings in each row's metadata['embedding'] or a payload column "

--- a/nemo_retriever/tests/test_beir_evaluation.py
+++ b/nemo_retriever/tests/test_beir_evaluation.py
@@ -151,8 +151,58 @@ def test_resolve_beir_dataset_options_does_not_guess_unknown_dataset() -> None:
 
     assert options.loader is None
     assert options.dataset_name == "custom_dataset"
-    assert options.doc_id_field is None
+    assert options.doc_id_field == "pdf_basename"
     assert options.ks == DEFAULT_BEIR_KS
+
+
+def test_pipeline_beir_evaluation_keeps_custom_dataset_doc_id_default(monkeypatch) -> None:
+    import nemo_retriever.model as model_module
+    import nemo_retriever.recall.beir as beir_module
+
+    captured: dict[str, BeirConfig] = {}
+
+    def _fake_evaluate_lancedb_beir(cfg: BeirConfig):
+        captured["cfg"] = cfg
+        return (
+            BeirDataset(dataset_name=cfg.dataset_name, query_ids=["q1"], queries=["query"], qrels={"q1": {"doc": 1}}),
+            [],
+            {},
+            {"recall@5": 1.0},
+        )
+
+    monkeypatch.setattr(model_module, "resolve_embed_model", lambda model_name: model_name)
+    monkeypatch.setattr(beir_module, "evaluate_lancedb_beir", _fake_evaluate_lancedb_beir)
+
+    label, _elapsed, _metrics, _query_count, ran = pipeline_main._run_evaluation(
+        evaluation_mode="beir",
+        vdb_op="lancedb",
+        vdb_kwargs={"uri": "lancedb", "table_name": "nv-ingest"},
+        embed_model_name="nvidia/llama-nemotron-embed-1b-v2",
+        embed_invoke_url=None,
+        embed_remote_api_key=None,
+        embed_modality="text",
+        query_csv=Path("unused.csv"),
+        recall_match_mode="audio_segment",
+        audio_match_tolerance_secs=2.0,
+        reranker=False,
+        reranker_model_name="reranker",
+        reranker_invoke_url=None,
+        reranker_api_key="",
+        local_reranker_backend="vllm",
+        local_hf_batch_size=32,
+        beir_loader="custom_csv",
+        beir_dataset_name="custom_dataset",
+        beir_split="test",
+        beir_query_language=None,
+        beir_doc_id_field=None,
+        beir_k=[],
+    )
+
+    assert label == "BEIR"
+    assert ran is True
+    assert captured["cfg"].loader == "custom_csv"
+    assert captured["cfg"].dataset_name == "custom_dataset"
+    assert captured["cfg"].doc_id_field == "pdf_basename"
 
 
 def test_pipeline_beir_evaluation_resolves_known_dataset_name(monkeypatch) -> None:

--- a/nemo_retriever/tests/test_beir_evaluation.py
+++ b/nemo_retriever/tests/test_beir_evaluation.py
@@ -3,15 +3,19 @@ from pathlib import Path
 
 import pytest
 
+from nemo_retriever.pipeline import __main__ as pipeline_main
 from nemo_retriever.recall.beir import (
     BeirConfig,
     BeirDataset,
+    BO767_ANNOTATIONS_PATH,
+    DEFAULT_BEIR_KS,
     build_beir_run_from_hits,
     build_qrels_by_query_id,
     build_queries_by_id,
     compute_beir_metrics,
     evaluate_lancedb_beir,
     load_beir_dataset,
+    resolve_beir_dataset_options,
 )
 
 
@@ -107,6 +111,103 @@ def test_build_beir_run_from_hits_uses_pdf_basename_and_dedupes() -> None:
 
     assert list(run["q1"].keys()) == ["doc_a", "doc_b"]
     assert run["q1"]["doc_a"] > run["q1"]["doc_b"]
+
+
+def test_resolve_beir_dataset_options_supports_known_dataset_name() -> None:
+    options = resolve_beir_dataset_options(dataset_name="bo767")
+
+    assert options.loader == "bo767_csv"
+    assert options.dataset_name == str(BO767_ANNOTATIONS_PATH)
+    assert options.doc_id_field == "pdf_page"
+    assert options.ks == DEFAULT_BEIR_KS
+
+
+def test_resolve_beir_dataset_options_supports_vidore_dataset_name() -> None:
+    options = resolve_beir_dataset_options(dataset_name="vidore_v3_computer_science")
+
+    assert options.loader == "vidore_hf"
+    assert options.dataset_name == "vidore_v3_computer_science"
+    assert options.doc_id_field == "pdf_basename"
+
+
+def test_resolve_beir_dataset_options_preserves_explicit_overrides(tmp_path: Path) -> None:
+    annotations = tmp_path / "custom.csv"
+
+    options = resolve_beir_dataset_options(
+        dataset_name=str(annotations),
+        loader="bo767_csv",
+        doc_id_field="pdf_page_modality",
+        ks=[5],
+    )
+
+    assert options.loader == "bo767_csv"
+    assert options.dataset_name == str(annotations)
+    assert options.doc_id_field == "pdf_page_modality"
+    assert options.ks == (5,)
+
+
+def test_resolve_beir_dataset_options_does_not_guess_unknown_dataset() -> None:
+    options = resolve_beir_dataset_options(dataset_name="custom_dataset")
+
+    assert options.loader is None
+    assert options.dataset_name == "custom_dataset"
+    assert options.doc_id_field is None
+    assert options.ks == DEFAULT_BEIR_KS
+
+
+def test_pipeline_beir_evaluation_resolves_known_dataset_name(monkeypatch) -> None:
+    import nemo_retriever.model as model_module
+    import nemo_retriever.recall.beir as beir_module
+
+    captured: dict[str, BeirConfig] = {}
+
+    def _fake_evaluate_lancedb_beir(cfg: BeirConfig):
+        captured["cfg"] = cfg
+        return (
+            BeirDataset(dataset_name=cfg.dataset_name, query_ids=["q1"], queries=["query"], qrels={"q1": {"doc": 1}}),
+            [],
+            {},
+            {"recall@5": 1.0},
+        )
+
+    monkeypatch.setattr(model_module, "resolve_embed_model", lambda model_name: model_name)
+    monkeypatch.setattr(beir_module, "evaluate_lancedb_beir", _fake_evaluate_lancedb_beir)
+
+    label, _elapsed, metrics, query_count, ran = pipeline_main._run_evaluation(
+        evaluation_mode="beir",
+        vdb_op="lancedb",
+        vdb_kwargs={"uri": "lancedb", "table_name": "nv-ingest"},
+        embed_model_name="nvidia/llama-nemotron-embed-1b-v2",
+        embed_invoke_url=None,
+        embed_remote_api_key=None,
+        embed_modality="text",
+        query_csv=Path("unused.csv"),
+        recall_match_mode="audio_segment",
+        audio_match_tolerance_secs=2.0,
+        reranker=False,
+        reranker_model_name="reranker",
+        reranker_invoke_url=None,
+        reranker_api_key="",
+        local_reranker_backend="vllm",
+        local_hf_batch_size=32,
+        beir_loader=None,
+        beir_dataset_name="bo767",
+        beir_split="validation",
+        beir_query_language="fr",
+        beir_doc_id_field=None,
+        beir_k=[3, 7],
+    )
+
+    assert label == "BEIR"
+    assert metrics == {"recall@5": 1.0}
+    assert query_count == 1
+    assert ran is True
+    assert captured["cfg"].loader == "bo767_csv"
+    assert captured["cfg"].dataset_name == str(BO767_ANNOTATIONS_PATH)
+    assert captured["cfg"].split == "validation"
+    assert captured["cfg"].query_language == "fr"
+    assert captured["cfg"].doc_id_field == "pdf_page"
+    assert tuple(captured["cfg"].ks) == (3, 7)
 
 
 def test_load_beir_dataset_supports_bo767_csv_pdf_page_modality(tmp_path: Path) -> None:

--- a/nemo_retriever/tests/test_beir_evaluation.py
+++ b/nemo_retriever/tests/test_beir_evaluation.py
@@ -190,6 +190,7 @@ def test_pipeline_beir_evaluation_keeps_custom_dataset_doc_id_default(monkeypatc
         reranker_api_key="",
         local_reranker_backend="vllm",
         local_hf_batch_size=32,
+        local_query_max_length=128,
         beir_loader="custom_csv",
         beir_dataset_name="custom_dataset",
         beir_split="test",
@@ -240,6 +241,7 @@ def test_pipeline_beir_evaluation_resolves_known_dataset_name(monkeypatch) -> No
         reranker_api_key="",
         local_reranker_backend="vllm",
         local_hf_batch_size=32,
+        local_query_max_length=256,
         beir_loader=None,
         beir_dataset_name="bo767",
         beir_split="validation",
@@ -258,6 +260,7 @@ def test_pipeline_beir_evaluation_resolves_known_dataset_name(monkeypatch) -> No
     assert captured["cfg"].query_language == "fr"
     assert captured["cfg"].doc_id_field == "pdf_page"
     assert tuple(captured["cfg"].ks) == (3, 7)
+    assert captured["cfg"].local_query_max_length == 256
 
 
 def test_load_beir_dataset_supports_bo767_csv_pdf_page_modality(tmp_path: Path) -> None:
@@ -573,6 +576,7 @@ def test_evaluate_lancedb_beir_uses_loader_and_retriever(monkeypatch) -> None:
                     "local_ingest_embed_backend": "hf",
                     "inference_batch_size": 32,
                     "embed_inference_batch_size": 32,
+                    "query_max_length": 128,
                     "embedding_endpoint": "http://embed.example/v1",
                     "embed_invoke_url": "http://embed.example/v1",
                     "api_key": "secret",

--- a/nemo_retriever/tests/test_create_local_embedder.py
+++ b/nemo_retriever/tests/test_create_local_embedder.py
@@ -113,12 +113,14 @@ def test_kwargs_forwarded_to_text_hf_embedder(_patch_embedders):
         hf_cache_dir="/models",
         normalize=False,
         max_length=512,
+        query_max_length=256,
     )
     kw = fake_text_hf.call_args.kwargs
     assert kw["device"] == "cuda:0"
     assert kw["hf_cache_dir"] == "/models"
     assert kw["normalize"] is False
     assert kw["max_length"] == 512
+    assert kw["query_max_length"] == 256
 
 
 def test_unknown_model_passes_through(_patch_embedders):

--- a/nemo_retriever/tests/test_hf_embedder_padding.py
+++ b/nemo_retriever/tests/test_hf_embedder_padding.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+import torch
+
+from nemo_retriever.model.local.llama_nemotron_embed_1b_v2_hf_embedder import LlamaNemotronEmbed1BV2HFEmbedder
+from nemo_retriever.text_embed.runtime import _embed_group
+
+
+class _FakeTokenizer:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def __call__(self, texts, *, padding, truncation, max_length, return_tensors):
+        self.calls.append(
+            {
+                "texts": list(texts),
+                "padding": padding,
+                "truncation": truncation,
+                "max_length": max_length,
+                "return_tensors": return_tensors,
+            }
+        )
+        seq_len = int(max_length) if padding == "max_length" else max(len(str(text).split()) for text in texts)
+        batch_size = len(texts)
+        return {
+            "input_ids": torch.ones((batch_size, seq_len), dtype=torch.long),
+            "attention_mask": torch.ones((batch_size, seq_len), dtype=torch.long),
+        }
+
+
+class _FakeModel:
+    def __call__(self, **batch):
+        input_ids = batch["input_ids"]
+        hidden = torch.ones((input_ids.shape[0], input_ids.shape[1], 2), dtype=torch.float32)
+        return SimpleNamespace(last_hidden_state=hidden)
+
+
+def _make_loaded_embedder() -> tuple[LlamaNemotronEmbed1BV2HFEmbedder, _FakeTokenizer]:
+    tokenizer = _FakeTokenizer()
+    embedder = LlamaNemotronEmbed1BV2HFEmbedder()
+    embedder._tokenizer = tokenizer
+    embedder._model = _FakeModel()
+    embedder._device = torch.device("cpu")
+    embedder._ensure_loaded = lambda: None  # type: ignore[method-assign]
+    return embedder, tokenizer
+
+
+def test_hf_query_embedder_uses_fixed_padding() -> None:
+    embedder, tokenizer = _make_loaded_embedder()
+
+    embedder.embed_queries(["short", "a slightly longer query"], batch_size=1)
+
+    assert [call["padding"] for call in tokenizer.calls] == ["max_length", "max_length"]
+    assert [call["max_length"] for call in tokenizer.calls] == [128, 128]
+
+
+def test_hf_passage_embedder_keeps_dynamic_padding() -> None:
+    embedder, tokenizer = _make_loaded_embedder()
+
+    embedder.embed(["short", "a slightly longer passage"], batch_size=1)
+
+    assert [call["padding"] for call in tokenizer.calls] == [True, True]
+    assert [call["max_length"] for call in tokenizer.calls] == [8192, 8192]
+
+
+class _FakeTextModel:
+    def __init__(self) -> None:
+        self.embed_calls: list[list[str]] = []
+        self.embed_query_calls: list[list[str]] = []
+
+    def embed(self, texts, *, batch_size):
+        self.embed_calls.append(list(texts))
+        return [[1.0, 0.0] for _ in texts]
+
+    def embed_queries(self, texts, *, batch_size):
+        self.embed_query_calls.append(list(texts))
+        return [[0.0, 1.0] for _ in texts]
+
+
+def test_runtime_local_query_embedding_uses_embed_queries() -> None:
+    model = _FakeTextModel()
+
+    _embed_group(
+        pd.DataFrame({"text": ["what is revenue?"]}),
+        group_modality="text",
+        model=model,
+        endpoint=None,
+        api_key=None,
+        text_column="text",
+        inference_batch_size=8,
+        output_column="embedding",
+        resolved_model_name="nvidia/llama-nemotron-embed-1b-v2",
+        input_type="query",
+    )
+
+    assert model.embed_query_calls == [["what is revenue?"]]
+    assert model.embed_calls == []
+
+
+def test_runtime_local_passage_embedding_uses_embed() -> None:
+    model = _FakeTextModel()
+
+    _embed_group(
+        pd.DataFrame({"text": ["annual revenue"]}),
+        group_modality="text",
+        model=model,
+        endpoint=None,
+        api_key=None,
+        text_column="text",
+        inference_batch_size=8,
+        output_column="embedding",
+        resolved_model_name="nvidia/llama-nemotron-embed-1b-v2",
+        input_type="passage",
+    )
+
+    assert model.embed_calls == [["annual revenue"]]
+    assert model.embed_query_calls == []

--- a/nemo_retriever/tests/test_hf_embedder_padding.py
+++ b/nemo_retriever/tests/test_hf_embedder_padding.py
@@ -17,6 +17,10 @@ class _FakeTokenizer:
     def __init__(self) -> None:
         self.calls: list[dict[str, object]] = []
 
+    def encode(self, text, *, add_special_tokens=True, truncation=False):
+        extra = 2 if add_special_tokens else 0
+        return list(range(len(str(text).split()) + extra))
+
     def __call__(self, texts, *, padding, truncation, max_length, return_tensors):
         self.calls.append(
             {
@@ -59,6 +63,16 @@ def test_hf_query_embedder_uses_fixed_padding() -> None:
 
     assert [call["padding"] for call in tokenizer.calls] == ["max_length", "max_length"]
     assert [call["max_length"] for call in tokenizer.calls] == [128, 128]
+
+
+def test_hf_query_embedder_warns_when_query_truncated(caplog) -> None:
+    embedder, _tokenizer = _make_loaded_embedder()
+    embedder.query_max_length = 3
+
+    with caplog.at_level("WARNING", logger="nemo_retriever.model.local.llama_nemotron_embed_1b_v2_hf_embedder"):
+        embedder.embed_queries(["one two three four"], batch_size=1)
+
+    assert "Truncating 1/1 HF query embeddings to query_max_length=3 tokens" in caplog.text
 
 
 def test_hf_passage_embedder_keeps_dynamic_padding() -> None:

--- a/nemo_retriever/tests/test_retriever_queries.py
+++ b/nemo_retriever/tests/test_retriever_queries.py
@@ -177,6 +177,20 @@ class TestRetrieveVdbOperatorPreprocess:
         vec = op.preprocess(df)
         assert vec == [[0.7, 0.8]]
 
+    def test_dataframe_to_vectors_skips_numeric_non_embedding_list_columns(self) -> None:
+        from nemo_retriever.vdb.operators import RetrieveVdbOperator
+
+        df = pd.DataFrame(
+            {
+                "text": ["a"],
+                "page_scores": [[9.9, 8.8]],
+                "text_embeddings_1b_v2": [[0.7, 0.8]],
+            }
+        )
+        op = RetrieveVdbOperator(vdb_op="lancedb", vdb_kwargs={"uri": "/tmp", "table_name": "t"})
+        vec = op.preprocess(df)
+        assert vec == [[0.7, 0.8]]
+
 
 class TestRerankLongDataframe:
     def test_groups_by_query_order(self) -> None:

--- a/nemo_retriever/tests/test_retriever_queries.py
+++ b/nemo_retriever/tests/test_retriever_queries.py
@@ -163,6 +163,20 @@ class TestRetrieveVdbOperatorPreprocess:
         vec = op.preprocess(df)
         assert vec == [[0.5, 0.6]]
 
+    def test_dataframe_to_vectors_skips_non_numeric_list_columns(self) -> None:
+        from nemo_retriever.vdb.operators import RetrieveVdbOperator
+
+        df = pd.DataFrame(
+            {
+                "text": ["a"],
+                "tags": [["finance", "annual"]],
+                "text_embeddings_1b_v2": [[0.7, 0.8]],
+            }
+        )
+        op = RetrieveVdbOperator(vdb_op="lancedb", vdb_kwargs={"uri": "/tmp", "table_name": "t"})
+        vec = op.preprocess(df)
+        assert vec == [[0.7, 0.8]]
+
 
 class TestRerankLongDataframe:
     def test_groups_by_query_order(self) -> None:

--- a/nemo_retriever/tests/test_retriever_queries.py
+++ b/nemo_retriever/tests/test_retriever_queries.py
@@ -137,6 +137,32 @@ class TestRetrieveVdbOperatorPreprocess:
         vec = op.preprocess(df)
         assert vec == [[0.1, 0.2]]
 
+    def test_dataframe_to_vectors_reads_payload_embedding_column(self) -> None:
+        from nemo_retriever.vdb.operators import RetrieveVdbOperator
+
+        df = pd.DataFrame(
+            {
+                "text": ["a"],
+                "text_embeddings_1b_v2": [{"embedding": [0.3, 0.4]}],
+            }
+        )
+        op = RetrieveVdbOperator(vdb_op="lancedb", vdb_kwargs={"uri": "/tmp", "table_name": "t"})
+        vec = op.preprocess(df)
+        assert vec == [[0.3, 0.4]]
+
+    def test_dataframe_to_vectors_reads_direct_embedding_column(self) -> None:
+        from nemo_retriever.vdb.operators import RetrieveVdbOperator
+
+        df = pd.DataFrame(
+            {
+                "text": ["a"],
+                "text_embeddings_1b_v2": [[0.5, 0.6]],
+            }
+        )
+        op = RetrieveVdbOperator(vdb_op="lancedb", vdb_kwargs={"uri": "/tmp", "table_name": "t"})
+        vec = op.preprocess(df)
+        assert vec == [[0.5, 0.6]]
+
 
 class TestRerankLongDataframe:
     def test_groups_by_query_order(self) -> None:


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->
### Summary

Simplifies BEIR recall evaluation and fixes local query embedding regressions.

- Adds first-class BEIR dataset resolution so known datasets like `bo767`, `bo10k`, `jp20`, `earnings`, `financebench`, and `vidore_v3_*` can be run with shorthand `--beir-dataset-name` values.
- Routes local query embedding through model-native `embed_queries()` when available, instead of the generic passage embedding path.
- Stabilizes HF `llama-nemotron-embed-1b-v2` query embeddings with fixed-length query padding.
- Enables native vLLM query embedding by allowing retrieval to read vectors from payload/direct embedding columns, not only `metadata["embedding"]`.

### Why

BO767 recall had dropped substantially, from the historical `recall@5 ~= 0.835` range to about `0.524`. The root cause was the HF query embedding path switching to batch-local dynamic padding, which made query vectors depend on batch grouping for `llama-nemotron-embed-1b-v2`.

Because recall quality is the main product signal here, query embeddings need to be stable and reproducible across batch sizes and execution paths. Fixed-length query padding restores the expected BO767 recall level.

The vLLM query path also could not complete evaluation reliably because its native output shape was not accepted by retrieval vector extraction.

Separately, the BEIR CLI was too easy to misconfigure because each dataset required loader, annotation path, doc-id field, and k values to be specified manually. The new resolver encodes those known dataset defaults while preserving explicit CLI overrides.

### Validation

- Added/updated unit coverage for BEIR dataset resolution, HF query padding behavior, runtime query routing, and vLLM query vector extraction.
- Ran focused tests:
  - `nemo_retriever/tests/test_retriever_queries.py`
  - `nemo_retriever/tests/test_beir_evaluation.py`
- Verified BO767 recall:
  - Before fix: `recall@5 ~= 0.524`
  - HF fixed-padding query backend: `recall@5 ~= 0.8378`
  - vLLM native query backend: `recall@5 ~= 0.8388`, `recall@10 ~= 0.8856`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
