### PR TITLE
skill: deeper rerank pool + duplicate-aware ranked_retrieved

### DIFF
--- a/.claude/skills/nemo-retriever/SKILL.md
+++ b/.claude/skills/nemo-retriever/SKILL.md
@@ -30,7 +30,7 @@ Don't pre-OCR, don't pre-chunk, don't write Python wrappers — the CLI handles 
 ## Query turn — the WHOLE workflow
 
 ```bash
-retriever query "<the user's question>" --top-k 10 --embed-model-name nvidia/llama-nemotron-embed-1b-v2 --rerank \
+retriever query "<the user's question>" --top-k 20 --embed-model-name nvidia/llama-nemotron-embed-1b-v2 --rerank \
   | tee /tmp/hits.json \
   | jq -r '.[] | "rank=\(.rank // 0) page=\(.page_number) pdf=\(.pdf_basename) type=\(.metadata.type // "?") text=\(.text[:200])"'
 ```
@@ -46,7 +46,7 @@ Each hit has: `text`, `pdf_basename`, `page_number` (int, **1-indexed**: the fir
 **Then write `./output.json` directly from $HITS:**
 
 - `final_answer`: synthesize from the top hits' `text`. Include the exact number / name / date / row / column the question asks for, plus the source PDF and 0-indexed page. One paragraph. No restating the question, no hedging caveats. If the chunks talk *around* the fact but don't state it, run ONE `retriever pdf stage page-elements ./pdfs --method pdfium --json-output-dir /tmp/pdf_text --compact-json` and read `/tmp/pdf_text/<top_pdf>.pdf.pdf_extraction.json` for the rank-1 page (or rank-2 if rank-1 is metadata) — that almost always surfaces the exact figure. Then synthesize. **If after both calls the asked-for fact still isn't in the evidence, write `final_answer` that says so explicitly** — e.g. "The retrieved pages do not state [X] for [entity]; the closest content is [Y]." Do NOT invent, extrapolate, or generate plausible-sounding content from adjacent material. A confidently-wrong answer scores worse than an honest "not in the retrieved pages".
-- `ranked_retrieved`: one entry per hit in the order `retriever query` returned: `{"doc_id": "<pdf_basename without .pdf>", "page_number": <int>, "rank": <i+1>}`. Up to 10. Duplicate `(doc, page)` is fine. **Indexing:** the retriever's `page_number` is 1-indexed. If the task's output schema says 0-indexed (e.g. "first page is page 0"), emit `hit.page_number - 1`; if the task says 1-indexed or doesn't specify, emit `hit.page_number` as-is.
+- `ranked_retrieved`: emit **up to 10 entries** `{"doc_id": "<pdf_basename without .pdf>", "page_number": <int>, "rank": <r>}` chosen from the reranked pool. `--top-k 20 --rerank` returns 20 reranked candidates (rerank's `refine_factor=4` means retriever pulled 80 candidates internally then the cross-encoder reranked them); the wider pool exists so you can surface 10 distinct pages even when multimodal indexes produce text + table + chart chunks on the same page. **Rule (deterministic):** walk the 20 reranked hits in order and emit each hit whose `(doc_id, page_number)` you have not emitted yet, with `rank` = 1, 2, 3, ... in emit order. Stop at 10 distinct pairs. Only if the full 20-candidate pool runs out before you reach 10 may you fall back to emitting a duplicate — and only enough to fill the remaining slots. **Indexing:** the retriever's `page_number` is 1-indexed. If the task's output schema says 0-indexed (e.g. "first page is page 0"), emit `hit.page_number - 1`; if the task says 1-indexed or doesn't specify, emit `hit.page_number` as-is.
 
 **Before writing `final_answer`, re-read the question.** If it lists multiple entities, years, or categories, your answer must address each one explicitly — even if for some of them the chunks say "not provided" or contain no data. Missing entities lose more judge points than imprecise numbers.
 


### PR DESCRIPTION
## Description
  ## Summary                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  Single 4-line change to `.claude/skills/nemo-retriever/SKILL.md`:                                                                                                                                                  
  bump the agent's `retriever query` invocation from `--top-k 10` to                                       
  `--top-k 20`, and update the `ranked_retrieved` guidance so the agent
  emits up to 10 distinct `(doc, page)` entries from the wider reranked                                    
  pool. No other behaviour changes — query budget, cost discipline,
  fallbacks all untouched.                                                                                 
                                                                                                           
  With `--rerank` enabled the retriever's internal `refine_factor=4`
  pulls `top_k × 4` candidates for the cross-encoder. Bumping top-k from                                   
  10 to 20 widens that pool from 40 → 80, lets the cross-encoder rerank
  a deeper set, and exposes the agent to 20 reranked candidates
  (vs 10) when it picks its top-10 page list.                                                              
 
  ## Measured gains (vidore_v3 batch 1, 46 queries: 15 finance + 15 HR + 16 pharma)                        
                                                      
  Same agent (claude-sonnet-4-6), same judge (nvidia/llama-3.3-nemotron-super-49b-v1.5), same eval harness — only the SKILL.md changed:
 
  | Metric | Baseline (top-k 10) | This PR (top-k 20) | Δ |
  |---|---|---|---|
  | Recall@1  | 0.224 | **0.300** | **+34%** |                                                             
  | Recall@5  | 0.505 | **0.565** | **+12%** |        
  | Recall@10 | 0.605 | **0.639** | **+5.6%** |                                                            
  | Judge (0–5) | 4.70 | 4.74 | +0.9% |                                                                    
  | Cost / query | $0.315 | $0.344 | +9% |            
                                                                                                           
  R@10 lift is concentrated on HR (+23%) — long-PDF, multi-relevant-page
  queries where the extra reranked headroom helps most. 
                                           
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
