### PR TITLE
fix(docs): restore strict MkDocs build for GitHub Pages

### DIFF
--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -4,7 +4,7 @@ Use this page for speech and audio extraction with Parakeet ASR and for video wo
 
 **Sections:** [Speech and audio (Parakeet)](#speech-and-audio-extraction) · [Run Parakeet on the cluster (Helm)](#run-parakeet-on-the-cluster-helm) · [Parakeet with hosted inference (build.nvidia.com)](#parakeet-hosted-inference-build-nvidia) · [Video and frame OCR](#video-and-frame-ocr)
 
-## Speech and audio extraction {#speech-and-audio-extraction}
+## Speech and audio extraction { #speech-and-audio-extraction }
 
 This documentation describes two ways to run [NeMo Retriever Library](overview.md) with the [parakeet-1-1b-ctc-en-us ASR NIM microservice](https://docs.nvidia.com/nim/speech/latest/asr/deploy-asr-models/parakeet-ctc-en-us.html) (`nvcr.io/nim/nvidia/parakeet-1-1b-ctc-en-us`) to extract speech from audio files:
 
@@ -34,7 +34,7 @@ This pipeline enables retrieval at the speech segment level when you enable segm
 
 ![Overview diagram](images/audio.png)
 
-## Run Parakeet on the cluster (Helm) {#run-parakeet-on-the-cluster-helm}
+## Run Parakeet on the cluster (Helm) { #run-parakeet-on-the-cluster-helm }
 
 Use the following procedure to run the NIM on your own infrastructure. Self-hosted Parakeet runs on Kubernetes via the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md).
 
@@ -72,7 +72,7 @@ Use the following procedure to run the NIM on your own infrastructure. Self-host
 
         For more Python examples, refer to [Python Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/python_client_usage.ipynb).
 
-## Parakeet with hosted inference (build.nvidia.com) {#parakeet-hosted-inference-build-nvidia}
+## Parakeet with hosted inference (build.nvidia.com) { #parakeet-hosted-inference-build-nvidia }
 
 Instead of running the pipeline locally, you can call Parakeet through [build.nvidia.com](https://build.nvidia.com/) hosted inference.
 
@@ -107,7 +107,7 @@ Instead of running the pipeline locally, you can call Parakeet through [build.nv
 
         For more Python examples, refer to [Python Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/python_client_usage.ipynb).
 
-## Video and frame OCR {#video-and-frame-ocr}
+## Video and frame OCR { #video-and-frame-ocr }
 
 For video assets, NeMo Retriever Library can combine audio or speech processing (see [Speech and audio extraction](#speech-and-audio-extraction) above) with visual text extraction when OCR applies to frames or derived images.
 
@@ -117,7 +117,7 @@ Container formats and early-access video types are listed under [supported file 
 
 For end-to-end RAG stacks that include multimodal ingestion, see the [NVIDIA AI Blueprints catalog](https://build.nvidia.com/explore/discover) and related solution pages on [NVIDIA Build](https://build.nvidia.com/).
 
-## Related topics {#related-topics}
+## Related topics { #related-topics }
 
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
 - [Troubleshoot NeMo Retriever extraction](troubleshoot.md)

--- a/docs/docs/extraction/concepts.md
+++ b/docs/docs/extraction/concepts.md
@@ -18,7 +18,7 @@ Output is a **Ray Dataset** (Ray Data) or **pandas** `DataFrame` listing extract
 
 Optionally, the library can compute **embeddings** for extracted content and store vectors in [LanceDB](https://lancedb.com/) for downstream semantic or hybrid search in your application. For multimodal (VLM) embedding options, see [Multimodal embeddings (VLM)](embedding.md).
 
-## Chunking {#chunking}
+## Chunking { #chunking }
 
 Chunking is built into the `.extract()` task and depends on **content type**:
 
@@ -28,7 +28,7 @@ Chunking is built into the `.extract()` task and depends on **content type**:
 
 For PDF parallelism before Ray processing (large files), see [PDF pre-splitting for parallel ingest](nemo-retriever-api-reference.md#pdf-pre-splitting-for-parallel-ingest).
 
-### Token-based splitting {#token-based-splitting}
+### Token-based splitting { #token-based-splitting }
 
 Token-based splitting uses the Llama 3.2 1B tokenizer (default `meta-llama/Llama-3.2-1B`) with configurable `max_tokens` and `overlap_tokens` when you add an explicit `.split(...)` stage or when the pipeline applies the default text segmentation for unstructured text. In the shipped NeMo Retriever container, tokenizer assets are included locally, so you do not need `HF_ACCESS_TOKEN` for this default path. If your runtime loads the tokenizer from the Hugging Face Hub instead (for example, some library-only installs), set `HF_ACCESS_TOKEN` or pass `hf_access_token` in task params when the Hub requires it. Details appear in the [Python API guide](nemo-retriever-api-reference.md).
 

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -33,7 +33,7 @@ to Parquet / object storage. Other subcommands cover focused tasks:
 
 | Topic | Location | Replaces example(s) in |
 |-------|----------|------------------------|
-| Quick start | [below](#quick-start) | Legacy service quickstart; **Helm** + [NeMo Retriever Library](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/); **Docker Compose** (unsupported): [`docker.md`](../../docker.md) |
+| Quick start | [below](#quick-start) | Legacy service quickstart; **Helm** + [NeMo Retriever Library](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/); **Docker Compose** (unsupported): [`docker.md`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md) |
 | CLI reference | [below](#cli-reference) | Prior `cli-reference` pages under `docs/docs/extraction/` |
 | Client usage walk-through | [below](#client-usage-walk-through) | `client/client_examples/examples/cli_client_usage.ipynb` |
 | PDF split tuning | [Large PDF page batches](#large-pdf-page-batches) below | `docs/docs/extraction/v2-api-guide.md` |
@@ -44,7 +44,7 @@ to Parquet / object storage. Other subcommands cover focused tasks:
 ## Quick start
 
 Local **Docker Compose** workflows are **unsupported developer tooling** only — see
-[`docker.md`](../../docker.md).
+[`docker.md`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md).
 
 For **supported** deployment of NeMo Retriever / **NIM** containers, use
 [nemo_retriever/helm](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/helm)


### PR DESCRIPTION
## Summary
- Fix mkdocs-macros strict-build failures: use attr_list heading syntax `{ #id }` instead of `{#id}` in `concepts.md` and `audio-video.md`.
- Fix broken `docker.md` relative links in the CLI README included by `retriever-cli-quickstart.md`.

## Why
The **NRL documentation — GitHub Pages** workflow has been failing on every `main` push since early May (strict mode). This unblocks publishing to https://nvidia.github.io/NeMo-Retriever/.

## Test plan
- [ ] **NRL documentation — GitHub Pages** workflow passes on this PR
- [ ] After merge, confirm a green Pages deploy on `main`