### PR TITLE
feat(tabular): support dict-shaped metadata filters in tabular semant…

### DIFF
--- a/nemo_retriever/src/nemo_retriever/tabular_data/retrieval/data_access/semantic_search.py
+++ b/nemo_retriever/src/nemo_retriever/tabular_data/retrieval/data_access/semantic_search.py
@@ -4,11 +4,22 @@
 
 """Vector semantic search primitives.
 
-The functions here build ``where`` predicates over the JSON ``metadata``
-column, run per-label vector queries through the injected
+The functions here build ``where`` predicates for the per-query metadata
+filter, run per-label vector queries through the injected
 :class:`~nemo_retriever.retriever.Retriever`, and shape the raw hits into a
 common ``{text, id, label, score}`` candidate dict consumed by the rest of
 the retrieval data-access modules.
+
+The filter shape is chosen by the VDB the caller plugged in (read off
+``retriever.vdb_kwargs["vdb"].metadata_filter_format``):
+
+* ``"sql"`` (default) — SQL ``LIKE`` predicate over the JSON ``metadata``
+  column, fed to LanceDB's ``.where()`` API.
+* ``"dict"`` — flat ``{column: value | [values]}`` mapping, fed straight
+  into the backend's native dict-filter API (e.g.
+  ``PGVector.similarity_search_with_score_by_vector(..., filter=)``). The
+  customer's VDB is responsible for storing ``label`` / ``database_name``
+  as top-level columns so the keys match.
 """
 
 from __future__ import annotations
@@ -16,10 +27,12 @@ from __future__ import annotations
 import ast
 import json
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from nemo_retriever.retriever import Retriever
+
+MetadataFilterFormat = Literal["sql", "dict"]
 
 logger = logging.getLogger(__name__)
 
@@ -103,14 +116,37 @@ def _escape_like(value: str) -> str:
 def _build_metadata_where_clause(
     labels: list[str] | None = None,
     database_name: str | None = None,
-) -> str | None:
-    """Build a SQL ``where`` predicate for the ``metadata`` JSON column.
+    *,
+    fmt: MetadataFilterFormat = "sql",
+) -> str | dict | None:
+    """Build a per-query metadata filter for ``label`` / ``database_name``.
 
-    Uses ``LIKE`` on the compact-JSON string (no spaces after ``:``) to match
-    ``"label":"<value>"`` and ``"database_name":"<value>"`` substrings. Values
-    are escaped via :func:`_escape_like` and the predicate declares
-    ``ESCAPE '\\'`` so ``%`` / ``_`` / ``\\`` in inputs are treated literally.
+    The output shape is selected by *fmt*:
+
+    * ``"sql"`` (default) — SQL ``LIKE`` predicate against the JSON
+      ``metadata`` column, suitable for LanceDB's ``.where()`` API. Uses
+      compact-JSON ``"key":"value"`` substring matching; values are
+      escaped via :func:`_escape_like` and the predicate declares
+      ``ESCAPE '\\'`` so ``%`` / ``_`` / ``\\`` in inputs are treated
+      literally.
+    * ``"dict"`` — flat mapping suitable for backends whose filter API
+      consumes a dict (e.g. pgvector). A single label lands as
+      ``{"label": "Column"}``; multiple labels become ``{"label": [...]}``
+      (which langchain-pgvector interprets as an ``IN``-list).
+
+    Returns ``None`` when neither *labels* nor *database_name* is supplied.
     """
+    if not labels and not database_name:
+        return None
+
+    if fmt == "dict":
+        out: dict = {}
+        if labels:
+            out["label"] = labels[0] if len(labels) == 1 else list(labels)
+        if database_name:
+            out["database_name"] = database_name
+        return out
+
     parts: list[str] = []
     if labels:
         label_preds = [f"""metadata LIKE '%"label":"{_escape_like(lab)}"%' ESCAPE '\\'""" for lab in labels]
@@ -118,6 +154,20 @@ def _build_metadata_where_clause(
     if database_name:
         parts.append(f"""metadata LIKE '%"database_name":"{_escape_like(database_name)}"%' ESCAPE '\\'""")
     return " AND ".join(parts) if parts else None
+
+
+def _metadata_filter_format(retriever: "Retriever") -> MetadataFilterFormat:
+    """Read the per-VDB filter format off the retriever's plugged-in VDB.
+
+    Tabular callers construct the VDB themselves and pass it as
+    ``Retriever(vdb_kwargs={"vdb": instance})``, so the instance is reachable
+    through ``retriever.vdb_kwargs["vdb"]``. Falls back to ``"sql"`` when no
+    instance is exposed (e.g. the reference :class:`LanceDB` reached via
+    ``vdb_op="lancedb"``), preserving historical behavior.
+    """
+    vdb = (getattr(retriever, "vdb_kwargs", None) or {}).get("vdb")
+    fmt = getattr(vdb, "metadata_filter_format", "sql")
+    return fmt if fmt in ("sql", "dict") else "sql"
 
 
 def _hits_to_semantic_rows(
@@ -169,13 +219,17 @@ def search_semantic_index(
 ) -> list[dict]:
     """Vector search via the injected :class:`~nemo_retriever.retriever.Retriever`.
 
-    Runs one query **per label** with a server-side ``where`` predicate on the
-    ``metadata`` JSON column (label + database_name), requesting exactly
-    the label-specific *k* rows.  *per_label_k* can be a single int or a
-    ``{label: k}`` dict (e.g. ``{"Column": 10, "CustomAnalysis": 3}``).
-    When no *label_filter* is given, falls back to a single query with
-    ``DEFAULT_FETCH_LIMIT``.
+    Runs one query **per label** with a server-side metadata filter on
+    ``label`` + ``database_name``, requesting exactly the label-specific *k*
+    rows.  *per_label_k* can be a single int or a ``{label: k}`` dict
+    (e.g. ``{"Column": 10, "CustomAnalysis": 3}``). When no *label_filter*
+    is given, falls back to a single query with ``DEFAULT_FETCH_LIMIT``.
+
+    The filter format (SQL string vs. dict) is read off the VDB the caller
+    plugged into the retriever — see :func:`_metadata_filter_format`.
     """
+    fmt = _metadata_filter_format(retriever)
+
     allowed_labels = {str(x) for x in (label_filter or []) if x is not None} or None
     labels_to_query = list(allowed_labels) if allowed_labels else [None]
 
@@ -184,6 +238,7 @@ def search_semantic_index(
         where_clause = _build_metadata_where_clause(
             labels=[label] if label else None,
             database_name=database_name,
+            fmt=fmt,
         )
         vdb_kwargs = {"where": where_clause} if where_clause else None
         top_k = _resolve_label_k(per_label_k, label) if where_clause else DEFAULT_FETCH_LIMIT

--- a/nemo_retriever/tests/test_semantic_search_metadata_filter_format.py
+++ b/nemo_retriever/tests/test_semantic_search_metadata_filter_format.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the metadata filter builder used by tabular semantic search.
+
+``_build_metadata_where_clause`` emits one of two shapes depending on the
+``fmt`` flag:
+
+* ``"sql"`` (default) — the historical ``LIKE``-over-JSON predicate that
+  LanceDB's ``.where()`` API accepts.
+* ``"dict"`` — a flat ``{column: value | [values]}`` mapping for backends
+  whose filter API consumes a dict (e.g. pgvector).
+
+``search_semantic_index`` picks the shape by reading
+``retriever.vdb_kwargs["vdb"].metadata_filter_format`` (defaulting to
+``"sql"`` when no VDB instance is injected).
+"""
+
+from __future__ import annotations
+
+from nemo_retriever.tabular_data.retrieval.data_access.semantic_search import (
+    _build_metadata_where_clause,
+    _metadata_filter_format,
+)
+
+
+# ---------------------------------------------------------------------------
+# fmt="sql" — preserves the historical LIKE-over-JSON predicate
+# ---------------------------------------------------------------------------
+
+
+def test_no_filters_returns_none() -> None:
+    assert _build_metadata_where_clause() is None
+    assert _build_metadata_where_clause(labels=[], database_name=None) is None
+    assert _build_metadata_where_clause(labels=None, database_name="") is None
+    assert _build_metadata_where_clause(fmt="dict") is None
+
+
+def test_sql_single_label_emits_like_predicate() -> None:
+    out = _build_metadata_where_clause(labels=["Column"])
+    assert out == """metadata LIKE '%"label":"Column"%' ESCAPE '\\'"""
+
+
+def test_sql_multiple_labels_join_with_or() -> None:
+    out = _build_metadata_where_clause(labels=["Column", "Table"])
+    assert out == (
+        """(metadata LIKE '%"label":"Column"%' ESCAPE '\\'""" """ OR metadata LIKE '%"label":"Table"%' ESCAPE '\\')"""
+    )
+
+
+def test_sql_label_and_database_name_combined() -> None:
+    # NB: ``_escape_like`` escapes ``_`` → ``\_`` so it isn't a LIKE wildcard.
+    out = _build_metadata_where_clause(labels=["Column"], database_name="dor_prod")
+    assert out == (
+        """metadata LIKE '%"label":"Column"%' ESCAPE '\\'"""
+        """ AND metadata LIKE '%"database_name":"dor\\_prod"%' ESCAPE '\\'"""
+    )
+
+
+def test_sql_database_name_only() -> None:
+    out = _build_metadata_where_clause(database_name="dor_prod")
+    assert out == """metadata LIKE '%"database_name":"dor\\_prod"%' ESCAPE '\\'"""
+
+
+# ---------------------------------------------------------------------------
+# fmt="dict" — pgvector-style flat mapping
+# ---------------------------------------------------------------------------
+
+
+def test_dict_single_label() -> None:
+    assert _build_metadata_where_clause(labels=["Column"], fmt="dict") == {"label": "Column"}
+
+
+def test_dict_multiple_labels_become_list() -> None:
+    assert _build_metadata_where_clause(labels=["Column", "Table"], fmt="dict") == {
+        "label": ["Column", "Table"],
+    }
+
+
+def test_dict_label_and_database_name() -> None:
+    assert _build_metadata_where_clause(labels=["Column"], database_name="dor_prod", fmt="dict") == {
+        "label": "Column",
+        "database_name": "dor_prod",
+    }
+
+
+def test_dict_database_name_only() -> None:
+    assert _build_metadata_where_clause(database_name="dor_prod", fmt="dict") == {
+        "database_name": "dor_prod",
+    }
+
+
+# ---------------------------------------------------------------------------
+# _metadata_filter_format — reads the flag off the retriever's injected VDB
+# ---------------------------------------------------------------------------
+
+
+class _FakeVdb:
+    def __init__(self, fmt: str) -> None:
+        self.metadata_filter_format = fmt
+
+
+class _FakeRetriever:
+    def __init__(self, vdb: object | None) -> None:
+        self.vdb_kwargs = {"vdb": vdb} if vdb is not None else {}
+
+
+def test_metadata_filter_format_reads_from_injected_vdb() -> None:
+    assert _metadata_filter_format(_FakeRetriever(_FakeVdb("dict"))) == "dict"
+    assert _metadata_filter_format(_FakeRetriever(_FakeVdb("sql"))) == "sql"
+
+
+def test_metadata_filter_format_defaults_to_sql() -> None:
+    assert _metadata_filter_format(_FakeRetriever(None)) == "sql"
+    assert _metadata_filter_format(_FakeRetriever(object())) == "sql"
+
+
+def test_metadata_filter_format_unknown_falls_back_to_sql() -> None:
+    assert _metadata_filter_format(_FakeRetriever(_FakeVdb("yaml"))) == "sql"

--- a/nemo_retriever/tests/test_semantic_search_metadata_filter_format.py
+++ b/nemo_retriever/tests/test_semantic_search_metadata_filter_format.py
@@ -30,10 +30,19 @@ from nemo_retriever.tabular_data.retrieval.data_access.semantic_search import (
 # ---------------------------------------------------------------------------
 
 
-def test_no_filters_returns_none() -> None:
+def test_no_arguments_returns_none() -> None:
     assert _build_metadata_where_clause() is None
+
+
+def test_empty_labels_and_no_database_name_returns_none() -> None:
     assert _build_metadata_where_clause(labels=[], database_name=None) is None
+
+
+def test_no_labels_and_empty_database_name_returns_none() -> None:
     assert _build_metadata_where_clause(labels=None, database_name="") is None
+
+
+def test_no_filters_returns_none_for_dict_format() -> None:
     assert _build_metadata_where_clause(fmt="dict") is None
 
 
@@ -106,15 +115,94 @@ class _FakeRetriever:
         self.vdb_kwargs = {"vdb": vdb} if vdb is not None else {}
 
 
-def test_metadata_filter_format_reads_from_injected_vdb() -> None:
+def test_metadata_filter_format_reads_dict_from_injected_vdb() -> None:
     assert _metadata_filter_format(_FakeRetriever(_FakeVdb("dict"))) == "dict"
+
+
+def test_metadata_filter_format_reads_sql_from_injected_vdb() -> None:
     assert _metadata_filter_format(_FakeRetriever(_FakeVdb("sql"))) == "sql"
 
 
-def test_metadata_filter_format_defaults_to_sql() -> None:
+def test_metadata_filter_format_defaults_to_sql_when_no_vdb_injected() -> None:
     assert _metadata_filter_format(_FakeRetriever(None)) == "sql"
+
+
+def test_metadata_filter_format_defaults_to_sql_when_vdb_lacks_attribute() -> None:
     assert _metadata_filter_format(_FakeRetriever(object())) == "sql"
 
 
 def test_metadata_filter_format_unknown_falls_back_to_sql() -> None:
     assert _metadata_filter_format(_FakeRetriever(_FakeVdb("yaml"))) == "sql"
+
+
+# ---------------------------------------------------------------------------
+# search_semantic_index — integration with retriever.query(vdb_kwargs=...)
+# ---------------------------------------------------------------------------
+
+
+from nemo_retriever.tabular_data.retrieval.data_access.semantic_search import (
+    DEFAULT_FETCH_LIMIT,
+    search_semantic_index,
+)
+
+
+class _RecordingRetriever:
+    """Fake retriever that records every ``query`` invocation and returns no hits."""
+
+    def __init__(self, vdb: object | None) -> None:
+        self.vdb_kwargs = {"vdb": vdb} if vdb is not None else {}
+        self.calls: list[dict] = []
+
+    def query(self, entity: str, *, top_k: int, vdb_kwargs: dict | None) -> list[dict]:
+        self.calls.append({"entity": entity, "top_k": top_k, "vdb_kwargs": vdb_kwargs})
+        return []
+
+
+def test_search_semantic_index_forwards_sql_where_per_label() -> None:
+    retriever = _RecordingRetriever(_FakeVdb("sql"))
+    search_semantic_index(retriever, "rev", label_filter=["Column"], database_name="dor_prod")
+
+    assert len(retriever.calls) == 1
+    sent = retriever.calls[0]["vdb_kwargs"]
+    assert isinstance(sent, dict)
+    assert set(sent.keys()) == {"where"}
+    assert isinstance(sent["where"], str)
+    assert """metadata LIKE '%"label":"Column"%'""" in sent["where"]
+    assert """metadata LIKE '%"database_name":"dor\\_prod"%'""" in sent["where"]
+
+
+def test_search_semantic_index_forwards_dict_filter_per_label() -> None:
+    retriever = _RecordingRetriever(_FakeVdb("dict"))
+    search_semantic_index(retriever, "rev", label_filter=["Column"], database_name="dor_prod")
+
+    assert len(retriever.calls) == 1
+    sent = retriever.calls[0]["vdb_kwargs"]
+    assert sent == {"where": {"label": "Column", "database_name": "dor_prod"}}
+
+
+def test_search_semantic_index_dict_runs_one_query_per_label() -> None:
+    retriever = _RecordingRetriever(_FakeVdb("dict"))
+    search_semantic_index(retriever, "rev", label_filter=["Column", "Table"])
+
+    assert len(retriever.calls) == 2
+    sent = [c["vdb_kwargs"] for c in retriever.calls]
+    assert {"where": {"label": "Column"}} in sent
+    assert {"where": {"label": "Table"}} in sent
+
+
+def test_search_semantic_index_no_filter_passes_none_and_default_limit() -> None:
+    retriever = _RecordingRetriever(_FakeVdb("dict"))
+    search_semantic_index(retriever, "rev")
+
+    assert len(retriever.calls) == 1
+    assert retriever.calls[0]["vdb_kwargs"] is None
+    assert retriever.calls[0]["top_k"] == DEFAULT_FETCH_LIMIT
+
+
+def test_search_semantic_index_defaults_to_sql_when_vdb_missing() -> None:
+    retriever = _RecordingRetriever(None)
+    search_semantic_index(retriever, "rev", label_filter=["Column"])
+
+    sent = retriever.calls[0]["vdb_kwargs"]
+    assert isinstance(sent["where"], str)
+    assert """metadata LIKE '%"label":"Column"%'""" in sent["where"]


### PR DESCRIPTION
…ic search

`_build_metadata_where_clause` gains a `fmt` flag and can now emit either the existing SQL `LIKE`-over-JSON predicate (default, unchanged for LanceDB callers) or a flat `{label, database_name}` dict for backends whose filter API consumes a dict (e.g. pgvector). `search_semantic_index` reads the format off the VDB the caller plugged in via `retriever.vdb_kwargs["vdb"].metadata_filter_format`, defaulting to `"sql"` so existing behavior is preserved.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
