### PR TITLE
Fix ASR and media pipeline parameter handling

### DIFF
--- a/nemo_retriever/src/nemo_retriever/audio/media_interface.py
+++ b/nemo_retriever/src/nemo_retriever/audio/media_interface.py
@@ -29,6 +29,7 @@ try:
 except ImportError:
     ffmpeg = None  # type: ignore[assignment]
 
+VIDEO_CONTAINER_SUFFIXES: Tuple[str, ...] = (".mp4", ".mov", ".avi", ".mkv")
 MANUAL_FFMPEG_INSTALL_COMMAND = "apt-get update && apt-get install -y --no-install-recommends ffmpeg"
 CONTAINER_FFMPEG_INSTALL_ENV = "-e INSTALL_FFMPEG=true"
 HELM_FFMPEG_INSTALL_VALUE = "service.installFfmpeg=true"
@@ -304,7 +305,14 @@ class MediaInterface(_LoaderInterface):
         # containers — so chunking the raw video would produce chunks the ASR
         # client immediately rejects. The historical ``audio_only`` opt-in
         # never had any other reachable consumer, so it's been retired.
-        if path_input.suffix.lower() in [".mp4", ".mov", ".avi", ".mkv"]:
+        if path_input.suffix.lower() in VIDEO_CONTAINER_SUFFIXES:
+            if video_audio_separate:
+                logger.warning(
+                    "video_audio_separate is ignored for video inputs in the ASR chunking path; "
+                    "MediaChunkActor always demuxes videos to ASR-safe audio chunks and does not "
+                    "emit video-container chunks. Use VideoSplitActor or the video pipeline for "
+                    "audio+visual video processing."
+                )
             out_mp3 = output_dir / f"{path_input.stem}.mp3"
             result = self.get_audio_from_video(str(input_path), str(out_mp3), cache_path)
             if result is None:
@@ -350,12 +358,6 @@ class MediaInterface(_LoaderInterface):
             return []
         # Use actual chunk files produced by ffmpeg (may differ from num_splits)
         files = sorted(str(p) for p in output_dir.glob(f"{file_name}_chunk_*{suffix}") if p.is_file())
-        if video_audio_separate and suffix.lower() in [".mp4", ".mov", ".avi", ".mkv"]:
-            for f in files:
-                fp = Path(f)
-                audio_path = self.get_audio_from_video(f, str(fp.with_suffix(".mp3")), str(cache_path))
-                if audio_path is not None:
-                    files.append(str(audio_path))
         return files
 
     def extract_frames(

--- a/nemo_retriever/src/nemo_retriever/audio/stage.py
+++ b/nemo_retriever/src/nemo_retriever/audio/stage.py
@@ -164,7 +164,10 @@ def extract(
     video_audio_separate: bool = typer.Option(
         False,
         "--video-audio-separate/--no-video-audio-separate",
-        help="If true and video, also add extracted MP3 as separate item.",
+        help=(
+            "Compatibility no-op for video inputs in this ASR path: videos are always demuxed "
+            "to ASR-safe audio chunks. Use VideoSplitActor or the video pipeline for audio+visual processing."
+        ),
     ),
     use_env_asr: bool = typer.Option(
         True,
@@ -214,11 +217,7 @@ def extract(
     )
 
     if use_env_asr:
-        asr_params = asr_params_from_env()
-        if audio_grpc_endpoint is not None:
-            asr_params = asr_params.model_copy(
-                update={"audio_endpoints": (audio_grpc_endpoint, asr_params.audio_endpoints[1])}
-            )
+        asr_params = asr_params_from_env(default_grpc_endpoint=audio_grpc_endpoint)
         if auth_token is not None:
             asr_params = asr_params.model_copy(update={"auth_token": auth_token})
     else:

--- a/nemo_retriever/src/nemo_retriever/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/params/models.py
@@ -154,6 +154,12 @@ class AudioChunkParams(_ParamsModel):
     ``audio_only=True`` on a video input extracts only the audio track,
     runs ASR over it, and skips the visual branch entirely — no frame
     extraction, no OCR, no audio/visual fusion.
+
+    ``video_audio_separate`` is accepted for compatibility but ignored by
+    ``MediaChunkActor`` on video inputs: this ASR chunking path always demuxes
+    videos to ASR-safe audio chunks and does not emit video-container chunks.
+    Use ``VideoSplitActor`` or the video pipeline when you need audio+visual
+    video processing.
     """
 
     enabled: bool = True

--- a/nemo_retriever/src/nemo_retriever/video/frame_actor.py
+++ b/nemo_retriever/src/nemo_retriever/video/frame_actor.py
@@ -58,8 +58,8 @@ class VideoFrameActor(AbstractOperator, CPUOperator):
       - ``path``: original video path (frames are not persisted on disk;
         ``image_b64`` / ``bytes`` carry the pixels)
       - ``source_path``: original video path
-      - ``image_b64``: base64-encoded PNG (the ``VideoFrameOCRActor`` reads this)
-      - ``bytes``: raw PNG bytes (kept for compatibility with Ray Data binary readers)
+      - ``image_b64``: base64-encoded frame image, JPEG by default
+      - ``bytes``: encoded frame image bytes, JPEG by default
       - ``page_number``: frame index (0, 1, 2, ...)
       - ``metadata``: dict with ``frame_timestamp_seconds``, ``segment_start_seconds``,
         ``segment_end_seconds``, ``fps``, ``source_path``, ``modality="video_frame"``,
@@ -157,7 +157,7 @@ def _extract_one(source_path: str, params: VideoFrameParams, interface: MediaInt
 
 
 def _dhash(image_b64: str, hash_size: int = 8) -> Optional[int]:
-    """Difference-hash of a base64-encoded PNG, packed into a 64-bit integer.
+    """Difference-hash of a base64-encoded frame image, packed into a 64-bit integer.
 
     Resize to ``(hash_size+1) x hash_size`` grayscale, compare each pixel to
     its right neighbour, pack the results as bits. Two frames with similar

--- a/nemo_retriever/tests/__init__.py
+++ b/nemo_retriever/tests/__init__.py
@@ -11,14 +11,15 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from nemo_retriever.audio.media_interface import is_ffmpeg_available
 from nemo_retriever.audio.media_interface import is_media_available
 
 __all__ = [
     "is_ffmpeg_cli_available",
     "is_media_extract_available",
     "_have_ffmpeg_binary",
-    "is_ffmpeg_png_encoder_available",
-    "_have_ffmpeg_binary_for_png_frames",
+    "is_ffmpeg_jpeg_encoder_available",
+    "_have_ffmpeg_binary_for_jpeg_frames",
     "_make_test_mp4_with_av",
 ]
 
@@ -38,16 +39,16 @@ def _have_ffmpeg_binary() -> bool:
     return is_media_extract_available()
 
 
-def is_ffmpeg_png_encoder_available() -> bool:
-    """True if ffmpeg can encode PNG stills (``image2`` / ``MediaInterface.extract_frames``).
+def is_ffmpeg_jpeg_encoder_available() -> bool:
+    """True if ffmpeg can encode JPEG stills for ``MediaInterface.extract_frames``.
 
-    Minimal ffmpeg builds may omit the PNG encoder; probe with a one-frame lavfi encode.
+    Minimal ffmpeg builds may omit encoders; probe the default mjpeg/JPEG frame path.
     """
     exe = shutil.which("ffmpeg")
     if not exe:
         return False
-    with tempfile.TemporaryDirectory(prefix="retriever_png_enc_probe_") as tmp:
-        out_path = Path(tmp) / "probe.png"
+    with tempfile.TemporaryDirectory(prefix="retriever_jpeg_enc_probe_") as tmp:
+        out_path = Path(tmp) / "probe.jpg"
         cmd = [
             exe,
             "-y",
@@ -59,6 +60,10 @@ def is_ffmpeg_png_encoder_available() -> bool:
             "testsrc=duration=0.1:size=16x16:rate=1",
             "-frames:v",
             "1",
+            "-vcodec",
+            "mjpeg",
+            "-q:v",
+            "2",
             str(out_path),
         ]
         try:
@@ -74,9 +79,9 @@ def is_ffmpeg_png_encoder_available() -> bool:
         return r.returncode == 0 and out_path.is_file() and out_path.stat().st_size > 0
 
 
-def _have_ffmpeg_binary_for_png_frames() -> bool:
-    """For pytest skips on paths that call ``MediaInterface.extract_frames`` (PNG output)."""
-    return is_media_extract_available() and is_ffmpeg_png_encoder_available()
+def _have_ffmpeg_binary_for_jpeg_frames() -> bool:
+    """For pytest skips on default JPEG frame extraction paths."""
+    return is_ffmpeg_available() and is_ffmpeg_jpeg_encoder_available()
 
 
 def _make_test_mp4_with_av(path: Path, duration_sec: int = 5) -> None:

--- a/nemo_retriever/tests/__init__.py
+++ b/nemo_retriever/tests/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "_have_media_dependencies_for_jpeg_video_pipeline",
     "_make_test_mp4_with_av",
     "_ffprobe_first_stream_type",
+    "_assert_jpeg_bytes",
 ]
 
 
@@ -136,3 +137,11 @@ def _ffprobe_first_stream_type(path: Path) -> str:
     )
     lines = result.stdout.splitlines()
     return lines[0].strip() if lines else ""
+
+
+def _assert_jpeg_bytes(raw: bytes) -> None:
+    import io
+    from PIL import Image
+
+    with Image.open(io.BytesIO(raw)) as image:
+        assert image.format == "JPEG"

--- a/nemo_retriever/tests/__init__.py
+++ b/nemo_retriever/tests/__init__.py
@@ -20,7 +20,9 @@ __all__ = [
     "_have_ffmpeg_binary",
     "is_ffmpeg_jpeg_encoder_available",
     "_have_ffmpeg_binary_for_jpeg_frames",
+    "_have_media_dependencies_for_jpeg_video_pipeline",
     "_make_test_mp4_with_av",
+    "_ffprobe_first_stream_type",
 ]
 
 
@@ -84,6 +86,11 @@ def _have_ffmpeg_binary_for_jpeg_frames() -> bool:
     return is_ffmpeg_available() and is_ffmpeg_jpeg_encoder_available()
 
 
+def _have_media_dependencies_for_jpeg_video_pipeline() -> bool:
+    """For pytest skips on video-pipeline paths needing ffprobe plus JPEG frames."""
+    return is_media_available() and is_ffmpeg_jpeg_encoder_available()
+
+
 def _make_test_mp4_with_av(path: Path, duration_sec: int = 5) -> None:
     """Synthetic MP4 with video+audio; ``mpeg4`` avoids requiring ``libx264``."""
     cmd = [
@@ -109,3 +116,23 @@ def _make_test_mp4_with_av(path: Path, duration_sec: int = 5) -> None:
         str(path),
     ]
     subprocess.run(cmd, check=True)
+
+
+def _ffprobe_first_stream_type(path: Path) -> str:
+    result = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "stream=codec_type",
+            "-of",
+            "csv=p=0",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    lines = result.stdout.splitlines()
+    return lines[0].strip() if lines else ""

--- a/nemo_retriever/tests/test_asr_actor.py
+++ b/nemo_retriever/tests/test_asr_actor.py
@@ -18,8 +18,13 @@ from unittest.mock import patch
 import pandas as pd
 
 from nemo_retriever.audio.asr_actor import ASRActor
+from nemo_retriever.audio.asr_actor import DEFAULT_NGC_ASR_FUNCTION_ID
 from nemo_retriever.audio.asr_actor import apply_asr_to_df
+from nemo_retriever.audio.asr_actor import asr_params_from_env
 from nemo_retriever.params import ASRParams
+
+
+NVCF_GRPC_ENDPOINT = "grpc.nvcf.nvidia.com:443"
 
 
 def test_strip_pad_from_transcript():
@@ -239,6 +244,51 @@ def test_local_asr_does_not_call_get_client():
             sys.modules.pop("nemo_retriever.model.local", None)
         else:
             sys.modules["nemo_retriever.model.local"] = prev_local
+
+
+def test_asr_params_from_env_default_grpc_endpoint_preserves_nvidia_auth(monkeypatch):
+    monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-test")
+    monkeypatch.delenv("NGC_API_KEY", raising=False)
+    monkeypatch.delenv("AUDIO_GRPC_ENDPOINT", raising=False)
+    monkeypatch.delenv("AUDIO_FUNCTION_ID", raising=False)
+
+    params = asr_params_from_env(default_grpc_endpoint=NVCF_GRPC_ENDPOINT)
+
+    assert params.audio_endpoints[0] == NVCF_GRPC_ENDPOINT
+    assert params.auth_token == "nvapi-test"
+    assert params.function_id == DEFAULT_NGC_ASR_FUNCTION_ID
+    assert params.audio_infer_protocol == "grpc"
+
+
+def test_asr_params_from_env_without_endpoint_drops_nvidia_auth(monkeypatch):
+    monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-test")
+    monkeypatch.setenv("AUDIO_FUNCTION_ID", "function-test")
+    monkeypatch.delenv("NGC_API_KEY", raising=False)
+    monkeypatch.delenv("AUDIO_GRPC_ENDPOINT", raising=False)
+
+    params = asr_params_from_env()
+
+    assert params.audio_endpoints == (None, None)
+    assert params.auth_token is None
+    assert params.function_id is None
+    assert params.audio_infer_protocol == "grpc"
+
+
+def test_asr_cpu_actor_defaults_with_only_nvidia_auth_populate_remote_defaults(monkeypatch):
+    from nemo_retriever.audio.cpu_actor import ASRCPUActor
+
+    monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-test")
+    monkeypatch.delenv("AUDIO_GRPC_ENDPOINT", raising=False)
+    monkeypatch.delenv("AUDIO_FUNCTION_ID", raising=False)
+
+    with patch("nemo_retriever.audio.asr_actor._get_client") as mock_get:
+        actor = ASRCPUActor(params=asr_params_from_env())
+
+    mock_get.assert_called_once()
+    assert actor._params.audio_endpoints[0] == NVCF_GRPC_ENDPOINT
+    assert actor._params.auth_token == "nvapi-test"
+    assert actor._params.function_id == DEFAULT_NGC_ASR_FUNCTION_ID
+    assert actor._params.audio_infer_protocol == "grpc"
 
 
 def test_local_asr_apply_asr_to_df():

--- a/nemo_retriever/tests/test_audio_chunk_actor.py
+++ b/nemo_retriever/tests/test_audio_chunk_actor.py
@@ -6,6 +6,8 @@
 Unit tests for nemo_retriever.audio: MediaChunkActor and audio_path_to_chunks_df.
 """
 
+import logging
+import subprocess
 import wave
 from pathlib import Path
 
@@ -17,6 +19,7 @@ from nemo_retriever.audio.chunk_actor import MediaChunkActor
 from nemo_retriever.audio.chunk_actor import audio_path_to_chunks_df
 from nemo_retriever.audio.media_interface import is_media_available
 from tests import _have_ffmpeg_binary
+from tests import _make_test_mp4_with_av
 from nemo_retriever.params import AudioChunkParams
 
 
@@ -28,6 +31,26 @@ def _make_small_wav(path: Path, duration_sec: float = 0.5, sample_rate: int = 80
         wav.setsampwidth(2)
         wav.setframerate(sample_rate)
         wav.writeframes(b"\x00\x00" * n_frames)
+
+
+def _ffprobe_first_stream_type(path: Path) -> str:
+    result = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            "stream=codec_type",
+            "-of",
+            "csv=p=0",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    lines = result.stdout.splitlines()
+    return lines[0].strip() if lines else ""
 
 
 @pytest.mark.skipif(not _have_ffmpeg_binary(), reason="ffmpeg not available")
@@ -64,6 +87,38 @@ def test_media_chunk_actor_single_small_file(tmp_path: Path):
     assert out["source_path"].iloc[0] == str(wav.resolve())
     assert out["chunk_index"].iloc[0] == 0
     assert isinstance(out["bytes"].iloc[0], bytes)
+
+
+@pytest.mark.skipif(not _have_ffmpeg_binary(), reason="ffmpeg not available")
+def test_video_audio_separate_true_on_video_warns_and_outputs_audio_chunks(tmp_path: Path, caplog) -> None:
+    fixture = tmp_path / "fixture.mp4"
+    _make_test_mp4_with_av(fixture, duration_sec=2)
+
+    caplog.set_level(logging.WARNING, logger="nemo_retriever.audio.media_interface")
+    params = AudioChunkParams(
+        split_type="time",
+        split_interval=10,
+        video_audio_separate=True,
+    )
+    actor = MediaChunkActor(params=params)
+
+    out = actor(pd.DataFrame([{"path": str(fixture), "bytes": fixture.read_bytes()}]))
+
+    assert isinstance(out, pd.DataFrame)
+    assert not out.empty
+    chunk_paths = [Path(path) for path in out["path"].tolist()]
+    assert all(path.suffix == ".mp3" for path in chunk_paths)
+    assert not any(path.suffix == ".mp4" for path in chunk_paths)
+    assert all(metadata["source_path"] == str(fixture) for metadata in out["metadata"])
+    for idx, raw in enumerate(out["bytes"]):
+        assert isinstance(raw, bytes) and raw
+        chunk_copy = tmp_path / f"chunk_{idx}.mp3"
+        chunk_copy.write_bytes(raw)
+        assert _ffprobe_first_stream_type(chunk_copy) == "audio"
+    assert "video_audio_separate is ignored" in caplog.text
+    assert "ASR-safe audio chunks" in caplog.text
+    assert "VideoSplitActor" in caplog.text
+    assert "video pipeline" in caplog.text
 
 
 @pytest.mark.skipif(not _have_ffmpeg_binary(), reason="ffmpeg not available")

--- a/nemo_retriever/tests/test_audio_chunk_actor.py
+++ b/nemo_retriever/tests/test_audio_chunk_actor.py
@@ -7,7 +7,6 @@ Unit tests for nemo_retriever.audio: MediaChunkActor and audio_path_to_chunks_df
 """
 
 import logging
-import subprocess
 import wave
 from pathlib import Path
 
@@ -19,6 +18,7 @@ from nemo_retriever.audio.chunk_actor import MediaChunkActor
 from nemo_retriever.audio.chunk_actor import audio_path_to_chunks_df
 from nemo_retriever.audio.media_interface import is_media_available
 from tests import _have_ffmpeg_binary
+from tests import _ffprobe_first_stream_type
 from tests import _make_test_mp4_with_av
 from nemo_retriever.params import AudioChunkParams
 
@@ -31,26 +31,6 @@ def _make_small_wav(path: Path, duration_sec: float = 0.5, sample_rate: int = 80
         wav.setsampwidth(2)
         wav.setframerate(sample_rate)
         wav.writeframes(b"\x00\x00" * n_frames)
-
-
-def _ffprobe_first_stream_type(path: Path) -> str:
-    result = subprocess.run(
-        [
-            "ffprobe",
-            "-v",
-            "error",
-            "-show_entries",
-            "stream=codec_type",
-            "-of",
-            "csv=p=0",
-            str(path),
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    lines = result.stdout.splitlines()
-    return lines[0].strip() if lines else ""
 
 
 @pytest.mark.skipif(not _have_ffmpeg_binary(), reason="ffmpeg not available")

--- a/nemo_retriever/tests/test_audio_stage.py
+++ b/nemo_retriever/tests/test_audio_stage.py
@@ -10,8 +10,10 @@ from pathlib import Path
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import pandas as pd
 import pytest
 
+from nemo_retriever.audio.asr_actor import DEFAULT_NGC_ASR_FUNCTION_ID
 from tests import _have_ffmpeg_binary
 from nemo_retriever.audio.stage import _audio_extraction_json_path
 from nemo_retriever.audio.stage import _run_extract_one
@@ -90,6 +92,57 @@ def test_audio_stage_extract_cli_writes_sidecar(tmp_path: Path):
         assert "text" in chunk
         assert "source_path" in chunk
         assert chunk["text"] == "cli mock transcript"
+
+
+def test_audio_stage_extract_cli_grpc_endpoint_preserves_env_auth(monkeypatch, tmp_path: Path):
+    """CLI endpoint defaults must resolve together with env auth/function_id."""
+    endpoint = "grpc.nvcf.nvidia.com:443"
+    wav = tmp_path / "sample.wav"
+    wav.write_bytes(b"")
+    captured: dict[str, ASRParams] = {}
+
+    def fake_run_extract_one(path: str, chunk_params: AudioChunkParams, asr_params: ASRParams) -> pd.DataFrame:
+        captured["asr_params"] = asr_params
+        return pd.DataFrame(
+            [
+                {
+                    "path": path,
+                    "source_path": path,
+                    "duration": 0.0,
+                    "chunk_index": 0,
+                    "text": "ok",
+                    "metadata": {},
+                }
+            ]
+        )
+
+    monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-test")
+    monkeypatch.delenv("NGC_API_KEY", raising=False)
+    monkeypatch.delenv("AUDIO_GRPC_ENDPOINT", raising=False)
+    monkeypatch.delenv("AUDIO_FUNCTION_ID", raising=False)
+
+    with (
+        patch("nemo_retriever.audio.stage.is_media_available", return_value=True),
+        patch("nemo_retriever.audio.stage._run_extract_one", side_effect=fake_run_extract_one),
+    ):
+        extract(
+            input_dir=tmp_path,
+            glob="*.wav",
+            output_dir=None,
+            split_type="size",
+            split_interval=500_000,
+            video_audio_separate=False,
+            use_env_asr=True,
+            audio_grpc_endpoint=endpoint,
+            auth_token=None,
+            limit=None,
+            write_json=False,
+        )
+
+    asr_params = captured["asr_params"]
+    assert asr_params.audio_endpoints[0] == endpoint
+    assert asr_params.auth_token == "nvapi-test"
+    assert asr_params.function_id == DEFAULT_NGC_ASR_FUNCTION_ID
 
 
 def test_audio_extraction_json_path():

--- a/nemo_retriever/tests/test_readme_video_pipeline_example.py
+++ b/nemo_retriever/tests/test_readme_video_pipeline_example.py
@@ -10,13 +10,16 @@ and that ``VideoSplitActor`` emits both audio and frame rows on a synthetic MP4.
 
 from __future__ import annotations
 
+import base64
+import io
 import subprocess
 from pathlib import Path
 
 import pandas as pd
 import pytest
 
-from tests import _have_ffmpeg_binary_for_png_frames
+from tests import _have_ffmpeg_binary
+from tests import _have_ffmpeg_binary_for_jpeg_frames
 from tests import _make_test_mp4_with_av
 from nemo_retriever.graph.ingestor_runtime import build_graph
 from nemo_retriever.graph.pipeline_graph import Graph
@@ -66,6 +69,13 @@ def _ffprobe_first_stream_type(path: Path) -> str:
     return lines[0].strip() if lines else ""
 
 
+def _assert_jpeg_bytes(raw: bytes) -> None:
+    from PIL import Image
+
+    with Image.open(io.BytesIO(raw)) as image:
+        assert image.format == "JPEG"
+
+
 def test_video_asr_chunk_params_force_audio_demux() -> None:
     params = AudioChunkParams(
         enabled=True,
@@ -103,8 +113,8 @@ def test_video_asr_chunk_params_disabled_passthrough() -> None:
 
 
 @pytest.mark.skipif(
-    not _have_ffmpeg_binary_for_png_frames(),
-    reason="ffmpeg with PNG encoder required for frame extraction",
+    not _have_ffmpeg_binary(),
+    reason="ffmpeg/ffprobe required for VideoSplitActor construction",
 )
 def test_readme_video_pipeline_build_graph_chain() -> None:
     """``build_graph`` for the README video params starts with the documented chain."""
@@ -138,15 +148,15 @@ def test_readme_video_pipeline_build_graph_chain() -> None:
 
 
 @pytest.mark.skipif(
-    not _have_ffmpeg_binary_for_png_frames(),
-    reason="ffmpeg with PNG encoder required for VideoSplitActor construction",
+    not _have_ffmpeg_binary(),
+    reason="ffmpeg/ffprobe required for VideoSplitActor construction",
 )
 def test_audio_only_excludes_visual_branch_from_graph() -> None:
     """``audio_only=True`` must strip VideoFrameOCRActor, VideoFrameTextDedup,
     and AudioVisualFuser from the graph — only the audio (ASR) branch runs.
 
     Graph-topology check that still instantiates ``VideoSplitActor``, whose
-    constructor probes ffmpeg/ffprobe — hence the PNG-encoder gate.
+    constructor probes ffmpeg/ffprobe.
     """
     graph = build_graph(
         extraction_mode="auto",
@@ -176,8 +186,8 @@ def test_audio_only_excludes_visual_branch_from_graph() -> None:
 
 
 @pytest.mark.skipif(
-    not _have_ffmpeg_binary_for_png_frames(),
-    reason="ffmpeg with PNG encoder required for frame extraction",
+    not _have_ffmpeg_binary_for_jpeg_frames(),
+    reason="ffmpeg with JPEG encoder required for default frame extraction",
 )
 def test_readme_video_split_actor_emits_audio_and_frame_rows(tmp_path: Path) -> None:
     """Mirror README ``AudioChunkParams`` / ``VideoFrameParams`` on a synthetic MP4."""
@@ -208,3 +218,8 @@ def test_readme_video_split_actor_emits_audio_and_frame_rows(tmp_path: Path) -> 
         audio_chunk = tmp_path / f"audio_chunk_{idx}.mp3"
         audio_chunk.write_bytes(row["bytes"])
         assert _ffprobe_first_stream_type(audio_chunk) == "audio"
+
+    frame_rows = out[out["_content_type"] == _CT.VIDEO_FRAME]
+    assert not frame_rows.empty
+    for image_b64 in frame_rows["image_b64"]:
+        _assert_jpeg_bytes(base64.b64decode(image_b64))

--- a/nemo_retriever/tests/test_readme_video_pipeline_example.py
+++ b/nemo_retriever/tests/test_readme_video_pipeline_example.py
@@ -11,7 +11,6 @@ and that ``VideoSplitActor`` emits both audio and frame rows on a synthetic MP4.
 from __future__ import annotations
 
 import base64
-import io
 from pathlib import Path
 
 import pandas as pd
@@ -19,6 +18,7 @@ import pytest
 
 from tests import _have_ffmpeg_binary
 from tests import _have_media_dependencies_for_jpeg_video_pipeline
+from tests import _assert_jpeg_bytes
 from tests import _ffprobe_first_stream_type
 from tests import _make_test_mp4_with_av
 from nemo_retriever.graph.ingestor_runtime import build_graph
@@ -47,13 +47,6 @@ def _collect_node_names(graph: Graph) -> list[str]:
     for root in graph.roots:
         walk(root)
     return names
-
-
-def _assert_jpeg_bytes(raw: bytes) -> None:
-    from PIL import Image
-
-    with Image.open(io.BytesIO(raw)) as image:
-        assert image.format == "JPEG"
 
 
 def test_video_asr_chunk_params_force_audio_demux() -> None:

--- a/nemo_retriever/tests/test_readme_video_pipeline_example.py
+++ b/nemo_retriever/tests/test_readme_video_pipeline_example.py
@@ -12,14 +12,14 @@ from __future__ import annotations
 
 import base64
 import io
-import subprocess
 from pathlib import Path
 
 import pandas as pd
 import pytest
 
 from tests import _have_ffmpeg_binary
-from tests import _have_ffmpeg_binary_for_jpeg_frames
+from tests import _have_media_dependencies_for_jpeg_video_pipeline
+from tests import _ffprobe_first_stream_type
 from tests import _make_test_mp4_with_av
 from nemo_retriever.graph.ingestor_runtime import build_graph
 from nemo_retriever.graph.pipeline_graph import Graph
@@ -47,26 +47,6 @@ def _collect_node_names(graph: Graph) -> list[str]:
     for root in graph.roots:
         walk(root)
     return names
-
-
-def _ffprobe_first_stream_type(path: Path) -> str:
-    result = subprocess.run(
-        [
-            "ffprobe",
-            "-v",
-            "error",
-            "-show_entries",
-            "stream=codec_type",
-            "-of",
-            "csv=p=0",
-            str(path),
-        ],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    lines = result.stdout.splitlines()
-    return lines[0].strip() if lines else ""
 
 
 def _assert_jpeg_bytes(raw: bytes) -> None:
@@ -186,8 +166,8 @@ def test_audio_only_excludes_visual_branch_from_graph() -> None:
 
 
 @pytest.mark.skipif(
-    not _have_ffmpeg_binary_for_jpeg_frames(),
-    reason="ffmpeg with JPEG encoder required for default frame extraction",
+    not _have_media_dependencies_for_jpeg_video_pipeline(),
+    reason="ffmpeg/ffprobe with JPEG encoder required for video pipeline frame extraction",
 )
 def test_readme_video_split_actor_emits_audio_and_frame_rows(tmp_path: Path) -> None:
     """Mirror README ``AudioChunkParams`` / ``VideoFrameParams`` on a synthetic MP4."""

--- a/nemo_retriever/tests/test_video_frame_actor.py
+++ b/nemo_retriever/tests/test_video_frame_actor.py
@@ -6,13 +6,16 @@
 
 from __future__ import annotations
 
+import base64
+import io
 import subprocess
 from pathlib import Path
 
 import pandas as pd
 import pytest
 
-from tests import _have_ffmpeg_binary_for_png_frames
+from tests import _have_ffmpeg_binary_for_jpeg_frames
+from nemo_retriever.audio.media_interface import MediaInterface
 from nemo_retriever.params import VideoFrameParams
 from nemo_retriever.video.frame_actor import (
     FRAME_COLUMNS,
@@ -42,9 +45,16 @@ def _make_test_mp4_video_only(path: Path, *, duration_sec: int = 5, size: str = 
     subprocess.run(cmd, check=True)
 
 
+def _assert_jpeg_bytes(raw: bytes) -> None:
+    from PIL import Image
+
+    with Image.open(io.BytesIO(raw)) as image:
+        assert image.format == "JPEG"
+
+
 @pytest.mark.skipif(
-    not _have_ffmpeg_binary_for_png_frames(),
-    reason="ffmpeg with PNG encoder required for frame extraction",
+    not _have_ffmpeg_binary_for_jpeg_frames(),
+    reason="ffmpeg with JPEG encoder required for default frame extraction",
 )
 def test_video_path_to_frames_df_basic_count_and_timestamps(tmp_path: Path) -> None:
     fixture = tmp_path / "fixture.mp4"
@@ -76,8 +86,26 @@ def test_video_path_to_frames_df_basic_count_and_timestamps(tmp_path: Path) -> N
 
 
 @pytest.mark.skipif(
-    not _have_ffmpeg_binary_for_png_frames(),
-    reason="ffmpeg with PNG encoder required for frame extraction",
+    not _have_ffmpeg_binary_for_jpeg_frames(),
+    reason="ffmpeg with JPEG encoder required for default frame extraction",
+)
+def test_media_interface_extract_frames_defaults_to_jpeg_files(tmp_path: Path) -> None:
+    fixture = tmp_path / "fixture.mp4"
+    _make_test_mp4_video_only(fixture, duration_sec=2)
+    output_dir = tmp_path / "frames"
+
+    frames = MediaInterface().extract_frames(str(fixture), str(output_dir), fps=1.0)
+
+    assert frames
+    for frame_path, _timestamp in frames:
+        path = Path(frame_path)
+        assert path.suffix == ".jpg"
+        _assert_jpeg_bytes(path.read_bytes())
+
+
+@pytest.mark.skipif(
+    not _have_ffmpeg_binary_for_jpeg_frames(),
+    reason="ffmpeg with JPEG encoder required for default frame extraction",
 )
 def test_video_frame_actor_runs_on_dataframe(tmp_path: Path) -> None:
     fixture = tmp_path / "fixture.mp4"
@@ -89,6 +117,8 @@ def test_video_frame_actor_runs_on_dataframe(tmp_path: Path) -> None:
     assert isinstance(out, pd.DataFrame)
     assert len(out) == 3
     assert all(isinstance(b, str) and b for b in out["image_b64"])
+    for image_b64 in out["image_b64"]:
+        _assert_jpeg_bytes(base64.b64decode(image_b64))
 
 
 def _solid_png_b64(rgb: tuple[int, int, int], size: int = 16) -> str:

--- a/nemo_retriever/tests/test_video_frame_actor.py
+++ b/nemo_retriever/tests/test_video_frame_actor.py
@@ -7,13 +7,13 @@
 from __future__ import annotations
 
 import base64
-import io
 import subprocess
 from pathlib import Path
 
 import pandas as pd
 import pytest
 
+from tests import _assert_jpeg_bytes
 from tests import _have_ffmpeg_binary_for_jpeg_frames
 from nemo_retriever.audio.media_interface import MediaInterface
 from nemo_retriever.params import VideoFrameParams
@@ -43,13 +43,6 @@ def _make_test_mp4_video_only(path: Path, *, duration_sec: int = 5, size: str = 
         str(path),
     ]
     subprocess.run(cmd, check=True)
-
-
-def _assert_jpeg_bytes(raw: bytes) -> None:
-    from PIL import Image
-
-    with Image.open(io.BytesIO(raw)) as image:
-        assert image.format == "JPEG"
 
 
 @pytest.mark.skipif(

--- a/nemo_retriever/tests/test_video_pipeline_batch.py
+++ b/nemo_retriever/tests/test_video_pipeline_batch.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
-from tests import _have_ffmpeg_binary_for_png_frames
+from tests import _have_ffmpeg_binary_for_jpeg_frames
 from tests import _make_test_mp4_with_av
 from nemo_retriever.params import (
     ASRParams,
@@ -62,8 +62,8 @@ def test_run_video_pipeline_forces_audio_demux_chunk_params_without_ffmpeg() -> 
 
 
 @pytest.mark.skipif(
-    not _have_ffmpeg_binary_for_png_frames(),
-    reason="ffmpeg with PNG encoder required for frame extraction",
+    not _have_ffmpeg_binary_for_jpeg_frames(),
+    reason="ffmpeg with JPEG encoder required for default frame extraction",
 )
 def test_run_video_pipeline_emits_audio_frame_and_scene_rows(tmp_path: Path) -> None:
     """End-to-end through MultiTypeExtractOperator._run_video_pipeline.

--- a/nemo_retriever/tests/test_video_pipeline_batch.py
+++ b/nemo_retriever/tests/test_video_pipeline_batch.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
-from tests import _have_ffmpeg_binary_for_jpeg_frames
+from tests import _have_media_dependencies_for_jpeg_video_pipeline
 from tests import _make_test_mp4_with_av
 from nemo_retriever.params import (
     ASRParams,
@@ -62,8 +62,8 @@ def test_run_video_pipeline_forces_audio_demux_chunk_params_without_ffmpeg() -> 
 
 
 @pytest.mark.skipif(
-    not _have_ffmpeg_binary_for_jpeg_frames(),
-    reason="ffmpeg with JPEG encoder required for default frame extraction",
+    not _have_media_dependencies_for_jpeg_video_pipeline(),
+    reason="ffmpeg/ffprobe with JPEG encoder required for video pipeline frame extraction",
 )
 def test_run_video_pipeline_emits_audio_frame_and_scene_rows(tmp_path: Path) -> None:
     """End-to-end through MultiTypeExtractOperator._run_video_pipeline.


### PR DESCRIPTION
## Description
This PR layers three related media ingestion fixes on top of `upstream/main`:

- Resolves ASR endpoint and credential params in one pass so `retriever audio extract --audio-grpc-endpoint grpc.nvcf.nvidia.com:443` preserves `NVIDIA_API_KEY` and the default NVCF function ID instead of late-updating only `audio_endpoints`.
- Keeps `video_audio_separate` accepted for compatibility, while documenting and warning that it is ignored for video inputs in the ASR chunking path. That path continues to emit ASR-safe audio chunks only; users needing audio+visual processing should use `VideoSplitActor` or the video pipeline.
- Cleans default video frame tests/docs around JPEG output, replacing PNG-encoder skips with JPEG/default media availability checks and asserting default frames are `.jpg` / JPEG-decodable.

Root causes:

- The audio CLI applied the gRPC endpoint override after env credential resolution, which dropped cloud auth/function ID when the endpoint came from CLI.
- Default video frame extraction already writes JPEG on upstream, but several tests/docs still carried PNG-specific skip conditions and wording.
- `video_audio_separate` remained accepted but misleading for `MediaChunkActor`, where video inputs are always demuxed to audio chunks for ASR safety.

Validation:

- `uv run --project nemo_retriever --extra dev pytest nemo_retriever/tests/test_audio_chunk_actor.py nemo_retriever/tests/test_asr_actor.py::test_asr_params_from_env_default_grpc_endpoint_preserves_nvidia_auth nemo_retriever/tests/test_asr_actor.py::test_asr_params_from_env_without_endpoint_drops_nvidia_auth nemo_retriever/tests/test_asr_actor.py::test_asr_cpu_actor_defaults_with_only_nvidia_auth_populate_remote_defaults nemo_retriever/tests/test_audio_stage.py nemo_retriever/tests/test_video_frame_actor.py nemo_retriever/tests/test_readme_video_pipeline_example.py nemo_retriever/tests/test_video_pipeline_batch.py nemo_retriever/tests/test_media_dependency_availability.py -q`
  - `35 passed, 1 skipped, 2 subtests passed`
- `git diff --cached --check`
  - clean

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file. (N/A; no docker-compose or Helm environment variable changes.)
