### PR TITLE
add named tuple for data loading, update docstrings to add bright

### DIFF
--- a/retrieval-bench/src/retrieval_bench/__init__.py
+++ b/retrieval-bench/src/retrieval_bench/__init__.py
@@ -15,7 +15,7 @@ from .pipeline_evaluation import (  # noqa: F401
     aggregate_results,
     evaluate_retrieval,
     get_available_datasets,
-    load_vidore_dataset,
+    load_benchmark_dataset,
     print_dataset_info,
 )
 
@@ -23,7 +23,7 @@ __all__ = [
     "BasePipeline",
     "evaluate_retrieval",
     "aggregate_results",
-    "load_vidore_dataset",
+    "load_benchmark_dataset",
     "get_available_datasets",
     "print_dataset_info",
 ]

--- a/retrieval-bench/src/retrieval_bench/cli/evaluate.py
+++ b/retrieval-bench/src/retrieval_bench/cli/evaluate.py
@@ -18,7 +18,7 @@ from retrieval_bench.pipeline_evaluation import (
     BasePipeline,
     aggregate_results,
     evaluate_retrieval,
-    load_vidore_dataset,
+    load_benchmark_dataset,
     print_dataset_info,
 )
 from retrieval_bench.pipeline_evaluation.tracing import dataset_trace_dir, default_trace_run_name
@@ -162,9 +162,15 @@ def _run_evaluation(
 
     # Load dataset
     try:
-        query_ids, queries, corpus_ids, corpus_images, corpus_texts, qrels, query_languages, excluded_ids_by_query = (
-            load_vidore_dataset(dataset_name=dataset_name, split=split, language=language)
-        )
+        dataset = load_benchmark_dataset(dataset_name=dataset_name, split=split, language=language)
+        query_ids = dataset.query_ids
+        queries = dataset.queries
+        corpus_ids = dataset.corpus_ids
+        corpus_images = dataset.corpus_images
+        corpus_texts = dataset.corpus_texts
+        qrels = dataset.qrels
+        query_languages = dataset.query_languages
+        excluded_ids_by_query = dataset.excluded_ids_by_query
     except Exception as e:
         print(f"\nError loading dataset: {e}\n")
         raise typer.Exit(code=1)

--- a/retrieval-bench/src/retrieval_bench/cli/pipeline_evaluation.py
+++ b/retrieval-bench/src/retrieval_bench/cli/pipeline_evaluation.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 app = typer.Typer(
     help="""
-    CLI for evaluating abstract pipelines on ViDoRe v3 datasets.
+    CLI for evaluating abstract pipelines on ViDoRe v3 and BRIGHT datasets.
 
     Evaluate custom retrieval pipelines that inherit from BasePipeline.
     Supports built-in pipelines (random, file-based) and custom Python implementations.
@@ -411,6 +411,36 @@ def _compute_llm_errors_from_traces(
     return out
 
 
+def _resolve_selected_datasets(*, all_datasets: bool, datasets: Optional[str]) -> tuple[list[str], dict[str, str]]:
+    """
+    Resolve dataset selection tokens into canonical full dataset names.
+
+    Returns:
+        (selected_dataset_full_names, short_by_full)
+    """
+    ds_full = get_available_datasets()
+    short_by_full = {ds: dataset_trace_dir(ds) for ds in ds_full}
+    full_by_short = {v: k for k, v in short_by_full.items()}
+
+    selected = list(ds_full)
+    if not all_datasets and datasets:
+        toks = [t.strip() for t in datasets.split(",") if t.strip()]
+        if not toks:
+            raise typer.BadParameter("--datasets was provided but empty.")
+        selected = []
+        for tok in toks:
+            if tok in short_by_full:
+                selected.append(tok)
+            elif tok in full_by_short:
+                selected.append(full_by_short[tok])
+            else:
+                raise typer.BadParameter(
+                    f"Unknown dataset '{tok}'. Expected one of: {', '.join(short_by_full.values())}"
+                )
+
+    return selected, short_by_full
+
+
 def _load_pipeline_from_module(module_path: str, class_name: str, **kwargs) -> BasePipeline:
     """
     Dynamically load a pipeline class from a Python file.
@@ -454,15 +484,15 @@ def _load_pipeline_from_module(module_path: str, class_name: str, **kwargs) -> B
 @app.command()
 def list_datasets():
     """
-    List all available ViDoRe v3 datasets.
+    List all available benchmark datasets.
 
     Example:
-        retrieval-bench pipeline list-datasets
+        retrieval-bench evaluate utils list-datasets
     """
     datasets = get_available_datasets()
 
     print("\n" + "=" * 70)
-    print("Available ViDoRe v3 Datasets")
+    print("Available Benchmark Datasets")
     print("=" * 70)
     for i, dataset_name in enumerate(datasets, 1):
         print(f"{i:2d}. {dataset_name}")
@@ -504,8 +534,8 @@ def report_results(
     """
     Report NDCG@10 and query-coverage per dataset for a results directory.
 
-    This command expects the JSON structure produced by `retrieval-bench pipeline evaluate`
-    and `retrieval-bench pipeline evaluate-all`, i.e. each file contains:
+    This command expects the JSON structure produced by `retrieval-bench evaluate dense-retrieval`
+    and `retrieval-bench evaluate agentic-retrieval`, i.e. each file contains:
       - aggregated_metrics (including ndcg_cut_10)
       - timing info (including expected_num_queries / num_queries / missing_num_queries) when available
 
@@ -592,15 +622,16 @@ def compare_results(
         typer.Option(
             "--all-datasets",
             "--all",
-            help="Report across all available ViDoRe v3 datasets (overrides --datasets).",
+            help="Report across all available benchmark datasets (overrides --datasets).",
         ),
     ] = False,
     datasets: Annotated[
         Optional[str],
         typer.Option(
             "--datasets",
-            help="Optional comma-separated dataset filter (accepts either full names like 'vidore/vidore_v3_hr' "
-            "or shorts like 'vidore_v3_hr'). Defaults to all datasets.",
+            help="Optional comma-separated dataset filter (accepts full names like 'bright/biology' "
+            "or 'vidore/vidore_v3_hr', plus shorts like 'bright__biology' or 'vidore_v3_hr'). "
+            "Defaults to all datasets.",
         ),
     ] = None,
     metric: Annotated[
@@ -621,29 +652,7 @@ def compare_results(
     if not results_dirs:
         raise typer.BadParameter("--results-dirs must include at least one directory.")
 
-    # Canonical dataset list.
-    all_ds = get_available_datasets()
-    short_by_full = {ds: dataset_trace_dir(ds) for ds in all_ds}
-    full_by_short = {v: k for k, v in short_by_full.items()}
-
-    # Optional dataset filter.
-    selected = list(all_ds)
-    if (not all_datasets) and datasets:
-        toks = [t.strip() for t in datasets.split(",") if t.strip()]
-        if not toks:
-            raise typer.BadParameter("--datasets was provided but empty.")
-        selected = []
-        for tok in toks:
-            # Allow specifying either the full dataset name (e.g. 'bright/biology')
-            # or the dataset file key used on disk (e.g. 'bright__biology').
-            if tok in short_by_full:
-                selected.append(tok)
-            elif tok in full_by_short:
-                selected.append(full_by_short[tok])
-            else:
-                raise typer.BadParameter(
-                    f"Unknown dataset '{tok}'. Expected one of: {', '.join(short_by_full.values())}"
-                )
+    selected, short_by_full = _resolve_selected_datasets(all_datasets=all_datasets, datasets=datasets)
 
     # Pipeline labels for columns.
     dirs: list[Path] = [Path(d) for d in results_dirs]
@@ -735,15 +744,16 @@ def report_llm_usage(
         typer.Option(
             "--all-datasets",
             "--all",
-            help="Report across all available ViDoRe v3 datasets (overrides --datasets).",
+            help="Report across all available benchmark datasets (overrides --datasets).",
         ),
     ] = False,
     datasets: Annotated[
         Optional[str],
         typer.Option(
             "--datasets",
-            help="Optional comma-separated dataset filter (accepts either full names like 'vidore/vidore_v3_hr' "
-            "or shorts like 'vidore_v3_hr'). Defaults to all datasets.",
+            help="Optional comma-separated dataset filter (accepts full names like 'bright/biology' "
+            "or 'vidore/vidore_v3_hr', plus shorts like 'bright__biology' or 'vidore_v3_hr'). "
+            "Defaults to all datasets.",
         ),
     ] = None,
     traces_dir: Annotated[
@@ -780,26 +790,7 @@ def report_llm_usage(
     if not results_root.exists() or not results_root.is_dir():
         raise typer.BadParameter(f"--results-dir must be an existing directory: {results_root}")
 
-    # Canonical dataset list.
-    ds_full = get_available_datasets()
-    short_by_full = {ds: dataset_trace_dir(ds) for ds in ds_full}
-    full_by_short = {v: k for k, v in short_by_full.items()}
-
-    selected = list(ds_full)
-    if not all_datasets and datasets:
-        toks = [t.strip() for t in datasets.split(",") if t.strip()]
-        if not toks:
-            raise typer.BadParameter("--datasets was provided but empty.")
-        selected = []
-        for tok in toks:
-            if tok in short_by_full:
-                selected.append(tok)
-            elif tok in full_by_short:
-                selected.append(full_by_short[tok])
-            else:
-                raise typer.BadParameter(
-                    f"Unknown dataset '{tok}'. Expected one of: {', '.join(short_by_full.values())}"
-                )
+    selected, short_by_full = _resolve_selected_datasets(all_datasets=all_datasets, datasets=datasets)
 
     # Table rows: (dataset_short, nq, err_count, pt, ct, tt, wall_ms_q, avg_traj, source)
     rows: list[tuple[str, str, str, str, str, str, str, str, str]] = []
@@ -1033,15 +1024,16 @@ def purge_llm_error_traces(
         typer.Option(
             "--all-datasets",
             "--all",
-            help="Purge across all available ViDoRe v3 datasets (overrides --datasets).",
+            help="Purge across all available benchmark datasets (overrides --datasets).",
         ),
     ] = False,
     datasets: Annotated[
         Optional[str],
         typer.Option(
             "--datasets",
-            help="Optional comma-separated dataset filter (accepts either full names like 'vidore/vidore_v3_hr' "
-            "or shorts like 'vidore_v3_hr'). Defaults to all datasets.",
+            help="Optional comma-separated dataset filter (accepts full names like 'bright/biology' "
+            "or 'vidore/vidore_v3_hr', plus shorts like 'bright__biology' or 'vidore_v3_hr'). "
+            "Defaults to all datasets.",
         ),
     ] = None,
     traces_dir: Annotated[
@@ -1086,26 +1078,7 @@ def purge_llm_error_traces(
     if (not dry_run) and (not yes):
         raise typer.BadParameter("Refusing to delete traces without --yes. Re-run with --no-dry-run --yes.")
 
-    # Canonical dataset list.
-    ds_full = get_available_datasets()
-    short_by_full = {ds: dataset_trace_dir(ds) for ds in ds_full}
-    full_by_short = {v: k for k, v in short_by_full.items()}
-
-    selected = list(ds_full)
-    if not all_datasets and datasets:
-        toks = [t.strip() for t in datasets.split(",") if t.strip()]
-        if not toks:
-            raise typer.BadParameter("--datasets was provided but empty.")
-        selected = []
-        for tok in toks:
-            if tok in short_by_full:
-                selected.append(tok)
-            elif tok in full_by_short:
-                selected.append(full_by_short[tok])
-            else:
-                raise typer.BadParameter(
-                    f"Unknown dataset '{tok}'. Expected one of: {', '.join(short_by_full.values())}"
-                )
+    selected, short_by_full = _resolve_selected_datasets(all_datasets=all_datasets, datasets=datasets)
 
     inferred_trace_run_name = results_root.name
     total_marked = 0

--- a/retrieval-bench/src/retrieval_bench/pipeline_evaluation/__init__.py
+++ b/retrieval-bench/src/retrieval_bench/pipeline_evaluation/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Python CLI tool for evaluating pipelines on vidore v3 datasets.
+CLI tool for evaluating pipelines on vidore v3 datasets and BRIGHT datasets.
 """
 
 __version__ = "0.1.0"
@@ -11,7 +11,7 @@ from vidore_benchmark.pipeline_evaluation.base_pipeline import BasePipeline
 from vidore_benchmark.pipeline_evaluation.dataset_loader import print_dataset_info
 from retrieval_bench.pipeline_evaluation.dataset_loader import (
     get_available_datasets,
-    load_vidore_dataset,
+    load_benchmark_dataset,
 )
 from retrieval_bench.pipeline_evaluation.evaluator import aggregate_results, evaluate_retrieval
 
@@ -19,7 +19,7 @@ __all__ = [
     "BasePipeline",
     "evaluate_retrieval",
     "aggregate_results",
-    "load_vidore_dataset",
+    "load_benchmark_dataset",
     "get_available_datasets",
     "print_dataset_info",
 ]

--- a/retrieval-bench/src/retrieval_bench/pipeline_evaluation/dataset_loader.py
+++ b/retrieval-bench/src/retrieval_bench/pipeline_evaluation/dataset_loader.py
@@ -2,16 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Dataset loader for vidore v3 benchmark datasets.
+Dataset loader for benchmark datasets.
 
-Handles downloading and preparing vidore v3 datasets from HuggingFace,
+Handles downloading and preparing ViDoRe v3 and BRIGHT datasets from HuggingFace,
 including queries, corpus images, and ground truth relevance judgments.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional
 
 from datasets import load_dataset
 from vidore_benchmark.pipeline_evaluation.dataset_loader import (
@@ -36,6 +36,17 @@ BRIGHT_TASKS: tuple[str, ...] = (
 )
 
 
+class BenchmarkDatasetBundle(NamedTuple):
+    query_ids: List[str]
+    queries: List[str]
+    corpus_ids: List[str]
+    corpus_images: List[Any]
+    corpus_texts: List[str]
+    qrels: Dict[str, Dict[str, int]]
+    query_languages: Dict[str, str]
+    excluded_ids_by_query: Dict[str, List[str]]
+
+
 def _repo_root() -> Path:
     # <repo>/src/retrieval_bench/pipeline_evaluation/dataset_loader.py
     return Path(__file__).resolve().parents[3]
@@ -58,16 +69,7 @@ def _load_bright_split(
     task: str,
     split: str = "test",
     language: Optional[str] = None,
-) -> Tuple[
-    List[str],
-    List[str],
-    List[str],
-    List[Any],
-    List[str],
-    Dict[str, Dict[str, int]],
-    Dict[str, str],
-    Dict[str, List[str]],
-]:
+) -> BenchmarkDatasetBundle:
     """
     Load one BRIGHT task as a dataset compatible with our pipeline evaluator.
 
@@ -153,19 +155,21 @@ def _load_bright_split(
     if not any(v for v in qrels.values()):
         raise ValueError(f"No relevance judgments found in BRIGHT task '{task}'.")
 
-    return query_ids, queries, corpus_ids, corpus_images, corpus_texts, qrels, query_languages, excluded_ids_by_query
+    return BenchmarkDatasetBundle(
+        query_ids=query_ids,
+        queries=queries,
+        corpus_ids=corpus_ids,
+        corpus_images=corpus_images,
+        corpus_texts=corpus_texts,
+        qrels=qrels,
+        query_languages=query_languages,
+        excluded_ids_by_query=excluded_ids_by_query,
+    )
 
 
-def load_vidore_dataset(dataset_name: str, split: str = "test", language: str = None) -> Tuple[
-    List[str],
-    List[str],
-    List[str],
-    List[Any],
-    List[str],
-    Dict[str, Dict[str, int]],
-    Dict[str, str],
-    Dict[str, List[str]],
-]:
+def load_benchmark_dataset(
+    dataset_name: str, split: str = "test", language: Optional[str] = None
+) -> BenchmarkDatasetBundle:
     """
     Load a dataset for the pipeline evaluator.
 
@@ -182,15 +186,24 @@ def load_vidore_dataset(dataset_name: str, split: str = "test", language: str = 
         language=language,
     )
     excluded_ids_by_query = {str(qid): ["N/A"] for qid in query_ids}
-    return query_ids, queries, corpus_ids, corpus_images, corpus_texts, qrels, query_languages, excluded_ids_by_query
+    return BenchmarkDatasetBundle(
+        query_ids=query_ids,
+        queries=queries,
+        corpus_ids=corpus_ids,
+        corpus_images=corpus_images,
+        corpus_texts=corpus_texts,
+        qrels=qrels,
+        query_languages=query_languages,
+        excluded_ids_by_query=excluded_ids_by_query,
+    )
 
 
 def get_available_datasets() -> List[str]:
     """
-    Get list of available vidore v3 datasets.
+    Get list of available benchmark datasets.
 
     Returns:
-        List of dataset names that can be used with load_vidore_dataset()
+        List of dataset names that can be used with load_benchmark_dataset()
     """
     datasets = list(_upstream_get_available_datasets())
     for name in (f"bright/{t}" for t in BRIGHT_TASKS):

--- a/retrieval-bench/src/retrieval_bench/pipelines/__init__.py
+++ b/retrieval-bench/src/retrieval_bench/pipelines/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Built-in retrieval pipelines for vidore-benchmark evaluation.
+Built-in retrieval pipelines for benchmark evaluation.
 """
 
 from retrieval_bench.pipelines.backends import VALID_BACKENDS, init_backend


### PR DESCRIPTION
## Description
This PR updates the load dataset function name to include BRIGHT in addition to ViDoRe and adds a named tuple for returned loaded objects. It also factors out the repeated dataset filtering code in a helper function in the cli, and updates the outdated example for list-dataset.

Note: This pr is a copy of #2001 created using diff patch.  The commit now is signed with a gpg key.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
