### PR TITLE
docs: fix graph_pipeline LanceDB examples

### DIFF
--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -10,7 +10,7 @@ To upgrade the Helm charts for this release, refer to the [NeMo Retriever Helm c
 
 Highlights for the 26.05 release line include everything in [26.03](#2603-release-notes-2630) plus changes on `main` merged into the `26.05` branch. See the [Git compare view](https://github.com/NVIDIA/NeMo-Retriever/compare/26.03...26.05) for the full commit list.
 
-**Migration note:** Direct `Retriever(...)` construction uses grouped configuration dictionaries. Replace flat `lancedb_uri=`, `lancedb_table=`, `embedder=`, `embedding_endpoint=`, and `reranker=` arguments with `vdb_kwargs={...}`, `embed_kwargs={...}`, and `rerank=...`. Helper APIs that document their own flat kwargs keep their own compatibility layer.
+**Migration note:** Direct `Retriever(...)` construction uses grouped configuration dictionaries. Replace flat `lancedb_uri=`, `lancedb_table=`, `embedder=`, `embedding_endpoint=`, `local_query_embed_backend=`, and `reranker=` arguments with `vdb_kwargs={...}`, `embed_kwargs={...}`, and `rerank=...`. For example, `local_query_embed_backend="hf"` maps to `embed_kwargs={"local_ingest_embed_backend": "hf"}`. Helper APIs that document their own flat kwargs keep their own compatibility layer.
 
 **Install (RC1 example):**
 

--- a/docs/docs/extraction/workflow-document-ingestion.md
+++ b/docs/docs/extraction/workflow-document-ingestion.md
@@ -59,7 +59,7 @@ Run the above with your working directory at the repository root (so `data/multi
 ```bash
 python -m nemo_retriever.examples.graph_pipeline \
   /your-example-dir \
-  --lancedb-uri lancedb
+  --vdb-kwargs-json '{"uri":"lancedb","table_name":"nemo-retriever"}'
 ```
 
 For build.nvidia.com hosted inference, set [`NVIDIA_API_KEY`](api-keys.md#nvidia-api-key) and pass the `--*-invoke-url` / `--embed-invoke-url` options shown in the [README remote inference section](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/README.md#ingest-a-test-corpus-cli).

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -151,7 +151,7 @@ Point it at a **directory** of PDFs to produce a ready-to-query LanceDB table.
 ```bash
 python -m nemo_retriever.examples.graph_pipeline \
   /your-example-dir \
-  --lancedb-uri lancedb
+  --vdb-kwargs-json '{"uri":"lancedb","table_name":"nemo-retriever"}'
 ```
 
 Chunks land at `./lancedb/nemo-retriever`, which matches the `vdb_kwargs`
@@ -168,7 +168,7 @@ export NVIDIA_API_KEY=nvapi-...
 
 python -m nemo_retriever.examples.graph_pipeline \
   /your-example-dir \
-  --lancedb-uri lancedb \
+  --vdb-kwargs-json '{"uri":"lancedb","table_name":"nemo-retriever"}' \
   --page-elements-invoke-url https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-page-elements-v3 \
   --ocr-invoke-url https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-ocr-v1 \
   --table-structure-invoke-url https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-table-structure-v1 \

--- a/nemo_retriever/src/nemo_retriever/evaluation/README.md
+++ b/nemo_retriever/src/nemo_retriever/evaluation/README.md
@@ -54,7 +54,7 @@ End-to-end bo767 + LanceDB + full-page markdown touches these **artifacts** and 
  Ingest + Embed                 Index       Export           QA Eval
 +-----------------------------+ +--------+  +----------+  +------------------+
 | graph_pipeline              | | Parquet|  | LanceDB  |  | RetrievalLoader  |
-|  --lancedb-uri lancedb      | | -> page|->| queries  |->| >> Generation    |
+|  --vdb-kwargs-json ...      | | -> page|->| queries  |->| >> Generation    |
 |  [--save-intermediate <dir>]| | md idx |  | + pages  |  | >> Judging       |
 | (always: LanceDB output)   | +--------+  | -> JSON  |  | >> Scoring       |
 | (optional: Parquet output)  |             +----------+  +------------------+
@@ -108,7 +108,7 @@ cd /path/to/nemo-retriever
 
 # 1. Ingest + embed + save Parquet in one pass (~45-90 min)
 python -m nemo_retriever.examples.graph_pipeline /path/to/bo767 \
-  --lancedb-uri lancedb \
+  --vdb-kwargs-json '{"uri":"lancedb","table_name":"nemo-retriever"}' \
   --save-intermediate data/bo767_extracted
 
 # 2. Build page markdown index (~5-10 min)
@@ -142,7 +142,7 @@ cd /path/to/nemo-retriever
 
 # 1. Ingest + embed into LanceDB
 python -m nemo_retriever.examples.graph_pipeline /path/to/bo767 \
-  --lancedb-uri lancedb
+  --vdb-kwargs-json '{"uri":"lancedb","table_name":"nemo-retriever"}'
 
 # 2. Export retrieval (sub-page chunks, no page index)
 retriever eval export \
@@ -169,7 +169,7 @@ cd /path/to/nemo-retriever
 
 # Single command: ingest -> page index -> LanceDB query -> QA eval
 python -m nemo_retriever.examples.graph_pipeline /path/to/bo767 \
-  --lancedb-uri lancedb \
+  --vdb-kwargs-json '{"uri":"lancedb","table_name":"nemo-retriever"}' \
   --evaluation-mode qa \
   --eval-config nemo_retriever/examples/eval_sweep.yaml \
   --query-csv data/bo767_annotations.csv \
@@ -269,7 +269,7 @@ to reconstruct full pages and generally yields better results on structured cont
 
 ```bash
 python -m nemo_retriever.examples.graph_pipeline /path/to/bo767 \
-  --lancedb-uri lancedb \
+  --vdb-kwargs-json '{"uri":"lancedb","table_name":"nemo-retriever"}' \
   --save-intermediate data/bo767_extracted
 ```
 
@@ -283,7 +283,7 @@ markdown.
 
 ```bash
 python -m nemo_retriever.examples.graph_pipeline /path/to/bo767 \
-  --lancedb-uri lancedb
+  --vdb-kwargs-json '{"uri":"lancedb","table_name":"nemo-retriever"}'
 ```
 
 Output:
@@ -835,7 +835,7 @@ separate `build-page-index` step is needed.
 
 ```bash
 python -m nemo_retriever.examples.graph_pipeline /data/pdfs \
-    --lancedb-uri lancedb \
+    --vdb-kwargs-json '{"uri":"lancedb","table_name":"nemo-retriever"}' \
     --evaluation-mode qa \
     --eval-config nemo_retriever/examples/eval_sweep.yaml \
     --query-csv data/bo767_annotations.csv \

--- a/nemo_retriever/tests/test_src_documentation_snippets.py
+++ b/nemo_retriever/tests/test_src_documentation_snippets.py
@@ -61,9 +61,35 @@ _PUBLIC_RETRIEVER_DOCS = (
     "nemo_retriever/src/nemo_retriever/evaluation/README.md",
     "nemo_retriever/src/nemo_retriever/vdb/README.md",
 )
-_UNSUPPORTED_DIRECT_RETRIEVER_KWARGS = frozenset(
-    {"lancedb_uri", "lancedb_table", "embedder", "embedding_endpoint", "reranker"}
+_PUBLIC_GRAPH_PIPELINE_DOCS = (
+    "docs/docs/extraction/workflow-document-ingestion.md",
+    "nemo_retriever/README.md",
+    "nemo_retriever/src/nemo_retriever/evaluation/README.md",
 )
+_UNSUPPORTED_DIRECT_RETRIEVER_KWARGS = frozenset(
+    {
+        "vdb",
+        "lancedb_uri",
+        "lancedb_table",
+        "embedder",
+        "embedding_endpoint",
+        "local_query_embed_backend",
+        "reranker",
+    }
+)
+_UNSUPPORTED_GRAPH_PIPELINE_OPTIONS = frozenset({"--lancedb-uri"})
+
+
+def _public_doc_path(root: Path, rel_path: str) -> Path | None:
+    path = root / rel_path
+    if path.exists():
+        return path
+    repo_only_doc = rel_path == "README.md" or rel_path.startswith(("docs/", "examples/"))
+    package_only_image = not (root / "README.md").exists() and not (root / "docs").exists()
+    if repo_only_doc and package_only_image:
+        return None
+    assert False, f"Expected public documentation file is missing: {rel_path}"
+    return path
 
 
 @pytest.mark.parametrize("block_id,code", _MD_BLOCKS, ids=[b[0] for b in _MD_BLOCKS])
@@ -76,7 +102,9 @@ def _iter_public_retriever_doc_code() -> list[tuple[str, str]]:
     root = _repo_root()
     blocks: list[tuple[str, str]] = []
     for rel_path in _PUBLIC_RETRIEVER_DOCS:
-        path = root / rel_path
+        path = _public_doc_path(root, rel_path)
+        if path is None:
+            continue
         if path.suffix == ".ipynb":
             nb = json.loads(path.read_text(encoding="utf-8"))
             for i, cell in enumerate(nb.get("cells", [])):
@@ -93,7 +121,31 @@ def _iter_public_retriever_doc_code() -> list[tuple[str, str]]:
     return blocks
 
 
-def _retriever_call_flat_kwargs(code: str) -> list[str]:
+def _iter_public_graph_pipeline_commands() -> list[tuple[str, str]]:
+    root = _repo_root()
+    commands: list[tuple[str, str]] = []
+    for rel_path in _PUBLIC_GRAPH_PIPELINE_DOCS:
+        path = _public_doc_path(root, rel_path)
+        if path is None:
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for i, code in enumerate(re.findall(r"```bash\n(.*?)```", text, re.DOTALL)):
+            lines = code.splitlines()
+            command_idx = 0
+            for line_idx, line in enumerate(lines):
+                if "python -m nemo_retriever.examples.graph_pipeline" not in line:
+                    continue
+                command_lines = [line]
+                next_idx = line_idx + 1
+                while command_lines[-1].rstrip().endswith("\\") and next_idx < len(lines):
+                    command_lines.append(lines[next_idx])
+                    next_idx += 1
+                commands.append((f"{rel_path}#bash-{i}-cmd-{command_idx}", "\n".join(command_lines)))
+                command_idx += 1
+    return commands
+
+
+def _retriever_call_unsupported_kwargs(code: str) -> list[str]:
     tree = ast.parse(code)
     found: list[str] = []
     for node in ast.walk(tree):
@@ -103,7 +155,17 @@ def _retriever_call_flat_kwargs(code: str) -> list[str]:
         is_retriever = isinstance(func, ast.Name) and func.id == "Retriever"
         is_retriever = is_retriever or isinstance(func, ast.Attribute) and func.attr == "Retriever"
         if is_retriever:
-            found.extend(str(kw.arg) for kw in node.keywords if kw.arg in _UNSUPPORTED_DIRECT_RETRIEVER_KWARGS)
+            for kw in node.keywords:
+                if kw.arg in _UNSUPPORTED_DIRECT_RETRIEVER_KWARGS:
+                    found.append(str(kw.arg))
+                if kw.arg is None and isinstance(kw.value, ast.Dict):
+                    found.extend(
+                        key.value
+                        for key in kw.value.keys
+                        if isinstance(key, ast.Constant)
+                        and isinstance(key.value, str)
+                        and key.value in _UNSUPPORTED_DIRECT_RETRIEVER_KWARGS
+                    )
     return found
 
 
@@ -112,13 +174,24 @@ def test_public_retriever_examples_do_not_use_unsupported_constructor_kwargs() -
     violations = []
     for block_id, code in _iter_public_retriever_doc_code():
         try:
-            flat_kwargs = _retriever_call_flat_kwargs(code)
+            unsupported_kwargs = _retriever_call_unsupported_kwargs(code)
         except SyntaxError:
             continue
-        if flat_kwargs:
-            violations.append(f"{block_id}: {', '.join(sorted(set(flat_kwargs)))}")
+        if unsupported_kwargs:
+            violations.append(f"{block_id}: {', '.join(sorted(set(unsupported_kwargs)))}")
 
     assert not violations, "Unsupported kwargs in public direct Retriever(...) examples:\n" + "\n".join(violations)
+
+
+def test_public_graph_pipeline_examples_do_not_use_unsupported_options() -> None:
+    """Public ``graph_pipeline`` examples should not use options that command rejects."""
+    violations = []
+    for block_id, command in _iter_public_graph_pipeline_commands():
+        unsupported_options = [option for option in _UNSUPPORTED_GRAPH_PIPELINE_OPTIONS if option in command]
+        if unsupported_options:
+            violations.append(f"{block_id}: {', '.join(sorted(unsupported_options))}")
+
+    assert not violations, "Unsupported options in public graph_pipeline examples:\n" + "\n".join(violations)
 
 
 def test_graph_readme_smallest_example() -> None:


### PR DESCRIPTION
## Summary
- replace unsupported `graph_pipeline --lancedb-uri` examples with `--vdb-kwargs-json` in README/evaluation/workflow docs
- update the evaluation README diagram to avoid documenting the removed option
- align the docs regression guard with #2135 and cover the workflow docs page too
- update the migration note with the `local_query_embed_backend` grouped-kwargs mapping

## Context
Follow-up to #2134 after review noticed ingestion docs still used an option rejected by the shipped `graph_pipeline` CLI. This is kept aligned with the main/GitHub Pages companion PR #2135.

## Testing
- `python -m py_compile nemo_retriever/tests/test_src_documentation_snippets.py && git diff --check`
- `UV_CACHE_DIR=$(mktemp -d /tmp/uv-cache-nemo-2605.XXXXXX) uv run --project nemo_retriever --with pytest --with neo4j pytest nemo_retriever/tests/test_src_documentation_snippets.py`
- CLI smoke: `--lancedb-uri` is rejected; `--vdb-kwargs-json` appears in help