### PR TITLE
mark non-ingest/query/pipeline retriever subcommands as experimental (NVBugs 6199005, 6198526)

### DIFF
--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -7,6 +7,21 @@ live under `docs/`, `api/`, `client/`, and `deploy/` in older repository layouts
 The historical CLI documentation is **not removed** from the ecosystem — these files sit
 alongside it as a new-CLI counterpart you can link to or migrate to.
 
+## Supported vs development / experimental subcommands
+
+For product use and published examples, treat only these top-level subcommands as
+**supported**:
+
+- **`retriever ingest`** — ingest documents into LanceDB
+- **`retriever query`** — query an existing LanceDB table
+- **`retriever pipeline`** — run the graph ingestion pipeline (for example `retriever pipeline run`)
+
+Any other top-level `retriever` subcommand — including but not limited to `pdf`, `html`,
+`txt`, `audio`, `chart`, `benchmark`, `harness`, `eval`, `recall`, `service`, `local`,
+`compare`, `image`, and `skill-eval` — is **development and experimental**. These commands
+may change or be removed without notice and **carry no compatibility, stability, or
+behavior guarantees**.
+
 ## Key shape difference
 
 The legacy **ingestion-service** CLI was a **single command that talks to a running REST service on
@@ -29,6 +44,9 @@ to Parquet / object storage. Other subcommands cover focused tasks:
 | Benchmark stage throughput | `retriever benchmark {split,extract,audio-extract,page-elements,ocr,all}` |
 | Benchmark orchestration | `retriever harness {run,sweep,nightly,summary,compare}` |
 
+Rows that use subcommands other than `ingest`, `query`, or `pipeline` are
+[development and experimental](#supported-vs-development--experimental-subcommands).
+
 ## Contents
 
 | Topic | Location | Replaces example(s) in |
@@ -40,6 +58,9 @@ to Parquet / object storage. Other subcommands cover focused tasks:
 | Benchmarking | [`benchmarking.md`](benchmarking.md) | `docs/docs/extraction/benchmarking.md` and `tools/harness/README.md` |
 
 <!-- --8<-- [start:quickstart] -->
+
+> Only `retriever ingest`, `retriever query`, and `retriever pipeline` are supported for
+> product use; see [Supported vs development / experimental subcommands](#supported-vs-development--experimental-subcommands).
 
 ## Quick start
 
@@ -143,8 +164,10 @@ hits = retriever.query(
 
 ## CLI reference
 
-`retriever` is the Typer app installed with the `nemo-retriever` package. Document
-ingestion is usually `retriever pipeline run INPUT_PATH`, which runs the graph pipeline
+`retriever` is the Typer app installed with the `nemo-retriever` package. Subcommand
+support policy: [Supported vs development / experimental subcommands](#supported-vs-development--experimental-subcommands).
+
+Document ingestion is usually `retriever pipeline run INPUT_PATH`, which runs the graph pipeline
 locally (in-process or Ray) and writes rows to LanceDB and optional Parquet.
 
 ```bash

--- a/nemo_retriever/docs/cli/benchmarking.md
+++ b/nemo_retriever/docs/cli/benchmarking.md
@@ -113,8 +113,9 @@ Each benchmark reports rows/sec (or chunk rows/sec for audio) for its actor.
   `nemo_retriever/harness/test_configs.yaml`.
 - **Datasets:** names like `bo767` and `jp20` exist in both configs but paths and
   defaults may differ; check the YAML for each stack.
-- **Launcher:** prefer `retriever harness run …` for new work; use
-  `nv_ingest_harness` only when you still depend on `--case` or `--managed` behavior
-  documented in `tools/harness/README.md`.
+- **Launcher:** for internal benchmarking, `retriever harness run …` is the
+  retriever-CLI entry point (development / experimental; no guarantees). Use
+  `nv_ingest_harness` when you still depend on `--case` or `--managed` behavior in
+  `tools/harness/README.md`.
 - **Stage benchmarks:** `retriever benchmark …` is specific to the retriever CLI and
   has no legacy service-CLI equivalent.

--- a/nemo_retriever/docs/cli/benchmarking.md
+++ b/nemo_retriever/docs/cli/benchmarking.md
@@ -1,5 +1,8 @@
 # Benchmarking with the `retriever` CLI
 
+`retriever benchmark` and `retriever harness` are development and experimental subcommands
+with no guarantees — see [Supported vs development / experimental subcommands](README.md#supported-vs-development--experimental-subcommands).
+
 This page covers benchmark workflows for NeMo Retriever Library. See also
 `docs/docs/extraction/benchmarking.md`, [`tools/harness/README.md`](../../../tools/harness/README.md)
 (legacy integration harness), and [`nemo_retriever/harness/HANDOFF.md`](../../harness/HANDOFF.md)
@@ -14,7 +17,7 @@ There are two harness stacks:
 
 The `retriever` CLI also exposes per-stage `retriever benchmark …` micro-benchmarks.
 
-## Retriever harness (recommended)
+## Retriever harness (development / experimental)
 
 Run from the repository root (or any directory; pass `--config` if needed). Uses
 `--dataset` and `--preset` — there is no `--case` flag on this harness.


### PR DESCRIPTION
## Summary

Documents which `retriever` CLI subcommands are supported for product use versus development and experimental tooling. Addresses [NVBug 6199005](https://nvbugs/6199005) and [NVBug 6198526](https://nvbugs/6198526).

- **Supported:** `retriever ingest`, `retriever query`, and `retriever pipeline` (including `retriever pipeline run`).
- **Development / experimental (no guarantees):** all other top-level subcommands (for example `pdf`, `html`, `benchmark`, `harness`, `eval`, `recall`, `service`, `local`).

Changes follow 26.05 doc rules: the full policy lives once in `nemo_retriever/docs/cli/README.md`; the quickstart snippet, CLI reference, legacy mapping table, and `benchmarking.md` use a one-line pointer plus link. The harness section heading no longer says “recommended.”

## Files changed

| File | Change |
|------|--------|
| `nemo_retriever/docs/cli/README.md` | Owning “Supported vs development / experimental subcommands” section; quickstart and CLI reference links |
| `nemo_retriever/docs/cli/benchmarking.md` | One-line policy link; harness heading labeled experimental |


