### PR TITLE
quiet mode default

### DIFF
--- a/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
+++ b/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
@@ -270,13 +270,13 @@ def ingest_command(
         help="CPUs reserved per embedding actor in batch mode.",
     ),
     quiet: bool = typer.Option(
-        False,
-        "--quiet",
+        True,
+        "--quiet/--no-quiet",
         help=(
             "Suppress verbose progress output (progress bars, HuggingFace "
             "downloads, vLLM init logs). On success, prints only the final "
             "summary line. On error, flushes all captured output to stderr "
-            "for debugging."
+            "for debugging. Enabled by default; pass --no-quiet for verbose output."
         ),
     ),
 ) -> None:


### PR DESCRIPTION
## Description
enable quiet by default for retriever ingest.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
