### PR TITLE
docs: backport 26.05 doc fixes (#2074, #2082, #2088) to main

### DIFF
--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -2,6 +2,8 @@
 
 Use this page for speech and audio extraction with Parakeet ASR and for video workflows that combine audio with OCR on frames or derived images.
 
+For air-gapped or disconnected deployments, see [Air-gapped and disconnected deployment](deployment-options.md#air-gapped-deployment).
+
 **Sections:** [Speech and audio (Parakeet)](#speech-and-audio-extraction) · [Run Parakeet on the cluster (Helm)](#run-parakeet-on-the-cluster-helm) · [Parakeet with hosted inference (build.nvidia.com)](#parakeet-hosted-inference-build-nvidia) · [Video and frame OCR](#video-and-frame-ocr)
 
 ## Speech and audio extraction { #speech-and-audio-extraction }
@@ -36,18 +38,18 @@ For audio and video workflows, install system FFmpeg so both binaries are on
 sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
 ```
 
-Containers use the FFmpeg package from the base Ubuntu image, rather than the
-previously source-built FFmpeg release. If your workflow depends on exact
-FFmpeg version or codec behavior, verify the package inside the image against
-those requirements.
+Containers use the FFmpeg package from the base Ubuntu image, rather than a
+source-built FFmpeg release. If your workflow depends on exact FFmpeg version
+or codec behavior, verify the package inside the image against those
+requirements.
 
-For Kubernetes deployments, set `service.installFfmpeg=true` in the
+For Kubernetes deployments with network access to package repositories, set
+`service.installFfmpeg=true` in the
 [Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#1-service-image)
 to install ffmpeg/ffprobe at service startup. This runtime path requires
 package-repository network egress, a writable root filesystem, and a security
-policy that allows the image's scoped sudo use. If your cluster blocks startup
-package installation, use a custom service image that already contains
-ffmpeg/ffprobe; see [troubleshooting](troubleshoot.md#audio-or-video-extraction-reports-missing-media-dependencies).
+policy that allows the image's scoped sudo use. For air-gapped clusters, see
+[Air-gapped and disconnected deployment](deployment-options.md#air-gapped-deployment).
 
 !!! important
 
@@ -59,20 +61,15 @@ This pipeline enables retrieval at the speech segment level when you enable segm
 
 ## Run Parakeet on the cluster (Helm) { #run-parakeet-on-the-cluster-helm }
 
-Use the following procedure to run the NIM on your own infrastructure. Self-hosted Parakeet runs on Kubernetes via the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md).
+Use the following procedure to run the NIM on your own infrastructure. Self-hosted Parakeet runs on Kubernetes via the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md). Enable the ASR NIM per [Optional Helm NIMs](prerequisites-support-matrix.md#optional-helm-nims-not-auto-wired-by-default) and the [Helm chart — NIM operator sub-stack](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#nim-operator-sub-stack); pin the workload to a dedicated GPU and wire the ASR endpoint in your pipeline.
 
 !!! important
 
     Pin the Parakeet workload to the dedicated GPU with your Helm values or the [NIM Operator](https://docs.nvidia.com/nim-operator/latest/index.html) (for example, node selectors, resource limits, or device requests appropriate to your cluster).
 
-1. Deploy or upgrade NeMo Retriever Library with the Helm chart and enable the ASR / audio components your release requires (Parakeet and related services). Follow [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) and [Deployment options](deployment-options.md). Ensure the chart values for your cluster request the ASR NIM.
+1. Deploy or upgrade with the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) and enable Parakeet for your release (see [Optional Helm NIMs](prerequisites-support-matrix.md#optional-helm-nims-not-auto-wired-by-default)). Follow [Deployment options](deployment-options.md).
 
-2. If the service will process audio or video files, set
-   `service.installFfmpeg=true` in the Helm chart. If your cluster blocks
-   runtime package installation, use a custom service image that already
-   contains ffmpeg/ffprobe and follow the
-   [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#1-service-image)
-   for the `service.image.repository` / `service.image.tag` override flow.
+2. If the service will process audio or video files, set `service.installFfmpeg=true` in the Helm chart when your cluster allows runtime package installation; for air-gapped clusters, see [Air-gapped and disconnected deployment](deployment-options.md#air-gapped-deployment) and the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#1-service-image) for `service.image` overrides.
 
 3. After the services are running, interact with the pipeline from Python.
 

--- a/docs/docs/extraction/deployment-options.md
+++ b/docs/docs/extraction/deployment-options.md
@@ -80,7 +80,7 @@ On a staging host with internet access, pull from NGC, retag to your private reg
 
     [Audio and video](audio-video.md) need **`ffmpeg` and `ffprobe` on `PATH`**. The bundled image omits them. Do **not** use `service.installFfmpeg=true` in an air gap (startup install needs package-repo egress). Build a custom service image on a connected staging host, mirror it, and set `service.image.repository` / `service.image.tag`. Skip this step if you do not use audio/video.
 
-For offline image captioning, deploy the in-cluster [Nemotron 3 Nano Omni](prerequisites-support-matrix.md#image-captioning-2605) NIM and point your pipeline caption endpoint at the in-cluster HTTP URL instead of `integrate.api.nvidia.com` or other hosted APIs.
+For offline image captioning, deploy the in-cluster [Nemotron 3 Nano Omni](prerequisites-support-matrix.md#image-captioning) NIM and point your pipeline caption endpoint at the in-cluster HTTP URL instead of `integrate.api.nvidia.com` or other hosted APIs.
 
 **Related**
 

--- a/docs/docs/extraction/deployment-options.md
+++ b/docs/docs/extraction/deployment-options.md
@@ -26,9 +26,9 @@ For audio and video extraction in Kubernetes, set `service.installFfmpeg=true`
 so the service container installs `ffmpeg` and `ffprobe` at startup. This
 runtime install requires package-repository network egress, a writable root
 filesystem, and security policy that allows the image's scoped sudo use. If
-your cluster blocks startup package installation, use a custom service image
-that already contains `ffmpeg` and `ffprobe`, then set
-`service.image.repository` and `service.image.tag`.
+your cluster blocks startup package installation (for example air-gapped
+environments), use a custom service image that already contains `ffmpeg` and
+`ffprobe`, then set `service.image.repository` and `service.image.tag`.
 
 ### I want examples and notebooks
 
@@ -70,9 +70,22 @@ Consider self-hosting when:
 
 **GPU sharing.** The NIM Operator supports time-slicing and MIG so multiple NIM workloads can share GPUs. A NIM used with NeMo Retriever Library does not always need a full dedicated GPU when the operator and GPU profile are set correctly. For scheduling and GPU partitioning, refer to the [NIM Operator documentation](https://docs.nvidia.com/nim-operator/latest/index.html).
 
+## Air-gapped and disconnected deployment { #air-gapped-deployment }
+
+The **default document extraction pipeline** (page elements, table structure, OCR, and VL embed) runs disconnected when you mirror images and models into a private registry and configure the [NIM Operator for air-gapped environments](https://docs.nvidia.com/nim-operator/latest/air-gap.html).
+
+On a staging host with internet access, pull from NGC, retag to your private registry, stage chart archives, then install in the enclave with registry overrides. Procedures, the chart image inventory, and Helm value patterns are in [Helm — Air-gapped deployment](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#air-gapped-deployment).
+
+!!! warning "Audio and video extraction"
+
+    [Audio and video](audio-video.md) need **`ffmpeg` and `ffprobe` on `PATH`**. The bundled image omits them. Do **not** use `service.installFfmpeg=true` in an air gap (startup install needs package-repo egress). Build a custom service image on a connected staging host, mirror it, and set `service.image.repository` / `service.image.tag`. Skip this step if you do not use audio/video.
+
+For offline image captioning, deploy the in-cluster [Nemotron 3 Nano Omni](prerequisites-support-matrix.md#image-captioning-2605) NIM and point your pipeline caption endpoint at the in-cluster HTTP URL instead of `integrate.api.nvidia.com` or other hosted APIs.
+
 **Related**
 
-- [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) ([`nemo_retriever/helm`](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/helm) on GitHub)
+- [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) ([`nemo_retriever/helm`](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/helm) on GitHub) — [air-gapped deployment](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#air-gapped-deployment)
 - [NeMo Retriever Library — prerequisites / deployment](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) (supported **Helm** handoff)
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
+- [Audio and video](audio-video.md)
 - **Docker Compose (unsupported):** [docker.md](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md) — local developer tooling only

--- a/docs/docs/extraction/multimodal-extraction.md
+++ b/docs/docs/extraction/multimodal-extraction.md
@@ -47,7 +47,10 @@ NeMo Retriever Library detects tables as structured page elements, processes the
 
 ## Charts and infographics { #charts-and-infographics }
 
-Charts and infographic regions are classified as graphic elements and processed with the corresponding NVIDIA NIM workflows (for example, **yolox-graphic-elements** in current releases). Outputs use the same metadata schema as other extracted objects.
+Charts and infographic regions are classified with other page layout elements (tables, text blocks, titles) and processed through layout detection and OCR. `extract_charts` and `extract_infographics` are enabled by default. Outputs use the same metadata schema as other extracted objects.
+
+
+For natural-language infographic descriptions, optionally enable [image captioning](#image-captioning).
 
 **Related**
 
@@ -69,15 +72,13 @@ Scanned PDFs and image-only pages rely on OCR and hybrid paths that combine nati
 
 Image captioning generates natural-language descriptions for unstructured image content. Retrieval can then use text embeddings over captions and visual embeddings where you configure them.
 
-**Captioning is optional** — it is not enabled in the default Helm deployment or core pipeline (same as Nemotron Parse and the VL reranker). Enable it in your ingest configuration (for example, the `caption` API or pipeline flag) and deploy a VLM NIM only when you need it.
-
-When you enable captioning, use [Nemotron 3 Nano Omni](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-nano-omni-30b-a3b-reasoning): deploy the self-hosted NIM (`nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:latest`), a local Hugging Face checkpoint such as `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16`, or the hosted model ID `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` with your OpenAI-compatible caption endpoint. HF and NIM space requirements are in the [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md#model-hardware-requirements). Omni reasoning traces are disabled by default for captioning.
+**Captioning is optional** — enable it in your ingest configuration (for example, the `caption` API or pipeline flag) when you need natural-language descriptions of image content. Reasoning traces are disabled by default for captioning.
 
 **Related**
 
 - [Multimodal embeddings (VLM)](embedding.md)
 - [Metadata reference](content-metadata.md)
-- [What is NeMo Retriever Library?](overview.md)
+- [Image captioning (26.05)](prerequisites-support-matrix.md#image-captioning-2605) — optional NIM and hardware on the support matrix
 
 ## Metadata and content schema { #metadata-and-content-schema }
 

--- a/docs/docs/extraction/multimodal-extraction.md
+++ b/docs/docs/extraction/multimodal-extraction.md
@@ -78,7 +78,7 @@ Image captioning generates natural-language descriptions for unstructured image 
 
 - [Multimodal embeddings (VLM)](embedding.md)
 - [Metadata reference](content-metadata.md)
-- [Image captioning (26.05)](prerequisites-support-matrix.md#image-captioning-2605) — optional NIM and hardware on the support matrix
+- [Image captioning](prerequisites-support-matrix.md#image-captioning) — optional NIM and hardware on the support matrix
 
 ## Metadata and content schema { #metadata-and-content-schema }
 

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -77,20 +77,22 @@ Default VL embedder container and model for release deployments:
 - **Image:** `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:1.12.0`
 - **Model ID:** `nvidia/llama-nemotron-embed-vl-1b-v2`
 
-### Optional Helm NIMs (disabled by default)
+### Optional Helm NIMs (not auto-wired by default)
 
-Enable these only when your workload needs them — the same pattern as the **VL reranker** (not deployed unless you turn on the reranker flags):
+The chart may reconcile these NIM microservices when `nimOperator.<key>.enabled` is `true`, but the retriever service does **not** call them until you enable the matching pipeline stage (reranker, Nemotron Parse, caption, or audio). Enable only what your workload needs. Chart keys and `enabled` defaults are in the [NeMo Retriever Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#nim-operator-sub-stack).
 
-- [llama-nemotron-rerank-vl-1b-v2](https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2) [NIM](https://docs.nvidia.com/nim/nemo-retriever/text-reranking/latest/overview.html) — reranking for improved retrieval accuracy
-- [nemotron-parse](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2) [NIM](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-parse) — optional PDF `extract_method="nemotron_parse"` (default PDF extraction uses **pdfium**)
+| Helm flag | NIM | Role |
+|-----------|-----|------|
+| `rerankqa` | [llama-nemotron-rerank-vl-1b-v2](https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2) | Reranking for improved retrieval accuracy |
+| `nemotron_parse` | [nemotron-parse](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2) | Optional PDF `extract_method="nemotron_parse"` (default PDF extraction uses **pdfium**) |
+| `nemotron_3_nano_omni_30b_a3b_reasoning` | [nemotron-3-nano-omni-30b-a3b-reasoning](https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16) | Supported image captioning when you enable the caption stage |
+| `audio` | [parakeet-1-1b-ctc-en-us](https://huggingface.co/nvidia/parakeet-ctc-1.1b) | [Audio and video](audio-video.md) transcription |
 
-Advanced features (for example, audio and video, Nemotron Parse, VLM image captioning, reranking) require additional GPU support, disk space, and feature-specific system dependencies.
-This includes the following:
+### Image captioning { #image-captioning }
 
-- [parakeet-1-1b-ctc-en-us](https://huggingface.co/nvidia/parakeet-ctc-1.1b) [NIM](https://docs.nvidia.com/nim/speech/latest/index.html) — transcript extraction from [audio and video](audio-video.md)
-- [nemotron-parse](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2) [NIM](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-parse) — alternate PDF extraction method when you set `extract_method="nemotron_parse"` (default PDF extraction uses **pdfium**)
-- [nemotron-3-nano-omni-30b-a3b-reasoning](https://huggingface.co/nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16) [NIM](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-nano-omni-30b-a3b-reasoning) — optional image captioning when you enable the caption stage
-- [llama-nemotron-rerank-vl-1b-v2](https://huggingface.co/nvidia/llama-nemotron-rerank-vl-1b-v2) [NIM](https://docs.nvidia.com/nim/nemo-retriever/text-reranking/latest/overview.html) — reranking for improved retrieval accuracy
+Use **`nemotron_3_nano_omni_30b_a3b_reasoning`** when you enable the caption stage (hosted model ID `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`). The Helm key is in the [optional NIMs](#optional-helm-nims-not-auto-wired-by-default) table above.
+
+Optional features listed in the table above require additional GPU support, disk space, and feature-specific system dependencies beyond the four default NIMs.
 
 For published NIM model IDs and deployment-specific constraints, use the product support matrices linked under [Related Topics](#related-topics) below.
 
@@ -99,7 +101,7 @@ For published NIM model IDs and deployment-specific constraints, use the product
 NeMo Retriever Library supports the following GPU hardware given system constraints in the table.
 
 - **HF model weights** — approximate Hugging Face checkpoint footprint (files such as `model*.safetensors`, `weights.pth`, or other published weight bundles in the model repository). Values are rounded from the current public file listing and can change when the repository is updated.
-- **NIM disk space** — approximate container and on-disk model cache for self-hosted NIM microservices (not the same as HF download size). For Nemotron 3 Nano Omni captioning, see the [NVIDIA NIM for Vision Language Models support matrix](https://docs.nvidia.com/nim/vision-language-models/latest/support-matrix.html#nemotron-3-nano-omni-30b-a3b-reasoning).
+- **NIM disk space** — approximate container and on-disk model cache for self-hosted NIM microservices (not the same as HF download size). For Nemotron 3 Nano Omni captioning, refer to the [NVIDIA NIM for Vision Language Models support matrix](https://docs.nvidia.com/nim/vision-language-models/latest/support-matrix.html#nemotron-3-nano-omni-30b-a3b-reasoning).
 
 Model repositories and NIM references are linked in [Core and Advanced Pipeline Features](#core-and-advanced-pipeline-features) above.
 
@@ -122,7 +124,7 @@ Model repositories and NIM references are linked in [Core and Advanced Pipeline 
 
 ² Nemotron Parse fails to start on 32GB.
 
-³ Opt-in Omni captioning uses the [nemotron-3-nano-omni-30b-a3b-reasoning](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-nano-omni-30b-a3b-reasoning) NIM (`nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:latest`). BF16 requires at least 80 GB total GPU memory; see the [VLM NIM support matrix](https://docs.nvidia.com/nim/vision-language-models/latest/support-matrix.html#nemotron-3-nano-omni-30b-a3b-reasoning). L40S requires two GPUs. A100 40GB, A10G, and RTX PRO 4500 are below the minimum.
+³ Omni caption: see the optional NIM table and [Image captioning (26.05)](#image-captioning-2605) above. BF16 requires at least 80 GB total GPU memory; refer to the [VLM NIM support matrix](https://docs.nvidia.com/nim/vision-language-models/latest/support-matrix.html#nemotron-3-nano-omni-30b-a3b-reasoning). L40S requires two GPUs. A100 40GB, A10G, and RTX PRO 4500 are below the minimum.
 
 \* GPUs with less than 80GB VRAM cannot run the reranker concurrently with the core pipeline. 
 To perform recall testing with the reranker on these GPUs, shut down the core pipeline NIM microservices 

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -124,7 +124,7 @@ Model repositories and NIM references are linked in [Core and Advanced Pipeline 
 
 ² Nemotron Parse fails to start on 32GB.
 
-³ Omni caption: see the optional NIM table and [Image captioning (26.05)](#image-captioning-2605) above. BF16 requires at least 80 GB total GPU memory; refer to the [VLM NIM support matrix](https://docs.nvidia.com/nim/vision-language-models/latest/support-matrix.html#nemotron-3-nano-omni-30b-a3b-reasoning). L40S requires two GPUs. A100 40GB, A10G, and RTX PRO 4500 are below the minimum.
+³ Omni caption: see the optional NIM table and [Image captioning](#image-captioning) above. BF16 requires at least 80 GB total GPU memory; refer to the [VLM NIM support matrix](https://docs.nvidia.com/nim/vision-language-models/latest/support-matrix.html#nemotron-3-nano-omni-30b-a3b-reasoning). L40S requires two GPUs. A100 40GB, A10G, and RTX PRO 4500 are below the minimum.
 
 \* GPUs with less than 80GB VRAM cannot run the reranker concurrently with the core pipeline. 
 To perform recall testing with the reranker on these GPUs, shut down the core pipeline NIM microservices 

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -8,13 +8,11 @@ Before you begin using [NeMo Retriever Library](overview.md), confirm your softw
 - [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads) (NVIDIA Driver >= `535`, CUDA >= `12.2`)
 - [Python](https://www.python.org/downloads/) `3.12` — required to install and run the NeMo Retriever Library Python API, CLI, and related packages from PyPI (for example `pip` or `uv`). Older Python versions will fail dependency resolution without a clear error.
 - [UV Python package and environment manager](https://docs.astral.sh/uv/getting-started/installation/) (optional; recommended for creating isolated environments)
-- For audio and video extraction, the `ffmpeg` and `ffprobe` command-line
-  binaries must be installed and available on `PATH`. On Debian/Ubuntu systems,
-  install them with root privileges, for example
-  `sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg`.
-  Python packages such as `ffmpeg-python` or `nemo-retriever[multimedia]` do not
-  provide these system binaries. For Helm deployments, set
-  `service.installFfmpeg=true`.
+- For audio and video, `ffmpeg` and `ffprobe` must be on `PATH` (for example
+  `sudo apt-get install -y --no-install-recommends ffmpeg` on Debian/Ubuntu).
+  `ffmpeg-python` and `nemo-retriever[multimedia]` do not install these binaries.
+  On Helm with package-repo access, set `service.installFfmpeg=true`. For
+  air-gapped clusters, see [Air-gapped and disconnected deployment](deployment-options.md#air-gapped-deployment).
 
 !!! note
 
@@ -77,7 +75,7 @@ Default VL embedder container and model for release deployments:
 - **Image:** `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:1.12.0`
 - **Model ID:** `nvidia/llama-nemotron-embed-vl-1b-v2`
 
-### Optional Helm NIMs (not auto-wired by default)
+### Optional Helm NIMs (not auto-wired by default) { #optional-helm-nims-not-auto-wired-by-default }
 
 The chart may reconcile these NIM microservices when `nimOperator.<key>.enabled` is `true`, but the retriever service does **not** call them until you enable the matching pipeline stage (reranker, Nemotron Parse, caption, or audio). Enable only what your workload needs. Chart keys and `enabled` defaults are in the [NeMo Retriever Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#nim-operator-sub-stack).
 
@@ -101,7 +99,7 @@ For published NIM model IDs and deployment-specific constraints, use the product
 NeMo Retriever Library supports the following GPU hardware given system constraints in the table.
 
 - **HF model weights** — approximate Hugging Face checkpoint footprint (files such as `model*.safetensors`, `weights.pth`, or other published weight bundles in the model repository). Values are rounded from the current public file listing and can change when the repository is updated.
-- **NIM disk space** — approximate container and on-disk model cache for self-hosted NIM microservices (not the same as HF download size). For Nemotron 3 Nano Omni captioning, refer to the [NVIDIA NIM for Vision Language Models support matrix](https://docs.nvidia.com/nim/vision-language-models/latest/support-matrix.html#nemotron-3-nano-omni-30b-a3b-reasoning).
+- **NIM disk space** — approximate container and on-disk model cache for self-hosted NIM microservices (not the same as HF download size). For Nemotron 3 Nano Omni captioning, see the [NVIDIA NIM for Vision Language Models support matrix](https://docs.nvidia.com/nim/vision-language-models/latest/support-matrix.html#nemotron-3-nano-omni-30b-a3b-reasoning).
 
 Model repositories and NIM references are linked in [Core and Advanced Pipeline Features](#core-and-advanced-pipeline-features) above.
 
@@ -124,7 +122,7 @@ Model repositories and NIM references are linked in [Core and Advanced Pipeline 
 
 ² Nemotron Parse fails to start on 32GB.
 
-³ Omni caption: see the optional NIM table and [Image captioning](#image-captioning) above. BF16 requires at least 80 GB total GPU memory; refer to the [VLM NIM support matrix](https://docs.nvidia.com/nim/vision-language-models/latest/support-matrix.html#nemotron-3-nano-omni-30b-a3b-reasoning). L40S requires two GPUs. A100 40GB, A10G, and RTX PRO 4500 are below the minimum.
+³ Opt-in Omni captioning uses the [nemotron-3-nano-omni-30b-a3b-reasoning](https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-nano-omni-30b-a3b-reasoning) NIM (`nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:1.7.0-variant`). See the [optional NIMs](#optional-helm-nims-not-auto-wired-by-default) table and [Image captioning](#image-captioning) above. BF16 requires at least 80 GB total GPU memory; see the [VLM NIM support matrix](https://docs.nvidia.com/nim/vision-language-models/latest/support-matrix.html#nemotron-3-nano-omni-30b-a3b-reasoning). L40S requires two GPUs. A100 40GB, A10G, and RTX PRO 4500 are below the minimum.
 
 \* GPUs with less than 80GB VRAM cannot run the reranker concurrently with the core pipeline. 
 To perform recall testing with the reranker on these GPUs, shut down the core pipeline NIM microservices 

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -20,7 +20,7 @@ When you run a job you might see errors similar to the following:
 These errors can occur when your input file is malformed. 
 Verify or fix the format of your input file, and try resubmitting your job.
 
-## Audio or video extraction reports missing media dependencies
+## Audio or video extraction reports missing media dependencies { #audio-or-video-extraction-reports-missing-media-dependencies }
 
 When you run audio or video extraction, you might see an error similar to one
 of the following:
@@ -30,39 +30,33 @@ Audio extraction requires media dependencies; missing: ffmpeg.
 VideoFrameActor requires media dependencies; missing: ffprobe.
 ```
 
-The Python package includes the `ffmpeg-python` wrapper, and
-`nemo-retriever[multimedia]` installs Python audio libraries. These do not
-install the `ffmpeg` or `ffprobe` command-line binaries that the media pipeline
-executes.
+The `ffmpeg-python` wrapper and `nemo-retriever[multimedia]` do not install the
+`ffmpeg` or `ffprobe` binaries the pipeline executes.
 
-On Debian or Ubuntu systems, install system FFmpeg with root privileges:
+For air-gapped or locked-down clusters, see [Air-gapped and disconnected deployment](deployment-options.md#air-gapped-deployment).
+
+**Connected environments:**
+
+On Debian or Ubuntu hosts:
 
 ```bash
 sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
 ```
 
-For the bundled service container, set `INSTALL_FFMPEG=true` at runtime to
-install ffmpeg/ffprobe during container startup:
+For the bundled service container at runtime:
 
 ```bash
 docker run -e INSTALL_FFMPEG=true nemo-retriever-service
 ```
 
-For Kubernetes or Helm deployments, set the first-class chart value:
+For Helm, when package-repo egress and the image security policy allow startup install:
 
 ```yaml
 service:
   installFfmpeg: true
 ```
 
-This runtime install requires network egress to package repositories, a
-writable root filesystem, and security policy that allows the image's scoped
-sudo use. It will fail if the service container sets
-`allowPrivilegeEscalation: false` or `readOnlyRootFilesystem: true`.
-
-For locked-down clusters that cannot install packages at startup, use a custom
-service image that already contains ffmpeg/ffprobe. Push that image to a
-registry and set `service.image.repository` and `service.image.tag`.
+This path fails with `allowPrivilegeEscalation: false` or `readOnlyRootFilesystem: true`.
 
 ## Can't start new thread error
 

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -170,9 +170,7 @@ python -m nemo_retriever.examples.graph_pipeline \
   /your-example-dir \
   --lancedb-uri lancedb \
   --page-elements-invoke-url https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-page-elements-v3 \
-  --graphic-elements-invoke-url https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-graphic-elements-v1 \
-  --ocr-invoke-url https://ai.api.nvidia.com/v1/cv/nvidia/nemoretriever-ocr-v1 \
-  --ocr-version v1 \
+  --ocr-invoke-url https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-ocr-v1 \
   --table-structure-invoke-url https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-table-structure-v1 \
   --embed-invoke-url https://integrate.api.nvidia.com/v1/embeddings \
   --embed-model-name nvidia/llama-nemotron-embed-1b-v2
@@ -183,8 +181,6 @@ python -m nemo_retriever.examples.graph_pipeline \
 > to multilingual mode (`multi`); pass `--ocr-lang english` for the English-only
 > v2 selector. Remote OCR NIM endpoints decide their own model and language
 > behavior, and the local OCR selectors are not added to remote request payloads.
-> The remote-inference example above pins `--ocr-version v1` because a hosted v2
-> endpoint is not yet available on `ai.api.nvidia.com`.
 
 When you use the remote embedder, pair the `Retriever` with the matching
 `embedder=` + `embedding_endpoint=` overrides shown in
@@ -530,9 +526,8 @@ ingestor = (
   .extract(
     # for self hosted NIMs, your URLs will depend on your NIM container DNS settings
     page_elements_invoke_url="https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-page-elements-v3",
-    graphic_elements_invoke_url="https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-graphic-elements-v1",
-    ocr_invoke_url="https://ai.api.nvidia.com/v1/cv/nvidia/nemoretriever-ocr-v1",
-    table_structure_invoke_url="https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-table-structure-v1"
+    ocr_invoke_url="https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-ocr-v1",
+    table_structure_invoke_url="https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-table-structure-v1",
   )
   .embed(
     embed_invoke_url="https://integrate.api.nvidia.com/v1/embeddings",

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -78,8 +78,6 @@ export NVIDIA_API_KEY=nvapi-...
 retriever ingest ./data/multimodal_test.pdf \
   --page-elements-invoke-url https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-page-elements-v3 \
   --ocr-invoke-url https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-ocr-v1 \
-  --ocr-version v1 \
-  --graphic-elements-invoke-url https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-graphic-elements-v1 \
   --table-structure-invoke-url https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-table-structure-v1 \
   --embed-invoke-url https://integrate.api.nvidia.com/v1/embeddings \
   --embed-model-name nvidia/llama-nemotron-embed-1b-v2
@@ -221,17 +219,14 @@ retriever pipeline run ./data/test.pdf \
   --input-type pdf \
   --method pdfium \
   --caption \
-  --caption-model-name nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16 \
+  --caption-model-name nvidia/nemotron-3-nano-omni-30b-a3b-reasoning \
   --caption-invoke-url https://integrate.api.nvidia.com/v1/chat/completions \
   --api-key "${NVIDIA_API_KEY}" \
   --store-images-uri ./processed_docs/images \
   --save-intermediate ./processed_docs
 ```
 
-For hosted Omni captioning, set
-`--caption-model-name nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`. Local Omni uses
-`nemo_retriever[local]` and a local Hugging Face model ID. Custom caption prompts and
-`reasoning` flags are not exposed on the CLI — use
+Custom caption prompts and `reasoning` flags are not exposed on the CLI — use
 `nemo_retriever.ingestor.Ingestor.caption(...)` in Python.
 
 ### Directory of documents

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -7,6 +7,21 @@ live under `docs/`, `api/`, `client/`, and `deploy/` in older repository layouts
 The historical CLI documentation is **not removed** from the ecosystem — these files sit
 alongside it as a new-CLI counterpart you can link to or migrate to.
 
+## Supported vs development / experimental subcommands
+
+For product use and published examples, treat only these top-level subcommands as
+**supported**:
+
+- **`retriever ingest`** — ingest documents into LanceDB
+- **`retriever query`** — query an existing LanceDB table
+- **`retriever pipeline`** — run the graph ingestion pipeline (for example `retriever pipeline run`)
+
+Any other top-level `retriever` subcommand — including but not limited to `pdf`, `html`,
+`txt`, `audio`, `chart`, `benchmark`, `harness`, `eval`, `recall`, `service`, `local`,
+`compare`, `image`, and `skill-eval` — is **development and experimental**. These commands
+may change or be removed without notice and **carry no compatibility, stability, or
+behavior guarantees**.
+
 ## Key shape difference
 
 The legacy **ingestion-service** CLI was a **single command that talks to a running REST service on
@@ -29,6 +44,9 @@ to Parquet / object storage. Other subcommands cover focused tasks:
 | Benchmark stage throughput | `retriever benchmark {split,extract,audio-extract,page-elements,ocr,all}` |
 | Benchmark orchestration | `retriever harness {run,sweep,nightly,summary,compare}` |
 
+Rows that use subcommands other than `ingest`, `query`, or `pipeline` are
+[development and experimental](#supported-vs-development--experimental-subcommands).
+
 ## Contents
 
 | Topic | Location | Replaces example(s) in |
@@ -40,6 +58,9 @@ to Parquet / object storage. Other subcommands cover focused tasks:
 | Benchmarking | [`benchmarking.md`](benchmarking.md) | `docs/docs/extraction/benchmarking.md` and `tools/harness/README.md` |
 
 <!-- --8<-- [start:quickstart] -->
+
+> Only `retriever ingest`, `retriever query`, and `retriever pipeline` are supported for
+> product use; see [Supported vs development / experimental subcommands](#supported-vs-development--experimental-subcommands).
 
 ## Quick start
 
@@ -143,8 +164,10 @@ hits = retriever.query(
 
 ## CLI reference
 
-`retriever` is the Typer app installed with the `nemo-retriever` package. Document
-ingestion is usually `retriever pipeline run INPUT_PATH`, which runs the graph pipeline
+`retriever` is the Typer app installed with the `nemo-retriever` package. Subcommand
+support policy: [Supported vs development / experimental subcommands](#supported-vs-development--experimental-subcommands).
+
+Document ingestion is usually `retriever pipeline run INPUT_PATH`, which runs the graph pipeline
 locally (in-process or Ray) and writes rows to LanceDB and optional Parquet.
 
 ```bash

--- a/nemo_retriever/docs/cli/benchmarking.md
+++ b/nemo_retriever/docs/cli/benchmarking.md
@@ -1,5 +1,8 @@
 # Benchmarking with the `retriever` CLI
 
+`retriever benchmark` and `retriever harness` are development and experimental subcommands
+with no guarantees — see [Supported vs development / experimental subcommands](README.md#supported-vs-development--experimental-subcommands).
+
 This page covers benchmark workflows for NeMo Retriever Library. See also
 `docs/docs/extraction/benchmarking.md`, [`tools/harness/README.md`](../../../tools/harness/README.md)
 (legacy integration harness), and [`nemo_retriever/harness/HANDOFF.md`](../../harness/HANDOFF.md)
@@ -14,7 +17,7 @@ There are two harness stacks:
 
 The `retriever` CLI also exposes per-stage `retriever benchmark …` micro-benchmarks.
 
-## Retriever harness (recommended)
+## Retriever harness (development / experimental)
 
 Run from the repository root (or any directory; pass `--config` if needed). Uses
 `--dataset` and `--preset` — there is no `--case` flag on this harness.
@@ -110,8 +113,9 @@ Each benchmark reports rows/sec (or chunk rows/sec for audio) for its actor.
   `nemo_retriever/harness/test_configs.yaml`.
 - **Datasets:** names like `bo767` and `jp20` exist in both configs but paths and
   defaults may differ; check the YAML for each stack.
-- **Launcher:** prefer `retriever harness run …` for new work; use
-  `nv_ingest_harness` only when you still depend on `--case` or `--managed` behavior
-  documented in `tools/harness/README.md`.
+- **Launcher:** for internal benchmarking, `retriever harness run …` is the
+  retriever-CLI entry point (development / experimental; no guarantees). Use
+  `nv_ingest_harness` when you still depend on `--case` or `--managed` behavior in
+  `tools/harness/README.md`.
 - **Stage benchmarks:** `retriever benchmark …` is specific to the retriever CLI and
   has no legacy service-CLI equivalent.

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -63,10 +63,9 @@ nemo_retriever/helm/
         ├── nemotron-table-structure-v1.yaml   # NIMCache + NIMService
         ├── nemotron-ocr-v1.yaml               # NIMCache + NIMService
         ├── llama-nemotron-embed-vl-1b-v2.yaml           # NIMCache + NIMService (VLM embed)
-        ├── llama-nemotron-rerank-1b-v2.yaml   # NIMCache + NIMService (off by default)
-        ├── nemotron-nano-12b-v2-vl.yaml       # NIMCache + NIMService (off by default)
-        ├── nemotron-parse.yaml                # NIMCache + NIMService (off by default)
-        └── audio.yaml                         # NIMCache + NIMService (off by default)
+        ├── llama-nemotron-rerank-1b-v2.yaml   # NIMCache + NIMService (optional; not auto-wired)
+        ├── nemotron-parse.yaml                # NIMCache + NIMService (optional; not auto-wired)
+        └── audio.yaml                         # NIMCache + NIMService (optional; not auto-wired)
 ```
 
 ---
@@ -153,7 +152,7 @@ Install the [NIM Operator](https://docs.nvidia.com/nim-operator/) first so
 the `NIMCache` / `NIMService` CRDs (`apps.nvidia.com/v1alpha1`) are
 registered. Then run the default install — `nims.enabled` is `true` out
 of the box, so every per-NIM block under `nimOperator.<key>.enabled: true`
-(all nine by default) is reconciled:
+(all eight by default) is reconciled:
 
 ```bash
 helm install retriever ./nemo_retriever/helm \
@@ -238,7 +237,6 @@ pair gated on three conditions ALL holding:
 | `nimOperator.vlm_embed.nimServiceName` | `llama-nemotron-embed-vl-1b-v2` | NIMService / in-cluster DNS name. |
 | `nimOperator.vlm_embed.image`          | `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:1.12.0` | Default VLM embed NIM image. |
 | `nimOperator.rerankqa.enabled`         | `true`  | Reranker NIM. |
-| `nimOperator.nemotron_nano_12b_v2_vl.enabled` | `true`  | VLM NIM. |
 | `nimOperator.nemotron_parse.enabled`   | `true`  | Structured-parse NIM. |
 | `nimOperator.nemotron_3_nano_omni_30b_a3b_reasoning.enabled` | `true` | Multimodal reasoning LLM (30B). |
 | `nimOperator.audio.enabled`            | `true`  | ASR NIM. |
@@ -255,6 +253,24 @@ pair gated on three conditions ALL holding:
 > are auto-wired into the retriever-service config. The other NIMs are
 > reconciled by the operator but the retriever-service won't call them
 > unless you wire your own pipeline to use them.
+
+### Charts, infographics, and captioning (26.05) { #charts-infographics-and-captioning-2605 }
+
+**Charts and infographics** — This chart does **not** ship a `graphic_elements` NIM
+(there is no `nimOperator.graphic_elements` in `values.yaml`). Chart and infographic
+extraction uses the default **page_elements** and **ocr** NIMs only. Keep
+`nimOperator.page_elements.enabled` and `nimOperator.ocr.enabled` at `true` for
+standard multimodal PDF ingest. The library enables `extract_charts` and
+`extract_infographics` by default; do not disable them unless you intentionally skip
+those content types. Override in-cluster URLs through `serviceConfig.nimEndpoints` if needed.
+
+**Image captioning** — For 26.05, the supported captioning NIM is
+`nemotron_3_nano_omni_30b_a3b_reasoning`
+(`nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`). The chart defaults
+`nimOperator.nemotron_3_nano_omni_30b_a3b_reasoning.enabled` to `true`; set it to
+`false` if you do not deploy that NIM. When you enable the caption stage in your ingest
+configuration, point the pipeline at that NIMService. GPU and disk requirements are in the published
+[Pre-Requisites & Support Matrix](https://nvidia.github.io/NeMo-Retriever/extraction/prerequisites-support-matrix/#image-captioning-2605).
 
 ### Persistence
 

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -63,9 +63,10 @@ nemo_retriever/helm/
         ├── nemotron-table-structure-v1.yaml   # NIMCache + NIMService
         ├── nemotron-ocr-v1.yaml               # NIMCache + NIMService
         ├── llama-nemotron-embed-vl-1b-v2.yaml           # NIMCache + NIMService (VLM embed)
-        ├── llama-nemotron-rerank-1b-v2.yaml   # NIMCache + NIMService (optional; not auto-wired)
-        ├── nemotron-parse.yaml                # NIMCache + NIMService (optional; not auto-wired)
-        └── audio.yaml                         # NIMCache + NIMService (optional; not auto-wired)
+        ├── llama-nemotron-rerank-1b-v2.yaml   # NIMCache + NIMService (optional; enabled by default; not auto-wired)
+        ├── nemotron-parse.yaml                # NIMCache + NIMService (optional; enabled by default; not auto-wired)
+        ├── nemotron-3-nano-omni-30b-a3b-reasoning.yaml  # NIMCache + NIMService (optional; enabled by default; not auto-wired)
+        └── audio.yaml                         # NIMCache + NIMService (optional; enabled by default; not auto-wired)
 ```
 
 ---
@@ -118,9 +119,17 @@ that allows sudo/setuid behavior. Do not set
 `service.securityContext.allowPrivilegeEscalation: false` or
 `service.securityContext.readOnlyRootFilesystem: true` for this path.
 
-For locked-down clusters that cannot install packages at startup, use a custom
-service image that already contains ffmpeg/ffprobe and point the chart at it
-with `service.image.repository` and `service.image.tag`.
+For air-gapped or locked-down clusters, see
+[Deployment options — Air-gapped and disconnected deployment](https://docs.nvidia.com/nemo/retriever/latest/extraction/deployment-options/#air-gapped-deployment).
+On a connected staging host you can extend the service image, for example:
+
+```dockerfile
+FROM <YOUR_REGISTRY>/nemo-retriever-service:<BASE_TAG>
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+USER nemo
+```
 
 ### 2. Install with external NIM endpoints (operator not required)
 
@@ -197,15 +206,14 @@ short list of knobs you'll touch first.
 | `service.image.repository`    | `localhost:32000/nemo-retriever-service` | Override to a published image. |
 | `service.image.tag`           | `latest`                           |       |
 | `service.replicas`            | `1`                                | Hard cap = 1 while SQLite is the backend. |
-| `service.installFfmpeg`       | `false`                            | Install `ffmpeg`/`ffprobe` at container startup by setting `INSTALL_FFMPEG=true`. Requires network egress, writable root filesystem, and sudo/setuid allowed. |
+| `service.installFfmpeg`       | `false`                            | Install `ffmpeg`/`ffprobe` at container startup by setting `INSTALL_FFMPEG=true`. Requires network egress, writable root filesystem, and sudo/setuid allowed. Not for air-gapped clusters — use a custom image instead. |
 | `service.resources.requests`  | `16 / 16Gi`                        | Tune in tandem with `serviceConfig.pipeline.*Workers`. |
 | `service.resources.limits`    | `96 / 96Gi`                        |       |
 | `service.gpu.enabled`         | `false`                            | The service does **not** need a GPU. |
 
-For audio and video extraction, set `service.installFfmpeg=true`. If your
-cluster blocks runtime package installation, use a custom service image that
-already contains ffmpeg/ffprobe and set `service.image.repository` and
-`service.image.tag`.
+For audio and video extraction, set `service.installFfmpeg=true` when your
+cluster allows runtime package installation. For air-gapped clusters, see
+[Deployment options — Air-gapped and disconnected deployment](https://docs.nvidia.com/nemo/retriever/latest/extraction/deployment-options/#air-gapped-deployment).
 
 ### Service configuration (rendered into `retriever-service.yaml`)
 
@@ -254,23 +262,10 @@ pair gated on three conditions ALL holding:
 > reconciled by the operator but the retriever-service won't call them
 > unless you wire your own pipeline to use them.
 
-### Charts, infographics, and captioning (26.05) { #charts-infographics-and-captioning-2605 }
-
-**Charts and infographics** — This chart does **not** ship a `graphic_elements` NIM
-(there is no `nimOperator.graphic_elements` in `values.yaml`). Chart and infographic
-extraction uses the default **page_elements** and **ocr** NIMs only. Keep
-`nimOperator.page_elements.enabled` and `nimOperator.ocr.enabled` at `true` for
-standard multimodal PDF ingest. The library enables `extract_charts` and
-`extract_infographics` by default; do not disable them unless you intentionally skip
-those content types. Override in-cluster URLs through `serviceConfig.nimEndpoints` if needed.
-
-**Image captioning** — For 26.05, the supported captioning NIM is
-`nemotron_3_nano_omni_30b_a3b_reasoning`
-(`nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`). The chart defaults
-`nimOperator.nemotron_3_nano_omni_30b_a3b_reasoning.enabled` to `true`; set it to
-`false` if you do not deploy that NIM. When you enable the caption stage in your ingest
-configuration, point the pipeline at that NIMService. GPU and disk requirements are in the published
-[Pre-Requisites & Support Matrix](https://nvidia.github.io/NeMo-Retriever/extraction/prerequisites-support-matrix/#image-captioning-2605).
+**Charts and captioning.** Charts and infographics use **page_elements**
+and **ocr** (no `graphic_elements` operator NIM in this chart). For image
+captioning, enable `nemotron_3_nano_omni_30b_a3b_reasoning` — see
+[Image captioning](https://docs.nvidia.com/nemo/retriever/latest/extraction/prerequisites-support-matrix/#image-captioning).
 
 ### Persistence
 
@@ -617,6 +612,90 @@ kubectl get hpa <release>-realtime -o jsonpath='{.metadata.annotations.nemo-retr
 The dashboard's *Worker Pool Capacity* card on the **Overview** page
 mirrors the same signal Prometheus is seeing, so it's a quick eyeball
 sanity check before opening Grafana.
+
+---
+
+## Air-gapped deployment { #air-gapped-deployment }
+
+See [Deployment options — Air-gapped and disconnected deployment](https://docs.nvidia.com/nemo/retriever/latest/extraction/deployment-options/#air-gapped-deployment) for overview and workflow. Chart-specific reference for mirroring:
+
+### Container images to mirror (chart defaults)
+
+Verify tags on the Git branch or tag you ship (for example `main` or a
+release tag). Defaults below match
+[`values.yaml`](./values.yaml) on the current chart.
+
+| Role | `nimOperator` key | Default image (`repository:tag`) |
+|------|-------------------|----------------------------------|
+| Retriever service | — | `service.image.repository`:`service.image.tag` (override for production) |
+| Page elements | `page_elements` | `nvcr.io/nim/nvidia/nemotron-page-elements-v3:1.8.0` |
+| Table structure | `table_structure` | `nvcr.io/nim/nvidia/nemotron-table-structure-v1:1.8.0` |
+| OCR | `ocr` | `nvcr.io/nim/nvidia/nemotron-ocr-v1:1.3.0` |
+| VL embed | `vlm_embed` | `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:1.12.0` |
+| Reranker (optional) | `rerankqa` | `nvcr.io/nim/nvidia/llama-nemotron-rerank-1b-v2:1.10.0` |
+| Nemotron Parse (optional) | `nemotron_parse` | `nvcr.io/nim/nvidia/nemotron-parse-v1.2:1.7.0-variant` |
+| Omni caption (optional) | `nemotron_3_nano_omni_30b_a3b_reasoning` | `nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:1.7.0-variant` |
+| Parakeet ASR (optional) | `audio` | `nvcr.io/nim/nvidia/parakeet-1-1b-ctc-en-us:1.5.0` |
+
+Also mirror images for the vectordb sidecar, Redis, or other subcharts if
+your values enable them.
+
+### Helm values for a private registry
+
+Example overrides (replace placeholders):
+
+```bash
+helm upgrade --install retriever ./nemo_retriever/helm \
+  -f my-airgap-values.yaml
+```
+
+`my-airgap-values.yaml` should include at least:
+
+```yaml
+service:
+  image:
+    repository: <PRIVATE_REGISTRY>/nemo-retriever-service
+    tag: <PINNED_TAG>
+    pullPolicy: IfNotPresent
+
+imagePullSecrets:
+  - name: my-private-registry
+
+ngcImagePullSecret:
+  create: false   # use secrets that authenticate to YOUR mirror
+
+nimOperator:
+  page_elements:
+    image:
+      repository: <PRIVATE_REGISTRY>/nemotron-page-elements-v3
+      tag: "1.8.0"
+      pullPolicy: IfNotPresent
+  # Repeat for table_structure, ocr, vlm_embed, and any optional keys you enable.
+```
+
+- Set `nimOperator.<key>.image.pullSecrets` to the Secret name your
+  `NIMService` resources should use (defaults to `ngc-secret`).
+- Leave `serviceConfig.nimEndpoints.*` empty when operator-managed NIMs
+  are in-cluster; set explicit URLs only for external or mirrored services
+  outside the chart.
+- For **offline captioning**, enable
+  `nimOperator.nemotron_3_nano_omni_30b_a3b_reasoning` and point the pipeline
+  caption endpoint at the in-cluster NIM URL (see
+  [Image captioning](https://docs.nvidia.com/nemo/retriever/latest/extraction/prerequisites-support-matrix/#image-captioning)).
+
+### Mirroring pattern
+
+```bash
+docker login nvcr.io -u '$oauthtoken' -p "$NGC_API_KEY"
+docker pull nvcr.io/nim/nvidia/nemotron-page-elements-v3:1.8.0
+docker tag nvcr.io/nim/nvidia/nemotron-page-elements-v3:1.8.0 \
+  <PRIVATE_REGISTRY>/nemotron-page-elements-v3:1.8.0
+docker push <PRIVATE_REGISTRY>/nemotron-page-elements-v3:1.8.0
+```
+
+For bulk sync, prefer [skopeo](https://github.com/containers/skopeo) or
+[crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md).
+Record `repository@sha256:...` digests for regulated environments.
 
 ---
 


### PR DESCRIPTION
## Summary

Cherry-picks documentation merged on **`26.05`** onto **`main`** so the live docs site (published from `main`) matches the release-line fixes.

| Source PR | Status on `main` before this PR | Backported |
|-----------|----------------------------------|------------|
| [#2074](https://github.com/NVIDIA/NeMo-Retriever/pull/2074) — captioning/chart extraction vs Helm NIM topology (NVBugs 6195023, 6195296) | Not present | Yes |
| [#2082](https://github.com/NVIDIA/NeMo-Retriever/pull/2082) — air-gapped deployment (NVBugs 6195103, PR #2052) | Not present | Yes |
| [#2088](https://github.com/NVIDIA/NeMo-Retriever/pull/2088) — experimental retriever CLI subcommands (NVBugs 6199005, 6198526) | Not present | Yes |
| [#2067](https://github.com/NVIDIA/NeMo-Retriever/pull/2067) — Helm NIM defaults, GA VL embedder | Already on `main` | N/A (skipped) |
| [#2062](https://github.com/NVIDIA/NeMo-Retriever/pull/2062) — telemetry page removal, Omni caption NIM | Already on `main` | N/A (skipped) |

> **Note:** The listed PRs were merged into **`26.05`**, not `26.03`. This branch uses focused cherry-picks from `26.05` → `main` (not a `26.05` → `main` merge PR).

## Files changed (9, docs only)

- `docs/docs/extraction/audio-video.md`
- `docs/docs/extraction/deployment-options.md`
- `docs/docs/extraction/multimodal-extraction.md`
- `docs/docs/extraction/prerequisites-support-matrix.md`
- `docs/docs/extraction/troubleshoot.md`
- `nemo_retriever/README.md`
- `nemo_retriever/docs/cli/README.md`
- `nemo_retriever/docs/cli/benchmarking.md`
- `nemo_retriever/helm/README.md`

## Adaptations for `main`

- GitHub/doc links use `blob/main` (not `26.05`).
- Image captioning anchor is `#image-captioning` (not `#image-captioning-2605`).

## Test plan

- [ ] Review MkDocs build / link check on `main` after merge
- [ ] Confirm air-gap section in `deployment-options.md` and Helm README cross-links resolve
- [ ] Spot-check optional NIM table and Omni caption footnote in prerequisites support matrix
