### PR TITLE
describe Nemotron Parse as alternate PDF extraction method

### DIFF
--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -28,8 +28,7 @@ For more information, refer to [Extract Captions from Images](nemo-retriever-api
 ## When should I consider advanced visual parsing?
 
 For scanned documents, or documents with complex layouts, 
-we recommend that you use [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse). 
-Nemotron parse provides higher-accuracy text extraction. 
+you can use [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse) as an alternate PDF extraction method by setting `extract_method="nemotron_parse"`. 
 For more information, refer to [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse).
 
 ## Why are the environment variables different between library mode and self-hosted mode?

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -64,7 +64,7 @@ Advanced features (for example, for audio/video) require additional GPU support 
 This includes the following:
 
 - [parakeet-1-1b-ctc-en-us](https://huggingface.co/nvidia/parakeet-ctc-1.1b) [NIM](https://docs.nvidia.com/nim/speech/latest/index.html) — for transcript extraction from [audio and video](audio-video.md).
-- [nemotron-parse](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2) [NIM](https://docs.nvidia.com/nim/vision-language-models/latest/overview.html) — for maximally accurate table extraction.
+- [nemotron-parse](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2) [NIM](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-parse) — alternate PDF extraction method when you set `extract_method="nemotron_parse"` (default PDF extraction uses **pdfium**)
 - [nemotron-nano-12b-v2-vl](https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2) [NIM](https://docs.nvidia.com/nim/vision-language-models/latest/overview.html) - default model family for image captioning of unstructured images.
 - [nemotron-3-nano-omni-30b-a3b-reasoning](https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16) [NIM](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-nano-omni-30b-a3b-reasoning) (`nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:latest`) — opt-in model family for image captioning. Local BF16, FP8, and NVFP4 Hugging Face checkpoints are supported, and remote captioning uses the hosted model ID `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`.
     

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -64,7 +64,7 @@ Advanced features (for example, for audio/video) require additional GPU support 
 This includes the following:
 
 - [parakeet-1-1b-ctc-en-us](https://huggingface.co/nvidia/parakeet-ctc-1.1b) [NIM](https://docs.nvidia.com/nim/speech/latest/index.html) — for transcript extraction from [audio and video](audio-video.md).
-- [nemotron-parse](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2) [NIM](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-parse) — alternate PDF extraction method when you set `extract_method="nemotron_parse"` (default PDF extraction uses **pdfium**)
+- [nemotron-parse](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2) [NIM](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-parse) — alternate PDF extraction method when you set `extract_method="nemotron_parse"` (default PDF extraction uses **pdfium**).
 - [nemotron-nano-12b-v2-vl](https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2) [NIM](https://docs.nvidia.com/nim/vision-language-models/latest/overview.html) - default model family for image captioning of unstructured images.
 - [nemotron-3-nano-omni-30b-a3b-reasoning](https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16) [NIM](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-nano-omni-30b-a3b-reasoning) (`nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:latest`) — opt-in model family for image captioning. Local BF16, FP8, and NVFP4 Hugging Face checkpoints are supported, and remote captioning uses the hosted model ID `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`.
     

--- a/docs/sphinx_docs/source/index.rst
+++ b/docs/sphinx_docs/source/index.rst
@@ -61,7 +61,7 @@ Ingestor link to see descriptions of the available tasks)
             extract_images=True,
             paddle_output_format="markdown",
             extract_infographics=True,
-            # extract_method="nemotron_parse", #Slower, but maximally accurate, especially for PDFs with pages that are scanned images
+            # extract_method="nemotron_parse",  # Alternate PDF extraction method
             text_depth="page"
         ).embed()
         .vdb_upload(


### PR DESCRIPTION
## Summary

Updates extraction docs so **Nemotron Parse** is described as an **alternate PDF extraction method** (`extract_method="nemotron_parse"`), not as higher-accuracy or maximally accurate extraction. Default PDF extraction remains **pdfium**.

## Changes

- **FAQ** — Replaces “higher-accuracy text extraction” with guidance to use `extract_method="nemotron_parse"` for scanned or complex-layout PDFs.
- **Pre-Requisites & Support Matrix** — Replaces “maximally accurate table extraction” with alternate-method wording; points the NIM link to the [Nemotron Parse API reference](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-parse); notes that **pdfium** is the default.
- **Sphinx quickstart** (`index.rst`) — Updates the sample `extract_method` comment to match (removes “maximally accurate” language).

## Motivation

Product/docs review requested neutral wording: Nemotron Parse is an optional alternate path, not a documented accuracy upgrade over the default pipeline.

