### PR TITLE
docs(extraction): describe Nemotron Parse as alternate PDF extraction method

### DIFF
--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -28,8 +28,7 @@ For more information, refer to [Extract Captions from Images](nemo-retriever-api
 ## When should I consider advanced visual parsing?
 
 For scanned documents, or documents with complex layouts, 
-we recommend that you use [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse). 
-Nemotron parse provides higher-accuracy text extraction. 
+you can use [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse) as an alternate PDF extraction method by setting `extract_method="nemotron_parse"`. 
 For more information, refer to [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse).
 
 ## Why are the environment variables different between library mode and self-hosted mode?

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -81,7 +81,7 @@ Advanced features (for example, audio and video, Nemotron Parse, VLM image capti
 This includes the following:
 
 - [parakeet-1-1b-ctc-en-us](https://huggingface.co/nvidia/parakeet-ctc-1.1b) [NIM](https://docs.nvidia.com/nim/speech/latest/index.html) — transcript extraction from [audio and video](audio-video.md)
-- [nemotron-parse](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2) [NIM](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-parse) — higher-accuracy PDF extraction when you set `extract_method="nemotron_parse"`
+- [nemotron-parse](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2) [NIM](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-parse) — alternate PDF extraction method when you set `extract_method="nemotron_parse"` (default PDF extraction uses **pdfium**)
 - [nemotron-3-nano-omni-30b-a3b-reasoning](https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16) [NIM](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-nano-omni-30b-a3b-reasoning) — optional image captioning when you enable the caption stage
 - [llama-nemotron-rerank-vl-1b-v2](https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2) [NIM](https://docs.nvidia.com/nim/nemo-retriever/text-reranking/latest/overview.html) — reranking for improved retrieval accuracy
 

--- a/docs/sphinx_docs/source/index.rst
+++ b/docs/sphinx_docs/source/index.rst
@@ -61,7 +61,7 @@ Ingestor link to see descriptions of the available tasks)
             extract_images=True,
             paddle_output_format="markdown",
             extract_infographics=True,
-            # extract_method="nemotron_parse", #Slower, but maximally accurate, especially for PDFs with pages that are scanned images
+            # extract_method="nemotron_parse",  # Alternate PDF extraction method
             text_depth="page"
         ).embed()
         .vdb_upload(

--- a/docs/sphinx_docs/source/index.rst
+++ b/docs/sphinx_docs/source/index.rst
@@ -61,7 +61,7 @@ Ingestor link to see descriptions of the available tasks)
             extract_images=True,
             paddle_output_format="markdown",
             extract_infographics=True,
-            # extract_method="nemotron_parse",  # Alternate PDF extraction method
+            # extract_method="nemotron_parse",  # Alternate PDF extraction method; use for scanned or complex-layout PDFs
             text_depth="page"
         ).embed()
         .vdb_upload(


### PR DESCRIPTION
## Summary

Backport of #2070 from `26.05` to `main`. Updates extraction docs so **Nemotron Parse** is described as an **alternate PDF extraction method** (`extract_method=nemotron_parse`), not as higher-accuracy or maximally accurate extraction. Default PDF extraction remains **pdfium**.

## Changes

- **FAQ** — Replaces higher-accuracy wording with guidance to use `extract_method=nemotron_parse` for scanned or complex-layout PDFs.
- **Pre-Requisites & Support Matrix** — Replaces higher-accuracy PDF extraction wording in the advanced-features list; notes that **pdfium** is the default.
- **Sphinx quickstart** (`index.rst`) — Updates the sample `extract_method` comment to match.

## Motivation

#2070 merged to `26.05`; this brings the same neutral Nemotron Parse wording to `main`.

## Test plan

- [ ] Review rendered docs for FAQ and prerequisites-support-matrix pages
- [ ] Confirm no remaining higher-accuracy / maximally accurate claims for Nemotron Parse in changed files