### PR TITLE
Add stable HF PyPI release dispatch

### DIFF
--- a/.github/workflows/huggingface-nightly.yml
+++ b/.github/workflows/huggingface-nightly.yml
@@ -20,6 +20,27 @@ on:
         required: true
         default: true
         type: boolean
+      package:
+        description: "Package to build (stable releases must select a single package)"
+        required: true
+        default: "all"
+        type: choice
+        options:
+          - all
+          - nemotron-ocr-v2
+      release_type:
+        description: "Version mode"
+        required: true
+        default: "nightly"
+        type: choice
+        options:
+          - nightly
+          - stable
+      release_version:
+        description: "Stable PyPI version when release_type=stable (for example: 2.0.0)"
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -34,10 +55,33 @@ jobs:
       nightly_date_suffix: ${{ steps.suffix.outputs.nightly_date_suffix }}
     steps:
       - id: suffix
-        run: echo "nightly_date_suffix=$(date -u +%Y%m%d%H%M%S)" >> "$GITHUB_OUTPUT"
+        shell: bash
+        env:
+          INPUT_PACKAGE: ${{ inputs.package }}
+          INPUT_RELEASE_TYPE: ${{ inputs.release_type }}
+          INPUT_RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [[ "${INPUT_RELEASE_TYPE}" == "stable" ]]; then
+              if [[ -z "${INPUT_RELEASE_VERSION}" ]]; then
+                echo "::error::release_version is required when release_type=stable"
+                exit 1
+              fi
+              if [[ "${INPUT_PACKAGE}" == "all" ]]; then
+                echo "::error::Stable releases must select a single package"
+                exit 1
+              fi
+            elif [[ -n "${INPUT_RELEASE_VERSION}" ]]; then
+              echo "::error::release_version is only valid when release_type=stable"
+              exit 1
+            fi
+          fi
+          echo "nightly_date_suffix=$(date -u +%Y%m%d%H%M%S)" >> "$GITHUB_OUTPUT"
 
   build:
     needs: nightly_coordinate
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.package == 'all' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -130,6 +174,7 @@ jobs:
 
   build_ocr_cuda:
     needs: nightly_coordinate
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.package == 'all' || inputs.package == 'nemotron-ocr-v2' }}
     # Nemotron OCR packages need nvcc/CUDA headers to build their extension.
     # Build with Python 3.12 to match upstream package constraints and
     # avoid producing an extension for the wrong Python ABI.
@@ -203,6 +248,8 @@ jobs:
           BUILD_CPP_FORCE: "1"
           OCR_TORCH_VERSION: "2.11.0"
           OCR_TORCHVISION_VERSION: "0.26.0"
+          INPUT_RELEASE_TYPE: ${{ inputs.release_type }}
+          INPUT_RELEASE_VERSION: ${{ inputs.release_version }}
           TORCH_CUDA_ARCH_LIST: "8.0;8.6;8.9;9.0;10.0;12.0+PTX"
           PIP_EXTRA_INDEX_URL: "https://download.pytorch.org/whl/cu130"
         shell: bash
@@ -234,6 +281,15 @@ jobs:
             arch_env_arg="--build-env ARCH=arm64"
           fi
 
+          release_type="nightly"
+          expected_version="${{ matrix.ocr.nightly_base_version }}.dev"
+          version_args=(--nightly-base-version "${{ matrix.ocr.nightly_base_version }}")
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${INPUT_RELEASE_TYPE}" == "stable" ]]; then
+            release_type="stable"
+            expected_version="${INPUT_RELEASE_VERSION}"
+            version_args=(--release-version "${INPUT_RELEASE_VERSION}")
+          fi
+
           python --version
           python -m pip install "packaging>=24"
           python ci/scripts/nightly_build_publish.py \
@@ -242,7 +298,7 @@ jobs:
             --work-dir ".work" \
             --dist-dir "dist-out" \
             --project-subdir "nemotron-ocr" \
-            --nightly-base-version "${{ matrix.ocr.nightly_base_version }}" \
+            "${version_args[@]}" \
             --hatch-force-platform-wheel \
             --auditwheel-repair \
             --auditwheel-exclude libtorch_cpu.so \
@@ -267,6 +323,8 @@ jobs:
             --token-env "${token_env}" \
             ${skip_existing_flag}
 
+          export EXPECTED_OCR_VERSION="${expected_version}"
+          export OCR_RELEASE_TYPE="${release_type}"
           python - <<'PY'
           import os
           import sys
@@ -286,7 +344,8 @@ jobs:
           py_tag = f"cpython-{sys.version_info.major}{sys.version_info.minor}"
           expected_project = "nemotron-ocr"
           expected_package = "nemotron_ocr"
-          expected_version_prefix = "${{ matrix.ocr.nightly_base_version }}.dev"
+          expected_version = os.environ["EXPECTED_OCR_VERSION"]
+          release_type = os.environ["OCR_RELEASE_TYPE"]
           expected_runtime_dependencies = {
               "torch": f"~={os.environ['OCR_TORCH_VERSION']}",
               "torchvision": f"~={os.environ['OCR_TORCHVISION_VERSION']}",
@@ -322,11 +381,20 @@ jobs:
                   names = zf.namelist()
                   metadata_names = [n for n in names if n.endswith(".dist-info/METADATA")]
                   metadata = "\n".join(zf.read(n).decode("utf-8") for n in metadata_names)
+              metadata_message = Parser().parsestr(metadata)
               if f"Name: {expected_project}" not in metadata:
                   raise SystemExit(f"Built wheel metadata does not declare project {expected_project!r}")
-              if f"Version: {expected_version_prefix}" not in metadata:
+              metadata_version = metadata_message.get("Version")
+              if release_type == "stable" and metadata_version != expected_version:
                   raise SystemExit(
-                      f"Built wheel metadata does not declare a {expected_version_prefix} nightly"
+                      "Built wheel metadata does not declare expected version "
+                      f"{expected_version!r}; got {metadata_version!r}"
+                  )
+              if release_type != "stable" and not (
+                  metadata_version and metadata_version.startswith(expected_version)
+              ):
+                  raise SystemExit(
+                      f"Built wheel metadata does not declare a {expected_version} nightly"
                   )
               if not any(name.startswith(f"{expected_package}/") for name in names):
                   raise SystemExit(f"Built wheel is missing {expected_package} package")

--- a/.gitignore
+++ b/.gitignore
@@ -272,3 +272,6 @@ nemo_retriever/tabular-dev-tools/benchmarks/**/*.sql
 nemo_retriever/tabular-dev-tools/benchmarks/**/*.json
 
 spool/
+
+# Local git worktrees
+.worktrees/

--- a/ci/scripts/nightly_build_publish.py
+++ b/ci/scripts/nightly_build_publish.py
@@ -135,10 +135,35 @@ def _pep440_nightly(base_version: str, suffix: str) -> str:
     return f"{base}.dev{suffix}"
 
 
+def _pep440_stable_release(version: str) -> str:
+    version = version.strip()
+    if not re.fullmatch(r"\d+(?:\.\d+)*(?:\.post\d+)?", version):
+        raise ValueError(
+            "--release-version must be a stable public version like '2.0.0' "
+            "or '2.0.0.post1' (no dev, pre-release, local, or whitespace suffixes)"
+        )
+    return version
+
+
+def _target_version(
+    old_version: str,
+    *,
+    nightly_base_version: str | None = None,
+    release_version: str | None = None,
+) -> str:
+    if release_version is not None:
+        return _pep440_stable_release(release_version)
+    return _pep440_nightly(
+        nightly_base_version or old_version,
+        _nightly_suffix(),
+    )
+
+
 def _patch_pyproject_version(
     repo_dir: Path,
     *,
     nightly_base_version: str | None = None,
+    release_version: str | None = None,
 ) -> bool:
     pyproject = repo_dir / "pyproject.toml"
     if not pyproject.exists():
@@ -151,9 +176,10 @@ def _patch_pyproject_version(
         return False
 
     old_version = m.group(1)
-    new_version = _pep440_nightly(
-        nightly_base_version or old_version,
-        _nightly_suffix(),
+    new_version = _target_version(
+        old_version,
+        nightly_base_version=nightly_base_version,
+        release_version=release_version,
     )
     if new_version == old_version:
         return False
@@ -437,6 +463,7 @@ def _patch_setup_cfg_version(
     repo_dir: Path,
     *,
     nightly_base_version: str | None = None,
+    release_version: str | None = None,
 ) -> bool:
     setup_cfg = repo_dir / "setup.cfg"
     if not setup_cfg.exists():
@@ -449,9 +476,10 @@ def _patch_setup_cfg_version(
         return False
 
     old_version = m.group(1).strip().strip('"').strip("'")
-    new_version = _pep440_nightly(
-        nightly_base_version or old_version,
-        _nightly_suffix(),
+    new_version = _target_version(
+        old_version,
+        nightly_base_version=nightly_base_version,
+        release_version=release_version,
     )
     if new_version == old_version:
         return False
@@ -724,6 +752,12 @@ def main() -> int:
         "(e.g. build 1.0.2.devYYYYMMDD from a source tree still declaring 1.0.0).",
     )
     ap.add_argument(
+        "--release-version",
+        default=None,
+        help="Patch the source project to this exact stable public version before building "
+        "(e.g. '2.0.0'). Mutually exclusive with --nightly-base-version.",
+    )
+    ap.add_argument(
         "--project-name",
         default=None,
         help="Patch the source Python project/distribution name before building "
@@ -797,6 +831,8 @@ def main() -> int:
         "Use for runtime deps like libtorch_cpu.so that should not be vendored.",
     )
     args = ap.parse_args()
+    if args.release_version is not None and args.nightly_base_version:
+        ap.error("--release-version cannot be used with --nightly-base-version")
 
     root = Path.cwd()
     work_root = root / args.work_dir
@@ -811,7 +847,8 @@ def main() -> int:
     print(f"=== Cloning {args.repo_url} -> {repo_dir} ===")
     _clone_repo(args.repo_url, repo_dir)
 
-    print("=== Attempting nightly version patch ===")
+    version_mode = "release" if args.release_version is not None else "nightly"
+    print(f"=== Attempting {version_mode} version patch ===")
     if not args.project_subdir:
         detected = _auto_project_subdir(repo_dir, args.repo_id)
         if detected:
@@ -821,9 +858,11 @@ def main() -> int:
     patched = _patch_pyproject_version(
         project_dir,
         nightly_base_version=args.nightly_base_version,
+        release_version=args.release_version,
     ) or _patch_setup_cfg_version(
         project_dir,
         nightly_base_version=args.nightly_base_version,
+        release_version=args.release_version,
     )
     if not patched:
         print("No static version field found to patch (continuing).")

--- a/ci/tests/test_huggingface_release_workflow.py
+++ b/ci/tests/test_huggingface_release_workflow.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_nightly_build_publish_module() -> ModuleType:
+    script_path = REPO_ROOT / "ci" / "scripts" / "nightly_build_publish.py"
+    spec = importlib.util.spec_from_file_location("nightly_build_publish", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_nightly_builder_can_patch_exact_release_version_in_pyproject(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    pyproject = project_dir / "pyproject.toml"
+    pyproject.write_text(
+        """
+[build-system]
+requires = ["hatchling"]
+
+[project]
+name = "example"
+version = "2.0.0.dev20260520010101"
+""".lstrip(),
+        encoding="utf-8",
+    )
+    nightly_build_publish = _load_nightly_build_publish_module()
+
+    assert nightly_build_publish._patch_pyproject_version(project_dir, release_version="2.0.0")
+
+    assert 'version = "2.0.0"' in pyproject.read_text(encoding="utf-8")
+
+
+def test_nightly_builder_can_patch_exact_release_version_in_setup_cfg(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    setup_cfg = project_dir / "setup.cfg"
+    setup_cfg.write_text(
+        """
+[metadata]
+name = example
+version = 2.0.0.dev20260520010101
+""".lstrip(),
+        encoding="utf-8",
+    )
+    nightly_build_publish = _load_nightly_build_publish_module()
+
+    assert nightly_build_publish._patch_setup_cfg_version(project_dir, release_version="2.0.0")
+
+    assert "version = 2.0.0" in setup_cfg.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["", "2.0.0a1", "2.0.0rc1", "2.0.0+local", "2.0.0.dev1"],
+)
+def test_nightly_builder_rejects_non_stable_release_versions(version: str) -> None:
+    nightly_build_publish = _load_nightly_build_publish_module()
+
+    with pytest.raises(ValueError, match="--release-version must be a stable public version"):
+        nightly_build_publish._pep440_stable_release(version)
+
+
+def test_nightly_builder_rejects_empty_release_version_with_nightly_base(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    nightly_build_publish = _load_nightly_build_publish_module()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "nightly_build_publish.py",
+            "--repo-id",
+            "example",
+            "--repo-url",
+            "https://huggingface.co/nvidia/example",
+            "--nightly-base-version",
+            "2.0.0",
+            "--release-version",
+            "",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        nightly_build_publish.main()
+
+    assert exc_info.value.code == 2
+
+
+def test_huggingface_workflow_has_manual_stable_ocr_release_controls() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "huggingface-nightly.yml").read_text(encoding="utf-8")
+
+    assert "package:" in workflow
+    assert "release_type:" in workflow
+    assert "release_version:" in workflow
+    assert "Stable releases must select a single package" in workflow
+    assert "--release-version" in workflow
+    assert 'expected_version="${INPUT_RELEASE_VERSION}"' in workflow
+    assert "Built wheel metadata does not declare expected version" in workflow


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

Adds a stable release mode to the Hugging Face package workflow so maintainers can manually dispatch an OCR v2 PyPI release without producing a `2.0.0.dev*` version.

- Adds `package`, `release_type`, and `release_version` workflow dispatch inputs.
- Requires stable releases to select a single package and provide an exact version.
- Teaches `ci/scripts/nightly_build_publish.py` to patch exact stable versions via `--release-version`.
- Keeps nightly behavior unchanged and adds focused tests for the release-version path.

Dry-run workflow dispatch with `upload_to=none`: https://github.com/NVIDIA/NeMo-Retriever/actions/runs/26187815548

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
