### PR TITLE
ci(docs): update docs-deploy.yml after Dockerfile docs stage removal

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,14 +1,18 @@
-# Full documentation pipeline in Docker (Sphinx + OpenAPI + MkDocs), then `make mkdocs`
-# (docs/mkdocs.yml --strict). CI only — uploads a downloadable artifact; does NOT publish to GitHub Pages.
+# NRL MkDocs build (strict) — CI artifact only; does NOT publish to GitHub Pages.
 #
 # Public documentation at https://nvidia.github.io/NeMo-Retriever/ is deployed only by
-# nrl-docs-github-pages.yml (docs/mkdocs.yml — 13-section NRL TOC).
+# nrl-docs-github-pages.yml. The Dockerfile no longer defines a `docs` target; this workflow
+# matches the Pages pipeline (pip + mkdocs build) instead of the legacy Docker docs stage.
 name: Documentation build (full pipeline, CI only)
 
 on:
   push:
     branches:
       - main
+    paths:
+      - "docs/**"
+      - "nemo_retriever/**"
+      - ".github/workflows/docs-deploy.yml"
   workflow_dispatch:
 
 permissions:
@@ -21,49 +25,33 @@ concurrency:
 jobs:
   build:
     name: Build Documentation
-    runs-on: linux-large-disk
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Setup Docker Buildx
-        uses: ./.github/actions/setup-docker-buildx
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
 
-      - name: Build Documentation Docker Image
+      - name: Install Python dependencies
         run: |
-          docker build \
-            -f Dockerfile \
-            --target docs \
-            --build-arg GIT_COMMIT=${GITHUB_SHA} \
-            -t nv-ingest-docs:latest \
-            .
+          python -m pip install --upgrade pip
+          pip install -r docs/requirements.txt
+          pip install -e ./nemo_retriever
 
-      - name: Run Documentation Build Container
-        run: |
-          CONTAINER_ID=$(docker run -d nv-ingest-docs:latest)
-          echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_ENV
-
-      - name: Wait for documentation generation
-        run: |
-          EXIT_CODE=$(docker wait "$CONTAINER_ID")
-          docker logs "$CONTAINER_ID"
-          if [ "$EXIT_CODE" != "0" ]; then
-            echo "Error: docs build failed with exit code $EXIT_CODE"
-            exit 1
-          fi
-
-      - name: Copy generated docs from container
-        run: docker cp "$CONTAINER_ID:/workspace/docs/site" ./generated-site
-
-      - name: Clean up container
-        if: always()
-        run: |
-          if [ -n "${CONTAINER_ID:-}" ]; then
-            docker rm -f "$CONTAINER_ID"
-          fi
+      - name: Build MkDocs (NRL, strict)
+        working-directory: docs
+        env:
+          SITE_URL: https://nvidia.github.io/NeMo-Retriever/
+          DISABLE_MKDOCS_2_WARNING: "true"
+        run: mkdocs build -f mkdocs.yml --strict
 
       - name: Upload site artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: docker-docs-site
-          path: ./generated-site
+          path: docs/site

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -53,5 +53,5 @@ jobs:
       - name: Upload site artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: docker-docs-site
+          name: nrl-docs-site
           path: docs/site


### PR DESCRIPTION
## Why this change is needed

Public documentation at [https://nvidia.github.io/NeMo-Retriever/](https://nvidia.github.io/NeMo-Retriever/) is published by **NRL documentation — GitHub Pages** (`.github/workflows/nrl-docs-github-pages.yml`). That workflow is healthy and was **not** broken by recent merges.

A separate workflow, **Documentation build (full pipeline, CI only)** (`.github/workflows/docs-deploy.yml`), still assumed a legacy Docker build path:

```yaml
docker build --target docs ...
```

The root `Dockerfile` no longer defines a `docs` stage (only `base`, `install`, and `service`). As a result, **docs-deploy** would fail or stall whenever it ran, even though the live GitHub Pages site could still build and deploy correctly via the Pages workflow.

This PR updates **one configuration file** — `docs-deploy.yml` — so CI matches the current repository layout and the same MkDocs pipeline used for GitHub Pages.

## What changed

| Before | After |
|--------|--------|
| `linux-large-disk` runner + Docker `docs` image + copy from container | `ubuntu-latest` + Python 3.12 + `pip install` + `mkdocs build --strict` |
| Triggered on every push to `main` | Triggered only when `docs/**`, `nemo_retriever/**`, or this workflow file changes |
| Artifact from `./generated-site` | Artifact from `docs/site` |

The build steps now mirror `nrl-docs-github-pages.yml` (install `docs/requirements.txt`, editable install `nemo_retriever`, strict MkDocs build with `SITE_URL` set for the public site). **docs-deploy** remains CI-only (uploads `docker-docs-site`); it does **not** deploy to GitHub Pages.

## Validation (fork + local)

| Check | Result | Notes |
|-------|--------|--------|
| **NRL documentation — GitHub Pages** (`nrl-docs-github-pages.yml`) | Passed | [Run 26106138185](https://github.com/kheiss-uwzoo/nv-ingest/actions/runs/26106138185) — MkDocs `--strict`, scan clean, `nrl-docs-site` artifact uploaded (deploy skipped on fork) |
| **Documentation build** (`docs-deploy.yml`, this PR) | Passed | [Run 26106678803](https://github.com/kheiss-uwzoo/nv-ingest/actions/runs/26106678803) — ~1m 16s, `docker-docs-site` artifact from `docs/site` |
| Local `mkdocs build -f mkdocs.yml --strict` | Passed | Same env as CI (`SITE_URL`, `DISABLE_MKDOCS_2_WARNING`) |

An earlier **docs-deploy** dispatch on the fork stayed `pending` with no jobs because a **stale queued run on `main`** held the shared concurrency group (`docs-docker-full-pipeline`, `cancel-in-progress: false`). Cancelling that run unblocked the queue; the re-triggered run completed successfully. That is an operational queue issue on the fork, not a failure of the updated build steps.

## Stakeholder takeaway

- **No change to how the public site is published** — still `nrl-docs-github-pages.yml` only.
- **CI docs validation is restored** — `docs-deploy.yml` is aligned with the Dockerfile and the Pages build, so full-pipeline doc checks on `main` work again without maintaining a removed Docker stage.
- **Scope is intentionally small** — one workflow file; no doc content or MkDocs config changes in this PR.

## Test plan

- [x] **NRL documentation — GitHub Pages** — strict MkDocs build succeeds
- [x] **Documentation build (full pipeline, CI only)** — passes on this branch after clearing stale concurrency
- [x] Local `mkdocs build -f mkdocs.yml --strict` in `docs/`
