### PR TITLE
stop double encoding metadata by typing query results

### DIFF
--- a/nemo_retriever/src/nemo_retriever/adapters/cli/sdk_workflow.py
+++ b/nemo_retriever/src/nemo_retriever/adapters/cli/sdk_workflow.py
@@ -14,6 +14,7 @@ from nemo_retriever.params.utils import normalize_embed_kwargs
 from nemo_retriever.retriever import Retriever
 from nemo_retriever.utils.input_files import expand_input_file_patterns, resolve_input_files
 from nemo_retriever.utils.remote_auth import resolve_remote_api_key
+from nemo_retriever.vdb.records import RetrievalHit
 
 
 IngestRunModeValue = Literal["inprocess", "batch"]
@@ -247,7 +248,7 @@ def query_documents(
     embed_invoke_url: str | None = None,
     embed_model_name: str | None = None,
     reranker_invoke_url: str | None = None,
-) -> list[dict[str, Any]]:
+) -> list[RetrievalHit]:
     """Run the minimal SDK query path used by the root CLI."""
     embed_kwargs = _build_embed_kwargs(embed_invoke_url, embed_model_name)
     rerank_kwargs = _build_rerank_kwargs(reranker_invoke_url)

--- a/nemo_retriever/src/nemo_retriever/retriever.py
+++ b/nemo_retriever/src/nemo_retriever/retriever.py
@@ -17,6 +17,7 @@ from nemo_retriever.retriever_graph_utils import (
     rerank_long_dataframe_to_hits,
 )
 from nemo_retriever.vdb.operators import RetrieveVdbOperator
+from nemo_retriever.vdb.records import RetrievalHit
 
 logger = logging.getLogger(__name__)
 
@@ -217,7 +218,7 @@ class Retriever:
         top_k: Optional[int] = None,
         vdb_kwargs: Optional[dict[str, Any]] = None,
         embed_kwargs: Optional[dict[str, Any]] = None,
-    ) -> list[dict[str, Any]]:
+    ) -> list[RetrievalHit]:
         return self.queries([query], top_k=top_k, vdb_kwargs=vdb_kwargs, embed_kwargs=embed_kwargs)[0]
 
     def queries(
@@ -227,7 +228,7 @@ class Retriever:
         top_k: Optional[int] = None,
         vdb_kwargs: Optional[dict[str, Any]] = None,
         embed_kwargs: Optional[dict[str, Any]] = None,
-    ) -> list[list[dict[str, Any]]]:
+    ) -> list[list[RetrievalHit]]:
         query_texts = [str(q) for q in queries]
         if not query_texts:
             return []

--- a/nemo_retriever/src/nemo_retriever/vdb/__init__.py
+++ b/nemo_retriever/src/nemo_retriever/vdb/__init__.py
@@ -7,7 +7,7 @@
 from nemo_retriever.vdb.adt_vdb import VDB
 from nemo_retriever.vdb.factory import get_vdb_op_cls
 from nemo_retriever.vdb.operators import IngestVdbOperator, RetrieveVdbOperator
-from nemo_retriever.vdb.records import normalize_retrieval_results, to_client_vdb_records
+from nemo_retriever.vdb.records import RetrievalHit, normalize_retrieval_results, to_client_vdb_records
 from nemo_retriever.vdb.sidecar_metadata import (
     apply_sidecar_metadata_to_client_batches,
     build_sidecar_lookup,
@@ -22,6 +22,7 @@ __all__ = [
     "VDB",
     "get_vdb_op_cls",
     "IngestVdbOperator",
+    "RetrievalHit",
     "RetrieveVdbOperator",
     "normalize_retrieval_results",
     "to_client_vdb_records",

--- a/nemo_retriever/src/nemo_retriever/vdb/records.py
+++ b/nemo_retriever/src/nemo_retriever/vdb/records.py
@@ -9,7 +9,34 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
+
+
+class RetrievalHit(TypedDict, total=False):
+    """Shape of a single hit returned by ``Retriever.query`` / ``Retriever.queries``.
+
+    ``metadata`` is a native ``dict`` at this boundary — never a JSON string. The
+    LanceDB storage layer JSON-encodes on write and decodes on read; do not let
+    a re-encoded string leak back out here. See ``_normalize_hit`` for the
+    contract enforcement point.
+
+    ``total=False`` because optional fields (``stored_image_uri``,
+    ``content_type``, ``bbox_xyxy_norm``, scores) are only set when present.
+    """
+
+    text: str
+    metadata: dict[str, Any]
+    source: str
+    source_id: str
+    path: str
+    page_number: int | None
+    pdf_basename: str
+    pdf_page: str
+    stored_image_uri: str
+    content_type: str
+    bbox_xyxy_norm: list[float]
+    _distance: float
+    _score: float
 
 
 def _embedding_from_graph_row(row: dict[str, Any], metadata: dict[str, Any]) -> Any:
@@ -125,7 +152,7 @@ def _mapping(value: Any) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
-def _normalize_hit(hit: dict[str, Any]) -> dict[str, Any]:
+def _normalize_hit(hit: dict[str, Any]) -> RetrievalHit:
     """Adapt LanceDB client hit shapes to Retriever hits."""
     entity = hit.get("entity") if isinstance(hit.get("entity"), dict) else hit
 
@@ -148,9 +175,16 @@ def _normalize_hit(hit: dict[str, Any]) -> dict[str, Any]:
 
     path = Path(source_id) if source_id else None
     pdf_basename = path.stem if path is not None else ""
-    normalized = {
+    normalized: RetrievalHit = {
         "text": _first_str(entity.get("text"), entity.get("content"), hit.get("text")),
-        "metadata": json.dumps(content_metadata, default=str),
+        # Keep `metadata` as a native dict on the API boundary. The LanceDB
+        # storage layer JSON-encodes it on write (see `_json_str` in
+        # `vdb/lancedb.py`); we already parse it back on read in
+        # `LanceDB.retrieval`. Re-encoding it here forced every downstream
+        # consumer (`Retriever.query()` callers, the CLI, the SKILL.md jq
+        # recipe) to do its own `fromjson`/`json.loads` — and most didn't,
+        # producing silent `metadata.type == "?"` lookups.
+        "metadata": content_metadata,
         "source": source_id,
         "source_id": source_id,
         "path": source_id,
@@ -180,16 +214,16 @@ def _hit_to_dict(hit: Any) -> dict[str, Any] | None:
     return None
 
 
-def normalize_retrieval_results(results: Any) -> list[list[dict[str, Any]]]:
+def normalize_retrieval_results(results: Any) -> list[list[RetrievalHit]]:
     if results is None:
         return []
     if isinstance(results, dict):
         results = [[results]]
-    normalized: list[list[dict[str, Any]]] = []
+    normalized: list[list[RetrievalHit]] = []
     for hits in results:
         if isinstance(hits, dict):
             hits = [hits]
-        normalized_hits = []
+        normalized_hits: list[RetrievalHit] = []
         for hit in hits:
             hit_dict = _hit_to_dict(hit)
             if hit_dict is not None:

--- a/nemo_retriever/src/nemo_retriever/vdb/records.py
+++ b/nemo_retriever/src/nemo_retriever/vdb/records.py
@@ -13,15 +13,11 @@ from typing import Any, TypedDict
 
 
 class RetrievalHit(TypedDict, total=False):
-    """Shape of a single hit returned by ``Retriever.query`` / ``Retriever.queries``.
+    """A hit from ``Retriever.query`` / ``Retriever.queries``.
 
-    ``metadata`` is a native ``dict`` at this boundary — never a JSON string. The
-    LanceDB storage layer JSON-encodes on write and decodes on read; do not let
-    a re-encoded string leak back out here. See ``_normalize_hit`` for the
-    contract enforcement point.
-
-    ``total=False`` because optional fields (``stored_image_uri``,
-    ``content_type``, ``bbox_xyxy_norm``, scores) are only set when present.
+    ``metadata`` is a native ``dict`` here, never a JSON string — LanceDB
+    encodes at rest, ``_normalize_hit`` decodes. Re-encoding leaks the string
+    back to downstream consumers (CLI, jq recipes) that expect a dict.
     """
 
     text: str
@@ -177,10 +173,6 @@ def _normalize_hit(hit: dict[str, Any]) -> RetrievalHit:
     pdf_basename = path.stem if path is not None else ""
     normalized: RetrievalHit = {
         "text": _first_str(entity.get("text"), entity.get("content"), hit.get("text")),
-        # `content_metadata` is already a dict here (parsed by `_mapping` above
-        # from the JSON string LanceDB stores at rest). Do not re-encode — the
-        # API boundary returns native dicts, and downstream consumers (CLI,
-        # SKILL.md jq recipes) rely on that.
         "metadata": content_metadata,
         "source": source_id,
         "source_id": source_id,

--- a/nemo_retriever/src/nemo_retriever/vdb/records.py
+++ b/nemo_retriever/src/nemo_retriever/vdb/records.py
@@ -177,13 +177,10 @@ def _normalize_hit(hit: dict[str, Any]) -> RetrievalHit:
     pdf_basename = path.stem if path is not None else ""
     normalized: RetrievalHit = {
         "text": _first_str(entity.get("text"), entity.get("content"), hit.get("text")),
-        # Keep `metadata` as a native dict on the API boundary. The LanceDB
-        # storage layer JSON-encodes it on write (see `_json_str` in
-        # `vdb/lancedb.py`); we already parse it back on read in
-        # `LanceDB.retrieval`. Re-encoding it here forced every downstream
-        # consumer (`Retriever.query()` callers, the CLI, the SKILL.md jq
-        # recipe) to do its own `fromjson`/`json.loads` — and most didn't,
-        # producing silent `metadata.type == "?"` lookups.
+        # `content_metadata` is already a dict here (parsed by `_mapping` above
+        # from the JSON string LanceDB stores at rest). Do not re-encode — the
+        # API boundary returns native dicts, and downstream consumers (CLI,
+        # SKILL.md jq recipes) rely on that.
         "metadata": content_metadata,
         "source": source_id,
         "source_id": source_id,

--- a/nemo_retriever/tests/test_nv_ingest_vdb_operator.py
+++ b/nemo_retriever/tests/test_nv_ingest_vdb_operator.py
@@ -144,7 +144,7 @@ def test_retrieve_operator_delegates_vectors_to_retrieval() -> None:
         [
             {
                 "text": "retrieved chunk",
-                "metadata": '{"page_number": 1}',
+                "metadata": {"page_number": 1},
                 "source": "doc-a.pdf",
                 "source_id": "doc-a.pdf",
                 "path": "doc-a.pdf",

--- a/nemo_retriever/tests/test_vdb_records.py
+++ b/nemo_retriever/tests/test_vdb_records.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+
+from nemo_retriever.vdb.records import _normalize_hit, normalize_retrieval_results
+
+
+def test_normalize_hit_decodes_json_metadata_string() -> None:
+    """LanceDB stores metadata as a JSON string; the hit must surface it as a dict."""
+    content_meta = {"type": "text", "page_number": 3}
+    hit = {
+        "entity": {
+            "text": "hello",
+            "metadata": json.dumps(content_meta),
+            "source": json.dumps({"source_id": "/tmp/doc.pdf"}),
+        },
+        "_distance": 0.42,
+    }
+
+    result = _normalize_hit(hit)
+
+    assert isinstance(result["metadata"], dict)
+    assert result["metadata"] == content_meta
+    assert result["source_id"] == "/tmp/doc.pdf"
+    assert result["page_number"] == 3
+    assert result["pdf_basename"] == "doc"
+    assert result["pdf_page"] == "doc_3"
+    assert result["_distance"] == 0.42
+
+
+def test_normalize_hit_passes_through_dict_metadata() -> None:
+    """Non-LanceDB backends may hand back metadata already as a dict — don't mangle it."""
+    content_meta = {"type": "table", "page_number": 1}
+    hit = {
+        "text": "hi",
+        "content_metadata": content_meta,
+        "source_id": "/tmp/a.pdf",
+    }
+
+    result = _normalize_hit(hit)
+
+    assert result["metadata"] is content_meta
+
+
+def test_normalize_hit_missing_metadata_yields_empty_dict() -> None:
+    result = _normalize_hit({"text": "x", "source_id": "/tmp/b.pdf"})
+
+    assert result["metadata"] == {}
+    assert isinstance(result["metadata"], dict)
+
+
+def test_normalize_retrieval_results_preserves_per_query_shape() -> None:
+    raw = [
+        [
+            {"entity": {"text": "q1-h1", "metadata": json.dumps({"type": "text"})}},
+            {"entity": {"text": "q1-h2", "metadata": json.dumps({"type": "image"})}},
+        ],
+        [
+            {"entity": {"text": "q2-h1", "metadata": json.dumps({"type": "chart"})}},
+        ],
+    ]
+
+    out = normalize_retrieval_results(raw)
+
+    assert [len(hits) for hits in out] == [2, 1]
+    assert out[0][0]["metadata"] == {"type": "text"}
+    assert out[0][1]["metadata"] == {"type": "image"}
+    assert out[1][0]["metadata"] == {"type": "chart"}
+
+
+def test_normalize_retrieval_results_handles_none_and_dict_inputs() -> None:
+    assert normalize_retrieval_results(None) == []
+
+    single = normalize_retrieval_results({"entity": {"text": "t", "metadata": json.dumps({"type": "text"})}})
+    assert len(single) == 1 and len(single[0]) == 1
+    assert single[0][0]["metadata"] == {"type": "text"}


### PR DESCRIPTION
## Description
This PR  introduces a `RetrievalHit` TypedDict. The shape uses `total=False` since fields like stored_image_uri, content_type, bbox_xyxy_norm, and the score columns are only populated when present. LanceDB storage layer already decodes the stored JSON in `LanceDB.retrieval`. Every downstream consumer had to re-parse the string, and most silently didn't, producing `metadata.type == "?"` lookups.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
