### PR TITLE
Update default judge model to Nemotron Super

### DIFF
--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -362,7 +362,11 @@ Live RAG with scoring and an LLM judge (requires a ground-truth `reference`):
 ```python
 from nemo_retriever.llm import LLMJudge
 
-judge = LLMJudge.from_kwargs(model="nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1")
+judge = LLMJudge.from_kwargs(
+    model="nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5",
+    temperature=0.1,
+    max_tokens=4096,
+)
 result = retriever.answer(
     "What is RAG?",
     llm=llm,

--- a/nemo_retriever/examples/eval_sweep.yaml
+++ b/nemo_retriever/examples/eval_sweep.yaml
@@ -35,24 +35,26 @@ models:
     model: "nvidia_nim/nvidia/nemotron-3-nano-30b-a3b"
     api_key: "${NVIDIA_API_KEY}"
 
-  mixtral-judge:
-    model: "nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1"
+  nemotron-super-judge:
+    model: "nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5"
     api_key: "${NVIDIA_API_KEY}"
+    temperature: 0.1
+    max_tokens: 4096
 
 # Each evaluation picks a generator + judge by name.
 # "runs" is optional (defaults to execution.runs, then 1).
 evaluations:
   - generator: "nemotron-nano-30b"
-    judge: "mixtral-judge"
+    judge: "nemotron-super-judge"
     runs: 1
 
   # Uncomment below to add more evaluations to the sweep.
   # - generator: "generator-b"
-  #   judge: "mixtral-judge"
+  #   judge: "nemotron-super-judge"
   #   runs: 2
   #
   # - generator: "nemotron-super-49b"
-  #   judge: "mixtral-judge"
+  #   judge: "nemotron-super-judge"
   #   runs: 5
 
 execution:

--- a/nemo_retriever/src/nemo_retriever/evaluation/README.md
+++ b/nemo_retriever/src/nemo_retriever/evaluation/README.md
@@ -379,8 +379,10 @@ retriever eval run --from-env
 | `GEN_API_BASE` | _(unset)_ | Override endpoint URL for the generator |
 | `GEN_MODELS` | _(unset)_ | Multi-model sweep: `name:model,...` (overrides `GEN_MODEL`) |
 | `GEN_TEMPERATURE` | `0.0` | Sampling temperature for generator |
-| `JUDGE_MODEL` | `nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1` | Judge model |
+| `JUDGE_MODEL` | `nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5` | Judge model |
 | `JUDGE_API_BASE` | _(unset)_ | Override endpoint URL for the judge |
+| `JUDGE_TEMPERATURE` | `0.1` | Sampling temperature for judge |
+| `JUDGE_MAX_TOKENS` | `4096` | Max tokens for judge JSON output |
 | `LITELLM_DEBUG` | `0` | Set `1` for full request/response logging |
 | `MIN_COVERAGE` | `0.0` | Abort if retrieval covers fewer queries (0.0-1.0, e.g. `0.8`) |
 
@@ -571,7 +573,7 @@ from nemo_retriever.evaluation.scoring_operator import ScoringOperator
 graph = (
     RetrievalLoaderOperator(retrieval_json="retrieval.json", ground_truth_csv="gt.csv")
     >> QAGenerationOperator(model="nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5")
-    >> JudgingOperator(model="nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1")
+    >> JudgingOperator(model="nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5")
     >> ScoringOperator()
 )
 result_df = graph.execute(None)
@@ -702,17 +704,19 @@ models:
     api_base: "https://your-openai-compatible-endpoint/v1"
     api_key: "${GEN_API_KEY}"
 
-  mixtral-judge:
-    model: "nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1"
+  nemotron-super-judge:
+    model: "nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5"
     api_key: "${NVIDIA_API_KEY}"
+    temperature: 0.1
+    max_tokens: 4096
 
 evaluations:
   - generator: "generator-b"
-    judge: "mixtral-judge"
+    judge: "nemotron-super-judge"
     runs: 2
 
   - generator: "generator-a"
-    judge: "mixtral-judge"
+    judge: "nemotron-super-judge"
     runs: 5
 
 execution:
@@ -753,8 +757,10 @@ generators:
     max_tokens: 4096
 
 judge:
-  model: "nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1"
+  model: "nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5"
   api_key: "${NVIDIA_API_KEY}"
+  temperature: 0.1
+  max_tokens: 4096
 
 execution:
   top_k: 5
@@ -883,7 +889,9 @@ llm = LiteLLMClient.from_kwargs(
 )
 
 judge = LLMJudge.from_kwargs(
-    model="nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1",
+    model="nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5",
+    temperature=0.1,
+    max_tokens=4096,
 )
 ```
 

--- a/nemo_retriever/src/nemo_retriever/evaluation/cli.py
+++ b/nemo_retriever/src/nemo_retriever/evaluation/cli.py
@@ -112,7 +112,9 @@ _ENV_DEFAULTS = {
     "GEN_MODEL": "nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5",
     "GEN_MODEL_NAME": "generator",
     "GEN_TEMPERATURE": "0.0",
-    "JUDGE_MODEL": "nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1",
+    "JUDGE_MODEL": "nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5",
+    "JUDGE_TEMPERATURE": "0.1",
+    "JUDGE_MAX_TOKENS": "4096",
     "QA_TOP_K": "5",
     "QA_MAX_WORKERS": "4",
     "QA_LIMIT": "0",
@@ -147,6 +149,8 @@ def _build_env_config() -> tuple[dict, str, str, str, float]:
     gen_temperature = float(os.environ.get("GEN_TEMPERATURE", _ENV_DEFAULTS["GEN_TEMPERATURE"]))
 
     judge_model = os.environ.get("JUDGE_MODEL", _ENV_DEFAULTS["JUDGE_MODEL"])
+    judge_temperature = float(os.environ.get("JUDGE_TEMPERATURE", _ENV_DEFAULTS["JUDGE_TEMPERATURE"]))
+    judge_max_tokens = int(os.environ.get("JUDGE_MAX_TOKENS", _ENV_DEFAULTS["JUDGE_MAX_TOKENS"]))
     judge_api_base = os.environ.get("JUDGE_API_BASE")
     gen_model = os.environ.get("GEN_MODEL", _ENV_DEFAULTS["GEN_MODEL"])
     gen_name = os.environ.get("GEN_MODEL_NAME", _ENV_DEFAULTS["GEN_MODEL_NAME"])
@@ -184,6 +188,8 @@ def _build_env_config() -> tuple[dict, str, str, str, float]:
         "model": judge_model,
         "api_base": judge_api_base,
         "api_key": judge_api_key,
+        "temperature": judge_temperature,
+        "max_tokens": judge_max_tokens,
     }
 
     results_dir = os.environ.get(

--- a/nemo_retriever/src/nemo_retriever/evaluation/config.py
+++ b/nemo_retriever/src/nemo_retriever/evaluation/config.py
@@ -22,13 +22,15 @@ with per-combo run counts::
       nemotron-super:
         model: "nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5"
         api_key: "${NVIDIA_API_KEY}"
-      mixtral-judge:
-        model: "nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1"
+      nemotron-super-judge:
+        model: "nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5"
         api_key: "${NVIDIA_API_KEY}"
+        temperature: 0.1
+        max_tokens: 4096
 
     evaluations:
       - generator: "nemotron-super"
-        judge: "mixtral-judge"
+        judge: "nemotron-super-judge"
         runs: 5
 
     execution:
@@ -44,8 +46,10 @@ auto-normalised internally::
         api_key: "${NVIDIA_API_KEY}"
 
     judge:
-      model: "nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1"
+      model: "nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5"
       api_key: "${NVIDIA_API_KEY}"
+      temperature: 0.1
+      max_tokens: 4096
 
 Environment variables are expanded in string values: ``${VAR}`` resolves
 to ``os.environ["VAR"]`` at load time. Secrets never live in the config.
@@ -323,6 +327,8 @@ def build_eval_chain(
         extra_params=judge_cfg.get("extra_params"),
         num_retries=judge_cfg.get("num_retries", 3),
         timeout=judge_cfg.get("timeout", default_timeout),
+        temperature=judge_cfg.get("temperature"),
+        max_tokens=judge_cfg.get("max_tokens"),
         max_workers=execution.get("max_workers", 8),
     )
 
@@ -394,6 +400,8 @@ def build_eval_pipeline(config: dict) -> "QAEvalPipeline":
         extra_params=judge_cfg.get("extra_params"),
         num_retries=judge_cfg.get("num_retries", 3),
         timeout=judge_cfg.get("timeout", default_timeout),
+        temperature=judge_cfg.get("temperature"),
+        max_tokens=judge_cfg.get("max_tokens"),
     )
 
     return QAEvalPipeline(

--- a/nemo_retriever/src/nemo_retriever/evaluation/judging.py
+++ b/nemo_retriever/src/nemo_retriever/evaluation/judging.py
@@ -29,13 +29,15 @@ class JudgingOperator(EvalOperator):
 
     def __init__(
         self,
-        model: str = "nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1",
+        model: str = "nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5",
         *,
         api_base: Optional[str] = None,
         api_key: Optional[str] = None,
         extra_params: Optional[dict[str, Any]] = None,
         num_retries: int = 3,
         timeout: float = 120.0,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
         max_workers: int = 8,
     ) -> None:
         super().__init__(
@@ -45,6 +47,8 @@ class JudgingOperator(EvalOperator):
             extra_params=extra_params,
             num_retries=num_retries,
             timeout=timeout,
+            temperature=temperature,
+            max_tokens=max_tokens,
             max_workers=max_workers,
         )
         self._judge = LLMJudge.from_kwargs(
@@ -54,6 +58,8 @@ class JudgingOperator(EvalOperator):
             extra_params=extra_params,
             num_retries=num_retries,
             timeout=timeout,
+            temperature=temperature,
+            max_tokens=max_tokens,
         )
         self._max_workers = max_workers
 

--- a/nemo_retriever/src/nemo_retriever/evaluation/runner.py
+++ b/nemo_retriever/src/nemo_retriever/evaluation/runner.py
@@ -125,6 +125,8 @@ def run_eval_sweep(
             api_base=judge_model_cfg.get("api_base"),
             api_key=judge_model_cfg.get("api_key"),
             extra_params=judge_model_cfg.get("extra_params"),
+            temperature=judge_model_cfg.get("temperature"),
+            max_tokens=judge_model_cfg.get("max_tokens"),
             timeout=judge_model_cfg.get("timeout", default_timeout),
         )
 

--- a/nemo_retriever/src/nemo_retriever/llm/clients/judge.py
+++ b/nemo_retriever/src/nemo_retriever/llm/clients/judge.py
@@ -68,13 +68,14 @@ class LLMJudge:
       owns the endpoint, api_key, retries, and timeout for the judge model.
     * ``sampling``: :class:`~nemo_retriever.params.LLMInferenceParams`
       owns ``temperature`` / ``top_p`` / ``max_tokens``. Defaults to
-      ``temperature=0.0, max_tokens=256`` for deterministic scoring.
+      ``temperature=0.1, max_tokens=4096`` for judge consistency on the
+      NVIDIA-hosted Nemotron judge.
 
     Use :meth:`from_kwargs` for a flat, backwards-compatible constructor.
     """
 
-    _DEFAULT_MODEL: str = "nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1"
-    _DEFAULT_SAMPLING: LLMInferenceParams = LLMInferenceParams(temperature=0.0, max_tokens=256)
+    _DEFAULT_MODEL: str = "nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5"
+    _DEFAULT_SAMPLING: LLMInferenceParams = LLMInferenceParams(temperature=0.1, max_tokens=4096)
 
     def __init__(
         self,
@@ -101,11 +102,14 @@ class LLMJudge:
         extra_params: Optional[dict[str, Any]] = None,
         num_retries: int = 3,
         timeout: float = 120.0,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
     ) -> "LLMJudge":
         """Flat-kwarg constructor for zero-churn migration from the old signature.
 
-        Sampling is left at the class default (deterministic 0.0 temperature,
-        256 max tokens). Use the two-arg constructor to override sampling.
+        Sampling is left at the class default unless ``temperature`` or
+        ``max_tokens`` is supplied. Use the two-arg constructor to override
+        the full sampling object.
         """
         transport = LLMRemoteClientParams(
             model=model,
@@ -115,7 +119,14 @@ class LLMJudge:
             timeout=timeout,
             extra_params=extra_params or {},
         )
-        return cls(transport=transport)
+        sampling = None
+        if temperature is not None or max_tokens is not None:
+            sampling = LLMInferenceParams(
+                temperature=cls._DEFAULT_SAMPLING.temperature if temperature is None else temperature,
+                top_p=cls._DEFAULT_SAMPLING.top_p,
+                max_tokens=cls._DEFAULT_SAMPLING.max_tokens if max_tokens is None else max_tokens,
+            )
+        return cls(transport=transport, sampling=sampling)
 
     def judge(self, query: str, reference: str, candidate: str) -> JudgeResult:
         """Score a candidate answer against the reference answer."""
@@ -133,7 +144,7 @@ class LLMJudge:
         ]
 
         try:
-            raw, _ = self._client.complete(messages, max_tokens=256)
+            raw, _ = self._client.complete(messages)
             return _parse_judge_response(raw)
         except Exception as exc:
             return JudgeResult(score=None, reasoning="", error=f"judge_api_error: {exc}")

--- a/nemo_retriever/src/nemo_retriever/skill_eval/cli.py
+++ b/nemo_retriever/src/nemo_retriever/skill_eval/cli.py
@@ -71,11 +71,16 @@ def _build_judge(cfg: dict) -> Optional[Any]:
     except ImportError as exc:
         typer.echo(f"Judge disabled: failed to import LLMJudge ({exc}). Install nemo-retriever[llm].")
         return None
-    judge = LLMJudge.from_kwargs(
-        model=str(judge_cfg.get("model", "nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1")),
-        api_base=judge_cfg.get("api_base"),
-        api_key=api_key,
-    )
+    judge_kwargs: dict[str, Any] = {
+        "model": str(judge_cfg.get("model", "nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5")),
+        "api_base": judge_cfg.get("api_base"),
+        "api_key": api_key,
+    }
+    if judge_cfg.get("temperature") is not None:
+        judge_kwargs["temperature"] = float(judge_cfg["temperature"])
+    if judge_cfg.get("max_tokens") is not None:
+        judge_kwargs["max_tokens"] = int(judge_cfg["max_tokens"])
+    judge = LLMJudge.from_kwargs(**judge_kwargs)
     typer.echo(f"Judge enabled: model={judge.model}")
     return judge
 

--- a/nemo_retriever/src/nemo_retriever/skill_eval/configs/skill_eval.yaml
+++ b/nemo_retriever/src/nemo_retriever/skill_eval/configs/skill_eval.yaml
@@ -87,6 +87,8 @@ conditions:
 # note. Set ``enabled: false`` to opt out explicitly.
 judge:
   enabled: true
-  model: nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1
+  model: nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5
   api_base: https://integrate.api.nvidia.com/v1
   api_key_env: NVIDIA_API_KEY
+  temperature: 0.1
+  max_tokens: 4096

--- a/nemo_retriever/src/nemo_retriever/utils/ray_resource_hueristics.py
+++ b/nemo_retriever/src/nemo_retriever/utils/ray_resource_hueristics.py
@@ -23,7 +23,9 @@ EMBED_GPUS_PER_ACTOR = (
     0.5  # Hueristic baseline num GPUs per actor. Used to determine which GPU to schedule the actor on.
 )
 EMBED_SINGLE_GPU_ACTORS = 1  # Single-GPU heuristic: one actor avoids over-reserving the GPU for embedding.
-EMBED_SINGLE_GPU_GPUS_PER_ACTOR = 0.2  # Single-GPU heuristic: smaller reservation leaves headroom for OCR/page-elements actors.
+EMBED_SINGLE_GPU_GPUS_PER_ACTOR = (
+    0.2  # Single-GPU heuristic: smaller reservation leaves headroom for OCR/page-elements actors.
+)
 EMBED_BATCH_SIZE = 256  # Ray batch size AND EMBEDDING inference batch size
 
 # Nemotron Parse Actor constants (PER-GPU)

--- a/nemo_retriever/tests/test_llm_params.py
+++ b/nemo_retriever/tests/test_llm_params.py
@@ -224,17 +224,17 @@ class TestLiteLLMCompleteCallKwargs:
 
 
 class TestLLMJudgeConstruction:
-    """LLMJudge should default to deterministic sampling and expose .model."""
+    """LLMJudge should use the current Nemotron judge defaults and expose .model."""
 
     def test_structured_construction_uses_defaults(self):
         from nemo_retriever.llm.clients import LLMJudge
         from nemo_retriever.params.models import LLMRemoteClientParams
 
-        transport = LLMRemoteClientParams(model="nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1")
+        transport = LLMRemoteClientParams(model="nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5")
         judge = LLMJudge(transport=transport)
-        assert judge.model == "nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1"
-        assert judge._client.sampling.temperature == 0.0
-        assert judge._client.sampling.max_tokens == 256
+        assert judge.model == "nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5"
+        assert judge._client.sampling.temperature == 0.1
+        assert judge._client.sampling.max_tokens == 4096
 
     def test_custom_sampling_override(self):
         from nemo_retriever.llm.clients import LLMJudge
@@ -262,8 +262,16 @@ class TestLLMJudgeConstruction:
         assert judge._client.transport.timeout == 60.0
         assert judge._client.transport.extra_params == {"user": "t"}
         # Sampling stays at judge defaults even when using flat constructor.
-        assert judge._client.sampling.temperature == 0.0
-        assert judge._client.sampling.max_tokens == 256
+        assert judge._client.sampling.temperature == 0.1
+        assert judge._client.sampling.max_tokens == 4096
+
+    def test_from_kwargs_accepts_sampling_overrides(self):
+        from nemo_retriever.llm.clients import LLMJudge
+
+        judge = LLMJudge.from_kwargs(model="m", temperature=0.2, max_tokens=512)
+
+        assert judge._client.sampling.temperature == 0.2
+        assert judge._client.sampling.max_tokens == 512
 
     def test_from_kwargs_uses_default_model(self):
         from nemo_retriever.llm.clients import LLMJudge
@@ -313,9 +321,10 @@ class TestBackCompatCallSites:
     def test_judging_operator_constructs_cleanly(self):
         from nemo_retriever.evaluation.judging import JudgingOperator
 
-        op = JudgingOperator(model="nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1")
-        assert op._judge.model == "nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1"
-        assert op._judge._client.sampling.temperature == 0.0
+        op = JudgingOperator(model="nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5")
+        assert op._judge.model == "nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5"
+        assert op._judge._client.sampling.temperature == 0.1
+        assert op._judge._client.sampling.max_tokens == 4096
 
     def test_judging_operator_plumbs_num_retries_to_inner_judge(self):
         """JudgingOperator(num_retries=...) must flow down to the LLMJudge it
@@ -328,7 +337,7 @@ class TestBackCompatCallSites:
         from nemo_retriever.evaluation.judging import JudgingOperator
 
         op = JudgingOperator(
-            model="nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1",
+            model="nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5",
             num_retries=7,
         )
         assert op._judge._client.transport.num_retries == 7
@@ -348,7 +357,7 @@ class TestBackCompatCallSites:
         builder = RetrieverPipelineBuilder(retriever, top_k=5)
 
         judge = LLMJudge.from_kwargs(
-            model="nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1",
+            model="nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5",
             num_retries=7,
         )
         builder.judge(judge)
@@ -369,7 +378,7 @@ class TestBackCompatCallSites:
         retriever.top_k = 5
         builder = RetrieverPipelineBuilder(retriever, top_k=5)
 
-        builder.judge(model="nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1")
+        builder.judge(model="nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5")
 
         judging_ops = [s for s in builder._steps if isinstance(s, JudgingOperator)]
         assert len(judging_ops) == 1


### PR DESCRIPTION
## Summary
- switch default LLM-as-judge model from deprecated Mixtral to `nvidia/llama-3.3-nemotron-super-49b-v1.5`
- standardize judge sampling defaults at `temperature=0.1` and `max_tokens=4096`
- plumb judge sampling settings through eval and skill-eval config paths, and refresh docs/examples/tests

## Test
- `uv run --extra llm --extra dev pytest -q tests/test_llm_params.py`