### PR TITLE
Add OCR language selector support to CLI 

### DIFF
--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -170,9 +170,12 @@ python -m nemo_retriever.examples.graph_pipeline \
 ```
 
 > **OCR engine default:** The default OCR engine is **Nemotron OCR v2**. Use
-> `--ocr-version v1` to opt into the legacy OCR engine. The remote-inference
-> example above pins `--ocr-version v1` because a hosted v2 endpoint is not yet
-> available on `ai.api.nvidia.com`.
+> `--ocr-version v1` to opt into the legacy OCR engine. Local OCR v2 defaults
+> to multilingual mode (`multi`); pass `--ocr-lang english` for the English-only
+> v2 selector. Remote OCR NIM endpoints decide their own model and language
+> behavior, and the local OCR selectors are not added to remote request payloads.
+> The remote-inference example above pins `--ocr-version v1` because a hosted v2
+> endpoint is not yet available on `ai.api.nvidia.com`.
 
 When you use the remote embedder, pair the `Retriever` with the matching
 `embedder=` + `embedding_endpoint=` overrides shown in

--- a/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
+++ b/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
@@ -8,6 +8,7 @@ import importlib
 import json
 import logging
 
+from pydantic import ValidationError
 import typer
 
 from nemo_retriever.adapters.cli.sdk_workflow import (
@@ -55,7 +56,7 @@ for _name, _module, _attr in _LAZY_SUBAPPS:
     except Exception:
         logger.debug("Skipping '%s' sub-command (import failed)", _name)
 
-_ROOT_CLI_ERRORS = (OSError, RuntimeError, ValueError)
+_ROOT_CLI_ERRORS = (OSError, RuntimeError, ValueError, ValidationError)
 
 
 def _version_callback(value: bool) -> None:

--- a/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
+++ b/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
@@ -12,6 +12,7 @@ import typer
 
 from nemo_retriever.adapters.cli.sdk_workflow import (
     IngestRunModeValue,
+    OcrLangValue,
     OcrVersionValue,
     ingest_documents,
     query_documents,
@@ -106,6 +107,11 @@ def ingest_command(
         None,
         "--ocr-version",
         help="OCR engine version for extraction.",
+    ),
+    ocr_lang: OcrLangValue | None = typer.Option(
+        None,
+        "--ocr-lang",
+        help="OCR v2 language selector for local extraction.",
     ),
     graphic_elements_invoke_url: str | None = typer.Option(
         None,
@@ -208,6 +214,7 @@ def ingest_command(
             page_elements_invoke_url=page_elements_invoke_url,
             ocr_invoke_url=ocr_invoke_url,
             ocr_version=ocr_version,
+            ocr_lang=ocr_lang,
             graphic_elements_invoke_url=graphic_elements_invoke_url,
             table_structure_invoke_url=table_structure_invoke_url,
             embed_invoke_url=embed_invoke_url,

--- a/nemo_retriever/src/nemo_retriever/adapters/cli/sdk_workflow.py
+++ b/nemo_retriever/src/nemo_retriever/adapters/cli/sdk_workflow.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Literal, Sequence, cast
 
 from nemo_retriever.ingestor import create_ingestor
+from nemo_retriever.ocr.config import OCRLang, OCRVersion
 from nemo_retriever.params import BatchTuningParams, EmbedParams, ExtractParams, VdbUploadParams
 from nemo_retriever.params.utils import normalize_embed_kwargs
 from nemo_retriever.retriever import Retriever
@@ -16,7 +17,8 @@ from nemo_retriever.utils.remote_auth import resolve_remote_api_key
 
 
 IngestRunModeValue = Literal["inprocess", "batch"]
-OcrVersionValue = Literal["v1", "v2"]
+OcrLangValue = OCRLang
+OcrVersionValue = OCRVersion
 _SUPPORTED_RUN_MODES: tuple[IngestRunModeValue, ...] = ("inprocess", "batch")
 
 
@@ -152,6 +154,7 @@ def ingest_documents(
     page_elements_invoke_url: str | None = None,
     ocr_invoke_url: str | None = None,
     ocr_version: OcrVersionValue | None = None,
+    ocr_lang: OcrLangValue | None = None,
     graphic_elements_invoke_url: str | None = None,
     table_structure_invoke_url: str | None = None,
     embed_invoke_url: str | None = None,
@@ -185,6 +188,7 @@ def ingest_documents(
             "page_elements_invoke_url": page_elements_invoke_url,
             "ocr_invoke_url": ocr_invoke_url,
             "ocr_version": ocr_version,
+            "ocr_lang": ocr_lang,
             "graphic_elements_invoke_url": graphic_elements_invoke_url,
             "table_structure_invoke_url": table_structure_invoke_url,
         }.items()

--- a/nemo_retriever/tests/test_ocr_version_selection.py
+++ b/nemo_retriever/tests/test_ocr_version_selection.py
@@ -169,7 +169,24 @@ def test_graph_forwards_v2_ocr_lang_selector() -> None:
     assert ocr_node.operator_kwargs["ocr_lang"] == "english"
 
 
-def test_video_graph_forwards_v2_ocr_lang_selector() -> None:
+def test_video_graph_forwards_v2_ocr_lang_selector(monkeypatch) -> None:
+    from nemo_retriever.graph.abstract_operator import AbstractOperator
+
+    class _GraphOnlyVideoSplitActor(AbstractOperator):
+        def preprocess(self, data, **kwargs):
+            return data
+
+        def process(self, data, **kwargs):
+            return data
+
+        def postprocess(self, data, **kwargs):
+            return data
+
+    monkeypatch.setattr(
+        "nemo_retriever.graph.ingestor_runtime.VideoSplitActor",
+        _GraphOnlyVideoSplitActor,
+    )
+
     graph = build_graph(
         extraction_mode="video",
         extract_params=ExtractParams(ocr_lang="english"),

--- a/nemo_retriever/tests/test_ocr_version_selection.py
+++ b/nemo_retriever/tests/test_ocr_version_selection.py
@@ -24,8 +24,16 @@ from nemo_retriever.graph.ingestor_runtime import build_graph
 from nemo_retriever.ocr import config as ocr_config
 from nemo_retriever.ocr.config import OCRLang, OCRVersion, resolve_ocr_v2_lang, resolve_ocr_v2_model_dir
 from nemo_retriever.ocr.ocr import OCRActor, resolve_ocr_archetype
-from nemo_retriever.params import EmbedParams, ExtractParams
+from nemo_retriever.params import (
+    AudioChunkParams,
+    AudioVisualFuseParams,
+    EmbedParams,
+    ExtractParams,
+    VideoFrameParams,
+    VideoFrameTextDedupParams,
+)
 from nemo_retriever.utils.ray_resource_hueristics import Resources
+from nemo_retriever.video.ocr_actor import VideoFrameOCRActor
 
 
 def _linear_nodes(graph):
@@ -159,6 +167,70 @@ def test_graph_forwards_v2_ocr_lang_selector() -> None:
 
     assert ocr_node.operator_kwargs["ocr_version"] == "v2"
     assert ocr_node.operator_kwargs["ocr_lang"] == "english"
+
+
+def test_video_graph_forwards_v2_ocr_lang_selector() -> None:
+    graph = build_graph(
+        extraction_mode="video",
+        extract_params=ExtractParams(ocr_lang="english"),
+        audio_chunk_params=AudioChunkParams(enabled=False),
+        video_frame_params=VideoFrameParams(enabled=True),
+    )
+
+    ocr_node = next(node for node in _linear_nodes(graph) if node.operator_class is VideoFrameOCRActor)
+
+    assert ocr_node.operator_kwargs["ocr_version"] == "v2"
+    assert ocr_node.operator_kwargs["ocr_lang"] == "english"
+
+
+def test_video_inprocess_pipeline_forwards_v2_ocr_lang_selector(monkeypatch) -> None:
+    from nemo_retriever.graph import multi_type_extract_operator as multi_type_module
+    from nemo_retriever.graph.multi_type_extract_operator import MultiTypeExtractCPUActor
+    import pandas as pd
+
+    captured_kwargs: list[tuple[str, dict]] = []
+
+    class _FakeFrameActor:
+        def __init__(self, **_kwargs):
+            pass
+
+        def run(self, _data):
+            return pd.DataFrame(
+                {
+                    "path": ["/tmp/frame_0.png"],
+                    "source_path": ["/tmp/video.mp4"],
+                    "image_b64": ["frame"],
+                    "_content_type": ["video_frame"],
+                }
+            )
+
+    class _IdentityStage:
+        def run(self, data):
+            return data
+
+    def _fake_instantiate_resolved(self, operator_class, **operator_kwargs):
+        captured_kwargs.append((operator_class.__name__, dict(operator_kwargs)))
+        return _IdentityStage()
+
+    monkeypatch.setattr(multi_type_module, "VideoFrameActor", _FakeFrameActor)
+    monkeypatch.setattr(MultiTypeExtractCPUActor, "_instantiate_resolved", _fake_instantiate_resolved)
+
+    op = MultiTypeExtractCPUActor(
+        extraction_mode="video",
+        extract_params=ExtractParams(ocr_lang="english"),
+        audio_chunk_params=AudioChunkParams(enabled=False),
+        video_frame_params=VideoFrameParams(enabled=True, dedup=False),
+        video_text_dedup_params=VideoFrameTextDedupParams(enabled=False),
+        av_fuse_params=AudioVisualFuseParams(enabled=False),
+        split_config={},
+    )
+
+    op._run_video_pipeline(pd.DataFrame({"path": ["/tmp/video.mp4"]}))
+
+    video_ocr_kwargs = next(kwargs for name, kwargs in captured_kwargs if name == "VideoFrameOCRActor")
+
+    assert video_ocr_kwargs["ocr_version"] == "v2"
+    assert video_ocr_kwargs["ocr_lang"] == "english"
 
 
 def test_resolved_remote_ocr_stages_drop_local_selector_kwargs() -> None:

--- a/nemo_retriever/tests/test_root_cli_workflow.py
+++ b/nemo_retriever/tests/test_root_cli_workflow.py
@@ -10,6 +10,7 @@ from typing import Any
 from unittest.mock import create_autospec
 
 import pytest
+from pydantic import ValidationError
 from typer.testing import CliRunner
 
 import nemo_retriever.adapters.cli.sdk_workflow as sdk_workflow
@@ -199,7 +200,9 @@ def test_root_ingest_rejects_ocr_lang_with_legacy_ocr_version(monkeypatch, tmp_p
     )
 
     assert result.exit_code == 1
+    assert result.output.startswith("Error: ")
     assert "ocr_lang is only supported when ocr_version='v2'" in result.output
+    assert "Traceback" not in result.output
     fake_ingestor.extract.assert_not_called()
 
 
@@ -308,6 +311,10 @@ def test_root_ingest_reports_os_errors(monkeypatch) -> None:
 
     assert result.exit_code == 1
     assert "Error: permission denied" in result.output
+
+
+def test_root_cli_error_handler_includes_pydantic_validation_error() -> None:
+    assert ValidationError in cli_main._ROOT_CLI_ERRORS
 
 
 def test_ingest_documents_validates_run_mode_before_creating_ingestor(monkeypatch) -> None:

--- a/nemo_retriever/tests/test_root_cli_workflow.py
+++ b/nemo_retriever/tests/test_root_cli_workflow.py
@@ -170,6 +170,39 @@ def test_root_ingest_passes_nim_url_options(monkeypatch, tmp_path) -> None:
     assert embed_params.embed_model_name == "nvidia/llama-nemotron-embed-1b-v2"
 
 
+def test_root_ingest_passes_ocr_lang_option(monkeypatch, tmp_path) -> None:
+    fake_ingestor = _make_fake_ingestor()
+    document = tmp_path / "english-ocr.pdf"
+    document.write_bytes(b"%PDF-1.4\n")
+
+    monkeypatch.setattr(sdk_workflow, "create_ingestor", lambda **_kwargs: fake_ingestor)
+
+    result = RUNNER.invoke(cli_main.app, ["ingest", str(document), "--ocr-lang", "english"])
+
+    assert result.exit_code == 0
+    extract_params = fake_ingestor.extract.call_args.args[0]
+    assert isinstance(extract_params, ExtractParams)
+    assert extract_params.ocr_version == "v2"
+    assert extract_params.ocr_lang == "english"
+
+
+def test_root_ingest_rejects_ocr_lang_with_legacy_ocr_version(monkeypatch, tmp_path) -> None:
+    fake_ingestor = _make_fake_ingestor()
+    document = tmp_path / "legacy-ocr.pdf"
+    document.write_bytes(b"%PDF-1.4\n")
+
+    monkeypatch.setattr(sdk_workflow, "create_ingestor", lambda **_kwargs: fake_ingestor)
+
+    result = RUNNER.invoke(
+        cli_main.app,
+        ["ingest", str(document), "--ocr-version", "v1", "--ocr-lang", "english"],
+    )
+
+    assert result.exit_code == 1
+    assert "ocr_lang is only supported when ocr_version='v2'" in result.output
+    fake_ingestor.extract.assert_not_called()
+
+
 def test_root_ingest_passes_batch_tuning_options(monkeypatch, tmp_path) -> None:
     fake_ingestor = _make_fake_ingestor()
     create_calls: list[dict[str, Any]] = []

--- a/nemo_retriever/tests/test_video_frame_ocr_actor.py
+++ b/nemo_retriever/tests/test_video_frame_ocr_actor.py
@@ -110,6 +110,18 @@ def test_gpu_actor_loads_v2_model_with_legacy_selector(monkeypatch) -> None:
     mock_ocr_v2.assert_called_once_with(lang="v1")
 
 
+def test_gpu_actor_loads_v2_model_with_english_selector(monkeypatch) -> None:
+    import nemo_retriever.model.local as local_models
+
+    mock_ocr_v2 = MagicMock()
+    monkeypatch.setitem(local_models.__dict__, "NemotronOCRV2", mock_ocr_v2)
+
+    actor = VideoFrameOCRGPUActor(ocr_lang="english")
+    actor._ensure_model()
+
+    mock_ocr_v2.assert_called_once_with(lang="english")
+
+
 def test_gpu_actor_drops_empty_text_rows() -> None:
     df = _make_frame_df(["b64_one", "b64_two"])
     fake_model = MagicMock()


### PR DESCRIPTION
## Description

Adds the remaining root SDK CLI surface for the local OCR v2 language selector:

- exposes `retriever ingest --ocr-lang` alongside the existing `--ocr-version`
- forwards `ocr_lang` into `ExtractParams` only when provided
- adds root CLI and video frame OCR selector coverage
- documents that local OCR v2 defaults to `multi`, supports `--ocr-lang english`, and that remote OCR NIM endpoints keep their own model/language behavior

Validation:

```bash
env UV_CACHE_DIR=/localhome/charlesb/.cache/tmp/uv-cache uv run --project nemo_retriever --extra dev pytest \
  nemo_retriever/tests/test_root_cli_workflow.py \
  nemo_retriever/tests/test_video_frame_ocr_actor.py \
  nemo_retriever/tests/test_ocr_version_selection.py \
  -q
```

Result: `38 passed in 1.50s`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file. Not applicable; no docker-compose or Helm values changes.
