### PR TITLE
Add PR install smoke for Windows and macOS

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -52,6 +52,46 @@ jobs:
           python -c "import importlib.util; import sys; sys.exit(0 if importlib.util.find_spec('tritonclient') is None else 1)"
           python -m pytest tests/test_slim_imports_no_triton.py -q
 
+  # Keep Windows/macOS library-mode installation covered in PRs without running secret-backed ingest.
+  library-mode-install:
+    name: Library mode install (${{ matrix.os-label }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-latest
+            os-label: windows-x64
+          - runner: macos-26
+            os-label: macos-arm64
+          - runner: macos-26-intel
+            os-label: macos-x64
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Install nemo-retriever and dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv pip install --system -e "nemo_retriever"
+
+      - name: Smoke-test installed package
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip check
+          python -c "import importlib.metadata as metadata; print('nemo-retriever', metadata.version('nemo-retriever'))"
+          retriever --help
+
   # Docker build + test for x86_64 (single job so built image is available locally)
   docker-build-and-test:
     name: Build & Test Docker (amd64)
@@ -73,6 +113,7 @@ jobs:
     needs:
       - pre-commit
       - slim-import-contract
+      - library-mode-install
       - docker-build-and-test
     runs-on: ubuntu-latest
     if: always()
@@ -81,6 +122,7 @@ jobs:
         run: |
           if [[ "${{ needs.pre-commit.result }}" != "success" ]] || \
              [[ "${{ needs.slim-import-contract.result }}" != "success" ]] || \
+             [[ "${{ needs.library-mode-install.result }}" != "success" ]] || \
              [[ "${{ needs.docker-build-and-test.result }}" != "success" ]]; then
             echo "One or more required jobs failed"
             exit 1


### PR DESCRIPTION
## Description
Adds an install-only Windows/macOS matrix job to PR validation, mirroring the existing nightly library-mode platform coverage without running secret-backed ingest.

The new PR job:
- installs `nemo-retriever` with `uv pip install --system -e "nemo_retriever"`
- runs `python -m pip check`
- verifies package metadata can be read
- runs `retriever --help` as a CLI smoke test
- feeds into the PR validation summary gate

No `secrets.*`, `NVIDIA_API_KEY`, `NGC_API_KEY`, or ingest integration steps are used in the PR path.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file. (Not applicable.)

Validation:
- `python -c "import yaml; ..."` structure check for the new workflow job and summary dependency
- `python - <<'PY' ...` no-secret/install-smoke contract check
- `git diff --check`
