### PR TITLE
skill-eval: add local 'judge' NIM compose profile + endpoint pre-flight

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -264,7 +264,7 @@ services:
   judge:
     # Nemotron-Super-49B-v1.5 NIM, used as the LLM-as-judge for
     # `retriever skill-eval`. Profile-gated: `docker compose up judge`.
-    image: ${JUDGE_IMAGE:-nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5}:${JUDGE_TAG:-latest}
+    image: ${JUDGE_IMAGE:-nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5}:${JUDGE_TAG:-2.0.5}
     shm_size: 16gb
     ports:
       - "${JUDGE_HTTP_PORT:-8000}:8000"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -261,6 +261,30 @@ services:
     profiles:
       - audio
 
+  judge:
+    # Nemotron-Super-49B-v1.5 NIM, used as the LLM-as-judge for
+    # `retriever skill-eval`. Profile-gated: `docker compose up judge`.
+    image: ${JUDGE_IMAGE:-nvcr.io/nim/nvidia/llama-3.3-nemotron-super-49b-v1.5}:${JUDGE_TAG:-latest}
+    shm_size: 16gb
+    ports:
+      - "${JUDGE_HTTP_PORT:-8000}:8000"
+    expose:
+      - "8000"
+    environment:
+      - NIM_HTTP_API_PORT=8000
+      - NGC_API_KEY=${NIM_NGC_API_KEY:-${NGC_API_KEY:-ngcapikey}}
+    command: ["--tool-call-parser", "llama3_json", "--enable-auto-tool-choice"]
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["${GPU_ID:-0}"]
+              capabilities: [gpu]
+    runtime: nvidia
+    profiles:
+      - judge
+
   nv-ingest-ms-runtime:
     image: nvcr.io/nvidia/nemo-microservices/nv-ingest:26.1.2
     shm_size: 40gb # Should be at minimum 30% of assigned memory per Ray documentation

--- a/nemo_retriever/src/nemo_retriever/skill_eval/cli.py
+++ b/nemo_retriever/src/nemo_retriever/skill_eval/cli.py
@@ -50,6 +50,37 @@ def _resolve_pdf_source(
     raise typer.BadParameter("config must define either 'pdf_dirs' (per-domain map) or 'pdf_dir'.")
 
 
+_LOCAL_JUDGE_HOSTS = {"localhost", "127.0.0.1", "::1", "host.docker.internal"}
+
+
+def _preflight_judge_endpoint(api_base: str, timeout: float = 5.0) -> None:
+    """Probe ``/health/ready`` when the judge endpoint is local; fail fast if down.
+
+    Cloud endpoints aren't probed (no guaranteed public health route, and a
+    bad cloud config isn't actionable from the runner). A local unreachable
+    endpoint nearly always means the user forgot to start the judge container,
+    so we surface the ``docker compose up judge`` hint up front instead of
+    burning trials on doomed judge calls.
+    """
+    from urllib.parse import urlparse
+    from urllib.request import urlopen
+
+    host = (urlparse(api_base).hostname or "").lower()
+    if host not in _LOCAL_JUDGE_HOSTS:
+        return
+    health_url = api_base.rstrip("/") + "/health/ready"
+    try:
+        with urlopen(health_url, timeout=timeout) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"HTTP {resp.status}")
+    except Exception as exc:
+        raise typer.BadParameter(
+            f"Judge endpoint {api_base} is unreachable ({exc}). "
+            "If you're using the local-NIM judge, start it first:\n"
+            "  docker compose up judge"
+        )
+
+
 def _build_judge(cfg: dict) -> Optional[Any]:
     """Construct an ``LLMJudge`` from ``cfg['judge']`` or return ``None``.
 
@@ -71,9 +102,12 @@ def _build_judge(cfg: dict) -> Optional[Any]:
     except ImportError as exc:
         typer.echo(f"Judge disabled: failed to import LLMJudge ({exc}). Install nemo-retriever[llm].")
         return None
+    api_base = judge_cfg.get("api_base")
+    if api_base:
+        _preflight_judge_endpoint(str(api_base))
     judge_kwargs: dict[str, Any] = {
         "model": str(judge_cfg.get("model", "nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5")),
-        "api_base": judge_cfg.get("api_base"),
+        "api_base": api_base,
         "api_key": api_key,
     }
     if judge_cfg.get("temperature") is not None:

--- a/nemo_retriever/src/nemo_retriever/skill_eval/configs/skill_eval.yaml
+++ b/nemo_retriever/src/nemo_retriever/skill_eval/configs/skill_eval.yaml
@@ -85,10 +85,14 @@ conditions:
 # on a 0-5 scale. Requires the ``litellm`` extra installed AND ``api_key_env``
 # populated in the environment; otherwise skipped silently with a console
 # note. Set ``enabled: false`` to opt out explicitly.
+#
+# For a local NIM judge: `docker compose up judge`, then point ``api_base``
+# at the localhost line below instead of the NVIDIA-hosted default.
 judge:
   enabled: true
   model: nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5
   api_base: https://integrate.api.nvidia.com/v1
+  # api_base: http://localhost:8000/v1    # `docker compose up judge` first
   api_key_env: NVIDIA_API_KEY
   temperature: 0.1
   max_tokens: 4096


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
