### PR TITLE
align batch ingest() return type with pandas DataFrame (NVBugs 6217023)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,24 +59,22 @@ ingestor = (
 )
 
 # ingestor.ingest() actually executes the pipeline
-# batch run_mode returns a ray.data.Dataset; inprocess returns a pandas DataFrame
-dataset = ingestor.ingest()
-chunks = dataset.take_all()  # Ray Dataset API (batch mode)
+chunks = ingestor.ingest()  # pandas.DataFrame (batch and inprocess)
 ```
 
 You can see the extracted text that represents the content of the ingested test document.
 
 ```python
 # page 1 raw text:
->>> chunks[0]["text"]
+>>> chunks.iloc[0]["text"]
 'TestingDocument\r\nA sample document with headings and placeholder text\r\nIntroduction\r\nThis is a placeholder document that can be used for any purpose...'
 
 # markdown formatted table from the first page
->>> chunks[1]["text"]
+>>> chunks.iloc[1]["text"]
 '| Table | 1 |\n| This | table | describes | some | animals, | and | some | activities | they | might | be | doing | in | specific |\n| locations. |\n| Animal | Activity | Place |\n| Giraffe | Driving | a | car | At | the | beach |\n| Lion | Putting | on | sunscreen | At | the | park |\n| Cat | Jumping | onto | a | laptop | In | a | home | office |\n| Dog | Chasing | a | squirrel | In | the | front | yard |\n| Chart | 1 |'
 
 # a chart from the first page
->>> chunks[2]["text"]
+>>> chunks.iloc[2]["text"]
 'Chart 1\nThis chart shows some gadgets, and some very fictitious costs.\nGadgets and their cost\n$160.00\n$140.00\n$120.00\n$100.00\nDollars\n$80.00\n$60.00\n$40.00\n$20.00\n$-\nPowerdrill\nBluetooth speaker\nMinifridge\nPremium desk fan\nHammer\nCost'
 
 # markdown formatting for full pages or documents:

--- a/docs/docs/extraction/workflow-document-ingestion.md
+++ b/docs/docs/extraction/workflow-document-ingestion.md
@@ -42,8 +42,7 @@ ingestor = (
     .embed()
 )
 
-dataset = ingestor.ingest()  # ``run_mode='batch'`` → ``ray.data.Dataset``; ``inprocess`` → ``pandas.DataFrame``
-chunks = dataset.take_all()  # ``take_all()`` is a Ray Dataset API; use DataFrame methods in ``inprocess``
+chunks = ingestor.ingest()  # ``pandas.DataFrame`` (batch and inprocess)
 ```
 
 Run the above with your working directory at the repository root (so `data/multimodal_test.pdf` resolves), or adjust `documents` to the absolute path of the test PDF.

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -131,9 +131,7 @@ uv run python nemo_retriever/src/nemo_retriever/examples/batch_pipeline.py /path
 
 ```python
 # ingestor.ingest() actually executes the pipeline
-# batch run_mode returns a ray.data.Dataset; inprocess returns a pandas DataFrame
-dataset = ingestor.ingest()
-chunks = dataset.take_all()  # Ray Dataset API (batch mode)
+chunks = ingestor.ingest()  # pandas.DataFrame (batch and inprocess)
 ```
 
 ### Ingest a test corpus (CLI)
@@ -186,14 +184,14 @@ When you use the remote embedder, pair the `Retriever` with the matching
 You can inspect how recall accuracy optimized text chunks for various content types were extracted into text representations:
 ```text
 # page 1 raw text:
->>> chunks[0]["text"]
+>>> chunks.iloc[0]["text"]
 'TestingDocument\r\nA sample document with headings and placeholder text\r\nIntroduction\r\nThis is a placeholder document that can be used for any purpose...'
 
 # markdown formatted table from the first page
 '| Table | 1 |\n| This | table | describes | some | animals, | and | some | activities | they | might | be | doing | in | specific |\n| locations. |\n| Animal | Activity | Place |\n| Giraffe | Driving | a | car | At | the | beach |\n| Lion | Putting | on | sunscreen | At | the | park |\n| Cat | Jumping | onto | a | laptop | In | a | home | office |\n| Dog | Chasing | a | squirrel | In | the | front | yard |\n| Chart | 1 |'
 
 # a chart from the first page
->>> chunks[2]["text"]
+>>> chunks.iloc[2]["text"]
 'Chart 1\nThis chart shows some gadgets, and some very fictitious costs.\nGadgets and their cost\n$160.00\n$140.00\n$120.00\n$100.00\nDollars\n$80.00\n$60.00\n$40.00\n$20.00\n$-\nPowerdrill\nBluetooth speaker\nMinifridge\nPremium desk fan\nHammer\nCost'
 
 # markdown formatting for full pages or documents:

--- a/nemo_retriever/src/nemo_retriever/graph/executor.py
+++ b/nemo_retriever/src/nemo_retriever/graph/executor.py
@@ -223,8 +223,9 @@ class RayDataExecutor(AbstractExecutor):
 
         Returns
         -------
-        ray.data.Dataset
-            The materialized result dataset.
+        pandas.DataFrame
+            The materialized result after executing the Ray Data pipeline
+            (``ds.to_pandas()``).
         """
         import ray
         import ray.data as rd

--- a/nemo_retriever/src/nemo_retriever/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/graph_ingestor.py
@@ -502,10 +502,10 @@ class GraphIngestor(ingestor):
 
         Returns
         -------
-        ``run_mode='batch'``
-            A materialized ``ray.data.Dataset``.
-        ``run_mode='inprocess'``
-            A ``pandas.DataFrame``.
+        pandas.DataFrame
+            Materialized extraction results. Both ``run_mode='batch'`` and
+            ``run_mode='inprocess'`` return a DataFrame; batch mode materializes
+            the Ray pipeline via ``ds.to_pandas()`` at the executor boundary.
         """
         effective_extraction = self._resolve_effective_extraction_inputs()
         # Auto-enable dedup before captioning so that images overlapping

--- a/nemo_retriever/src/nemo_retriever/pipeline/__main__.py
+++ b/nemo_retriever/src/nemo_retriever/pipeline/__main__.py
@@ -593,10 +593,10 @@ def _build_ingestor(
 def _collect_results(run_mode: str, result: Any) -> tuple[list[dict[str, Any]], Any, float, int]:
     """Materialize the graph result into a list of records + DataFrame.
 
-    Ingest may return a ``pandas.DataFrame`` (in-process or after
-    ``ray.data.Dataset.to_pandas()`` in the executor), a ``ray.data.Dataset``,
-    or a :class:`~nemo_retriever.service_ingestor.ServiceIngestResult` (service
-    mode); normalize to a consistent ``(records, DataFrame, secs, units)`` tuple.
+    Ingest may return a ``pandas.DataFrame`` (in-process and batch graph paths,
+    where batch materializes via ``ds.to_pandas()`` in the executor) or a
+    :class:`~nemo_retriever.service_ingestor.ServiceIngestResult` (service mode);
+    normalize to a consistent ``(records, DataFrame, secs, units)`` tuple.
 
     Returns ``(records, result_df, ray_download_secs, num_input_units)``.
     """


### PR DESCRIPTION
## Summary

Fixes doc rot where the package README and two in-source docstrings claimed `create_ingestor(run_mode="batch").ingest()` returns a `ray.data.Dataset` and showed `dataset.take_all()`. The implementation materializes results to a `pandas.DataFrame` at the Ray executor boundary (`ds.to_pandas()`), and first-party tests assert that contract.

- Update Quick-Start snippets in `nemo_retriever/README.md`, root `README.md`, and `workflow-document-ingestion.md` so copy-paste no longer crashes with `AttributeError: 'DataFrame' object has no attribute 'take_all'`.
- Correct `GraphIngestor.ingest()` and `RayDataExecutor.ingest()` docstring Returns sections.
- Align `_collect_results` helper docstring with the same contract.

Doc-only; no behavior changes.

## NVBugs

6217023

## Test plan

- [ ] Copy-paste the updated Quick-Start from `nemo_retriever/README.md` with `run_mode="batch"`; confirm `ingest()` returns `pandas.DataFrame` and no `take_all()` call is needed.
- [ ] `help(GraphIngestor.ingest)` / IDE hover shows `pandas.DataFrame` for batch mode.