### PR TITLE
test Kheiss/audits

### DIFF
--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -67,32 +67,36 @@ When you explicitly configure remote NIM endpoints in Python library mode, graph
 
 Refer to [Evaluate on your data](evaluate-on-your-data.md) for extraction tuning and optimization guidance.
 
-You can configure the `extract`, `caption`, and other tasks by using the [Ingestor API](nemo-retriever-api-reference.md).
+You can configure the `extract`, `caption`, and other tasks by using the [Python API guide](nemo-retriever-api-reference.md) (`create_ingestor` and `GraphIngestor`).
 
-To choose what types of content to extract, use code similar to the following. 
+To choose what types of content to extract, use code similar to the following.
 For more information, refer to [Extract Specific Elements from PDFs](nemo-retriever-api-reference.md).
 
 ```python
-Ingestor(client=client)
-    .files("data/multimodal_test.pdf")
-    .extract(              
-        extract_text=True,
-        extract_tables=True,
-        extract_charts=True,
-        extract_images=True,
-        extract_infographics=True,
-        text_depth="page"
-    )
+from pathlib import Path
+
+from nemo_retriever import create_ingestor
+
+documents = [str(Path("data/multimodal_test.pdf"))]
+ingestor = create_ingestor(run_mode="batch")
+ingestor = ingestor.files(documents).extract(
+    extract_text=True,
+    extract_tables=True,
+    extract_charts=True,
+    extract_images=True,
+    extract_infographics=True,
+)
 ```
 
 To generate captions for images, use code similar to the following.
 For more information, refer to [Extract Captions from Images](nemo-retriever-api-reference.md).
 
 ```python
-Ingestor(client=client)
-    .files("data/multimodal_test.pdf")
-    .extract()
-    .embed()
-    .caption()
+from pathlib import Path
 
+from nemo_retriever import create_ingestor
+
+documents = [str(Path("data/multimodal_test.pdf"))]
+ingestor = create_ingestor(run_mode="batch")
+ingestor = ingestor.files(documents).extract().embed().caption()
 ```

--- a/docs/docs/extraction/user-defined-stages.md
+++ b/docs/docs/extraction/user-defined-stages.md
@@ -8,11 +8,12 @@ and operate on a well-defined DataFrame payload and metadata structure.
 
 To add user-defined stages to your pipeline, you need the following:
 
-- **A callable function** — Your function must have the following exact signature. For more information, refer to []().
-  
-    ```python
-    def my_fn(control_message: IngestControlMessage, stage_config: MyConfig) -> IngestControlMessage:
-    ```
+- **A callable function** — Your function must have the following exact signature. For more information, refer to [Extending NeMo Retriever Library with custom code](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/src/nemo_retriever/graph/README.md).
+
+```python
+def my_fn(control_message: IngestControlMessage, stage_config: MyConfig) -> IngestControlMessage:
+    ...
+```
 
 - **A DataFrame payload** — The `control_message.payload` field must be a [pandas.DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html). For more information, refer to [Create a DataFrame Payload](#create-a-dataframe-payload).
 
@@ -227,61 +228,63 @@ The  following example adds user-defined stages to your NeMo Retriever Library p
 
 1. The following code creates a function for a user-defined stage.
 
-    ```python
-    # my_pipeline/stages.py
-    from pydantic import BaseModel
-    from nv_ingest_api.internal.primitives.ingest_control_message import IngestControlMessage
-    from nv_ingest_api.internal.schemas.meta.metadata_schema import validate_metadata
+```python
+# my_pipeline/stages.py
+from pydantic import BaseModel
+from nv_ingest_api.internal.primitives.ingest_control_message import IngestControlMessage
+from nv_ingest_api.internal.schemas.meta.metadata_schema import validate_metadata
 
-    class DoubleConfig(BaseModel):
+
+class DoubleConfig(BaseModel):
     multiply_by: int = 2
 
-    def double_amount(control_message: IngestControlMessage, stage_config: DoubleConfig) -> IngestControlMessage:
+
+def double_amount(control_message: IngestControlMessage, stage_config: DoubleConfig) -> IngestControlMessage:
     df = control_message.payload()
-    
+
     # Suppose the metadata for each row includes 'amount' under 'content_metadata'
     def double_meta(meta):
         meta = dict(meta)
         if "content_metadata" in meta and isinstance(meta["content_metadata"], dict):
-        cm = dict(meta["content_metadata"])
-        if "amount" in cm and isinstance(cm["amount"], (int, float)):
-            cm["amount"] *= stage_config.multiply_by
-        meta["content_metadata"] = cm
+            cm = dict(meta["content_metadata"])
+            if "amount" in cm and isinstance(cm["amount"], (int, float)):
+                cm["amount"] *= stage_config.multiply_by
+            meta["content_metadata"] = cm
         validate_metadata(meta)
         return meta
 
     df["metadata"] = df["metadata"].apply(double_meta)
     control_message.payload(df)
     return control_message
-    ```
+```
 
 2. The following code adds the user-defined stage to the pipeline.
 
     - (Option 1)  For a function that is defined in the module my_pipeline.stages.
 
-        ```python
-        from my_pipeline.stages import double_amount, DoubleConfig
+```python
+from my_pipeline.stages import double_amount, DoubleConfig
 
-        pipeline.add_stage(
-        name="doubler",
-        stage_actor="my_pipeline.stages:double_amount",
-        config=DoubleConfig(multiply_by=3),
-        min_replicas=1,
-        max_replicas=2,
-        )
-        ```
+pipeline.add_stage(
+    name="doubler",
+    stage_actor="my_pipeline.stages:double_amount",
+    config=DoubleConfig(multiply_by=3),
+    min_replicas=1,
+    max_replicas=2,
+)
+```
 
     - (Option 2) For a function that you have already imported.
 
-        ```python
-        pipeline.add_stage(
-        name="doubler",
-        stage_actor=double_amount,
-        config=DoubleConfig(multiply_by=3),
-        min_replicas=1,
-        max_replicas=2,
-        )
-        ```
+```python
+pipeline.add_stage(
+    name="doubler",
+    stage_actor=double_amount,
+    config=DoubleConfig(multiply_by=3),
+    min_replicas=1,
+    max_replicas=2,
+)
+```
 
 
 

--- a/docs/docs/extraction/workflow-document-ingestion.md
+++ b/docs/docs/extraction/workflow-document-ingestion.md
@@ -14,7 +14,7 @@ Follow these steps:
 
 Pipeline concepts and stage overview appear in [Key concepts](concepts.md). Default chunking behavior is summarized under [Chunking](concepts.md#chunking).
 
-`create_ingestor(...)` returns a `GraphIngestor`, which chains `.extract()` and `.embed()` but does **not** implement `.vdb_upload()` yet (the base method records the intent only and raises `NotImplementedError` if you call it). To write embeddings into LanceDB after graph ingest, use the `graph_pipeline` CLI below (it performs upload via an internal helper, not the fluent builder) or follow the storage patterns in [Vector databases](vdbs.md). The Python example stops after `.embed()` and returns a dataset you can index in a separate step.
+`create_ingestor(...)` returns a `GraphIngestor` for `run_mode` `"batch"` or `"inprocess"`. The abstract `ingestor` interface raises `NotImplementedError` for unimplemented methods, but **`GraphIngestor` implements `.vdb_upload()`**: it records `VdbUploadParams` (for example `vdb_op="lancedb"` and `vdb_kwargs` with `uri` / `table_name`) and runs in-graph vector DB upload after embed when you include that stage before `.ingest()`. The minimal Python example below stops after `.embed()` so you can inspect a `ray.data.Dataset` or `pandas.DataFrame` without writing a VDB; for LanceDB in one fluent chain, append `.vdb_upload(...)` then `.ingest()` or follow [Vector databases](vdbs.md). The `graph_pipeline` / `retriever pipeline run` CLI is another supported path that builds the same graph parameters for you.
 
 ## Choose how you call the library
 
@@ -22,7 +22,7 @@ The following examples match the [NeMo Retriever Library README](https://github.
 
 ### Ingest a test PDF (Python)
 
-The [test PDF](https://github.com/NVIDIA/NeMo-Retriever/blob/main/data/multimodal_test.pdf) contains text, tables, charts, and images. The pipeline below chains `.extract()` and `.embed()` only—**do not** append `.vdb_upload()` on `GraphIngestor`; it is not implemented on this code path.
+The [test PDF](https://github.com/NVIDIA/NeMo-Retriever/blob/main/data/multimodal_test.pdf) contains text, tables, charts, and images. The pipeline below chains `.extract()` and `.embed()` only so you can inspect embeddings in-process; you **may** append `.vdb_upload(VdbUploadParams(...))` before `.ingest()` when you want in-graph LanceDB (or another supported VDB) upload on the same fluent builder.
 
 ```python
 from nemo_retriever import create_ingestor
@@ -57,9 +57,9 @@ Run the above with your working directory at the repository root (so `data/multi
     LanceDB's default IVF index needs enough chunks to train its partitions (often on the order of tens of chunks). A single small PDF can be insufficient; use a directory with enough documents for your index settings. Replace `/your-example-dir` with your corpus path.
 
 ```bash
-python -m nemo_retriever.examples.graph_pipeline \
+python -m nemo_retriever.examples.graph_pipeline run \
   /your-example-dir \
-  --lancedb-uri lancedb
+  --vdb-kwargs-json '{"uri":"lancedb"}'
 ```
 
 For build.nvidia.com hosted inference, set [`NVIDIA_API_KEY`](api-keys.md#nvidia-api-key) and pass the `--*-invoke-url` / `--embed-invoke-url` options shown in the [README remote inference section](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/README.md#ingest-a-test-corpus-cli).


### PR DESCRIPTION
## Summary

Addresses documentation issues found by a targeted doc audit of `docs/docs/extraction/`: invalid fenced Python, inaccurate guidance for `GraphIngestor.vdb_upload()`, and a CLI example that did not match the current `nemo_retriever.pipeline` Typer entrypoint. No library (`*.py`) changes.

## Changes

| Area | File | What changed |
|------|------|----------------|
| FAQ examples | `docs/docs/extraction/faq.md` | Replaced invalid `Ingestor(client=client)` chained snippets with valid `create_ingestor` / `GraphIngestor` examples; aligned `.extract()` kwargs with `ExtractParams` (removed unsupported `text_depth` from the snippet); clarified pointer to the Python API guide. |
| Ingest → VDB workflow | `docs/docs/extraction/workflow-document-ingestion.md` | Documented that **`GraphIngestor` implements `.vdb_upload()`** via `VdbUploadParams` (vs `NotImplementedError` on the abstract `ingestor` base); updated the test-PDF section so optional in-graph VDB is described correctly; fixed CLI to **`graph_pipeline run`** with **`--vdb-kwargs-json`** instead of **`--lancedb-uri`**. |
| UDF / custom stages | `docs/docs/extraction/user-defined-stages.md` | Fixed broken `refer to []()` link; repaired signature and “minimal complete” Python blocks and `pipeline.add_stage` indentation so fenced `python` parses; corrected nested `double_meta` / `DoubleConfig` structure. |

