### PR TITLE
fix PDF pre-split docs and document Parakeet ASR limits on Blackwell (NVBugs 6218013, 6217294)

### DIFF
--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -61,11 +61,7 @@ This pipeline enables retrieval at the speech segment level when you enable segm
 
 ## Run Parakeet on the cluster (Helm) { #run-parakeet-on-the-cluster-helm }
 
-Use the following procedure to run the NIM on your own infrastructure. Self-hosted Parakeet runs on Kubernetes via the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md). Enable the ASR NIM per [Optional Helm NIMs](prerequisites-support-matrix.md#optional-helm-nims-not-auto-wired-by-default) and the [Helm chart — NIM operator sub-stack](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#nim-operator-sub-stack); pin the workload to a dedicated GPU and wire the ASR endpoint in your pipeline.
-
-!!! warning "Blackwell GPUs (26.05)"
-
-    The chart-pinned Parakeet image (`parakeet-1-1b-ctc-en-us:1.5.0`) does not start on Blackwell GPUs (compute capability 12.0) via Helm + NIM Operator. See [Model hardware requirements](prerequisites-support-matrix.md#model-hardware-requirements) (footnote ⁴) for supported SKUs, workarounds, and troubleshooting.
+Use the following procedure to run the NIM on your own infrastructure. Self-hosted Parakeet runs on Kubernetes via the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md). Enable the ASR NIM per [Optional Helm NIMs](prerequisites-support-matrix.md#optional-helm-nims-not-auto-wired-by-default) and the [Helm chart — NIM operator sub-stack](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#nim-operator-sub-stack); pin the workload to a dedicated GPU and wire the ASR endpoint in your pipeline. Confirm your GPU SKU against [Model hardware requirements](prerequisites-support-matrix.md#model-hardware-requirements) before enabling Parakeet.
 
 !!! important
 

--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -61,43 +61,29 @@ This pipeline enables retrieval at the speech segment level when you enable segm
 
 ## Run Parakeet on the cluster (Helm) { #run-parakeet-on-the-cluster-helm }
 
-Use the following procedure to run the NIM on your own infrastructure. Self-hosted Parakeet runs on Kubernetes via the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md). Enable the ASR NIM per [Optional Helm NIMs](prerequisites-support-matrix.md#optional-helm-nims-not-auto-wired-by-default) and the [Helm chart — NIM operator sub-stack](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#nim-operator-sub-stack); pin the workload to a dedicated GPU and wire the ASR endpoint in your pipeline. Confirm your GPU SKU against [Model hardware requirements](prerequisites-support-matrix.md#model-hardware-requirements) before enabling Parakeet.
+For Kubernetes deployment details, see the [NeMo Retriever Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#audio-video-parakeet).
 
-!!! important
+After deploy, call the pipeline from Python:
 
-    Pin the Parakeet workload to the dedicated GPU with your Helm values or the [NIM Operator](https://docs.nvidia.com/nim-operator/latest/index.html) (for example, node selectors, resource limits, or device requests appropriate to your cluster).
-
-1. Deploy or upgrade with the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) and enable Parakeet for your release (see [Optional Helm NIMs](prerequisites-support-matrix.md#optional-helm-nims-not-auto-wired-by-default)). Follow [Deployment options](deployment-options.md).
-
-2. If the service will process audio or video files, set `service.installFfmpeg=true` in the Helm chart when your cluster allows runtime package installation; for air-gapped clusters, see [Air-gapped and disconnected deployment](deployment-options.md#air-gapped-deployment) and the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#1-service-image) for `service.image` overrides.
-
-3. After the services are running, interact with the pipeline from Python.
-
-    - The `Ingestor` object initializes the ingestion process.
-    - The `files` method specifies the input files to process.
-    - The `extract` method runs audio extraction.
-
-    ```python
-    ingestor = (
-        Ingestor()
-        .files("./data/*.wav")
-        .extract(
-            document_type="wav",  # Ingestor should detect type automatically in most cases
-            extract_method="audio",
-            extract_audio_params={
-                "segment_audio": True,
-            },
-        )
+```python
+ingestor = (
+    Ingestor()
+    .files("./data/*.wav")
+    .extract(
+        document_type="wav",  # Ingestor should detect type automatically in most cases
+        extract_method="audio",
+        extract_audio_params={
+            "segment_audio": True,
+        },
     )
-    ```
+)
+```
 
+To generate one extracted element for each sentence-like ASR segment, include `extract_audio_params={"segment_audio": True}` when calling `.extract(...)`. This option applies when audio extraction runs with a self-hosted Parakeet NIM or using build.nvidia.com hosted inference, but has no effect when using the local Hugging Face Parakeet model.
 
-    To generate one extracted element for each sentence-like ASR segment, include `extract_audio_params={"segment_audio": True}` when calling `.extract(...)`. This option applies when audio extraction runs with a self-hosted Parakeet NIM or using build.nvidia.com hosted inference, but has no effect when using the local Hugging Face Parakeet model.
+!!! tip
 
-
-    !!! tip
-
-        For more Python examples, refer to [Python Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/python_client_usage.ipynb).
+    For more Python examples, refer to [Python Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/python_client_usage.ipynb).
 
 ## Parakeet with hosted inference (build.nvidia.com) { #parakeet-hosted-inference-build-nvidia }
 

--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -63,6 +63,10 @@ This pipeline enables retrieval at the speech segment level when you enable segm
 
 Use the following procedure to run the NIM on your own infrastructure. Self-hosted Parakeet runs on Kubernetes via the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md). Enable the ASR NIM per [Optional Helm NIMs](prerequisites-support-matrix.md#optional-helm-nims-not-auto-wired-by-default) and the [Helm chart — NIM operator sub-stack](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#nim-operator-sub-stack); pin the workload to a dedicated GPU and wire the ASR endpoint in your pipeline.
 
+!!! warning "Blackwell GPUs (26.05)"
+
+    The chart-pinned Parakeet image (`parakeet-1-1b-ctc-en-us:1.5.0`) does not start on Blackwell GPUs (compute capability 12.0) via Helm + NIM Operator. See [Model hardware requirements](prerequisites-support-matrix.md#model-hardware-requirements) (footnote ⁴) for supported SKUs, workarounds, and troubleshooting.
+
 !!! important
 
     Pin the Parakeet workload to the dedicated GPU with your Helm values or the [NIM Operator](https://docs.nvidia.com/nim-operator/latest/index.html) (for example, node selectors, resource limits, or device requests appropriate to your cluster).

--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -2,7 +2,9 @@
 
 ## PDF pre-splitting for parallel ingest
 
-Server-side PDF splitting supports configurable page chunking. Use `.pdf_split_config(pages_per_chunk=...)` in the Python client, or use the equivalent PDF split page count option in the CLI. See this API guide and the [CLI reference](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli) for parameter tables and examples.
+Large PDFs are split into page batches before Ray processing so extraction can run in parallel. This happens on the default ingest path; you do not need extra configuration for typical workloads.
+
+To tune splitter throughput from the CLI, use `--pdf-split-batch-size` (Ray actor batch size, not per-PDF page count). See [Text chunking and PDF page batches](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli#text-chunking-and-pdf-page-batches) in the CLI reference.
 
 ::: nemo_retriever.ingestor
 

--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -4,9 +4,12 @@
 
 Large PDFs are split into page batches before Ray processing so extraction can run in parallel. This happens on the default ingest path; you do not need extra configuration for typical workloads.
 
-To tune splitter throughput from the CLI, use `--pdf-split-batch-size` (Ray actor batch size, not per-PDF page count). See [Text chunking and PDF page batches](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli#text-chunking-and-pdf-page-batches) in the CLI reference.
+To tune splitter throughput from the CLI, use `--pdf-split-batch-size` (Ray actor batch size for the splitter stage). See [Text chunking and PDF page batches](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli#text-chunking-and-pdf-page-batches) in the CLI reference.
 
 ::: nemo_retriever.ingestor
+    options:
+      filters:
+        - "!^pdf_split_config$"
 
 ::: nemo_retriever.retriever
 

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -116,8 +116,8 @@ Model repositories and NIM references are linked in [Core and Advanced Pipeline 
 | GPU | — | Memory | 96GB | 180GB | 141GB | 80GB | 80GB | 40GB | 24GB | 48GB | 32GB GDDR7 (GB203) |
 | Core Features | ~4.8 GiB combined: embed VL 1b ~3.1 GiB; page-elements ~0.41 GiB; table-structure ~0.81 GiB; OCR ~0.51 GiB | Total GPUs | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 |
 | Core Features | — | Total Disk Space | ~150GB | ~150GB | ~150GB | ~150GB | ~150GB | ~150GB | ~150GB | ~150GB | ~150GB |
-| Audio (parakeet-1-1b-ctc-en-us) | ~4.0 GiB (`model.safetensors`; the repo also ships `parakeet-ctc-1.1b.nemo` of similar size—use one format to avoid roughly doubling disk use) | Additional Dedicated GPUs | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1¹ |
-| Audio (parakeet-1-1b-ctc-en-us) | — | Additional Disk Space | ~37GB | ~37GB | ~37GB | ~37GB | ~37GB | ~37GB | ~37GB | ~37GB | ~37GB¹ |
+| Audio (parakeet-1-1b-ctc-en-us) | ~4.0 GiB (`model.safetensors`; the repo also ships `parakeet-ctc-1.1b.nemo` of similar size—use one format to avoid roughly doubling disk use) | Additional Dedicated GPUs | Not supported⁴ | Not supported⁴ | 1¹ | 1¹ | 1¹ | 1¹ | 1¹ | 1¹ | Not supported⁴ |
+| Audio (parakeet-1-1b-ctc-en-us) | — | Additional Disk Space | Not supported⁴ | Not supported⁴ | ~37GB¹ | ~37GB¹ | ~37GB¹ | ~37GB¹ | ~37GB¹ | ~37GB¹ | Not supported⁴ |
 | nemotron-parse | ~3.5 GiB | Additional Dedicated GPUs | Not supported | 1 | Not supported | 1 | 1 | 1 | 1 | 1 | Not supported² |
 | nemotron-parse | — | Additional Disk Space | Not supported | ~16GB | Not supported | ~16GB | ~16GB | ~16GB | ~16GB | ~16GB | Not supported² |
 | Omni caption (nemotron-3-nano-omni-30b-a3b-reasoning) | ~62 GiB (BF16); ~33 GiB (FP8); ~21 GiB (NVFP4) | Additional Dedicated GPUs | 1 | 1 | 1 | 1 | 1 | Not supported | Not supported | 2 | Not supported³ |
@@ -126,7 +126,9 @@ Model repositories and NIM references are linked in [Core and Advanced Pipeline 
 | Reranker | ~3.1 GiB (llama-nemotron-rerank-vl-1b-v2) | With Core Pipeline | Yes | Yes | Yes | Yes | Yes | No* | No* | No* | No* |
 | Reranker | — | Standalone (recall only) | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 
-¹ Audio runs but requires runtime engine build — no pre-defined model profile.
+¹ On other supported GPUs, Parakeet ASR (`parakeet-1-1b-ctc-en-us:1.5.0`) may require a runtime TensorRT engine build (no prebuilt profile in the chart image).
+
+⁴ Parakeet ASR is **not supported on Blackwell** GPUs (compute capability 12.0), including RTX PRO 6000 Blackwell, B200, and RTX PRO 4500 Blackwell. With Helm + NIM Operator, `NIMService` for `nimOperator.audio` may stay not Ready or enter `CrashLoopBackOff` while building the Riva/TensorRT engine (for example ONNX Runtime IR version, cuDNN visibility, or FP8 tactic errors). Use a non-Blackwell dedicated GPU, [hosted Parakeet on build.nvidia.com](audio-video.md#parakeet-hosted-inference-build-nvidia), or set `nimOperator.audio.enabled=false`.
 
 ² Nemotron Parse fails to start on 32GB.
 

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -111,13 +111,15 @@ NeMo Retriever Library supports the following GPU hardware given system constrai
 
 Model repositories and NIM references are linked in [Core and Advanced Pipeline Features](#core-and-advanced-pipeline-features) above.
 
+**B200 and audio/video extraction (26.05):** The [audio and video](audio-video.md) transcription path (self-hosted Parakeet ASR via `nimOperator.audio`) is **not supported on B200** or other Blackwell GPUs. Core PDF and multimodal extraction on B200 is unchanged. See footnote ⁴ below.
+
 | Feature | HF Model Weights | GPU Option | [RTX Pro 6000](https://www.nvidia.com/en-us/data-center/rtx-pro-6000-blackwell-server-edition/) | [B200](https://www.nvidia.com/en-us/data-center/dgx-b200/) | [H200 NVL](https://www.nvidia.com/en-us/data-center/h200/) | [H100](https://www.nvidia.com/en-us/data-center/h100/) | [A100 80GB](https://www.nvidia.com/en-us/data-center/a100/) | A100 40GB | [A10G](https://aws.amazon.com/ec2/instance-types/g5/) | L40S | [RTX PRO 4500 Blackwell](https://www.nvidia.com/en-us/products/workstations/professional-desktop-gpus/rtx-pro-4500/) |
 |---------|------------------|------------|--------|--------|--------|--------|--------|--------|--------|--------|------------------------|
 | GPU | — | Memory | 96GB | 180GB | 141GB | 80GB | 80GB | 40GB | 24GB | 48GB | 32GB GDDR7 (GB203) |
 | Core Features | ~4.8 GiB combined: embed VL 1b ~3.1 GiB; page-elements ~0.41 GiB; table-structure ~0.81 GiB; OCR ~0.51 GiB | Total GPUs | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 |
 | Core Features | — | Total Disk Space | ~150GB | ~150GB | ~150GB | ~150GB | ~150GB | ~150GB | ~150GB | ~150GB | ~150GB |
-| Audio (parakeet-1-1b-ctc-en-us) | ~4.0 GiB (`model.safetensors`; the repo also ships `parakeet-ctc-1.1b.nemo` of similar size—use one format to avoid roughly doubling disk use) | Additional Dedicated GPUs | Not supported⁴ | Not supported⁴ | 1¹ | 1¹ | 1¹ | 1¹ | 1¹ | 1¹ | Not supported⁴ |
-| Audio (parakeet-1-1b-ctc-en-us) | — | Additional Disk Space | Not supported⁴ | Not supported⁴ | ~37GB¹ | ~37GB¹ | ~37GB¹ | ~37GB¹ | ~37GB¹ | ~37GB¹ | Not supported⁴ |
+| Audio/video extraction (parakeet-1-1b-ctc-en-us) | ~4.0 GiB (`model.safetensors`; the repo also ships `parakeet-ctc-1.1b.nemo` of similar size—use one format to avoid roughly doubling disk use) | Additional Dedicated GPUs | Not supported⁴ | Not supported⁴ | 1¹ | 1¹ | 1¹ | 1¹ | 1¹ | 1¹ | Not supported⁴ |
+| Audio/video extraction (parakeet-1-1b-ctc-en-us) | — | Additional Disk Space | Not supported⁴ | Not supported⁴ | ~37GB¹ | ~37GB¹ | ~37GB¹ | ~37GB¹ | ~37GB¹ | ~37GB¹ | Not supported⁴ |
 | nemotron-parse | ~3.5 GiB | Additional Dedicated GPUs | Not supported | 1 | Not supported | 1 | 1 | 1 | 1 | 1 | Not supported² |
 | nemotron-parse | — | Additional Disk Space | Not supported | ~16GB | Not supported | ~16GB | ~16GB | ~16GB | ~16GB | ~16GB | Not supported² |
 | Omni caption (nemotron-3-nano-omni-30b-a3b-reasoning) | ~62 GiB (BF16); ~33 GiB (FP8); ~21 GiB (NVFP4) | Additional Dedicated GPUs | 1 | 1 | 1 | 1 | 1 | Not supported | Not supported | 2 | Not supported³ |
@@ -128,7 +130,7 @@ Model repositories and NIM references are linked in [Core and Advanced Pipeline 
 
 ¹ On other supported GPUs, Parakeet ASR (`parakeet-1-1b-ctc-en-us:1.5.0`) may require a runtime TensorRT engine build (no prebuilt profile in the chart image).
 
-⁴ Parakeet ASR is **not supported on Blackwell** GPUs (compute capability 12.0), including RTX PRO 6000 Blackwell, B200, and RTX PRO 4500 Blackwell. With Helm + NIM Operator, `NIMService` for `nimOperator.audio` may stay not Ready or enter `CrashLoopBackOff` while building the Riva/TensorRT engine (for example ONNX Runtime IR version, cuDNN visibility, or FP8 tactic errors). Use a non-Blackwell dedicated GPU, [hosted Parakeet on build.nvidia.com](audio-video.md#parakeet-hosted-inference-build-nvidia), or set `nimOperator.audio.enabled=false`.
+⁴ **B200** and other **Blackwell** GPUs (compute capability 12.0), including RTX PRO 6000 Blackwell and RTX PRO 4500 Blackwell, do **not** support the [audio/video extraction](audio-video.md) path when Parakeet ASR (`parakeet-1-1b-ctc-en-us:1.5.0`) runs self-hosted via Helm + NIM Operator. Video workflows that depend on Parakeet for speech transcription are affected the same way. `NIMService` for `nimOperator.audio` may stay not Ready or enter `CrashLoopBackOff` while building the Riva/TensorRT engine (for example ONNX Runtime IR version, cuDNN visibility, or FP8 tactic errors). Use a non-Blackwell dedicated GPU, [hosted Parakeet on build.nvidia.com](audio-video.md#parakeet-hosted-inference-build-nvidia), or set `nimOperator.audio.enabled=false`.
 
 ² Nemotron Parse fails to start on 32GB.
 

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -58,6 +58,19 @@ service:
 
 This path fails with `allowPrivilegeEscalation: false` or `readOnlyRootFilesystem: true`.
 
+## Parakeet ASR NIM does not become Ready on Blackwell { #parakeet-asr-blackwell }
+
+On Blackwell GPUs (compute capability 12.0), the optional Parakeet ASR NIM
+(`nvcr.io/nim/nvidia/parakeet-1-1b-ctc-en-us:1.5.0`) deployed with
+`nimOperator.audio` may never reach Ready. The pod can enter `CrashLoopBackOff`
+while building the TensorRT engine, with logs that mention ONNX Runtime IR
+version, missing cuDNN on `LD_LIBRARY_PATH`, or unsupported FP8 tactics.
+
+This is a known limitation for 26.05 on Blackwell SKUs. See
+[Model hardware requirements](prerequisites-support-matrix.md#model-hardware-requirements)
+(footnote ⁴) for supported GPUs and alternatives (non-Blackwell GPU, hosted
+inference, or `nimOperator.audio.enabled=false`).
+
 ## Can't start new thread error
 
 In rare cases, when you run a job you might an see an error similar to `can't start new thread`. 

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -58,19 +58,6 @@ service:
 
 This path fails with `allowPrivilegeEscalation: false` or `readOnlyRootFilesystem: true`.
 
-## Parakeet ASR NIM does not become Ready on Blackwell { #parakeet-asr-blackwell }
-
-On Blackwell GPUs (compute capability 12.0), the optional Parakeet ASR NIM
-(`nvcr.io/nim/nvidia/parakeet-1-1b-ctc-en-us:1.5.0`) deployed with
-`nimOperator.audio` may never reach Ready. The pod can enter `CrashLoopBackOff`
-while building the TensorRT engine, with logs that mention ONNX Runtime IR
-version, missing cuDNN on `LD_LIBRARY_PATH`, or unsupported FP8 tactics.
-
-This is a known limitation for 26.05 on Blackwell SKUs. See
-[Model hardware requirements](prerequisites-support-matrix.md#model-hardware-requirements)
-(footnote ⁴) for supported GPUs and alternatives (non-Blackwell GPU, hosted
-inference, or `nimOperator.audio.enabled=false`).
-
 ## Can't start new thread error
 
 In rare cases, when you run a job you might an see an error similar to `can't start new thread`. 

--- a/docs/docs/extraction/workflow-document-ingestion.md
+++ b/docs/docs/extraction/workflow-document-ingestion.md
@@ -9,7 +9,7 @@ Document ingestion is the step where NeMo Retriever Library reads your files (PD
 Follow these steps:
 
 1. **Choose how you call the library.** Use the [Python API](nemo-retriever-api-reference.md) or [CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli) from application code, or run a deployment (for example [NeMo Retriever Library on GitHub](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever), [Deployment options](deployment-options.md), or [Quickstart: Kubernetes (Helm)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)) and send jobs over the network. Runnable examples appear in [Choose how you call the library](#choose-how-you-call-the-library) below.
-2. **Use parallel PDF handling.** The default ingest path splits large PDFs before Ray processing; behavior and tuning are described in the [API guide — PDF pre-splitting](nemo-retriever-api-reference.md#pdf-pre-splitting-for-parallel-ingest). Set `message_client_kwargs={"api_version": "v2"}` when using the client if you need to be explicit.
+2. **Use parallel PDF handling.** The default ingest path splits large PDFs before Ray processing; see [API guide — PDF pre-splitting](nemo-retriever-api-reference.md#pdf-pre-splitting-for-parallel-ingest).
 3. **Tune extraction for your content.** Refer to [Multimodal extraction](multimodal-extraction.md) for formats, [text and layout](multimodal-extraction.md#text-and-layout-extraction), [tables](multimodal-extraction.md#tables), [OCR](multimodal-extraction.md#ocr-and-scanned-documents), and related subsections on that page.
 
 Pipeline concepts and stage overview appear in [Key concepts](concepts.md). Default chunking behavior is summarized under [Chunking](concepts.md#chunking).

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -54,7 +54,7 @@ Rows that use subcommands other than `ingest`, `query`, or `pipeline` are
 | Quick start | [below](#quick-start) | Legacy service quickstart; **Helm** + [NeMo Retriever Library](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/); **Docker Compose** (unsupported): [`docker.md`](https://github.com/NVIDIA/NeMo-Retriever/blob/HEAD/nemo_retriever/docker.md) |
 | CLI reference | [below](#cli-reference) | Prior `cli-reference` pages under `docs/docs/extraction/` |
 | Client usage walk-through | [below](#client-usage-walk-through) | `client/client_examples/examples/cli_client_usage.ipynb` |
-| PDF pre-splitting | [API guide](../../../docs/docs/extraction/nemo-retriever-api-reference.md#pdf-pre-splitting-for-parallel-ingest); [Large PDF page batches](#large-pdf-page-batches) below | Prior extraction PDF-split topics |
+| PDF pre-splitting | [API guide](../../../docs/docs/extraction/nemo-retriever-api-reference.md#pdf-pre-splitting-for-parallel-ingest); [Large PDF page batches](#large-pdf-page-batches) below | Prior extraction docs |
 | Benchmarking | [`benchmarking.md`](benchmarking.md) | `docs/docs/extraction/benchmarking.md` and `tools/harness/README.md` |
 
 <!-- --8<-- [start:quickstart] -->

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -54,7 +54,7 @@ Rows that use subcommands other than `ingest`, `query`, or `pipeline` are
 | Quick start | [below](#quick-start) | Legacy service quickstart; **Helm** + [NeMo Retriever Library](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/); **Docker Compose** (unsupported): [`docker.md`](https://github.com/NVIDIA/NeMo-Retriever/blob/HEAD/nemo_retriever/docker.md) |
 | CLI reference | [below](#cli-reference) | Prior `cli-reference` pages under `docs/docs/extraction/` |
 | Client usage walk-through | [below](#client-usage-walk-through) | `client/client_examples/examples/cli_client_usage.ipynb` |
-| PDF split tuning | [Large PDF page batches](#large-pdf-page-batches) below | `docs/docs/extraction/v2-api-guide.md` |
+| PDF pre-splitting | [API guide](../../../docs/docs/extraction/nemo-retriever-api-reference.md#pdf-pre-splitting-for-parallel-ingest); [Large PDF page batches](#large-pdf-page-batches) below | Prior extraction PDF-split topics |
 | Benchmarking | [`benchmarking.md`](benchmarking.md) | `docs/docs/extraction/benchmarking.md` and `tools/harness/README.md` |
 
 <!-- --8<-- [start:quickstart] -->
@@ -191,8 +191,10 @@ Results go to LanceDB (`./lancedb`, table `nv-ingest` by default) and, with
 
 ### Text chunking and PDF page batches
 
-Splitting is intrinsic to the pipeline. Control text chunks with `--text-chunk` and
-page-batch sizing with `--pdf-split-batch-size`:
+Splitting is intrinsic to the pipeline. Control text chunks with `--text-chunk`. For
+PDF pre-splitting and `--pdf-split-batch-size`, see
+[PDF pre-splitting](../../../docs/docs/extraction/nemo-retriever-api-reference.md#pdf-pre-splitting-for-parallel-ingest)
+and [Large PDF page batches](#large-pdf-page-batches):
 
 ```bash
 retriever pipeline run ./data/test.pdf \

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -652,11 +652,7 @@ Verify tags on the Git branch or tag you ship (for example `26.05` or
 | Omni caption (optional) | `nemotron_3_nano_omni_30b_a3b_reasoning` | `nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:1.7.0-variant` |
 | Parakeet ASR (optional) | `audio` | `nvcr.io/nim/nvidia/parakeet-1-1b-ctc-en-us:1.5.0` |
 
-**Parakeet on Blackwell (26.05):** `parakeet-1-1b-ctc-en-us:1.5.0` is not
-supported on Blackwell GPUs (compute capability 12.0). On Blackwell clusters,
-set `nimOperator.audio.enabled=false` unless you schedule the ASR NIM on a
-non-Blackwell GPU. See [Model hardware requirements](https://github.com/NVIDIA/NeMo-Retriever/blob/26.05/docs/docs/extraction/prerequisites-support-matrix.md#model-hardware-requirements)
-and [Parakeet ASR on Blackwell](https://github.com/NVIDIA/NeMo-Retriever/blob/26.05/docs/docs/extraction/troubleshoot.md#parakeet-asr-blackwell).
+GPU SKU support for `audio` is in [Model hardware requirements](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/prerequisites-support-matrix.md#model-hardware-requirements).
 
 Also mirror images for the vectordb sidecar, Redis, or other subcharts if
 your values enable them.

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -652,6 +652,12 @@ Verify tags on the Git branch or tag you ship (for example `26.05` or
 | Omni caption (optional) | `nemotron_3_nano_omni_30b_a3b_reasoning` | `nvcr.io/nim/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:1.7.0-variant` |
 | Parakeet ASR (optional) | `audio` | `nvcr.io/nim/nvidia/parakeet-1-1b-ctc-en-us:1.5.0` |
 
+**Parakeet on Blackwell (26.05):** `parakeet-1-1b-ctc-en-us:1.5.0` is not
+supported on Blackwell GPUs (compute capability 12.0). On Blackwell clusters,
+set `nimOperator.audio.enabled=false` unless you schedule the ASR NIM on a
+non-Blackwell GPU. See [Model hardware requirements](https://github.com/NVIDIA/NeMo-Retriever/blob/26.05/docs/docs/extraction/prerequisites-support-matrix.md#model-hardware-requirements)
+and [Parakeet ASR on Blackwell](https://github.com/NVIDIA/NeMo-Retriever/blob/26.05/docs/docs/extraction/troubleshoot.md#parakeet-asr-blackwell).
+
 Also mirror images for the vectordb sidecar, Redis, or other subcharts if
 your values enable them.
 

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -229,6 +229,17 @@ For audio and video extraction, set `service.installFfmpeg=true` when your
 cluster allows runtime package installation. For air-gapped clusters, see
 [Deployment options — Air-gapped and disconnected deployment](https://docs.nvidia.com/nemo/retriever/latest/extraction/deployment-options/#air-gapped-deployment).
 
+### Audio and video (Parakeet ASR) { #audio-video-parakeet }
+
+To run self-hosted Parakeet for [audio and video extraction](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/audio-video.md):
+
+1. Set `nimOperator.audio.enabled=true` (it is on by default; disable other optional NIMs you do not need per [Recommended minimal install (26.05)](#recommended-minimal-install-2605)).
+2. Pin the ASR `NIMService` to a **dedicated GPU** with `nimOperator.audio.resources`, `nodeSelector`, or `tolerations` (see [NIM Operator](https://docs.nvidia.com/nim-operator/latest/index.html)).
+3. Confirm the GPU SKU in [Model hardware requirements](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/prerequisites-support-matrix.md#model-hardware-requirements) (footnote ⁴ lists Blackwell limitations).
+4. Set `service.installFfmpeg=true` when the retriever service will process audio or video (see `service.installFfmpeg` above).
+
+The retriever service picks up the in-cluster ASR endpoint when `nimOperator.audio` is enabled; see [NIM Operator sub-stack](#nim-operator-sub-stack).
+
 ### Service configuration (rendered into `retriever-service.yaml`)
 
 | Path                                              | Default | Notes |


### PR DESCRIPTION
## Summary

Documentation-only PR for NeMo Retriever Library **26.05**. Addresses two QA-filed doc bugs:

- **NVBug 6218013** — Public docs incorrectly claimed that `.pdf_split_config(pages_per_chunk=...)` and an equivalent CLI flag work end-to-end in 26.05. In reality, `inprocess`/`batch` raise `NotImplementedError`, service mode does not apply the value to chunking, and there is no CLI flag for per-document page count (`--pdf-split-batch-size` is Ray splitter throughput tuning only).
- **NVBug 6217294** — `parakeet-1-1b-ctc-en-us:1.5.0` does not start on Blackwell GPUs (including **B200**) via Helm + NIM Operator; the audio/video extraction path is not supported on those SKUs for 26.05.

## Changes

### NVBug 6218013 (PDF pre-splitting)

- **`docs/docs/extraction/nemo-retriever-api-reference.md`** — Describe default parallel PDF pre-splitting; remove legacy `pages_per_chunk` / v2 API claims; exclude `pdf_split_config` from mkdocstrings output.
- **`nemo_retriever/docs/cli/README.md`** — Clarify `--pdf-split-batch-size`; remove `v2-api-guide.md` reference; cross-link to the API guide.
- **`docs/docs/extraction/workflow-document-ingestion.md`** — One-line link to the API section; remove `message_client_kwargs={"api_version": "v2"}`.

### NVBug 6217294 (Parakeet on Blackwell / B200)

- **`docs/docs/extraction/prerequisites-support-matrix.md`** — Mark audio/video extraction **Not supported** on Blackwell columns (including B200); add B200 callout and footnote ⁴ with workarounds.
- **`docs/docs/extraction/audio-video.md`** — Warning under Helm Parakeet procedure → matrix.
- **`docs/docs/extraction/troubleshoot.md`** — New section [Parakeet ASR on Blackwell](troubleshoot.md#parakeet-asr-blackwell) with typical failure symptoms.
- **`nemo_retriever/helm/README.md`** — Note to disable `nimOperator.audio` on Blackwell or use a non-Blackwell GPU.

## Scope

- **Base:** `main`
- **Files:** 7 (extraction docs, CLI README, Helm README only)
- **No** code, CI, chart values, or agent/link-audit artifacts

## Follow-up: `57dafb8c` — review feedback (Parakeet / Blackwell consolidation)

Addresses PR comments to stop duplicating SKU-specific Parakeet / Blackwell content across pages.

### Review feedback addressed

| Comment | Resolution |
|---------|------------|
| Move Blackwell warning out of `audio-video.md` | Removed `!!! warning "Blackwell GPUs (26.05)"`. Added one sentence in the Helm procedure linking to [Model hardware requirements](prerequisites-support-matrix.md#model-hardware-requirements). |
| Remove duplicate troubleshoot section | Deleted **Parakeet ASR NIM does not become Ready on Blackwell** (`#parakeet-asr-blackwell`). |
| Remove duplicate Helm README paragraph | Removed **Parakeet on Blackwell (26.05)** block. Replaced with a single line: GPU SKU support for `audio` → support matrix. |

### Where Blackwell / B200 / Parakeet limits live (canonical)

**`prerequisites-support-matrix.md` only:**

- B200 / audio-video callout above the hardware table
- Audio/video extraction rows: **Not supported⁴** on Blackwell columns (including B200)
- Footnote ⁴: limitations, typical `CrashLoopBackOff` / engine-build symptoms, and workarounds (non-Blackwell GPU, hosted Parakeet, `nimOperator.audio.enabled=false`)

### Commit `57dafb8c` diff

- `docs/docs/extraction/audio-video.md` — −4 lines (warning), +1 link sentence
- `docs/docs/extraction/troubleshoot.md` — −13 lines (section removed)
- `nemo_retriever/helm/README.md` — −4 lines (paragraph), +1 link line

**Net:** 3 files, +2 / −23 lines

### Cumulative PR state (base: `main`, HEAD: `57dafb8c`)

| NVBugs | Files touched |
|--------|----------------|
| **6218013** — PDF pre-split docs | `nemo-retriever-api-reference.md`, `workflow-document-ingestion.md`, `nemo_retriever/docs/cli/README.md` |
| **6217294** — Parakeet on Blackwell | `prerequisites-support-matrix.md` (+ links from `audio-video.md`, `helm/README.md`) |

**6 files total**, docs only (+22 / −9 vs `main`). `troubleshoot.md` is not in the final PR diff.

### Test plan (reviewer)

- [ ] Blackwell / B200 Parakeet limits appear only on the support matrix (callout + footnote ⁴ + table)
- [ ] `audio-video.md` and `helm/README.md` link to the matrix without repeating SKU prose
- [ ] No broken links to removed `#parakeet-asr-blackwell` anchor


## Follow-up: `5a6fb85f` — move Parakeet Helm deploy details to chart README

Addresses review feedback to stop deployment/configuration prose from leaking into `audio-video.md`.

### Review feedback addressed

| Comment | Resolution |
|---------|------------|
| Deployment details leaking into `audio-video.md` | Replaced the long Helm procedure (enable ASR NIM, NIM Operator sub-stack links, GPU pinning admonition, numbered deploy/ffmpeg steps) with a single link to the Helm chart. |
| Keep configuration in the Helm README | Added **Audio and video (Parakeet ASR)** (`#audio-video-parakeet`) with deploy steps moved from the extraction page. |

### `docs/docs/extraction/audio-video.md`

- **Removed:** Multi-paragraph deploy instructions, `!!! important` GPU pinning note, and numbered steps 1–2 (Helm install, `service.installFfmpeg`, optional NIM links).
- **Added:** One line — [NeMo Retriever Helm chart README — Audio and video (Parakeet ASR)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#audio-video-parakeet).
- **Kept:** Python ingest example, `segment_audio` note, and tip (pipeline usage, not deployment).

### `nemo_retriever/helm/README.md`

New section **`### Audio and video (Parakeet ASR)`** (`#audio-video-parakeet`):

1. `nimOperator.audio.enabled=true` (with pointer to minimal install)
2. Pin ASR `NIMService` to a dedicated GPU (`resources`, `nodeSelector`, `tolerations`)
3. Confirm GPU SKU via [Model hardware requirements](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/prerequisites-support-matrix.md#model-hardware-requirements) (footnote ⁴)
4. `service.installFfmpeg=true` for audio/video workloads

Plus a note that the retriever service auto-wires the in-cluster ASR endpoint when `nimOperator.audio` is enabled.

### Commit stats

| | |
|--|--|
| **Files** | 2 |
| **Diff** | +30 / −33 lines |

### Test plan

- [ ] [Run Parakeet on the cluster (Helm)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/audio-video.md#run-parakeet-on-the-cluster-helm) links to `#audio-video-parakeet` and contains no Helm values / NIM Operator deploy steps
- [ ] Helm README `#audio-video-parakeet` covers enable audio, GPU pin, ffmpeg, and matrix SKU check
- [ ] Python example on `audio-video.md` still renders correctly after indentation cleanup