### PR TITLE
fix(tabular): raise SQLSyntaxError on unparseable SQL

### DIFF
--- a/nemo_retriever/src/nemo_retriever/tabular_data/ingestion/parsers/sqlglot_extractor.py
+++ b/nemo_retriever/src/nemo_retriever/tabular_data/ingestion/parsers/sqlglot_extractor.py
@@ -28,7 +28,18 @@ from dataclasses import dataclass, field
 
 import sqlglot
 from sqlglot import exp
+from sqlglot.errors import ParseError, TokenError
 from sqlglot.optimizer.qualify import qualify
+
+
+class SQLSyntaxError(ValueError):
+    """Raised when ``sqlglot`` cannot parse the SQL for the given dialect.
+
+    Distinguishes pure syntax/tokenization failures from later resolution
+    issues (e.g. unknown tables, schema mismatches), so callers can classify
+    validation outcomes precisely instead of treating an unparseable query
+    the same as a parseable query that references no known tables.
+    """
 
 
 @dataclass
@@ -506,8 +517,8 @@ def extract_tables_and_columns(
     """
     try:
         statement = sqlglot.parse_one(sql, dialect=dialect)
-    except Exception:
-        return ExtractionResult()
+    except (ParseError, TokenError) as err:
+        raise SQLSyntaxError(str(err)) from err
 
     ast_node_count = sum(1 for _ in statement.walk())
 

--- a/nemo_retriever/tests/test_sqlglot_extractor.py
+++ b/nemo_retriever/tests/test_sqlglot_extractor.py
@@ -6,9 +6,11 @@ attribute consumed by ``extract_tables_and_columns``.
 """
 
 import pandas as pd
+import pytest
 
 from nemo_retriever.tabular_data.ingestion.parsers.sqlglot_extractor import (
     JoinPair,
+    SQLSyntaxError,
     TableMatch,
     UnionPair,
     extract_tables_and_columns,
@@ -224,14 +226,17 @@ def test_ast_node_count_is_positive():
     assert result.ast_node_count > 0
 
 
-def test_empty_sql_returns_empty():
-    result = extract_tables_and_columns("", all_schemas=_ALL_SCHEMAS)
-    assert result.tables == {}
+def test_empty_sql_raises_syntax_error():
+    """An empty SQL string is a parse failure, not a "no tables found" outcome."""
+    with pytest.raises(SQLSyntaxError):
+        extract_tables_and_columns("", all_schemas=_ALL_SCHEMAS)
 
 
-def test_invalid_sql_returns_empty():
-    result = extract_tables_and_columns("NOT VALID SQL !!!", all_schemas=_ALL_SCHEMAS)
-    assert result.tables == {}
+def test_invalid_sql_raises_syntax_error():
+    """sqlglot ParseError surfaces as a dedicated SQLSyntaxError so callers can
+    distinguish unparseable SQL from valid SQL that references no known table."""
+    with pytest.raises(SQLSyntaxError):
+        extract_tables_and_columns("NOT VALID SQL !!!", all_schemas=_ALL_SCHEMAS)
 
 
 # ---------------------------------------------------------------------------
@@ -527,9 +532,10 @@ def test_canonical_order_consistent():
     assert result_a.joins[0].right_table == result_b.joins[0].right_table
 
 
-def test_empty_sql_returns_no_joins():
-    result = extract_tables_and_columns("", all_schemas=_ALL_SCHEMAS)
-    assert result.joins == []
+def test_empty_sql_raises_for_join_extraction():
+    """Empty SQL is a parse failure; the join-extraction path must surface it."""
+    with pytest.raises(SQLSyntaxError):
+        extract_tables_and_columns("", all_schemas=_ALL_SCHEMAS)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Previously `extract_tables_and_columns` swallowed sqlglot parse/token errors and returned an empty `ExtractionResult`, making truly invalid SQL indistinguishable from valid SQL that referenced no known tables. Both reached callers as the same silent "no tables found" signal, so the SQL-validation agent reported success on syntactically broken SQL.

Introduce a dedicated `SQLSyntaxError(ValueError)` and raise it when sqlglot rejects the input. Valid-but-unresolved SQL still returns the empty extraction as before, so callers can classify the two outcomes.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
