### PR TITLE
docs(helm): backport PR #2097 — core vs optional Helm NIMs

### DIFF
--- a/docs/docs/extraction/deployment-options.md
+++ b/docs/docs/extraction/deployment-options.md
@@ -18,7 +18,7 @@ Use the sections below to pick documentation and deployment options that match y
 3. **Published Library Helm charts (supported):** cluster install and upgrade procedures are covered in the [NeMo Retriever Library](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) — use alongside the NeMo Retriever chart README for your release
 4. [Environment variables](environment-config.md) and [Troubleshoot](troubleshoot.md) as needed
 
-**Default NIMs in the published NeMo Retriever Library Helm chart** (26.03): `page_elements`, `table_structure`, `ocr`, and `vlm_embed` (`llama-nemotron-embed-vl-1b-v2:1.12.0`). **Nemotron Parse**, **Nemotron 3 Nano Omni**, and the **VL reranker** are optional and disabled by default—enable them only when needed. See [Pre-Requisites & Support Matrix — Default Helm NIMs](prerequisites-support-matrix.md#default-helm-nims).
+**Core NIMs for the default extraction pipeline** (26.05): `page_elements`, `table_structure`, `ocr`, and `vlm_embed` (`llama-nemotron-embed-vl-1b-v2:1.12.0`). These four are auto-wired into the retriever service. **Nemotron Parse**, **Nemotron 3 Nano Omni**, the **VL reranker**, and **Parakeet ASR** are optional and not auto-wired. For a minimal GPU footprint, disable optional keys you do not need (see [Recommended minimal install (26.05)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#recommended-minimal-install-2605)). See [Pre-Requisites & Support Matrix — Default Helm NIMs](prerequisites-support-matrix.md#default-helm-nims).
 
 **Docker Compose (unsupported, developer-only):** [Docker Compose for local development](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md) — **not** a substitute for Helm or the published Library charts.
 

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -75,9 +75,9 @@ Default VL embedder container and model for release deployments:
 - **Image:** `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:1.12.0`
 - **Model ID:** `nvidia/llama-nemotron-embed-vl-1b-v2`
 
-### Optional Helm NIMs (not auto-wired by default) { #optional-helm-nims-not-auto-wired-by-default }
+### Optional Helm NIMs (not auto-wired) { #optional-helm-nims-not-auto-wired-by-default }
 
-The chart may reconcile these NIM microservices when `nimOperator.<key>.enabled` is `true`, but the retriever service does **not** call them until you enable the matching pipeline stage (reranker, Nemotron Parse, caption, or audio). Enable only what your workload needs. Chart keys and `enabled` defaults are in the [NeMo Retriever Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#nim-operator-sub-stack).
+These NIM microservices are **optional** for the default extraction pipeline. The retriever service does **not** call them until you enable the matching pipeline stage (reranker, Nemotron Parse, caption, or audio). For installs that need only the four core NIMs, disable keys you do not need (see [Recommended minimal install (26.05)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#recommended-minimal-install-2605)). Set `nimOperator.<key>.enabled=true` when you want that NIM reconciled. Chart keys and `enabled` defaults are in the [NeMo Retriever Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#nim-operator-sub-stack).
 
 | Helm flag | NIM | Role |
 |-----------|-----|------|

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -63,10 +63,10 @@ nemo_retriever/helm/
         ├── nemotron-table-structure-v1.yaml   # NIMCache + NIMService
         ├── nemotron-ocr-v1.yaml               # NIMCache + NIMService
         ├── llama-nemotron-embed-vl-1b-v2.yaml           # NIMCache + NIMService (VLM embed)
-        ├── llama-nemotron-rerank-1b-v2.yaml   # NIMCache + NIMService (optional; enabled by default; not auto-wired)
-        ├── nemotron-parse.yaml                # NIMCache + NIMService (optional; enabled by default; not auto-wired)
-        ├── nemotron-3-nano-omni-30b-a3b-reasoning.yaml  # NIMCache + NIMService (optional; enabled by default; not auto-wired)
-        └── audio.yaml                         # NIMCache + NIMService (optional; enabled by default; not auto-wired)
+        ├── llama-nemotron-rerank-1b-v2.yaml   # NIMCache + NIMService (optional; not auto-wired)
+        ├── nemotron-parse.yaml                # NIMCache + NIMService (optional; not auto-wired)
+        ├── nemotron-3-nano-omni-30b-a3b-reasoning.yaml  # NIMCache + NIMService (optional; not auto-wired)
+        └── audio.yaml                         # NIMCache + NIMService (optional; not auto-wired)
 ```
 
 ---
@@ -159,9 +159,7 @@ the secret is absent (useful for fully local NIM endpoints).
 
 Install the [NIM Operator](https://docs.nvidia.com/nim-operator/) first so
 the `NIMCache` / `NIMService` CRDs (`apps.nvidia.com/v1alpha1`) are
-registered. Then run the default install — `nims.enabled` is `true` out
-of the box, so every per-NIM block under `nimOperator.<key>.enabled: true`
-(all eight by default) is reconciled:
+registered. For **26.05 production**, use the [recommended minimal install](#recommended-minimal-install-2605) (four core NIMs only). A plain `helm install` without overrides may also reconcile optional NIMs when their `enabled` flags are `true` in `values.yaml`.
 
 ```bash
 helm install retriever ./nemo_retriever/helm \
@@ -169,6 +167,22 @@ helm install retriever ./nemo_retriever/helm \
   --set ngcImagePullSecret.password=$NGC_API_KEY \
   --set ngcApiSecret.create=true \
   --set ngcApiSecret.password=$NGC_API_KEY
+```
+
+### Recommended minimal install (26.05)
+
+Deploy only the four core NIMs that the retriever service auto-wires (`page_elements`, `table_structure`, `ocr`, `vlm_embed`). Disable optional NIMs unless your workload needs reranking, Nemotron Parse, Omni captioning, or ASR:
+
+```bash
+helm install retriever ./nemo_retriever/helm \
+  --set ngcImagePullSecret.create=true \
+  --set ngcImagePullSecret.password=$NGC_API_KEY \
+  --set ngcApiSecret.create=true \
+  --set ngcApiSecret.password=$NGC_API_KEY \
+  --set nimOperator.rerankqa.enabled=false \
+  --set nimOperator.nemotron_parse.enabled=false \
+  --set nimOperator.nemotron_3_nano_omni_30b_a3b_reasoning.enabled=false \
+  --set nimOperator.audio.enabled=false
 ```
 
 The chart auto-wires the operator-managed in-cluster URLs of the four
@@ -244,10 +258,10 @@ pair gated on three conditions ALL holding:
 | `nimOperator.vlm_embed.enabled`        | `true`  | Multimodal embedding NIM (also used by the vectordb Pod). |
 | `nimOperator.vlm_embed.nimServiceName` | `llama-nemotron-embed-vl-1b-v2` | NIMService / in-cluster DNS name. |
 | `nimOperator.vlm_embed.image`          | `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:1.12.0` | Default VLM embed NIM image. |
-| `nimOperator.rerankqa.enabled`         | `true`  | Reranker NIM. |
-| `nimOperator.nemotron_parse.enabled`   | `true`  | Structured-parse NIM. |
-| `nimOperator.nemotron_3_nano_omni_30b_a3b_reasoning.enabled` | `true` | Multimodal reasoning LLM (30B). |
-| `nimOperator.audio.enabled`            | `true`  | ASR NIM. |
+| `nimOperator.rerankqa.enabled`         | `true`  | Reranker NIM (optional; not auto-wired). Set `false` for [minimal install](#recommended-minimal-install-2605). |
+| `nimOperator.nemotron_parse.enabled`   | `true`  | Structured-parse NIM (optional). Set `false` unless using `extract_method="nemotron_parse"`. |
+| `nimOperator.nemotron_3_nano_omni_30b_a3b_reasoning.enabled` | `true` | Omni caption NIM (optional). Set `false` unless enabling image captioning. |
+| `nimOperator.audio.enabled`            | `true`  | ASR NIM (optional). Set `false` unless using audio/video transcription. |
 | `nimOperator.<key>.image.repository`   | `nvcr.io/nim/nvidia/...` | Per-NIM image. |
 | `nimOperator.<key>.image.pullSecrets`  | `[ngc-secret]` | Referenced by the NIMService CR. |
 | `nimOperator.<key>.authSecret`         | `ngc-api`      | NIM auth Secret name. |
@@ -258,13 +272,14 @@ pair gated on three conditions ALL holding:
 | `nimOperator.<key>.expose.service.grpcPort` | `8001` (50051 for audio) | gRPC port. |
 
 > Only the four "core" NIMs (page_elements, table_structure, ocr, vlm_embed)
-> are auto-wired into the retriever-service config. The other NIMs are
-> reconciled by the operator but the retriever-service won't call them
-> unless you wire your own pipeline to use them.
+> are auto-wired into the retriever-service config. Optional NIMs may reconcile
+> when `nimOperator.<key>.enabled` is `true` in `values.yaml`, but the
+> retriever-service won't call them unless you wire your pipeline to use them.
+> For 26.05, prefer the [minimal install](#recommended-minimal-install-2605) overrides.
 
 **Charts and captioning.** Charts and infographics use **page_elements**
 and **ocr** (no `graphic_elements` operator NIM in this chart). For image
-captioning, enable `nemotron_3_nano_omni_30b_a3b_reasoning` — see
+captioning, set `nimOperator.nemotron_3_nano_omni_30b_a3b_reasoning.enabled=true` — see
 [Image captioning](https://docs.nvidia.com/nemo/retriever/latest/extraction/prerequisites-support-matrix/#image-captioning).
 
 ### Persistence


### PR DESCRIPTION
## Summary

Backport of [#2097](https://github.com/NVIDIA/NeMo-Retriever/pull/2097) (merged to `26.05`) onto `main`.

- Document four **core** Helm NIMs auto-wired into the retriever service (`page_elements`, `table_structure`, `ocr`, `vlm_embed`).
- Clarify **optional** NIMs (reranker, Nemotron Parse, Omni caption, Parakeet ASR) are not auto-wired.
- Add **recommended minimal install (26.05)** Helm README section with `--set nimOperator.<key>.enabled=false` overrides.
- GitHub-compatible heading anchor (no MkDocs `{ #... }` suffix on Helm README).

**Docs and `.md` only** — does not modify `values.yaml`, Helm templates, or `Chart.yaml`.

## Out of scope

Chart defaults and non-documentation Helm artifacts are unchanged on `main` (same as #2097 on `26.05`).

## Test plan

- [ ] Review doc changes against `values.yaml` on `main`.
- [ ] Confirm GitHub fragment `#recommended-minimal-install-2605` resolves in Helm README.
- [ ] Verify minimal-install `--set` flags match release intent.