### PR TITLE
support matrix Omni FP8 and nemotron-parse GPUs (NVBugs 6216894, 6204537)

### DIFF
--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -118,10 +118,10 @@ Model repositories and NIM references are linked in [Core and Advanced Pipeline 
 | Core Features | — | Total Disk Space | ~150GB | ~150GB | ~150GB | ~150GB | ~150GB | ~150GB | ~150GB | ~150GB | ~150GB |
 | Audio/video extraction (parakeet-1-1b-ctc-en-us) | ~4.0 GiB (`model.safetensors`; the repo also ships `parakeet-ctc-1.1b.nemo` of similar size—use one format to avoid roughly doubling disk use) | Additional Dedicated GPUs | Not supported⁴ | Not supported⁴ | 1¹ | 1¹ | 1¹ | 1¹ | 1¹ | 1¹ | Not supported⁴ |
 | Audio/video extraction (parakeet-1-1b-ctc-en-us) | — | Additional Disk Space | Not supported⁴ | Not supported⁴ | ~37GB¹ | ~37GB¹ | ~37GB¹ | ~37GB¹ | ~37GB¹ | ~37GB¹ | Not supported⁴ |
-| nemotron-parse | ~3.5 GiB | Additional Dedicated GPUs | Not supported | 1 | Not supported | 1 | 1 | 1 | 1 | 1 | Not supported² |
-| nemotron-parse | — | Additional Disk Space | Not supported | ~16GB | Not supported | ~16GB | ~16GB | ~16GB | ~16GB | ~16GB | Not supported² |
-| Omni caption (nemotron-3-nano-omni-30b-a3b-reasoning) | ~62 GiB (BF16); ~33 GiB (FP8); ~21 GiB (NVFP4) | Additional Dedicated GPUs | 1 | 1 | 1 | 1 | 1 | Not supported | Not supported | 2 | Not supported³ |
-| Omni caption (nemotron-3-nano-omni-30b-a3b-reasoning) | — | Additional Disk Space (HF) | ~21–62GB | ~21–62GB | ~21–62GB | ~21–62GB | ~21–62GB | Not supported | Not supported | ~21–62GB | Not supported³ |
+| nemotron-parse | ~3.5 GiB | Additional Dedicated GPUs | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | Not supported² |
+| nemotron-parse | — | Additional Disk Space | ~16GB | ~16GB | ~16GB | ~16GB | ~16GB | ~16GB | ~16GB | ~16GB | Not supported² |
+| Omni caption (nemotron-3-nano-omni-30b-a3b-reasoning) | ~62 GiB (BF16) | Additional Dedicated GPUs | 1 | 1 | 1 | 1 | 1 | Not supported | Not supported | 2 | Not supported³ |
+| Omni caption (nemotron-3-nano-omni-30b-a3b-reasoning) | — | Additional Disk Space (HF) | ~62GB | ~62GB | ~62GB | ~62GB | ~62GB | Not supported | Not supported | ~62GB | Not supported³ |
 | Omni caption (nemotron-3-nano-omni-30b-a3b-reasoning) | — | Additional Disk Space (NIM) | ~80GB | ~80GB | ~80GB | ~80GB | ~80GB | Not supported | Not supported | ~80GB | Not supported³ |
 | Reranker | ~3.1 GiB (llama-nemotron-rerank-vl-1b-v2) | With Core Pipeline | Yes | Yes | Yes | Yes | Yes | No* | No* | No* | No* |
 | Reranker | — | Standalone (recall only) | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |


### PR DESCRIPTION
## Summary

- **NVBugs 6216894** — Remove FP8 and NVFP4 weight/disk entries from the Omni caption rows so the support matrix documents BF16 only (~62 GiB HF weights, ~62 GB HF disk, ~80 GB NIM disk). The FP8 size implied a supported precision path that does not work for 26.05 Omni captioning.
- **NVBugs 6204537 / 6216894** — Align the Nemotron Parse optional-NIM rows with current support: mark RTX Pro 6000, B200, and H200 NVL as supported (`1` GPU, `~16GB` disk). B200 was partially updated in #2103; RTX Pro 6000 and H200 NVL still showed outdated "Not supported" cells from the earlier Blackwell restriction.

## Test plan

- [ ] Review [prerequisites-support-matrix.md](docs/docs/extraction/prerequisites-support-matrix.md) model hardware table: Omni caption shows BF16 only; nemotron-parse shows `1` / `~16GB` for RTX Pro 6000, B200, and H200 NVL; RTX PRO 4500 remains `Not supported²` (32 GB).
- [ ] Confirm footnote ² still applies only to 32 GB (RTX PRO 4500).
- [ ] Published docs preview (if available) renders the table without broken markdown.
