### PR TITLE
fix(docs): strict MkDocs build and extraction TOC cleanup (Randy review)

### DIFF
--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -4,7 +4,7 @@ Use this page for speech and audio extraction with Parakeet ASR and for video wo
 
 **Sections:** [Speech and audio (Parakeet)](#speech-and-audio-extraction) · [Run Parakeet on the cluster (Helm)](#run-parakeet-on-the-cluster-helm) · [Parakeet with hosted inference (build.nvidia.com)](#parakeet-hosted-inference-build-nvidia) · [Video and frame OCR](#video-and-frame-ocr)
 
-## Speech and audio extraction {#speech-and-audio-extraction}
+## Speech and audio extraction { #speech-and-audio-extraction }
 
 This documentation describes two ways to run [NeMo Retriever Library](overview.md) with the [parakeet-1-1b-ctc-en-us ASR NIM microservice](https://docs.nvidia.com/nim/speech/latest/asr/deploy-asr-models/parakeet-ctc-en-us.html) (`nvcr.io/nim/nvidia/parakeet-1-1b-ctc-en-us`) to extract speech from audio files:
 
@@ -34,7 +34,7 @@ This pipeline enables retrieval at the speech segment level when you enable segm
 
 ![Overview diagram](images/audio.png)
 
-## Run Parakeet on the cluster (Helm) {#run-parakeet-on-the-cluster-helm}
+## Run Parakeet on the cluster (Helm) { #run-parakeet-on-the-cluster-helm }
 
 Use the following procedure to run the NIM on your own infrastructure. Self-hosted Parakeet runs on Kubernetes via the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md).
 
@@ -72,7 +72,7 @@ Use the following procedure to run the NIM on your own infrastructure. Self-host
 
         For more Python examples, refer to [Python Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/python_client_usage.ipynb).
 
-## Parakeet with hosted inference (build.nvidia.com) {#parakeet-hosted-inference-build-nvidia}
+## Parakeet with hosted inference (build.nvidia.com) { #parakeet-hosted-inference-build-nvidia }
 
 Instead of running the pipeline locally, you can call Parakeet through [build.nvidia.com](https://build.nvidia.com/) hosted inference.
 
@@ -107,7 +107,7 @@ Instead of running the pipeline locally, you can call Parakeet through [build.nv
 
         For more Python examples, refer to [Python Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/python_client_usage.ipynb).
 
-## Video and frame OCR {#video-and-frame-ocr}
+## Video and frame OCR { #video-and-frame-ocr }
 
 For video assets, NeMo Retriever Library can combine audio or speech processing (see [Speech and audio extraction](#speech-and-audio-extraction) above) with visual text extraction when OCR applies to frames or derived images.
 
@@ -117,7 +117,7 @@ Container formats and early-access video types are listed under [supported file 
 
 For end-to-end RAG stacks that include multimodal ingestion, see the [NVIDIA AI Blueprints catalog](https://build.nvidia.com/explore/discover) and related solution pages on [NVIDIA Build](https://build.nvidia.com/).
 
-## Related topics {#related-topics}
+## Related topics { #related-topics }
 
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
 - [Troubleshoot NeMo Retriever extraction](troubleshoot.md)

--- a/docs/docs/extraction/concepts.md
+++ b/docs/docs/extraction/concepts.md
@@ -4,7 +4,7 @@ These terms appear throughout NeMo Retriever Library documentation.
 
 ## Job
 
-An **ingestion job** is a unit of work done on input content (documents, audio, video, and other supported types). There are default tasks with built-in configurations aimed at strong recall, but behavior can be customized via task keyword arguments and via custom UDF-style operations ([NeMo Retriever graph](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph)). Results are retrieved as structured metadata and annotations.
+An **ingestion job** is a unit of work you run on input content (documents, audio, video, and other supported types). You submit jobs through the **ingestor Python API** (for example `Ingestor` task chains such as `.extract(...)`) or the **`retriever ingest` CLI**—not by posting a standalone JSON job document. Default tasks target strong recall; customize behavior with task keyword arguments (including chunking and splitting on `.extract()`) or custom UDF-style operations ([NeMo Retriever graph](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph)). Results are structured metadata and annotations (Ray Dataset, pandas `DataFrame`, or similar).
 
 ## Pipeline and tasks
 
@@ -18,7 +18,7 @@ Output is a **Ray Dataset** (Ray Data) or **pandas** `DataFrame` listing extract
 
 Optionally, the library can compute **embeddings** for extracted content and store vectors in [LanceDB](https://lancedb.com/) for downstream semantic or hybrid search in your application. For multimodal (VLM) embedding options, see [Multimodal embeddings (VLM)](embedding.md).
 
-## Chunking {#chunking}
+## Chunking { #chunking }
 
 Chunking is built into the `.extract()` task and depends on **content type**:
 
@@ -28,7 +28,7 @@ Chunking is built into the `.extract()` task and depends on **content type**:
 
 For PDF parallelism before Ray processing (large files), see [PDF pre-splitting for parallel ingest](nemo-retriever-api-reference.md#pdf-pre-splitting-for-parallel-ingest).
 
-### Token-based splitting {#token-based-splitting}
+### Token-based splitting { #token-based-splitting }
 
 Token-based splitting uses the Llama 3.2 1B tokenizer (default `meta-llama/Llama-3.2-1B`) with configurable `max_tokens` and `overlap_tokens` when you add an explicit `.split(...)` stage or when the pipeline applies the default text segmentation for unstructured text. In the shipped NeMo Retriever container, tokenizer assets are included locally, so you do not need `HF_ACCESS_TOKEN` for this default path. If your runtime loads the tokenizer from the Hugging Face Hub instead (for example, some library-only installs), set `HF_ACCESS_TOKEN` or pass `hf_access_token` in task params when the Hub requires it. Details appear in the [Python API guide](nemo-retriever-api-reference.md).
 

--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -14,7 +14,7 @@ and [Multimodal RAG with LangChain](https://github.com/NVIDIA/NeMo-Retriever/blo
 NeMo Retriever Library supports extracting text representations of various forms of content,
 and ingesting to a vector database. **[LanceDB](https://lancedb.com/)** stores vectors as local Lance files on disk for the supported ingestion path.
 You can ingest to other data stores; however, you must configure other data stores yourself.
-For more information, refer to [Data Upload](vdbs.md).
+For more information, refer to [Vector databases](vdbs.md).
 
 ## How would I process unstructured images?
 

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -3,7 +3,7 @@
 NVIDIA NeMo Retriever Library (NRL) is a high retrieval accuracy, performant, and scalable framework for content and metadata extraction from various media types (PDFs, HTML, Word docs, Powerpoint, audio, video, and image files). It supports both NVIDIA NIM microservices and a range of models to find, contextualize, and extract text, tables, charts, infographics, and transcripts for use in downstream generative and retrieval-augmented applications.
 
 NeMo Retriever Library enables parallelization of splitting documents into pages where sub-page content is classified (such as text paragraphs, tables, charts, and infographics), extracted, and further contextualized through optical character recognition (OCR) into a standard schema. From there, NeMo Retriever Library manages computation of embeddings for the extracted content,
-and can store vectors in [LanceDB](https://lancedb.com/) for the recommended embedded path when you pass `vdb_op="lancedb"` to upload (refer to [Data Upload](vdbs.md)).
+and can store vectors in [LanceDB](https://lancedb.com/) for the recommended embedded path when you pass `vdb_op="lancedb"` to upload (refer to [Vector databases](vdbs.md)).
 
 ## What NeMo Retriever Library Is ✔️
 

--- a/docs/docs/extraction/vdbs.md
+++ b/docs/docs/extraction/vdbs.md
@@ -1,6 +1,6 @@
-# Data Upload for NeMo Retriever Library
+# Vector databases
 
-Use this documentation to learn how [NeMo Retriever Library](overview.md) handles and uploads data.
+Use this documentation to learn how [NeMo Retriever Library](overview.md) stores extracted embeddings and uploads data to vector databases.
 
 ## On this page { #on-this-page }
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -97,7 +97,6 @@ nav:
       - "Vector databases": extraction/vdbs.md
   - "7. Retrieval & ranking":
       - "Custom metadata and filtering": extraction/custom-metadata.md
-      - "Agentic retrieval (concept)": extraction/agentic-retrieval-concept.md
   - "8. Deployment & operations":
       - "Ray and distributed ingest": extraction/ray-logging.md
       - "Telemetry and observability": extraction/telemetry.md
@@ -173,7 +172,8 @@ plugins:
         extraction/throughput-is-dataset-dependent.md: extraction/multimodal-extraction.md#extraction-limitations-and-quality
         extraction/vlm-embed.md: extraction/embedding.md
         extraction/audio.md: extraction/audio-video.md
-        extraction/workflow-agentic-retrieval.md: extraction/agentic-retrieval-concept.md
+        extraction/workflow-agentic-retrieval.md: extraction/overview.md
+        extraction/agentic-retrieval-concept.md: extraction/overview.md
         extraction/workflow-build-searchable-collection.md: extraction/workflow-document-ingestion.md
         extraction/workflow-query-rerank.md: extraction/vdbs.md
         extraction/semantic-hybrid-retrieval.md: extraction/vdbs.md#semantic-and-hybrid-retrieval
@@ -217,6 +217,7 @@ exclude_docs: |
   extraction/workflow-e2e-blueprints.md
   extraction/releasenotes-nv-ingest.md
   extraction/workflow-agentic-retrieval.md
+  extraction/agentic-retrieval-concept.md
   extraction/workflow-build-searchable-collection.md
   extraction/vector-db-partners.md
   extraction/performance_guide.md

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -33,7 +33,7 @@ to Parquet / object storage. Other subcommands cover focused tasks:
 
 | Topic | Location | Replaces example(s) in |
 |-------|----------|------------------------|
-| Quick start | [below](#quick-start) | Legacy service quickstart; **Helm** + [NeMo Retriever Library](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/); **Docker Compose** (unsupported): [`docker.md`](../../docker.md) |
+| Quick start | [below](#quick-start) | Legacy service quickstart; **Helm** + [NeMo Retriever Library](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/); **Docker Compose** (unsupported): [`docker.md`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md) |
 | CLI reference | [below](#cli-reference) | Prior `cli-reference` pages under `docs/docs/extraction/` |
 | Client usage walk-through | [below](#client-usage-walk-through) | `client/client_examples/examples/cli_client_usage.ipynb` |
 | PDF split tuning | [Large PDF page batches](#large-pdf-page-batches) below | `docs/docs/extraction/v2-api-guide.md` |
@@ -44,7 +44,7 @@ to Parquet / object storage. Other subcommands cover focused tasks:
 ## Quick start
 
 Local **Docker Compose** workflows are **unsupported developer tooling** only — see
-[`docker.md`](../../docker.md).
+[`docker.md`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md).
 
 For **supported** deployment of NeMo Retriever / **NIM** containers, use
 [nemo_retriever/helm](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/helm)

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -33,7 +33,7 @@ to Parquet / object storage. Other subcommands cover focused tasks:
 
 | Topic | Location | Replaces example(s) in |
 |-------|----------|------------------------|
-| Quick start | [below](#quick-start) | Legacy service quickstart; **Helm** + [NeMo Retriever Library](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/); **Docker Compose** (unsupported): [`docker.md`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md) |
+| Quick start | [below](#quick-start) | Legacy service quickstart; **Helm** + [NeMo Retriever Library](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/); **Docker Compose** (unsupported): [`docker.md`](https://github.com/NVIDIA/NeMo-Retriever/blob/HEAD/nemo_retriever/docker.md) |
 | CLI reference | [below](#cli-reference) | Prior `cli-reference` pages under `docs/docs/extraction/` |
 | Client usage walk-through | [below](#client-usage-walk-through) | `client/client_examples/examples/cli_client_usage.ipynb` |
 | PDF split tuning | [Large PDF page batches](#large-pdf-page-batches) below | `docs/docs/extraction/v2-api-guide.md` |
@@ -44,7 +44,7 @@ to Parquet / object storage. Other subcommands cover focused tasks:
 ## Quick start
 
 Local **Docker Compose** workflows are **unsupported developer tooling** only — see
-[`docker.md`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md).
+[`docker.md`](https://github.com/NVIDIA/NeMo-Retriever/blob/HEAD/nemo_retriever/docker.md) (GitHub `HEAD` = default branch; pin to your release tag when not on `main`).
 
 For **supported** deployment of NeMo Retriever / **NIM** containers, use
 [nemo_retriever/helm](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/helm)


### PR DESCRIPTION
## Summary

Fixes the **NRL documentation — GitHub Pages** strict build and addresses extraction doc / TOC feedback from Randy.

### Strict MkDocs (unblocks publish)
- `concepts.md`, `audio-video.md` — `{ #id }` heading anchors (mkdocs-macros safe)
- `nemo_retriever/docs/cli/README.md` — absolute `docker.md` URLs for snippet include

### TOC / navigation (Randy)
- **Audio + video** — single page (`audio-video.md`); `workflow-video-ocr` redirects here
- **Chunking** — no standalone page; content under `concepts.md#chunking`; legacy URL redirects
- **user-defined-stages** — excluded from site; redirects to NeMo Retriever graph docs on GitHub
- **agentic-retrieval-concept** — removed from nav; excluded; redirects to overview (not supported yet)
- **Vector databases** — `vdbs.md` title matches nav (was "Data Upload…", duplicated label in sidebar)

### Concepts
- **Job** — ingestor API / `retriever ingest` CLI task arguments, not a JSON job description

## Why

GitHub Pages has not updated since early May because `mkdocs build --strict` failed. The live site still shows the old TOC until this merges and the workflow goes green.

## Test plan

- [ ] **NRL documentation — GitHub Pages** passes on this PR
- [ ] After merge, confirm https://nvidia.github.io/NeMo-Retriever/ updates
- [ ] Spot-check redirects: `/extraction/chunking/`, `/extraction/workflow-video-ocr/`, `/extraction/user-defined-stages/`, `/extraction/agentic-retrieval-concept/`
