### PR TITLE
clarify pdf_split_config is service-only (NVBugs 6218013)

### DIFF
--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -6,6 +6,8 @@ Large PDFs are split into page batches before Ray processing so extraction can r
 
 To tune splitter throughput from the CLI, use `--pdf-split-batch-size` (Ray actor batch size for the splitter stage). See [Text chunking and PDF page batches](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli#text-chunking-and-pdf-page-batches) in the CLI reference.
 
+**Python client (`pdf_split_config`):** Only `create_ingestor(run_mode="service")` implements `.pdf_split_config(pages_per_chunk=...)`, which records page-chunking settings in the request pipeline spec for the remote gateway. Local graph ingest (`run_mode="inprocess"` or `"batch"`) raises `NotImplementedError` if you call this method; PDFs are split automatically on the default ingest path without client-side configuration.
+
 ::: nemo_retriever.ingestor
     options:
       filters:


### PR DESCRIPTION
## Summary

- Adds a short note to the [PDF pre-splitting](docs/docs/extraction/nemo-retriever-api-reference.md#pdf-pre-splitting-for-parallel-ingest) section: `.pdf_split_config(pages_per_chunk=...)` is implemented for `create_ingestor(run_mode=service)` only.
- Documents that local graph ingest (`run_mode=inprocess` or batch`) raises `NotImplementedError` if you call this method; PDF splitting happens on the default ingest path without client configuration.

Follow-up to PR #2112 (doc half of NVBugs 6218013). The SDK stub on `GraphIngestor` remains a separate dev-track item.

## Test plan

- [ ] Rendered docs: PDF pre-splitting section reads clearly for service vs local deployments.
- [ ] No code changes; docs-only PR.