### PR TITLE
[bug-fix] Updated open-clip-torch requirements

### DIFF
--- a/docs/docs/extraction/multimodal-extraction.md
+++ b/docs/docs/extraction/multimodal-extraction.md
@@ -24,7 +24,10 @@ NeMo Retriever Library accepts multiple document and media types. A current list
 
 ## Text and layout extraction { #text-and-layout-extraction }
 
-For PDFs, NeMo Retriever Library typically uses **pdfium**-based extraction with configurable depth and paths. Scanned or mixed pages may use hybrid or OCR-oriented methods. For `extract_method` options such as `pdfium`, `pdfium_hybrid`, and `ocr`, refer to the [Python API reference](nemo-retriever-api-reference.md).
+For PDFs, NeMo Retriever Library typically uses **pdfium**-based extraction with configurable depth and paths. Scanned or mixed pages may use hybrid, OCR-oriented, or Nemotron Parse methods. For `extract_method` options such as `pdfium`, `pdfium_hybrid`, `ocr`, and `nemotron_parse`, refer to the [Python API reference](nemo-retriever-api-reference.md).
+
+!!! note
+    `extract_method="nemotron_parse"` requires the Nemotron Parse NIM client dependencies. Install them with the `nemotron-parse` extra, for example `pip install "nemo-retriever[nemotron-parse]"`, before running PDF extraction through Nemotron Parse.
 
 **Related**
 

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -18,6 +18,9 @@ NeMo Retriever Library does the following:
 - Support multiple methods of extraction for each document type to balance trade-offs between throughput and accuracy. For example, for .pdf documents, extraction is performed by using pdfium and [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse).
 - Support various types of pre- and post- processing operations, including text splitting and chunking, transform and filtering, embedding generation, and image offloading to storage.
 
+!!! note
+    To use `extract_method="nemotron_parse"` with PDFs, install the Nemotron Parse client dependencies with the `nemotron-parse` extra, for example `pip install "nemo-retriever[nemotron-parse]"`.
+
 NeMo Retriever Library supports the following file types:
 
 - `avi`

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -52,6 +52,14 @@ uv pip install nemo-retriever==26.3.0 nv-ingest-client==26.3.0 nv-ingest==26.3.0
 
 This creates a dedicated Python environment and installs the `nemo-retriever` PyPI package, the canonical distribution for the NeMo Retriever Library.
 
+If your PDF pipeline uses `extract_method="nemotron_parse"`, install the Nemotron Parse client dependencies with the `nemotron-parse` extra:
+
+```bash
+uv pip install "nemo-retriever[nemotron-parse]==26.3.0" nv-ingest-client==26.3.0 nv-ingest==26.3.0
+```
+
+For local GPU inference with Nemotron Parse, combine the extras as `nemo-retriever[local,nemotron-parse]`.
+
 > **Note:** `uv python install 3.12` installs a uv-managed Python that includes development headers (`Python.h`). These headers are required by vLLM, which compiles CUDA kernels at runtime using torch inductor. If you skip this step and use a system Python without headers, vLLM actor initialization will fail with `InductorError: fatal error: Python.h: No such file or directory`.
 
 2. Override Torch and Torchvision with CUDA 13 builds (local GPU only)

--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -155,8 +155,11 @@ tabular = [
 ]
 
 # BEIR benchmarking and evaluation tools (not needed for production use).
+# Keep open-clip-torch here for compatibility with existing benchmark installs;
+# the production-facing Nemotron Parse path uses the dedicated extra above.
 benchmarks = [
   "datasets>=4.8.2",
+  "open-clip-torch==3.2.0",
 ]
 
 # ── LLM client (generation + judge) ──────────────────────────────────────────

--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -136,6 +136,14 @@ multimedia = [
   "librosa>=0.10.2",
 ]
 
+# ── Nemotron Parse NIM client support ────────────────────────────────────────
+# Required when using ``extract_method="nemotron_parse"``. Kept separate from
+# the default install so remote-only deployments can opt into the visual parser
+# client without pulling benchmarking tools.
+nemotron-parse = [
+  "open-clip-torch==3.2.0",
+]
+
 # ── Independent extras ───────────────────────────────────────────────────────
 
 # SQL and graph storage backends (lancedb is in core deps).
@@ -149,7 +157,6 @@ tabular = [
 # BEIR benchmarking and evaluation tools (not needed for production use).
 benchmarks = [
   "datasets>=4.8.2",
-  "open-clip-torch==3.2.0",
 ]
 
 # ── LLM client (generation + judge) ──────────────────────────────────────────
@@ -166,7 +173,7 @@ dev = [
 
 # ── Convenience: full install ─────────────────────────────────────────────────
 all = [
-  "nemo_retriever[service,local,multimedia,tabular,benchmarks,llm]",
+  "nemo_retriever[service,local,multimedia,nemotron-parse,tabular,benchmarks,llm]",
 ]
 
 [project.scripts]

--- a/nemo_retriever/uv.lock
+++ b/nemo_retriever/uv.lock
@@ -2444,6 +2444,7 @@ all = [
     { name = "addict" },
     { name = "albumentations" },
     { name = "apscheduler" },
+    { name = "backoff" },
     { name = "cairosvg" },
     { name = "datasets" },
     { name = "duckdb" },
@@ -2479,7 +2480,6 @@ all = [
 ]
 benchmarks = [
     { name = "datasets" },
-    { name = "open-clip-torch" },
 ]
 dev = [
     { name = "build" },
@@ -2520,6 +2520,9 @@ multimedia = [
     { name = "librosa" },
     { name = "scipy" },
     { name = "soundfile" },
+]
+nemotron-parse = [
+    { name = "open-clip-torch" },
 ]
 service = [
     { name = "addict" },
@@ -2572,7 +2575,7 @@ requires-dist = [
     { name = "librosa", marker = "extra == 'multimedia'", specifier = ">=0.10.2" },
     { name = "litellm", marker = "extra == 'llm'", specifier = ">=1.40.0" },
     { name = "markitdown" },
-    { name = "nemo-retriever", extras = ["benchmarks", "llm", "local", "multimedia", "service", "tabular"], marker = "extra == 'all'" },
+    { name = "nemo-retriever", extras = ["benchmarks", "llm", "local", "multimedia", "nemotron-parse", "service", "tabular"], marker = "extra == 'all'" },
     { name = "nemotron-graphic-elements-v1", marker = "extra == 'local'", specifier = ">=0.dev0", index = "https://test.pypi.org/simple/" },
     { name = "nemotron-ocr", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'local') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'local')", specifier = ">=2.0.0.dev0,<2.0.0a0", index = "https://test.pypi.org/simple/" },
     { name = "nemotron-page-elements-v3", marker = "extra == 'local'", specifier = ">=0.dev0", index = "https://test.pypi.org/simple/" },
@@ -2581,7 +2584,7 @@ requires-dist = [
     { name = "nltk", specifier = "==3.9.3" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "nvidia-ml-py", marker = "extra == 'local'" },
-    { name = "open-clip-torch", marker = "extra == 'benchmarks'", specifier = "==3.2.0" },
+    { name = "open-clip-torch", marker = "extra == 'nemotron-parse'", specifier = "==3.2.0" },
     { name = "pandas", specifier = ">=2.0,<3" },
     { name = "pillow", specifier = "==12.2.0" },
     { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0,<8" },
@@ -2616,7 +2619,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
     { name = "vllm", marker = "sys_platform == 'linux' and extra == 'local'", specifier = "==0.20.0" },
 ]
-provides-extras = ["service", "local", "multimedia", "tabular", "benchmarks", "llm", "dev", "all"]
+provides-extras = ["service", "local", "multimedia", "nemotron-parse", "tabular", "benchmarks", "llm", "dev", "all"]
 
 [[package]]
 name = "nemotron-graphic-elements-v1"

--- a/nemo_retriever/uv.lock
+++ b/nemo_retriever/uv.lock
@@ -2480,6 +2480,7 @@ all = [
 ]
 benchmarks = [
     { name = "datasets" },
+    { name = "open-clip-torch" },
 ]
 dev = [
     { name = "build" },
@@ -2584,6 +2585,7 @@ requires-dist = [
     { name = "nltk", specifier = "==3.9.3" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "nvidia-ml-py", marker = "extra == 'local'" },
+    { name = "open-clip-torch", marker = "extra == 'benchmarks'", specifier = "==3.2.0" },
     { name = "open-clip-torch", marker = "extra == 'nemotron-parse'", specifier = "==3.2.0" },
     { name = "pandas", specifier = ">=2.0,<3" },
     { name = "pillow", specifier = "==12.2.0" },


### PR DESCRIPTION
## Description
addresses [#6170950](https://nvbugspro.nvidia.com/bug/6170950)
Fixed the nemotron_parse install gap by adding a dedicated nemo-retriever[nemotron-parse] extra that pulls open-clip-torch, and updated the extraction docs/README to tell users to install it for that path.

Kept open-clip-torch in the existing benchmarks extra, preserving compatibility.

<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
