### PR TITLE
Fix ModelOpt FP8 local vLLM startup

### DIFF
--- a/nemo_retriever/src/nemo_retriever/caption/model_profiles.py
+++ b/nemo_retriever/src/nemo_retriever/caption/model_profiles.py
@@ -219,11 +219,9 @@ def _unique(names: tuple[str, ...]) -> tuple[str, ...]:
 
 
 _BF16_ENGINE_KWARGS = {"dtype": "bfloat16"}
-_FP8_ENGINE_KWARGS = {
-    "dtype": "auto",
-    "quantization": "fp8",
-    "hf_overrides": {"quantization_config": {"quant_method": "fp8", "activation_scheme": "static"}},
-}
+# ModelOpt FP8 checkpoints provide the quantization config. These kwargs
+# intentionally omit `quantization` and `hf_overrides`.
+_MODEL_OPT_FP8_ENGINE_KWARGS = {"dtype": "auto"}
 _NVFP4_ENGINE_KWARGS = {"dtype": "auto", "quantization": "modelopt"}
 
 _OMNI_CAPABILITIES = CaptionCapabilities(
@@ -250,7 +248,7 @@ _NANO_FP8_PROFILE = CaptionModelProfile(
     local_model_id=NANO_FP8_MODEL_ID,
     remote_model_id=_NANO_FP8_REMOTE_MODEL_ID,
     revision=get_hf_revision(NANO_FP8_MODEL_ID, strict=False),
-    local_engine_kwargs=_FP8_ENGINE_KWARGS,
+    local_engine_kwargs=_MODEL_OPT_FP8_ENGINE_KWARGS,
 )
 _NANO_NVFP4_QAD_PROFILE = CaptionModelProfile(
     family="nemotron-nano",
@@ -280,7 +278,7 @@ _OMNI_FP8_PROFILE = CaptionModelProfile(
     capabilities=_OMNI_CAPABILITIES,
     local_request_extras=_OMNI_NO_THINK_EXTRAS,
     remote_request_extras=_OMNI_NO_THINK_EXTRAS,
-    local_engine_kwargs=_FP8_ENGINE_KWARGS,
+    local_engine_kwargs=_MODEL_OPT_FP8_ENGINE_KWARGS,
 )
 _OMNI_NVFP4_PROFILE = CaptionModelProfile(
     family="nemotron-3-nano-omni",

--- a/nemo_retriever/tests/test_caption_model_profiles.py
+++ b/nemo_retriever/tests/test_caption_model_profiles.py
@@ -286,21 +286,45 @@ def test_public_request_extra_fields_are_immutable():
     assert profile.request_extras_for("remote") == {"chat_template_kwargs": {"enable_thinking": False}}
 
 
-def test_public_fp8_engine_kwargs_are_immutable():
+@pytest.mark.parametrize(
+    ("model_name", "expected_engine"),
+    [
+        (NANO_FP8, {"dtype": "auto"}),
+        (OMNI_FP8, {"dtype": "auto"}),
+    ],
+)
+def test_modelopt_fp8_profiles_preserve_checkpoint_quantization(model_name, expected_engine):
+    from nemo_retriever.caption.model_profiles import get_caption_model_profile
+
+    profile = get_caption_model_profile(model_name, target="local")
+
+    engine_kwargs = profile.engine_kwargs_for_local()
+
+    assert engine_kwargs == expected_engine
+    assert "quantization" not in engine_kwargs
+    assert "hf_overrides" not in engine_kwargs
+
+
+def test_public_nano_fp8_engine_kwargs_are_immutable():
+    from nemo_retriever.caption.model_profiles import get_caption_model_profile
+
+    profile = get_caption_model_profile(NANO_FP8, target="local")
+
+    with pytest.raises(TypeError):
+        profile.local_engine_kwargs["dtype"] = "bfloat16"
+
+    assert profile.engine_kwargs_for_local() == {"dtype": "auto"}
+
+
+def test_public_omni_fp8_engine_kwargs_are_immutable():
     from nemo_retriever.caption.model_profiles import get_caption_model_profile
 
     profile = get_caption_model_profile(OMNI_FP8, target="local")
 
     with pytest.raises(TypeError):
-        profile.local_engine_kwargs["hf_overrides"]["quantization_config"]["activation_scheme"] = "dynamic"
-    with pytest.raises(TypeError):
-        profile.local_engine_kwargs["quantization"] = "modelopt"
+        profile.local_engine_kwargs["dtype"] = "bfloat16"
 
-    assert profile.engine_kwargs_for_local() == {
-        "dtype": "auto",
-        "quantization": "fp8",
-        "hf_overrides": {"quantization_config": {"quant_method": "fp8", "activation_scheme": "static"}},
-    }
+    assert profile.engine_kwargs_for_local() == {"dtype": "auto"}
 
 
 def _install_fake_torch():
@@ -369,6 +393,11 @@ def _install_fake_vllm():
     ("model_name", "expected_revision", "expected_engine"),
     [
         (
+            NANO_FP8,
+            "7394488badb786e1decc0e00e308de1cab9560e6",
+            {"dtype": "auto"},
+        ),
+        (
             OMNI_BF16,
             "24e67ea000b7c2837fc8f9488aa2008524fac8ba",
             {"dtype": "bfloat16"},
@@ -376,11 +405,7 @@ def _install_fake_vllm():
         (
             OMNI_FP8,
             "6647b845a4b786c6e2c7adb1b6a909e1aa71fac2",
-            {
-                "dtype": "auto",
-                "quantization": "fp8",
-                "hf_overrides": {"quantization_config": {"quant_method": "fp8", "activation_scheme": "static"}},
-            },
+            {"dtype": "auto"},
         ),
         (
             OMNI_NVFP4,
@@ -389,7 +414,7 @@ def _install_fake_vllm():
         ),
     ],
 )
-def test_local_omni_captioner_uses_profile_metadata(
+def test_local_captioner_uses_profile_metadata(
     isolated_local_captioner_imports, model_name, expected_revision, expected_engine
 ):
     FakeLLM, _FakeSamplingParams = _install_fake_vllm()
@@ -411,6 +436,9 @@ def test_local_omni_captioner_uses_profile_metadata(
     assert llm_kwargs["gpu_memory_utilization"] == 0.25
     for key, value in expected_engine.items():
         assert llm_kwargs[key] == value
+    if model_name in {NANO_FP8, OMNI_FP8}:
+        assert "quantization" not in llm_kwargs
+        assert "hf_overrides" not in llm_kwargs
 
 
 def test_local_captioner_passes_omni_no_think_chat_kwargs(isolated_local_captioner_imports):


### PR DESCRIPTION
## Description
Preserve the Hugging Face checkpoint ModelOpt FP8 quantization metadata for both local ModelOpt FP8 caption profiles.

Previously, Nano FP8 and Omni FP8 reused a shared generic FP8 vLLM kwargs map that passed `quantization="fp8"` and `hf_overrides`. That overrode checkpoint-provided ModelOpt metadata such as the quantization method, ignored modules, producer/version metadata, and KV-cache scheme.

This PR changes the local profile behavior as follows:
- Nano FP8 now passes only `{"dtype": "auto"}`, allowing vLLM to read `quantization=modelopt` from the checkpoint.
- Omni FP8 now also passes only `{"dtype": "auto"}`, allowing vLLM to read `quantization=modelopt` from the checkpoint.
- BF16 and NVFP4 profile behavior is unchanged.

The PR intentionally does not force a MoE backend for Omni FP8. Local B200 validation showed the default vLLM FlashInfer FP8 MoE path can have a long cold-start path, while `moe_backend="triton"` starts faster, but the default path eventually initializes once the checkpoint ModelOpt metadata is preserved. Any backend-specific startup/performance workaround should be tracked separately from this ModelOpt metadata fix.

Validation performed on this branch:
- `uv run --extra local --extra dev pytest tests/test_caption_model_profiles.py tests/test_caption.py` (`71 passed`)
- Nano FP8 live init check, without `VLLM_USE_FLASHINFER_MOE_FP8=0`: `NemotronVLMCaptioner(model_path="nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-FP8", gpu_memory_utilization=0.5, tensor_parallel_size=1)` loaded successfully. vLLM logs showed no NeMo-side `quantization` or `hf_overrides`, detected the ModelOpt FP8 checkpoint, and resolved `quantization=modelopt`.
- Omni FP8 live init check, without `VLLM_USE_FLASHINFER_MOE_FP8=0` and without a NeMo-side `moe_backend` override: `LLM(model="nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8", revision="6647b845a4b786c6e2c7adb1b6a909e1aa71fac2", trust_remote_code=True, gpu_memory_utilization=0.5, tensor_parallel_size=1, disable_log_stats=True, dtype="auto")` loaded successfully. vLLM logs showed `quantization=modelopt`, `moe_backend="auto"`, and `Using FLASHINFER_TRTLLM Fp8 MoE backend`.

Refs NVBUGS 6216894.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes. No documentation changes are needed for this local profile fix.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file. Not applicable; this PR does not change docker-compose.yaml or Helm values.
