### PR TITLE
Skip workflow tests in Docker image

### DIFF
--- a/nemo_retriever/tests/test_ci_workflows.py
+++ b/nemo_retriever/tests/test_ci_workflows.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 import yaml
 
 
@@ -7,6 +8,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = REPO_ROOT / ".github" / "workflows"
 REUSABLE_PRE_COMMIT = "./.github/workflows/reusable-pre-commit.yml"
 REUSABLE_DOCKER_BUILD_AND_TEST = "./.github/workflows/reusable-docker-build-and-test.yml"
+
+pytestmark = pytest.mark.skipif(
+    not WORKFLOWS.exists(),
+    reason="Workflow files are not present in the Docker image test environment.",
+)
 
 
 def _load_workflow(name):


### PR DESCRIPTION
## Description
Follow-up to #2084. The merge push showed Main Branch CI now reaches the reusable Docker build/test job, but the newly added workflow regression tests fail inside the service Docker image because that image intentionally contains `data/` and `nemo_retriever/`, not `.github/workflows/`.

This keeps the workflow regression tests active in normal checkout-based unit CI, while skipping them in Docker-image test environments where the workflow files are not part of the image.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file. Not applicable; no docker-compose or Helm environment variables changed.

Validation:
- `nemo_retriever/.venv/bin/python -m pytest nemo_retriever/tests/test_ci_workflows.py -q` -> 4 passed
- `git diff --check` -> clean
