### PR TITLE
Tune single-GPU embed resource heuristic

### DIFF
--- a/nemo_retriever/src/nemo_retriever/utils/ray_resource_hueristics.py
+++ b/nemo_retriever/src/nemo_retriever/utils/ray_resource_hueristics.py
@@ -22,6 +22,8 @@ EMBED_MAX_ACTORS = 4  # Hueristic baseline num actors per GPU (max_size of Actor
 EMBED_GPUS_PER_ACTOR = (
     0.5  # Hueristic baseline num GPUs per actor. Used to determine which GPU to schedule the actor on.
 )
+EMBED_SINGLE_GPU_ACTORS = 1
+EMBED_SINGLE_GPU_GPUS_PER_ACTOR = 0.2
 EMBED_BATCH_SIZE = 256  # Ray batch size AND EMBEDDING inference batch size
 
 # Nemotron Parse Actor constants (PER-GPU)
@@ -601,6 +603,20 @@ def resolve_requested_plan(
     embed_max_actors = _resolve_int_actors(override_embed_max_actors, EMBED_MAX_ACTORS, True)
     embed_gpus_per_actor = _resolve_float_actors(override_embed_gpus_per_actor, EMBED_GPUS_PER_ACTOR, False)
     embed_batch_size = _resolve_int(override_embed_batch_size, EMBED_BATCH_SIZE, False)
+
+    # The local vLLM embedder manages batching internally and uses substantial
+    # GPU memory. On single-GPU batch pipelines, one smaller GPU reservation
+    # prevents the embed stage from crowding OCR/page-elements actors while
+    # still allowing the embedder to run on CUDA.
+    if available_gpu_count == 1:
+        if override_embed_initial_actors is None:
+            embed_initial_actors = EMBED_SINGLE_GPU_ACTORS
+        if override_embed_min_actors is None:
+            embed_min_actors = EMBED_SINGLE_GPU_ACTORS
+        if override_embed_max_actors is None:
+            embed_max_actors = EMBED_SINGLE_GPU_ACTORS
+        if override_embed_gpus_per_actor is None:
+            embed_gpus_per_actor = EMBED_SINGLE_GPU_GPUS_PER_ACTOR
 
     nemotron_parse_initial_actors = _resolve_int_actors(
         override_nemotron_parse_initial_actors, NEMOTRON_PARSE_INITIAL_ACTORS, True

--- a/nemo_retriever/src/nemo_retriever/utils/ray_resource_hueristics.py
+++ b/nemo_retriever/src/nemo_retriever/utils/ray_resource_hueristics.py
@@ -22,8 +22,8 @@ EMBED_MAX_ACTORS = 4  # Hueristic baseline num actors per GPU (max_size of Actor
 EMBED_GPUS_PER_ACTOR = (
     0.5  # Hueristic baseline num GPUs per actor. Used to determine which GPU to schedule the actor on.
 )
-EMBED_SINGLE_GPU_ACTORS = 1
-EMBED_SINGLE_GPU_GPUS_PER_ACTOR = 0.2
+EMBED_SINGLE_GPU_ACTORS = 1  # Single-GPU heuristic: one actor avoids over-reserving the GPU for embedding.
+EMBED_SINGLE_GPU_GPUS_PER_ACTOR = 0.2  # Single-GPU heuristic: smaller reservation leaves headroom for OCR/page-elements actors.
 EMBED_BATCH_SIZE = 256  # Ray batch size AND EMBEDDING inference batch size
 
 # Nemotron Parse Actor constants (PER-GPU)

--- a/nemo_retriever/tests/test_resource_heuristics.py
+++ b/nemo_retriever/tests/test_resource_heuristics.py
@@ -154,10 +154,27 @@ def test_resolve_requested_plan_defaults_with_2_gpus() -> None:
 def test_resolve_requested_plan_defaults_with_1_gpu() -> None:
     plan = rh.resolve_requested_plan(cluster_resources=_make_cluster(total_gpu=1))
 
-    assert plan.embed_initial_actors == rh.EMBED_INITIAL_ACTORS
-    assert plan.embed_max_actors == rh.EMBED_MAX_ACTORS
+    assert plan.embed_initial_actors == rh.EMBED_SINGLE_GPU_ACTORS
+    assert plan.embed_min_actors == rh.EMBED_SINGLE_GPU_ACTORS
+    assert plan.embed_max_actors == rh.EMBED_SINGLE_GPU_ACTORS
+    assert plan.embed_gpus_per_actor == rh.EMBED_SINGLE_GPU_GPUS_PER_ACTOR
     assert plan.ocr_initial_actors == rh.OCR_INITIAL_ACTORS
     assert plan.page_elements_initial_actors == rh.PAGE_ELEMENTS_INITIAL_ACTORS
+
+
+def test_resolve_requested_plan_single_gpu_embed_overrides_win() -> None:
+    plan = rh.resolve_requested_plan(
+        cluster_resources=_make_cluster(total_gpu=1),
+        override_embed_initial_actors=2,
+        override_embed_min_actors=2,
+        override_embed_max_actors=3,
+        override_embed_gpus_per_actor=0.5,
+    )
+
+    assert plan.embed_initial_actors == 2
+    assert plan.embed_min_actors == 2
+    assert plan.embed_max_actors == 3
+    assert plan.embed_gpus_per_actor == 0.5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
NOTE: general perf bump, not too worried about this functionality for 26.05 release. PR against main 

## Description

- Tune the default local embedding resource plan for single-GPU batch ingest.
- Use one embedding actor with a 0.2 GPU Ray reservation on single-GPU systems.
- Keep multi-GPU defaults unchanged.
- Preserve explicit `--embed-workers` and `--embed-gpus-per-actor` overrides.

## Motivation

On a single H100 NVL, the previous default local embedding plan used two embedding actors at 0.5 GPU each. In `retriever ingest --run-mode batch`, that shape can over-reserve the single GPU for embedding and reduce scheduler room for the rest of the local pipeline.

Empirically, one local vLLM embedding actor with a 0.2 GPU reservation kept the GPU busier and improved end-to-end ingest time while producing the same LanceDB output row count.

Measured on the same machine:

| Dataset | Prior default | Tuned setting | Result |
| --- | ---: | ---: | --- |
| jp20 | 168.4s | 150.8s | ~10.4% faster |
| bo767 | 3631.8s | 2069.7s | ~43.0% faster |

For bo767, LanceDB row count remained `79978`, with `dropped_no_embedding=0` and the same `dropped_bad_length=64` pattern as the prior run. Average GPU utilization increased from ~38.8% to ~65.6%.

## Implementation

This keeps the existing heuristic model intact:

- the change is isolated to `resolve_requested_plan()`;
- it only applies when `available_gpu_count == 1`;
- multi-GPU defaults continue to use the existing per-GPU scaling;
- explicit embed worker/GPU overrides still win.

## Validation

- `uv run --frozen --extra local --extra dev pytest tests/test_resource_heuristics.py`
## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
