### PR TITLE
Bump OCR nightly train and relax retriever pin

### DIFF
--- a/.github/workflows/huggingface-nightly.yml
+++ b/.github/workflows/huggingface-nightly.yml
@@ -194,7 +194,7 @@ jobs:
         ocr:
           - id: nemotron-ocr-v2
             url: https://huggingface.co/nvidia/nemotron-ocr-v2
-            nightly_base_version: "2.0.0"
+            nightly_base_version: "2.0.1"
     container:
       image: ${{ matrix.platform.cuda_image }}
     steps:

--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -112,8 +112,8 @@ local = [
   "nemotron-page-elements-v3>=0.dev0",
   "nemotron-graphic-elements-v1>=0.dev0",
   "nemotron-table-structure-v1>=0.dev0",
-  # Stay on the 2.0.0 OCR dev train and exclude older PyPI finals.
-  "nemotron-ocr>=2.0.0.dev0,<2.0.0a0; sys_platform == 'linux' and (platform_machine == 'x86_64' or platform_machine == 'aarch64')",
+  # Accept the 2.0.0 stable release and newer OCR dev/final trains.
+  "nemotron-ocr>=2.0.0.dev0; sys_platform == 'linux' and (platform_machine == 'x86_64' or platform_machine == 'aarch64')",
   "nvidia-ml-py",
   "apscheduler>=3.10",
   "psutil>=5.9.0",

--- a/nemo_retriever/src/nemo_retriever/model/local/nemotron_ocr_v2.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/nemotron_ocr_v2.py
@@ -57,7 +57,7 @@ class NemotronOCRV2(BaseModel):
         except ImportError as exc:
             raise ImportError(
                 "Local Nemotron OCR v2 requires the `nemotron_ocr` package. "
-                "Install `nemotron-ocr` 2.0 nightlies from TestPyPI, or install from source via: "
+                "Install `nemotron-ocr` 2.0.0 or newer, or install from source via: "
                 "git clone https://huggingface.co/nvidia/nemotron-ocr-v2 && "
                 "cd nemotron-ocr-v2/nemotron-ocr && pip install --no-build-isolation -v . "
                 "Alternatively, run with --ocr-invoke-url pointed at a v2 endpoint. "

--- a/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
+++ b/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from types import ModuleType
 
 import pytest
+from packaging.requirements import Requirement
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -64,17 +65,24 @@ def _install_upstream_ocr_v2_stub(monkeypatch: pytest.MonkeyPatch) -> list[dict[
     return captured_kwargs
 
 
-def test_local_extra_depends_on_ocr_2_nightly_only() -> None:
+def test_local_extra_accepts_stable_ocr_2_and_newer_dev_releases() -> None:
     pyproject = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     local_deps = pyproject["project"]["optional-dependencies"]["local"]
     uv_tool = pyproject["tool"]["uv"]
     uv_sources = uv_tool["sources"]
 
-    assert (
-        "nemotron-ocr>=2.0.0.dev0,<2.0.0a0; sys_platform == 'linux' "
-        "and (platform_machine == 'x86_64' or platform_machine == 'aarch64')"
-    ) in local_deps
+    ocr_dep = next(dep for dep in local_deps if dep.startswith("nemotron-ocr"))
+    ocr_requirement = Requirement(ocr_dep)
+
+    assert str(ocr_requirement.specifier) == ">=2.0.0.dev0"
+    assert ocr_requirement.specifier.contains("2.0.0")
+    assert ocr_requirement.specifier.contains("2.0.1.dev20260521010101")
+    assert ocr_requirement.specifier.contains("2.0.1")
+    assert not ocr_requirement.specifier.contains("1.0.1")
+    assert str(ocr_requirement.marker) == (
+        'sys_platform == "linux" and (platform_machine == "x86_64" or platform_machine == "aarch64")'
+    )
     assert not any(dep.startswith("nemotron-ocr-v2") for dep in local_deps)
     assert "nemotron-ocr" in uv_tool["no-build-package"]
     assert "nemotron-ocr-v2" not in uv_tool["no-build-package"]
@@ -160,7 +168,7 @@ def test_huggingface_ocr_nightly_does_not_carry_namespace_patch_knobs() -> None:
     v2_stanza = workflow.split("- id: nemotron-ocr-v2", 1)[1].split("container:", 1)[0]
 
     assert "nemotron-ocr-v1" not in workflow
-    assert 'nightly_base_version: "2.0.0"' in v2_stanza
+    assert 'nightly_base_version: "2.0.1"' in v2_stanza
     assert "project_name:" not in workflow
     assert "package_rename:" not in workflow
     assert "expected_project_name:" not in workflow

--- a/nemo_retriever/uv.lock
+++ b/nemo_retriever/uv.lock
@@ -2578,7 +2578,7 @@ requires-dist = [
     { name = "markitdown" },
     { name = "nemo-retriever", extras = ["benchmarks", "llm", "local", "multimedia", "nemotron-parse", "service", "tabular"], marker = "extra == 'all'" },
     { name = "nemotron-graphic-elements-v1", marker = "extra == 'local'", specifier = ">=0.dev0", index = "https://test.pypi.org/simple/" },
-    { name = "nemotron-ocr", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'local') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'local')", specifier = ">=2.0.0.dev0,<2.0.0a0", index = "https://test.pypi.org/simple/" },
+    { name = "nemotron-ocr", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'local') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'local')", specifier = ">=2.0.0.dev0", index = "https://test.pypi.org/simple/" },
     { name = "nemotron-page-elements-v3", marker = "extra == 'local'", specifier = ">=0.dev0", index = "https://test.pypi.org/simple/" },
     { name = "nemotron-table-structure-v1", marker = "extra == 'local'", specifier = ">=0.dev0", index = "https://test.pypi.org/simple/" },
     { name = "neo4j", marker = "extra == 'tabular'", specifier = ">=5.0" },


### PR DESCRIPTION
## Description

Bump the `nemotron-ocr-v2` nightly build train to `2.0.1` now that `2.0.0` has been published as a stable PyPI release.

Relax the Retriever `local` extra dependency from the old `2.0.0.dev*`-only window to accept `nemotron-ocr` `2.0.0` and newer dev/final trains. The lockfile metadata and OCR v2 install guidance are updated to match.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file. N/A.
