### PR TITLE
override opencv-headless install

### DIFF
--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -9,6 +9,9 @@ no-build-package = ["nemotron-ocr"]
 # fastparquet 2026.3.0 has no wheel for Linux x86_64 (manylinux); constrain to last version that does.
 override-dependencies = [
   "fastparquet>=2024.11.0,<2026",
+  # Suppress opencv-python from transitive deps. nemotron wheels pull in both
+  # opencv-python and opencv-python-headless, which stomp on the same cv2/ dir.
+  # The 'never' marker makes uv treat this as unsatisfiable on all platforms.
   "opencv-python ; sys_platform == 'never'",
 ]
 
@@ -101,7 +104,7 @@ local = [
   "transformers>=4.57.6,<5",
   "tokenizers>=0.21.1",
   "accelerate==1.12.0",
-  "opencv-python-headless",
+  "opencv-python-headless>=4.8.0",
   "torch~=2.11.0",
   "torchvision>=0.26.0,<0.27",
   "tritonclient",

--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -9,6 +9,7 @@ no-build-package = ["nemotron-ocr"]
 # fastparquet 2026.3.0 has no wheel for Linux x86_64 (manylinux); constrain to last version that does.
 override-dependencies = [
   "fastparquet>=2024.11.0,<2026",
+  "opencv-python ; sys_platform == 'never'",
 ]
 
 [project]
@@ -100,6 +101,7 @@ local = [
   "transformers>=4.57.6,<5",
   "tokenizers>=0.21.1",
   "accelerate==1.12.0",
+  "opencv-python-headless",
   "torch~=2.11.0",
   "torchvision>=0.26.0,<0.27",
   "tritonclient",

--- a/nemo_retriever/uv.lock
+++ b/nemo_retriever/uv.lock
@@ -13,7 +13,10 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "fastparquet", specifier = ">=2024.11.0,<2026" }]
+overrides = [
+    { name = "fastparquet", specifier = ">=2024.11.0,<2026" },
+    { name = "opencv-python", marker = "sys_platform == 'never'" },
+]
 
 [[package]]
 name = "absl-py"
@@ -2464,6 +2467,7 @@ all = [
     { name = "neo4j" },
     { name = "nvidia-ml-py" },
     { name = "open-clip-torch" },
+    { name = "opencv-python-headless" },
     { name = "psutil" },
     { name = "scikit-learn" },
     { name = "scipy" },
@@ -2504,6 +2508,7 @@ local = [
     { name = "nemotron-page-elements-v3" },
     { name = "nemotron-table-structure-v1" },
     { name = "nvidia-ml-py" },
+    { name = "opencv-python-headless" },
     { name = "psutil" },
     { name = "scikit-learn" },
     { name = "timm" },
@@ -2587,6 +2592,7 @@ requires-dist = [
     { name = "nvidia-ml-py", marker = "extra == 'local'" },
     { name = "open-clip-torch", marker = "extra == 'benchmarks'", specifier = "==3.2.0" },
     { name = "open-clip-torch", marker = "extra == 'nemotron-parse'", specifier = "==3.2.0" },
+    { name = "opencv-python-headless", marker = "extra == 'local'", specifier = ">=4.8.0" },
     { name = "pandas", specifier = ">=2.0,<3" },
     { name = "pillow", specifier = "==12.2.0" },
     { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0,<8" },
@@ -2669,7 +2675,7 @@ dependencies = [
     { name = "ninja" },
     { name = "numpy" },
     { name = "onnx" },
-    { name = "opencv-python" },
+    { name = "opencv-python", marker = "sys_platform == 'never'" },
     { name = "psutil" },
     { name = "pycocotools" },
     { name = "tabulate" },
@@ -3182,17 +3188,7 @@ name = "opencv-python"
 version = "4.13.0.92"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/6f/5a28fef4c4a382be06afe3938c64cc168223016fa520c5abaf37e8862aa5/opencv_python-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:caf60c071ec391ba51ed00a4a920f996d0b64e3e46068aac1f646b5de0326a19", size = 46247052, upload-time = "2026-02-05T07:01:25.046Z" },
-    { url = "https://files.pythonhosted.org/packages/08/ac/6c98c44c650b8114a0fb901691351cfb3956d502e8e9b5cd27f4ee7fbf2f/opencv_python-4.13.0.92-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:5868a8c028a0b37561579bfb8ac1875babdc69546d236249fff296a8c010ccf9", size = 32568781, upload-time = "2026-02-05T07:01:41.379Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/51/82fed528b45173bf629fa44effb76dff8bc9f4eeaee759038362dfa60237/opencv_python-4.13.0.92-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0bc2596e68f972ca452d80f444bc404e08807d021fbba40df26b61b18e01838a", size = 47685527, upload-time = "2026-02-05T06:59:11.24Z" },
-    { url = "https://files.pythonhosted.org/packages/db/07/90b34a8e2cf9c50fe8ed25cac9011cde0676b4d9d9c973751ac7616223a2/opencv_python-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:402033cddf9d294693094de5ef532339f14ce821da3ad7df7c9f6e8316da32cf", size = 70460872, upload-time = "2026-02-05T06:59:19.162Z" },
-    { url = "https://files.pythonhosted.org/packages/02/6d/7a9cc719b3eaf4377b9c2e3edeb7ed3a81de41f96421510c0a169ca3cfd4/opencv_python-4.13.0.92-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:bccaabf9eb7f897ca61880ce2869dcd9b25b72129c28478e7f2a5e8dee945616", size = 46708208, upload-time = "2026-02-05T06:59:15.419Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/55/b3b49a1b97aabcfbbd6c7326df9cb0b6fa0c0aefa8e89d500939e04aa229/opencv_python-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:620d602b8f7d8b8dab5f4b99c6eb353e78d3fb8b0f53db1bd258bb1aa001c1d5", size = 72927042, upload-time = "2026-02-05T06:59:23.389Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/17/de5458312bcb07ddf434d7bfcb24bb52c59635ad58c6e7c751b48949b009/opencv_python-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:372fe164a3148ac1ca51e5f3ad0541a4a276452273f503441d718fab9c5e5f59", size = 30932638, upload-time = "2026-02-05T07:02:14.98Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/a5/1be1516390333ff9be3a9cb648c9f33df79d5096e5884b5df71a588af463/opencv_python-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:423d934c9fafb91aad38edf26efb46da91ffbc05f3f59c4b0c72e699720706f5", size = 40212062, upload-time = "2026-02-05T07:02:12.724Z" },
+    { name = "numpy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

When you install .[local] from scratch, pip/uv end up resolving both opencv-python and opencv-python-headless. Neither one is declared by us, but both come in probably through the nemotron wheels. Those two packages both install to the same cv2/ directory on disk, so they stomp on each other.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
