### PR TITLE
[bug fix] Remove stale fused run mode typing surface

### DIFF
--- a/nemo_retriever/src/nemo_retriever/audio/__init__.py
+++ b/nemo_retriever/src/nemo_retriever/audio/__init__.py
@@ -6,7 +6,7 @@
 Audio pipeline: media chunking (MediaChunkActor) and ASR (ASRActor).
 
 Provides the same semantics as `nemo_retriever.api` dataloader + Parakeet for
-batch, inprocess, fused, and online run modes.
+batch and inprocess ingestion run modes.
 """
 
 from __future__ import annotations

--- a/nemo_retriever/src/nemo_retriever/harness/parsers.py
+++ b/nemo_retriever/src/nemo_retriever/harness/parsers.py
@@ -8,7 +8,7 @@ import re
 from collections import deque
 from dataclasses import dataclass, field
 
-# Legacy patterns (inprocess_pipeline / fused_pipeline)
+# Legacy patterns (inprocess_pipeline)
 DONE_RE = re.compile(r"\[done\]\s+(?P<files>\d+)\s+files,\s+(?P<pages>\d+)\s+pages\s+in\s+(?P<secs>[0-9.]+)s")
 INGEST_ROWS_RE = re.compile(
     r"Ingestion complete\.\s+(?P<rows>\d+)\s+rows\s+proces+ed\s+in\s+(?P<secs>[0-9.]+)\s+seconds\.\s+"

--- a/nemo_retriever/src/nemo_retriever/ingest-config.yaml
+++ b/nemo_retriever/src/nemo_retriever/ingest-config.yaml
@@ -92,7 +92,7 @@ image:
   # All ExtractParams options (extract_text, extract_tables, etc.) apply.
   pass: true  # placeholder; no image-specific knobs beyond ExtractParams
 
-# Optional config for .extract_audio() API (batch, inprocess, fused).
+# Optional config for .extract_audio() API (batch, inprocess).
 # ASR can be remote (Parakeet/Riva gRPC) or local (HuggingFace nvidia/parakeet-ctc-1.1b).
 audio_chunk:
   split_type: size

--- a/nemo_retriever/src/nemo_retriever/ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor.py
@@ -10,7 +10,7 @@ Concrete implementations are provided by runmodes:
 
 - inprocess: local Python process, no framework assumptions
 - batch: large-scale batch execution
-- fused: low-latency single-actor GPU model fusion
+- service: remote ingestion service
 """
 
 from __future__ import annotations
@@ -24,7 +24,7 @@ from nemo_retriever.params import EmbedParams
 from nemo_retriever.params import ExtractParams
 from nemo_retriever.params import IngestExecuteParams
 from nemo_retriever.params import IngestorCreateParams
-from nemo_retriever.params import RunMode
+from nemo_retriever.params import IngestorRunMode
 from nemo_retriever.params import StoreParams
 from nemo_retriever.params import VdbUploadParams
 from nemo_retriever.params import WebhookParams
@@ -42,7 +42,7 @@ def _merge_params[T](params: T | None, kwargs: dict[str, Any]) -> T:
 
 def create_ingestor(
     *,
-    run_mode: RunMode = "inprocess",
+    run_mode: IngestorRunMode = "inprocess",
     params: IngestorCreateParams | None = None,
     **kwargs: Any,
 ) -> "Ingestor":

--- a/nemo_retriever/src/nemo_retriever/model/local/nemotron_graphic_elements_v1.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/nemotron_graphic_elements_v1.py
@@ -8,7 +8,7 @@ import torch
 from nemo_retriever.utils.hf_cache import configure_global_hf_cache_base
 from nemo_retriever.utils.hf_model_registry import install_pinned_hf_hub_download
 from nemo_retriever.utils.nvtx import gpu_inference_range
-from ..model import BaseModel, RunMode
+from ..model import BaseModel, ModelRunMode
 
 import nemotron_graphic_elements_v1.model as _graphic_elements_model
 from nemotron_graphic_elements_v1.model import define_model as define_model_graphic_elements
@@ -94,7 +94,7 @@ class NemotronGraphicElementsV1(BaseModel):
         return "object-detection"
 
     @property
-    def model_runmode(self) -> RunMode:
+    def model_runmode(self) -> ModelRunMode:
         """Execution mode: local, NIM, or build-endpoint."""
         return "local"
 

--- a/nemo_retriever/src/nemo_retriever/model/local/nemotron_ocr_v1.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/nemotron_ocr_v1.py
@@ -14,7 +14,7 @@ import torch
 from nemo_retriever.utils.hf_cache import configure_global_hf_cache_base
 from nemo_retriever.utils.hf_model_registry import install_pinned_hf_hub_download
 from nemo_retriever.utils.nvtx import gpu_inference_range
-from ..model import BaseModel, RunMode
+from ..model import BaseModel, ModelRunMode
 
 from PIL import Image
 
@@ -217,7 +217,7 @@ class NemotronOCRV1(BaseModel):
         return "ocr"
 
     @property
-    def model_runmode(self) -> RunMode:
+    def model_runmode(self) -> ModelRunMode:
         """Execution mode: local, NIM, or build-endpoint."""
         return "local"
 

--- a/nemo_retriever/src/nemo_retriever/model/local/nemotron_ocr_v2.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/nemotron_ocr_v2.py
@@ -13,7 +13,7 @@ import numpy as np
 import torch
 from nemo_retriever.utils.hf_cache import configure_global_hf_cache_base
 from nemo_retriever.utils.hf_model_registry import install_pinned_hf_hub_download
-from ..model import BaseModel, RunMode
+from ..model import BaseModel, ModelRunMode
 
 from PIL import Image
 
@@ -220,7 +220,7 @@ class NemotronOCRV2(BaseModel):
         return "ocr"
 
     @property
-    def model_runmode(self) -> RunMode:
+    def model_runmode(self) -> ModelRunMode:
         """Execution mode: local, NIM, or build-endpoint."""
         return "local"
 

--- a/nemo_retriever/src/nemo_retriever/model/local/nemotron_page_elements_v3.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/nemotron_page_elements_v3.py
@@ -10,7 +10,7 @@ import numpy as np
 from nemo_retriever.utils.hf_cache import configure_global_hf_cache_base
 from nemo_retriever.utils.hf_model_registry import install_pinned_hf_hub_download
 from nemo_retriever.utils.nvtx import gpu_inference_range
-from ..model import HuggingFaceModel, RunMode
+from ..model import HuggingFaceModel, ModelRunMode
 
 import nemotron_page_elements_v3.model as _page_elements_model
 from nemotron_page_elements_v3.model import define_model as define_model_page_elements
@@ -192,7 +192,7 @@ class NemotronPageElementsV3(HuggingFaceModel):
         return "object-detection"
 
     @property
-    def model_runmode(self) -> RunMode:
+    def model_runmode(self) -> ModelRunMode:
         """Execution mode: local, NIM, or build-endpoint."""
         return "local"
 

--- a/nemo_retriever/src/nemo_retriever/model/local/nemotron_parse_v1_2.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/nemotron_parse_v1_2.py
@@ -13,7 +13,7 @@ from PIL import Image
 
 from nemo_retriever.utils.hf_cache import configure_global_hf_cache_base
 from nemo_retriever.utils.hf_model_registry import get_hf_revision
-from ..model import BaseModel, RunMode
+from ..model import BaseModel, ModelRunMode
 
 # Type alias for all supported single-image input formats.
 ImageInput = Union[torch.Tensor, np.ndarray, Image.Image, str, Path]
@@ -226,7 +226,7 @@ class NemotronParseV12(BaseModel):
         return "document-parse"
 
     @property
-    def model_runmode(self) -> RunMode:
+    def model_runmode(self) -> ModelRunMode:
         return "local"
 
     @property

--- a/nemo_retriever/src/nemo_retriever/model/local/nemotron_rerank_v2.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/nemotron_rerank_v2.py
@@ -10,7 +10,7 @@ from typing import List, Optional
 
 from nemo_retriever.utils.hf_cache import configure_global_hf_cache_base
 from nemo_retriever.utils.hf_model_registry import get_hf_revision
-from ..model import BaseModel, RunMode
+from ..model import BaseModel, ModelRunMode
 
 
 _DEFAULT_MODEL = "nvidia/llama-nemotron-rerank-1b-v2"
@@ -95,7 +95,7 @@ class NemotronRerankV2(BaseModel):
         return "reranker"
 
     @property
-    def model_runmode(self) -> RunMode:
+    def model_runmode(self) -> ModelRunMode:
         return "local"
 
     @property

--- a/nemo_retriever/src/nemo_retriever/model/local/nemotron_rerank_vl_v2.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/nemotron_rerank_vl_v2.py
@@ -11,7 +11,7 @@ from typing import Any, List, Optional, Sequence
 
 from nemo_retriever.utils.hf_cache import configure_global_hf_cache_base
 from nemo_retriever.utils.hf_model_registry import get_hf_revision
-from ..model import BaseModel, RunMode
+from ..model import BaseModel, ModelRunMode
 
 from nemo_retriever.model import VL_RERANK_MODEL
 
@@ -136,7 +136,7 @@ class NemotronRerankVLV2VLLM(BaseModel):
         return "vl_reranker"
 
     @property
-    def model_runmode(self) -> RunMode:
+    def model_runmode(self) -> ModelRunMode:
         return "local"
 
     @property

--- a/nemo_retriever/src/nemo_retriever/model/local/nemotron_rerank_vl_v2_hf.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/nemotron_rerank_vl_v2_hf.py
@@ -10,7 +10,7 @@ from typing import Any, List, Optional, Sequence
 
 from nemo_retriever.utils.hf_cache import configure_global_hf_cache_base
 from nemo_retriever.utils.hf_model_registry import get_hf_revision
-from ..model import BaseModel, RunMode
+from ..model import BaseModel, ModelRunMode
 
 
 from nemo_retriever.model import VL_RERANK_MODEL
@@ -112,7 +112,7 @@ class NemotronRerankVLV2(BaseModel):
         return "vl_reranker"
 
     @property
-    def model_runmode(self) -> RunMode:
+    def model_runmode(self) -> ModelRunMode:
         return "local"
 
     @property

--- a/nemo_retriever/src/nemo_retriever/model/local/nemotron_table_structure_v1.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/nemotron_table_structure_v1.py
@@ -8,7 +8,7 @@ import torch
 from nemo_retriever.utils.hf_cache import configure_global_hf_cache_base
 from nemo_retriever.utils.hf_model_registry import install_pinned_hf_hub_download
 from nemo_retriever.utils.nvtx import gpu_inference_range
-from ..model import BaseModel, RunMode
+from ..model import BaseModel, ModelRunMode
 
 import nemotron_table_structure_v1.model as _table_structure_model
 from nemotron_table_structure_v1.model import define_model as define_model_table_structure
@@ -90,7 +90,7 @@ class NemotronTableStructureV1(BaseModel):
         return "object-detection"
 
     @property
-    def model_runmode(self) -> RunMode:
+    def model_runmode(self) -> ModelRunMode:
         """Execution mode: local, NIM, or build-endpoint."""
         return "local"
 

--- a/nemo_retriever/src/nemo_retriever/model/local/nemotron_vlm_captioner.py
+++ b/nemo_retriever/src/nemo_retriever/model/local/nemotron_vlm_captioner.py
@@ -22,7 +22,7 @@ from nemo_retriever.caption.model_profiles import (
 )
 from nemo_retriever.utils.hf_cache import configure_global_hf_cache_base
 from nemo_retriever.utils.nvtx import gpu_inference_range
-from ..model import BaseModel, RunMode
+from ..model import BaseModel, ModelRunMode
 
 
 def _b64_to_pil(b64: str) -> Image.Image:
@@ -202,7 +202,7 @@ class NemotronVLMCaptioner(BaseModel):
         return "vlm-captioner"
 
     @property
-    def model_runmode(self) -> RunMode:
+    def model_runmode(self) -> ModelRunMode:
         return "local"
 
     @property

--- a/nemo_retriever/src/nemo_retriever/model/model.py
+++ b/nemo_retriever/src/nemo_retriever/model/model.py
@@ -2,12 +2,16 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Any, Literal, Tuple
-import torch.nn as nn
+from typing import TYPE_CHECKING, Any, Literal, Tuple
+
+if TYPE_CHECKING:
+    import torch.nn as nn
 
 
-RunMode = Literal["local", "NIM", "build-endpoint"]
+ModelRunMode = Literal["local", "NIM", "build-endpoint"]
 
 
 class BaseModel(ABC):
@@ -37,7 +41,7 @@ class BaseModel(ABC):
 
     @property
     @abstractmethod
-    def model_runmode(self) -> RunMode:
+    def model_runmode(self) -> ModelRunMode:
         """Execution mode: local, NIM, or build-endpoint."""
         pass
 

--- a/nemo_retriever/src/nemo_retriever/params/__init__.py
+++ b/nemo_retriever/src/nemo_retriever/params/__init__.py
@@ -11,12 +11,12 @@ from .models import ChartParams
 from .models import DedupParams
 from .models import EmbedParams
 from .models import ExtractParams
-from .models import FusedTuningParams
 from .models import GpuAllocationParams
 from .models import HtmlChunkParams
 from .models import InfographicParams
 from .models import IngestExecuteParams
 from .models import IngestorCreateParams
+from .models import IngestorRunMode
 from .models import LanceDbParams
 from .models import LLMInferenceParams
 from .models import LLMRemoteClientParams
@@ -26,7 +26,6 @@ from .models import PageElementsParams
 from .models import PdfSplitParams
 from .models import RemoteInvokeParams
 from .models import RemoteRetryParams
-from .models import RunMode
 from .models import StoreParams
 from .models import TabularExtractParams
 from .models import TableParams
@@ -49,12 +48,12 @@ __all__ = [
     "DedupParams",
     "EmbedParams",
     "ExtractParams",
-    "FusedTuningParams",
     "GpuAllocationParams",
     "HtmlChunkParams",
     "InfographicParams",
     "IngestExecuteParams",
     "IngestorCreateParams",
+    "IngestorRunMode",
     "LanceDbParams",
     "LLMInferenceParams",
     "LLMRemoteClientParams",
@@ -64,7 +63,6 @@ __all__ = [
     "PdfSplitParams",
     "RemoteInvokeParams",
     "RemoteRetryParams",
-    "RunMode",
     "SPLIT_CONFIG_VALID_KEYS",
     "StoreParams",
     "TabularExtractParams",

--- a/nemo_retriever/src/nemo_retriever/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/params/models.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from nemo_retriever.utils.remote_auth import resolve_remote_api_key
 
-RunMode = Literal["inprocess", "batch", "fused", "service"]
+IngestorRunMode = Literal["inprocess", "batch", "service"]
 
 # Pass as an api_key value to suppress auto-resolution from environment variables.
 # Example: EmbedParams(api_key=NO_API_KEY)
@@ -286,13 +286,6 @@ class BatchTuningParams(_ParamsModel):
     inference_batch_size: int = 8
 
 
-class FusedTuningParams(_ParamsModel):
-    fused_workers: int = 1
-    fused_batch_size: int = 64
-    fused_cpus_per_actor: float = 1
-    fused_gpus_per_actor: float = 1.0
-
-
 class GpuAllocationParams(_ParamsModel):
     gpu_devices: list[str] = Field(default_factory=list)
     startup_timeout: float = 600.0
@@ -412,7 +405,6 @@ class EmbedParams(_ParamsModel):
 
     runtime: ModelRuntimeParams = Field(default_factory=ModelRuntimeParams)
     batch_tuning: BatchTuningParams = Field(default_factory=BatchTuningParams)
-    fused_tuning: FusedTuningParams = Field(default_factory=FusedTuningParams)
 
     @field_validator("local_ingest_embed_backend", mode="before")
     @classmethod

--- a/nemo_retriever/src/nemo_retriever/params/utils.py
+++ b/nemo_retriever/src/nemo_retriever/params/utils.py
@@ -56,7 +56,7 @@ def build_embed_kwargs(resolved: Any, *, include_batch_tuning: bool = False) -> 
     Merges ``runtime`` (always) and optionally ``batch_tuning`` sub-models.
     Also normalises ``embed_invoke_url`` → ``embedding_endpoint``.
     """
-    exclude = {"runtime", "batch_tuning", "fused_tuning"}
+    exclude = {"runtime", "batch_tuning"}
     kwargs: Dict[str, Any] = {
         **resolved.model_dump(mode="python", exclude=exclude, exclude_none=True),
         **resolved.runtime.model_dump(mode="python", exclude_none=True),

--- a/nemo_retriever/src/nemo_retriever/text_embed/shared.py
+++ b/nemo_retriever/src/nemo_retriever/text_embed/shared.py
@@ -19,7 +19,7 @@ def _to_bool(v: object, default: bool = False) -> bool:
 
 def build_embed_kwargs(params: EmbedParams) -> dict[str, object]:
     kwargs = {
-        **params.model_dump(mode="python", exclude={"runtime", "batch_tuning", "fused_tuning"}, exclude_none=True),
+        **params.model_dump(mode="python", exclude={"runtime", "batch_tuning"}, exclude_none=True),
         **params.runtime.model_dump(mode="python", exclude_none=True),
     }
     if "embedding_endpoint" not in kwargs and kwargs.get("embed_invoke_url"):

--- a/nemo_retriever/tests/test_ingest_interface.py
+++ b/nemo_retriever/tests/test_ingest_interface.py
@@ -85,9 +85,9 @@ def test_create_ingestor_rejects_unknown_kwargs() -> None:
         create_ingestor(run_mode="inprocess", unknown_field=True)
 
 
-def test_create_ingestor_rejects_legacy_non_graph_modes() -> None:
+def test_create_ingestor_rejects_unknown_run_modes() -> None:
     with pytest.raises(ValueError, match="supports run modes"):
-        create_ingestor(run_mode="fused")  # type: ignore[arg-type]
+        create_ingestor(run_mode="parallel")  # type: ignore[arg-type]
 
 
 def test_graph_ingestor_action_methods_materialize_default_params() -> None:

--- a/nemo_retriever/tests/test_multimodal_embed.py
+++ b/nemo_retriever/tests/test_multimodal_embed.py
@@ -28,19 +28,18 @@ from nemo_retriever.text_embed.main_text_embed import (
 # Stub heavy internal modules so the content-transform helpers can be imported
 # in lightweight CI (only pytest, pandas, pydantic, pyyaml).
 #
-# The ``nemo_retriever.ingest_modes`` __init__.py eagerly imports batch/fused/online
-# which pull in ray, torch, nemotron_*, nemo_retriever.api, etc.  And inprocess.py
-# itself imports model/local (torch, nemotron_*), page_elements, ocr, and
-# pdf.extract — each with their own heavy transitive deps.
+# Older ingest modules can pull in ray, torch, nemotron_*, nemo_retriever.api,
+# etc. And inprocess.py itself imports model/local (torch, nemotron_*),
+# page_elements, ocr, and pdf.extract — each with their own heavy transitive
+# deps.
 #
 # Rather than chasing every third-party leaf dependency, we pre-populate
 # sys.modules for the heavy *internal* nemo_retriever sub-packages with MagicMock.
 # This cuts off the entire transitive tree at the root.
 # ---------------------------------------------------------------------------
 _HEAVY_INTERNAL = [
-    # -- sibling ingest modes (prevents batch.py/fused.py from loading) ------
+    # -- sibling ingest modes (prevents batch.py from loading) ------------------
     "nemo_retriever.ingest_modes.batch",
-    "nemo_retriever.ingest_modes.fused",
     # -- model / ML packages (torch, nemotron_*, transformers) ---------------
     "nemo_retriever.model.local",
     "nemo_retriever.model.local.llama_nemotron_embed_1b_v2_embedder",

--- a/nemo_retriever/tests/test_params_utils.py
+++ b/nemo_retriever/tests/test_params_utils.py
@@ -62,7 +62,6 @@ class TestBuildEmbedKwargs:
         kwargs = build_embed_kwargs(params)
         assert "runtime" not in kwargs
         assert "batch_tuning" not in kwargs
-        assert "fused_tuning" not in kwargs
 
 
 class TestNormalizeEmbedKwargs:

--- a/nemo_retriever/tests/test_type_aliases.py
+++ b/nemo_retriever/tests/test_type_aliases.py
@@ -1,0 +1,31 @@
+from importlib import import_module
+from typing import get_args
+
+import nemo_retriever.params as params_module
+from nemo_retriever.model.model import ModelRunMode
+from nemo_retriever.params import EmbedParams
+from nemo_retriever.params import IngestorRunMode
+
+
+def test_run_mode_type_aliases_are_domain_specific() -> None:
+    assert set(get_args(IngestorRunMode)) == {"inprocess", "batch", "service"}
+    assert set(get_args(ModelRunMode)) == {"local", "NIM", "build-endpoint"}
+
+
+def test_generic_run_mode_aliases_are_not_exported() -> None:
+    params_models = import_module("nemo_retriever.params.models")
+    model_module = import_module("nemo_retriever.model.model")
+
+    assert not hasattr(params_module, "RunMode")
+    assert "RunMode" not in params_module.__all__
+    assert not hasattr(params_models, "RunMode")
+    assert not hasattr(model_module, "RunMode")
+
+
+def test_fused_mode_tuning_surface_is_not_exported() -> None:
+    params_models = import_module("nemo_retriever.params.models")
+
+    assert not hasattr(params_module, "FusedTuningParams")
+    assert "FusedTuningParams" not in params_module.__all__
+    assert not hasattr(params_models, "FusedTuningParams")
+    assert "fused_tuning" not in EmbedParams.model_fields

--- a/nemo_retriever/tests/test_type_aliases.py
+++ b/nemo_retriever/tests/test_type_aliases.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from importlib import import_module
 from typing import get_args
 


### PR DESCRIPTION
## Description
- Replace the stale public ingestion `RunMode` alias with `IngestorRunMode = Literal["inprocess", "batch", "service"]`
- Rename the model backend typing alias from `RunMode` to `ModelRunMode` so ingestion run modes and model backend modes no longer share a generic alias name
- Remove the old fused-mode tuning surface: `FusedTuningParams`, `EmbedParams.fused_tuning`, and related flattening exclusions
- Clean stale fused run-mode comments/stubs while preserving active audio/visual fusion terminology
- Add regression tests to ensure generic `RunMode` aliases and fused-mode tuning exports stay removed

addresses bug: https://nvbugspro.nvidia.com/bug/6218080

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
