### PR TITLE
ci: declare workflow-level `contents: read` on 6 workflows

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   # Pre-commit checks
   pre-commit:

--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Fast pre-commit checks (runs first)
   pre-commit:

--- a/.github/workflows/docker-build-arm.yml
+++ b/.github/workflows/docker-build-arm.yml
@@ -4,6 +4,9 @@ on:
   # Manual-only: arm64 builds run in scheduled nightly workflow.
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: linux-large-disk

--- a/.github/workflows/integration-test-library-mode.yml
+++ b/.github/workflows/integration-test-library-mode.yml
@@ -16,6 +16,9 @@ on:
         type: string
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   integration-test:
     name: Integration Tests (${{ matrix.os-label }})

--- a/.github/workflows/retriever-unit-tests.yml
+++ b/.github/workflows/retriever-unit-tests.yml
@@ -8,6 +8,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   retriever-unit-tests:
     name: Run Retriever Unit Tests

--- a/.github/workflows/scheduled-nightly.yml
+++ b/.github/workflows/scheduled-nightly.yml
@@ -17,6 +17,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   # Generate version for all nightly builds
   determine-version:


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 6 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.