### PR TITLE
Fix .extract() silently dropping unknown kwargs and docs

### DIFF
--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -75,24 +75,22 @@ Use the following procedure to run the NIM on your own infrastructure. Self-host
 
     - The `Ingestor` object initializes the ingestion process.
     - The `files` method specifies the input files to process.
-    - The `extract` method runs audio extraction.
+    - The `extract_audio` method runs audio extraction.
 
     ```python
+    from nemo_retriever.params.models import ASRParams
+
     ingestor = (
         Ingestor()
         .files("./data/*.wav")
-        .extract(
-            document_type="wav",  # Ingestor should detect type automatically in most cases
-            extract_method="audio",
-            extract_audio_params={
-                "segment_audio": True,
-            },
+        .extract_audio(
+            asr_params=ASRParams(segment_audio=True),
         )
     )
     ```
 
 
-    To generate one extracted element for each sentence-like ASR segment, include `extract_audio_params={"segment_audio": True}` when calling `.extract(...)`. This option applies when audio extraction runs with a self-hosted Parakeet NIM or using build.nvidia.com hosted inference, but has no effect when using the local Hugging Face Parakeet model.
+    To generate one extracted element for each sentence-like ASR segment, pass `asr_params=ASRParams(segment_audio=True)` to `.extract_audio(...)`. This option applies when audio extraction runs with a self-hosted Parakeet NIM or using build.nvidia.com hosted inference, but has no effect when using the local Hugging Face Parakeet model.
 
 
     !!! tip
@@ -109,23 +107,22 @@ Instead of running the pipeline locally, you can call Parakeet through [build.nv
 
     - The `Ingestor` object initializes the ingestion process.
     - The `files` method specifies the input files to process.
-    - The `extract` method runs audio extraction.
-    - The `document_type` parameter is optional because `Ingestor` should detect the file type automatically in most cases.
+    - The `extract_audio` method runs audio extraction.
+    - The hosted gRPC endpoint, function ID, and API key are routed through `ASRParams`. Pass them via `asr_params=ASRParams(...)`; the ASR actor reads `audio_endpoints`, `function_id`, and `auth_token` from that object.
 
     ```python
+    from nemo_retriever.params.models import ASRParams
+
     ingestor = (
         Ingestor()
         .files("./data/*.mp3")
-        .extract(
-            document_type="mp3",
-            extract_method="audio",
-            extract_audio_params={
-                "grpc_endpoint": "grpc.nvcf.nvidia.com:443",
-                "auth_token": "<API key>",
-                "function_id": "<function ID>",
-                "use_ssl": True,
-                "segment_audio": True,
-            },
+        .extract_audio(
+            asr_params=ASRParams(
+                audio_endpoints=("grpc.nvcf.nvidia.com:443", None),
+                function_id="<function ID>",
+                auth_token="<API key>",
+                segment_audio=True,
+            ),
         )
     )
     ```

--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -118,7 +118,7 @@ Instead of running the pipeline locally, you can call Parakeet through [build.nv
         .files("./data/*.mp3")
         .extract_audio(
             asr_params=ASRParams(
-                audio_endpoints=("grpc.nvcf.nvidia.com:443", None),
+                audio_endpoints=("grpc.nvcf.nvidia.com:443", None),  # (grpc_endpoint, http_endpoint)
                 function_id="<function ID>",
                 auth_token="<API key>",
                 segment_audio=True,

--- a/nemo_retriever/src/nemo_retriever/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/graph_ingestor.py
@@ -524,7 +524,21 @@ class GraphIngestor(ingestor):
         :class:`MultiTypeExtractOperator`.
         Chunking is opt-in: pass ``split_config={"<key>": {...}}`` to enable
         post-extract token chunking for that source type.
+
+        Unknown ``**kwargs`` raise :class:`TypeError`. Only fields declared
+        on :class:`ExtractParams` are accepted as extra kwargs; ASR / audio
+        configuration belongs on :class:`ASRParams` (pass ``asr_params=``
+        or use :meth:`extract_audio`).
         """
+        unknown = set(kwargs) - set(ExtractParams.model_fields)
+        if unknown:
+            raise TypeError(
+                f"extract() got unexpected keyword argument(s) {sorted(unknown)!r}. "
+                f"Allowed extra kwargs must be fields of ExtractParams. "
+                f"For ASR / audio configuration, pass asr_params=ASRParams(...) "
+                f"or use .extract_audio(asr_params=ASRParams(...)) "
+                f"(see docs/extraction/audio-video.md)."
+            )
         self._extraction_mode = extraction_mode
         self._extract_params = _resolve_api_key(_coerce(params, kwargs, default_factory=ExtractParams))
         if text_params is not None:

--- a/nemo_retriever/tests/test_ingest_interface.py
+++ b/nemo_retriever/tests/test_ingest_interface.py
@@ -142,7 +142,7 @@ def test_extract_rejects_unknown_kwargs() -> None:
     with pytest.raises(TypeError, match="garbage_kwarg"):
         ingestor.extract(garbage_kwarg="x")
 
-    with pytest.raises(TypeError, match="extract_audio_params") as exc_info:
+    with pytest.raises(TypeError) as exc_info:
         ingestor.extract(
             document_type="mp3",
             extract_method="audio",
@@ -154,8 +154,10 @@ def test_extract_rejects_unknown_kwargs() -> None:
             },
         )
     message = str(exc_info.value)
-    assert "extract_method" in message
-    assert "document_type" in message
+    # Pin the rejected-keys list as a single repr so this test fails loudly if
+    # any of these keys ever become real ExtractParams fields.
+    expected_rejected = repr(sorted(["document_type", "extract_method", "extract_audio_params"]))
+    assert expected_rejected in message
     assert "asr_params" in message
 
 

--- a/nemo_retriever/tests/test_ingest_interface.py
+++ b/nemo_retriever/tests/test_ingest_interface.py
@@ -126,6 +126,39 @@ def test_extract_unified_defaults() -> None:
     assert all(ingestor._split_config[k] is None for k in ("text", "html", "pdf", "audio", "image", "video"))
 
 
+def test_extract_rejects_unknown_kwargs() -> None:
+    """`.extract()` must fail loudly on kwargs that are not fields of ExtractParams.
+
+    The audio-video.md hosted-Parakeet snippet historically passed
+    ``extract_method``/``extract_audio_params`` (and ``document_type``) into
+    ``.extract()``; those silently flowed through ``_coerce()`` /
+    ``params.model_copy(update=...)``, bypassing ``ExtractParams``'s
+    ``extra="forbid"`` config. Audio credentials never reached the ASR actor,
+    which then fell back to the local HF model with no signal to the user.
+    Regression-guard the strict validation that fixes that silent drop.
+    """
+    ingestor = GraphIngestor(run_mode="inprocess")
+
+    with pytest.raises(TypeError, match="garbage_kwarg"):
+        ingestor.extract(garbage_kwarg="x")
+
+    with pytest.raises(TypeError, match="extract_audio_params") as exc_info:
+        ingestor.extract(
+            document_type="mp3",
+            extract_method="audio",
+            extract_audio_params={
+                "grpc_endpoint": "grpc.nvcf.nvidia.com:443",
+                "auth_token": "fake-key",
+                "function_id": "fake-function-id",
+                "segment_audio": True,
+            },
+        )
+    message = str(exc_info.value)
+    assert "extract_method" in message
+    assert "document_type" in message
+    assert "asr_params" in message
+
+
 def test_extract_default_pdf_only_builds_dedicated_pdf_graph(tmp_path) -> None:
     document = tmp_path / "manual.pdf"
     document.write_bytes(b"%PDF-1.4\n")


### PR DESCRIPTION
## Description
  .extract() flowed unknown **kwargs through _coerce()/model_copy(update=),
  bypassing ExtractParams's extra="forbid"; the audio-video.md hosted-Parakeet
  snippet's kwargs were silently dropped and ingestion fell back to local HF
  Parakeet. Now validate against ExtractParams.model_fields and raise on
  unknown keys. Rewrite both audio-video.md snippets to use
  .extract_audio(asr_params=ASRParams(...)).
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
