### PR TITLE
backport Nemotron Parse alternate-method wording to main - 26.05 -> main (#2070)

### DIFF
--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -194,8 +194,8 @@ jobs:
       - name: Package chart (validate)
         run: |
           python ci/scripts/release_helm_chart.py \
-            --org nvidian \
-            --team nemo-llm \
+            --org "${{ secrets.NGC_ORG }}" \
+            --team "${{ secrets.NGC_TEAM }}" \
             --name "${HELM_CHART_NAME}" \
             --chart-dir "${HELM_CHART_DIR}" \
             --version "${{ needs.determine-version.outputs.version }}" \
@@ -302,8 +302,8 @@ jobs:
           NGC_CLI_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
         run: |
           python ci/scripts/release_helm_chart.py \
-            --org ${{ secrets.NGC_ORG }} \
-            --team ${{ secrets.NGC_TEAM }} \
+            --org "${{ secrets.NGC_ORG }}" \
+            --team "${{ secrets.NGC_TEAM }}" \
             --name "${HELM_CHART_NAME}" \
             --chart-dir "${HELM_CHART_DIR}" \
             --version "${{ needs.determine-version.outputs.version }}"
@@ -380,6 +380,8 @@ jobs:
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
+          NGC_ORG: ${{ secrets.NGC_ORG }}
+          NGC_TEAM: ${{ secrets.NGC_TEAM }}
         run: |
           status_emoji() {
             case "$1" in
@@ -448,7 +450,7 @@ jobs:
           fi
 
           # — Helm Chart —
-          HELM_REF="nvidian/nemo-llm/nemo-retriever:${VERSION}"
+          HELM_REF="${NGC_ORG}/${NGC_TEAM}/nemo-retriever:${VERSION}"
           if [ "$SKIP_HELM" = "true" ]; then
             MSG+="\n:fast_forward: *Helm Chart* — Disabled (skip-helm-chart)"
           elif [ "$DRY_RUN" = "true" ]; then

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -17,16 +17,6 @@ on:
         required: false
         type: boolean
         default: false
-      ngc-org:
-        description: 'NGC organization'
-        required: false
-        type: string
-        default: 'nvidian'
-      ngc-team:
-        description: 'NGC team'
-        required: false
-        type: string
-        default: 'nemo-llm'
       chart-name:
         description: 'Helm chart name'
         required: false
@@ -42,8 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NGC_CLI_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
-      NGC_CLI_ORG: ${{ inputs.ngc-org }}
-      NGC_CLI_TEAM: ${{ inputs.ngc-team }}
+      NGC_CLI_ORG: ${{ secrets.NGC_ORG }}
+      NGC_CLI_TEAM: ${{ secrets.NGC_TEAM }}
       NGC_CLI_FORMAT_TYPE: json
     steps:
       - name: Checkout code
@@ -72,8 +62,8 @@ jobs:
             DRY_RUN_FLAG="--dry-run"
           fi
           python ci/scripts/release_helm_chart.py \
-            --org "${{ inputs.ngc-org }}" \
-            --team "${{ inputs.ngc-team }}" \
+            --org "${{ secrets.NGC_ORG }}" \
+            --team "${{ secrets.NGC_TEAM }}" \
             --name "${{ inputs.chart-name }}" \
             --chart-dir "${HELM_CHART_DIR}" \
             --version "${{ inputs.version }}" \
@@ -95,5 +85,5 @@ jobs:
           echo "| Chart source | \`${HELM_CHART_DIR}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Chart | \`${{ inputs.chart-name }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Version | \`${{ inputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| NGC | \`${{ inputs.ngc-org }}/${{ inputs.ngc-team }}/${{ inputs.chart-name }}:${{ inputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| NGC | \`${{ inputs.chart-name }}:${{ inputs.version }}\` (org/team from repository secrets) |" >> $GITHUB_STEP_SUMMARY
           echo "| Dry Run | \`${{ inputs.dry-run }}\` |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Chart version (e.g. 26.03)'
+        description: 'Chart version (e.g. 26.05-RC1)'
         required: true
         type: string
       source-ref:

--- a/.github/workflows/reusable-pypi-build.yml
+++ b/.github/workflows/reusable-pypi-build.yml
@@ -97,14 +97,46 @@ jobs:
           RETRIEVER_GIT_SHA=${{ github.sha }} \
           python -m build
 
+      - name: Debug — wheels after build
+        run: |
+          set -x
+          echo "=== PyPI build debug (post python -m build) ==="
+          echo "pwd=$(pwd)"
+          echo "github.sha=${{ github.sha }}"
+          echo "version=${{ steps.set-version.outputs.version }}"
+          echo "release-type=${{ inputs.release-type }}"
+          echo "--- nemo_retriever/dist ---"
+          ls -la nemo_retriever/dist/ 2>&1 || echo "(missing nemo_retriever/dist)"
+          find nemo_retriever/dist -type f \( -name '*.whl' -o -name '*.tar.gz' \) -ls 2>/dev/null || true
+          du -sh nemo_retriever/dist 2>/dev/null || true
+
       - name: Stage wheels for publish artifact layout
         run: |
+          set -euxo pipefail
           # Preserve nemo_retriever/dist/ in the artifact so download-artifact + the
           # legacy publish path ./dist/nemo_retriever/dist/* both work (upload-artifact
           # strips the common parent when uploading bare globs).
           mkdir -p python-wheels-artifact/nemo_retriever/dist
-          cp -v nemo_retriever/dist/*.whl nemo_retriever/dist/*.tar.gz \
-            python-wheels-artifact/nemo_retriever/dist/
+          shopt -s nullglob
+          built=(nemo_retriever/dist/*.whl nemo_retriever/dist/*.tar.gz)
+          if [ "${#built[@]}" -eq 0 ]; then
+            echo "::error::No wheels or sdists in nemo_retriever/dist to stage"
+            ls -laR nemo_retriever/dist || true
+            exit 1
+          fi
+          cp -v "${built[@]}" python-wheels-artifact/nemo_retriever/dist/
+
+      - name: Debug — staged artifact tree before upload
+        run: |
+          set -x
+          echo "=== PyPI build debug (pre upload-artifact) ==="
+          echo "pwd=$(pwd)"
+          echo "github.run_id=${{ github.run_id }}"
+          echo "github.run_attempt=${{ github.run_attempt }}"
+          echo "--- python-wheels-artifact/ ---"
+          find python-wheels-artifact -type f -ls 2>/dev/null || true
+          du -sh python-wheels-artifact 2>/dev/null || true
+          ls -laR python-wheels-artifact 2>&1 || true
 
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v5
@@ -112,3 +144,4 @@ jobs:
           name: python-wheels
           path: python-wheels-artifact/
           retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/reusable-pypi-build.yml
+++ b/.github/workflows/reusable-pypi-build.yml
@@ -97,11 +97,18 @@ jobs:
           RETRIEVER_GIT_SHA=${{ github.sha }} \
           python -m build
 
+      - name: Stage wheels for publish artifact layout
+        run: |
+          # Preserve nemo_retriever/dist/ in the artifact so download-artifact + the
+          # legacy publish path ./dist/nemo_retriever/dist/* both work (upload-artifact
+          # strips the common parent when uploading bare globs).
+          mkdir -p python-wheels-artifact/nemo_retriever/dist
+          cp -v nemo_retriever/dist/*.whl nemo_retriever/dist/*.tar.gz \
+            python-wheels-artifact/nemo_retriever/dist/
+
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v5
         with:
           name: python-wheels
-          path: |
-            nemo_retriever/dist/*.whl
-            nemo_retriever/dist/*.tar.gz
+          path: python-wheels-artifact/
           retention-days: 7

--- a/.github/workflows/reusable-pypi-publish.yml
+++ b/.github/workflows/reusable-pypi-publish.yml
@@ -35,9 +35,17 @@ jobs:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
         run: |
-          # Publish all wheels
+          # upload-artifact strips to the common parent (nemo_retriever/dist/), so
+          # downloaded files land directly under ./dist/, not ./dist/nemo_retriever/dist/.
+          mapfile -t DIST_FILES < <(find ./dist -type f \( -name '*.whl' -o -name '*.tar.gz' \))
+          if [ "${#DIST_FILES[@]}" -eq 0 ]; then
+            echo "::error::No wheel or sdist files under ./dist"
+            find ./dist -type f || true
+            exit 1
+          fi
+          printf 'Publishing:\n%s\n' "${DIST_FILES[@]}"
           twine upload --verbose \
-            --repository-url $ARTIFACTORY_URL \
-            -u $ARTIFACTORY_USERNAME \
-            -p $ARTIFACTORY_PASSWORD \
-            ./dist/nemo_retriever/dist/*
+            --repository-url "$ARTIFACTORY_URL" \
+            -u "$ARTIFACTORY_USERNAME" \
+            -p "$ARTIFACTORY_PASSWORD" \
+            "${DIST_FILES[@]}"

--- a/.github/workflows/reusable-pypi-publish.yml
+++ b/.github/workflows/reusable-pypi-publish.yml
@@ -21,6 +21,12 @@ jobs:
           name: python-wheels
           path: ./dist
 
+      - name: List downloaded wheel artifacts
+        run: |
+          echo "Contents of ./dist after download-artifact:"
+          find ./dist -type f -ls 2>/dev/null || true
+          find ./dist -type d 2>/dev/null || true
+
       - name: Setup Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/reusable-pypi-publish.yml
+++ b/.github/workflows/reusable-pypi-publish.yml
@@ -15,17 +15,48 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Debug — publish job context (before download)
+        run: |
+          echo "=== PyPI publish debug (job start) ==="
+          echo "pwd=$(pwd)"
+          echo "github.workflow=${{ github.workflow }}"
+          echo "github.job=${{ github.job }}"
+          echo "github.ref=${{ github.ref }}"
+          echo "github.sha=${{ github.sha }}"
+          echo "github.run_id=${{ github.run_id }}"
+          echo "github.run_attempt=${{ github.run_attempt }}"
+          echo "github.event_name=${{ github.event_name }}"
+          echo "Note: Re-run uses the workflow YAML frozen at workflow run creation, not the latest branch tip."
+          echo "Note: Artifacts are per workflow run (not Actions cache). Re-run publish reuses the same run's python-wheels artifact."
+          ls -la
+          test -d ./dist && ls -laR ./dist || echo "./dist does not exist yet (expected before download)"
+
       - name: Download wheel artifacts
         uses: actions/download-artifact@v5
         with:
           name: python-wheels
           path: ./dist
 
-      - name: List downloaded wheel artifacts
+      - name: Debug — tree after download-artifact
         run: |
-          echo "Contents of ./dist after download-artifact:"
-          find ./dist -type f -ls 2>/dev/null || true
-          find ./dist -type d 2>/dev/null || true
+          set -x
+          echo "=== PyPI publish debug (after download-artifact) ==="
+          echo "pwd=$(pwd)"
+          echo "artifact name=python-wheels download path=./dist"
+          echo "--- ./dist (top level) ---"
+          ls -la ./dist 2>&1 || echo "./dist missing"
+          echo "--- full tree under ./dist ---"
+          find ./dist -print 2>/dev/null || echo "find ./dist failed"
+          find ./dist -type f -ls 2>/dev/null || echo "no files under ./dist"
+          du -sh ./dist 2>/dev/null || true
+          echo "--- glob probes (what publish will try) ---"
+          shopt -s nullglob
+          legacy=(./dist/nemo_retriever/dist/*.whl ./dist/nemo_retriever/dist/*.tar.gz)
+          flat=(./dist/*.whl ./dist/*.tar.gz)
+          echo "legacy count=${#legacy[@]}: ${legacy[*]:-<none>}"
+          echo "flat count=${#flat[@]}: ${flat[*]:-<none>}"
+          mapfile -t found < <(find ./dist -type f \( -name '*.whl' -o -name '*.tar.gz' \) 2>/dev/null)
+          echo "find count=${#found[@]}: ${found[*]:-<none>}"
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -44,22 +75,31 @@ jobs:
           set -euo pipefail
           shopt -s nullglob
 
+          echo "=== PyPI publish debug (publish step) ==="
+          echo "pwd=$(pwd)"
+          ls -la
+          ls -laR ./dist 2>&1 || true
+
           # Legacy layout (staged by reusable-pypi-build): ./dist/nemo_retriever/dist/*
           DIST_FILES=(./dist/nemo_retriever/dist/*.whl ./dist/nemo_retriever/dist/*.tar.gz)
+          echo "After legacy glob: count=${#DIST_FILES[@]} files=${DIST_FILES[*]:-<none>}"
 
           # Flat layout (older upload-artifact glob uploads): ./dist/*
           if [ "${#DIST_FILES[@]}" -eq 0 ]; then
             DIST_FILES=(./dist/*.whl ./dist/*.tar.gz)
+            echo "After flat glob: count=${#DIST_FILES[@]} files=${DIST_FILES[*]:-<none>}"
           fi
 
           # Any other nested layout
           if [ "${#DIST_FILES[@]}" -eq 0 ]; then
             mapfile -t DIST_FILES < <(find ./dist -type f \( -name '*.whl' -o -name '*.tar.gz' \))
+            echo "After find: count=${#DIST_FILES[@]} files=${DIST_FILES[*]:-<none>}"
           fi
 
           if [ "${#DIST_FILES[@]}" -eq 0 ]; then
             echo "::error::No wheel or sdist files under ./dist"
-            find ./dist -type f 2>/dev/null || true
+            echo "This is usually: (1) build job did not upload wheels, (2) wrong artifact from another run, or (3) publish re-run with an empty/missing artifact — start a new full workflow run after merging build+publish fixes."
+            find ./dist -type f 2>/dev/null || echo "no files under ./dist at all"
             exit 1
           fi
 

--- a/.github/workflows/reusable-pypi-publish.yml
+++ b/.github/workflows/reusable-pypi-publish.yml
@@ -41,14 +41,28 @@ jobs:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
         run: |
-          # upload-artifact strips to the common parent (nemo_retriever/dist/), so
-          # downloaded files land directly under ./dist/, not ./dist/nemo_retriever/dist/.
-          mapfile -t DIST_FILES < <(find ./dist -type f \( -name '*.whl' -o -name '*.tar.gz' \))
+          set -euo pipefail
+          shopt -s nullglob
+
+          # Legacy layout (staged by reusable-pypi-build): ./dist/nemo_retriever/dist/*
+          DIST_FILES=(./dist/nemo_retriever/dist/*.whl ./dist/nemo_retriever/dist/*.tar.gz)
+
+          # Flat layout (older upload-artifact glob uploads): ./dist/*
+          if [ "${#DIST_FILES[@]}" -eq 0 ]; then
+            DIST_FILES=(./dist/*.whl ./dist/*.tar.gz)
+          fi
+
+          # Any other nested layout
+          if [ "${#DIST_FILES[@]}" -eq 0 ]; then
+            mapfile -t DIST_FILES < <(find ./dist -type f \( -name '*.whl' -o -name '*.tar.gz' \))
+          fi
+
           if [ "${#DIST_FILES[@]}" -eq 0 ]; then
             echo "::error::No wheel or sdist files under ./dist"
-            find ./dist -type f || true
+            find ./dist -type f 2>/dev/null || true
             exit 1
           fi
+
           printf 'Publishing:\n%s\n' "${DIST_FILES[@]}"
           twine upload --verbose \
             --repository-url "$ARTIFACTORY_URL" \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 **Important: The default branch is main, which tracks active development and may be ahead of the latest supported release.**
 
-For the latest stable release use the [release/26.03 branch](https://github.com/NVIDIA/NeMo-Retriever/tree/26.03).
+For the latest release line use the [26.05 branch](https://github.com/NVIDIA/NeMo-Retriever/tree/26.05) (RC builds are tagged `26.05-RC1`, `26.05-RC2`, …). The previous stable line is [26.03](https://github.com/NVIDIA/NeMo-Retriever/tree/26.03).
 
 See the corresponding [NeMo Retriever Library documentation](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/).
 

--- a/ci/scripts/release_helm_chart.py
+++ b/ci/scripts/release_helm_chart.py
@@ -4,14 +4,12 @@ Usage:
 helm lint nemo_retriever/helm
 
 python ci/scripts/release_helm_chart.py
-    -o nvidian
-    -t nemo-llm
-    -v 26.05-RC1
-    -n nemo-retriever
+    -o <ngc-org> -t <ngc-team> -v <chart-version> -n nemo-retriever \\
     --chart-dir nemo_retriever/helm
 
 Requires: pip install ngcsdk pyyaml
-Env vars: NGC_CLI_API_KEY (required for publish)
+Env vars: NGC_CLI_API_KEY (required for publish). In CI, org/team come from
+NGC_ORG and NGC_TEAM repository secrets (not committed to the repo).
 """
 
 import argparse
@@ -141,15 +139,23 @@ def main() -> None:
         clt.configure(api_key=api_key, org_name=o, team_name=t)
 
         target = f"{o}/{t}/{n}"
-        print(f"Updating chart metadata for {target} ...")
-        clt.registry.chart.update(
-            target=target,
+        metadata_kwargs = dict(
             overview_filepath=overview,
             short_description=d,
             logo=logo,
             display_name=dn,
             publisher="NVIDIA",
         )
+        print(f"Updating chart metadata for {target} ...")
+        try:
+            clt.registry.chart.update(target=target, **metadata_kwargs)
+        except Exception as exc:
+            # First publish of a renamed or new chart (e.g. nemo-retriever) is not in NGC yet.
+            exc_name = type(exc).__name__
+            if exc_name not in ("ResourceNotFoundException", "ChartNotFoundException"):
+                raise
+            print(f"Chart '{target}' not found ({exc_name}); creating registry entry ...")
+            clt.registry.chart.create(target=target, **metadata_kwargs)
 
         print(f"Pushing chart {target}:{v} ...")
         clt.registry.chart.push(

--- a/ci/scripts/release_helm_chart.py
+++ b/ci/scripts/release_helm_chart.py
@@ -6,7 +6,7 @@ helm lint nemo_retriever/helm
 python ci/scripts/release_helm_chart.py
     -o nvidian
     -t nemo-llm
-    -v 26.03
+    -v 26.05-RC1
     -n nemo-retriever
     --chart-dir nemo_retriever/helm
 

--- a/ci/scripts/release_helm_chart.py
+++ b/ci/scripts/release_helm_chart.py
@@ -21,6 +21,13 @@ import yaml
 
 LOGO = "https://developer-blogs.nvidia.com/wp-content/uploads/2024/03/nemo-retriever-graphic.png"
 
+_NOT_FOUND_EXC = frozenset({"ResourceNotFoundException", "ChartNotFoundException"})
+_ALREADY_EXISTS_EXC = frozenset({"ResourceAlreadyExistsException", "ChartAlreadyExistsException"})
+
+
+def _exc_name(exc: BaseException) -> str:
+    return type(exc).__name__
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Release helm chart to specified org and team.")
@@ -150,19 +157,25 @@ def main() -> None:
         try:
             clt.registry.chart.update(target=target, **metadata_kwargs)
         except Exception as exc:
-            # First publish of a renamed or new chart (e.g. nemo-retriever) is not in NGC yet.
-            exc_name = type(exc).__name__
-            if exc_name not in ("ResourceNotFoundException", "ChartNotFoundException"):
+            if _exc_name(exc) not in _NOT_FOUND_EXC:
                 raise
-            print(f"Chart '{target}' not found ({exc_name}); creating registry entry ...")
+            print(f"Chart '{target}' not found ({_exc_name(exc)}); creating registry entry ...")
             clt.registry.chart.create(target=target, **metadata_kwargs)
 
         print(f"Pushing chart {target}:{v} ...")
-        clt.registry.chart.push(
-            target=f"{target}:{v}",
-            source_dir=".",
-        )
-        print(f"Successfully pushed {target}:{v}")
+        try:
+            clt.registry.chart.push(
+                target=f"{target}:{v}",
+                source_dir=".",
+            )
+            print(f"Successfully pushed {target}:{v}")
+        except Exception as exc:
+            if _exc_name(exc) not in _ALREADY_EXISTS_EXC:
+                raise
+            print(
+                f"Chart version '{v}' already exists in NGC ({_exc_name(exc)}); "
+                "skipping push. Re-run with a new version tag to publish different chart contents."
+            )
 
 
 if __name__ == "__main__":

--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -28,8 +28,7 @@ For more information, refer to [Extract Captions from Images](nemo-retriever-api
 ## When should I consider advanced visual parsing?
 
 For scanned documents, or documents with complex layouts, 
-we recommend that you use [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse). 
-Nemotron parse provides higher-accuracy text extraction. 
+you can use [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse) as an alternate PDF extraction method by setting `extract_method="nemotron_parse"`. 
 For more information, refer to [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse).
 
 ## Why are the environment variables different between library mode and self-hosted mode?

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -64,7 +64,7 @@ Advanced features (for example, for audio/video) require additional GPU support 
 This includes the following:
 
 - [parakeet-1-1b-ctc-en-us](https://huggingface.co/nvidia/parakeet-ctc-1.1b) [NIM](https://docs.nvidia.com/nim/speech/latest/index.html) — for transcript extraction from [audio and video](audio-video.md).
-- [nemotron-parse](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2) [NIM](https://docs.nvidia.com/nim/vision-language-models/latest/overview.html) — for maximally accurate table extraction.
+- [nemotron-parse](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2) [NIM](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-parse) — alternate PDF extraction method when you set `extract_method="nemotron_parse"` (default PDF extraction uses **pdfium**).
 - [nemotron-nano-12b-v2-vl](https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2) [NIM](https://docs.nvidia.com/nim/vision-language-models/latest/overview.html) - default model family for image captioning of unstructured images.
 - [nemotron-3-nano-omni-30b-a3b-reasoning](https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16) [NIM](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-nano-omni-30b-a3b-reasoning) (`nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:latest`) — opt-in model family for image captioning. Local BF16, FP8, and NVFP4 Hugging Face checkpoints are supported, and remote captioning uses the hosted model ID `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`.
     

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -2,6 +2,22 @@
 
 This documentation contains the release notes for [NeMo Retriever Library](overview.md).
 
+## 26.05 Release Notes (26.5.0)
+
+NVIDIA® NeMo Retriever Library version **26.05** (PyPI **26.5.0** at GA) continues the 26.05 release line on the [`26.05`](https://github.com/NVIDIA/NeMo-Retriever/tree/26.05) branch. Pre-release builds are tagged **`26.05-RC1`**, **`26.05-RC2`**, and so on; install and deploy using the RC tag that matches your build.
+
+To upgrade the Helm charts for this release, refer to the [NeMo Retriever Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.05/nemo_retriever/helm/README.md) and pin chart version **`26.05-RC1`** (or the RC you are validating).
+
+Highlights for the 26.05 release line include everything in [26.03](#2603-release-notes-2630) plus changes on `main` merged into the `26.05` branch. See the [Git compare view](https://github.com/NVIDIA/NeMo-Retriever/compare/26.03...26.05) for the full commit list.
+
+**Install (RC1 example):**
+
+```bash
+uv pip install nemo-retriever==26.05-RC1
+```
+
+Use your organization's Artifactory or PyPI index URL when installing published wheels from CI (see the Perform Release workflow summary for the exact index).
+
 ## 26.03 Release Notes (26.3.0)
 
 NVIDIA® NeMo Retriever Library version 26.03 adds broader hardware and software support along with many pipeline, evaluation, and deployment enhancements.
@@ -32,6 +48,7 @@ Highlights for the 26.03 release include:
 
 ## Release Notes for Previous Versions
 
+| [26.03](https://docs.nvidia.com/nemo/retriever/26.03/extraction/releasenotes/)
 | [26.1.2](https://docs.nvidia.com/nemo/retriever/26.1.2/extraction/releasenotes/)
 | [26.1.1](https://docs.nvidia.com/nemo/retriever/26.1.1/extraction/releasenotes/)
 | [25.9.0](https://docs.nvidia.com/nemo/retriever/25.9.0/extraction/releasenotes/) 

--- a/docs/sphinx_docs/source/index.rst
+++ b/docs/sphinx_docs/source/index.rst
@@ -61,7 +61,7 @@ Ingestor link to see descriptions of the available tasks)
             extract_images=True,
             paddle_output_format="markdown",
             extract_infographics=True,
-            # extract_method="nemotron_parse", #Slower, but maximally accurate, especially for PDFs with pages that are scanned images
+            # extract_method="nemotron_parse",  # Alternate PDF extraction method
             text_depth="page"
         ).embed()
         .vdb_upload(

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -43,7 +43,7 @@ For **local GPU inference** (Nemotron models running on your GPU), install with 
 ```bash
 uv venv retriever --python 3.12
 source retriever/bin/activate
-uv pip install "nemo-retriever[local]==26.3.0"
+uv pip install "nemo-retriever[local]==26.05-RC1"
 ```
 
 Install matching **ingestion client** and **ingestion runtime** wheels at the same version when your workflow expects them (see the [NeMo Retriever Library prerequisites](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the exact PyPI coordinates for your release).
@@ -54,7 +54,7 @@ For **remote NIM inference only** (no local GPU required), the base package is s
 uv python install 3.12
 uv venv retriever --python 3.12
 source retriever/bin/activate
-uv pip install nemo-retriever==26.3.0
+uv pip install nemo-retriever==26.05-RC1
 ```
 
 Install matching **ingestion client** and **ingestion runtime** wheels at the same version when your workflow expects them (see the [NeMo Retriever Library prerequisites](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the exact PyPI coordinates for your release).
@@ -64,7 +64,7 @@ This creates a dedicated Python environment and installs the `nemo-retriever` Py
 If your PDF pipeline uses `extract_method="nemotron_parse"`, install the Nemotron Parse client dependencies with the `nemotron-parse` extra:
 
 ```bash
-uv pip install "nemo-retriever[nemotron-parse]==26.3.0" nv-ingest-client==26.3.0 nv-ingest==26.3.0
+uv pip install "nemo-retriever[nemotron-parse]==26.05-RC1"
 ```
 
 For local GPU inference with Nemotron Parse, combine the extras as `nemo-retriever[local,nemotron-parse]`.

--- a/nemo_retriever/helm/Chart.yaml
+++ b/nemo_retriever/helm/Chart.yaml
@@ -18,8 +18,8 @@ description: |
   shared PostgreSQL backend so the service can scale horizontally.
 
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 26.05-RC1
+appVersion: "26.05-RC1"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/NVIDIA/NeMo-Retriever
 sources:


### PR DESCRIPTION
## Summary

Cherry-pick of [#2070](https://github.com/NVIDIA/NeMo-Retriever/pull/2070) from `26.05` onto `main`. Describes **Nemotron Parse** as an **alternate PDF extraction method** (`extract_method="nemotron_parse"`), not as higher-accuracy or maximally accurate extraction. Default PDF extraction remains **pdfium**.

## Changes

- **FAQ** — Removes “higher-accuracy text extraction”; directs readers to `extract_method="nemotron_parse"` for scanned or complex-layout PDFs.
- **Pre-Requisites & Support Matrix** — Replaces “higher-accuracy PDF extraction” in the advanced-features list with alternate-method wording and notes that **pdfium** is the default.
- **Sphinx quickstart** (`index.rst`) — Updates the sample `extract_method` comment (removes “maximally accurate” language).

## Motivation

#2070 merged to `26.05`; this backport aligns `main` documentation with the same neutral Nemotron Parse positioning.

## Test plan

- [ ] Review rendered FAQ and prerequisites-support-matrix pages on `main`
- [ ] Confirm no remaining “higher-accuracy” / “maximally accurate” Nemotron Parse claims in the changed files