### PR TITLE
move notebooks to subfolder (PR #1963 follow-up)

### DIFF
--- a/docs/docs/extraction/concepts.md
+++ b/docs/docs/extraction/concepts.md
@@ -36,6 +36,6 @@ Token-based splitting uses the Llama 3.2 1B tokenizer (default `meta-llama/Llama
 
 - **Library mode** — Run without the full container stack where appropriate; see [Deployment options](deployment-options.md).
 - **Kubernetes / Helm (self-hosted)** — See [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) and [deployment options](deployment-options.md) for running the full microservices pipeline on your infrastructure.
-- **Notebooks** — [Jupyter examples](notebooks.md) for experimentation and RAG demos.
+- **Notebooks** — [Jupyter examples](notebooks/index.md) for experimentation and RAG demos.
 
 For a concise comparison, refer to [Deployment options](deployment-options.md).

--- a/docs/docs/extraction/deployment-options.md
+++ b/docs/docs/extraction/deployment-options.md
@@ -32,7 +32,7 @@ environments), use a custom service image that already contains `ffmpeg` and
 
 ### I want examples and notebooks
 
-1. [Jupyter Notebooks](notebooks.md)
+1. [Jupyter Notebooks](notebooks/index.md)
 2. [Integrate with LangChain, LlamaIndex, Haystack](integrations-langchain-llamaindex-haystack.md)
 
 ### I need API details and keys

--- a/docs/docs/extraction/getting-started-about.md
+++ b/docs/docs/extraction/getting-started-about.md
@@ -10,6 +10,6 @@ Typical order:
     - [Deployment options](deployment-options.md) for how to run NeMo Retriever Library
     - **Supported:** [Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) for Kubernetes, plus [NeMo Retriever Library install docs](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the published charts
     - **Unsupported (developer-only):** [Docker Compose (local)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md) — not a supported NIM deployment path
-4. Explore [Jupyter Notebooks](notebooks.md) for end-to-end examples.
+4. Explore [Jupyter Notebooks](notebooks/index.md) for end-to-end examples.
 
 If you are new to the product, read [What is NeMo Retriever Library?](overview.md) and [Concepts](concepts.md) under **Introduction** first.

--- a/docs/docs/extraction/integrations-langchain-llamaindex-haystack.md
+++ b/docs/docs/extraction/integrations-langchain-llamaindex-haystack.md
@@ -9,7 +9,7 @@ The repository includes notebooks that demonstrate multimodal RAG patterns:
 - [Multimodal RAG with LangChain](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/langchain_multimodal_rag.ipynb)
 - [Multimodal RAG with LlamaIndex](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/llama_index_multimodal_rag.ipynb)
 
-These are also linked from [Jupyter Notebooks](notebooks.md) and the [FAQ](faq.md).
+These are also linked from [Jupyter Notebooks](notebooks/index.md) and the [FAQ](faq.md).
 
 ## Haystack
 

--- a/docs/docs/extraction/notebooks/index.md
+++ b/docs/docs/extraction/notebooks/index.md
@@ -1,6 +1,6 @@
 # Notebooks for NeMo Retriever Library
 
-To get started using [NeMo Retriever Library](overview.md), you can try one of the ready-made notebooks that are available.
+To get started using [NeMo Retriever Library](../overview.md), you can try one of the ready-made notebooks that are available.
 
 ## Dataset Downloads for Benchmarking
 
@@ -23,11 +23,3 @@ For more advanced scenarios, try one of the following notebooks:
 - [Evaluate bo767 retrieval recall accuracy with NeMo Retriever Library](https://github.com/NVIDIA/NeMo-Retriever/blob/main/evaluation/bo767_recall.ipynb)
 - [Multimodal RAG with LangChain](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/langchain_multimodal_rag.ipynb)
 - [Multimodal RAG with LlamaIndex](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/llama_index_multimodal_rag.ipynb)
-
-
-
-## Related Topics
-
-- [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
-- [Deployment options](deployment-options.md)
-- [Deploy with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -50,5 +50,5 @@ NeMo Retriever Library supports the following file types:
 - [Deploy on Kubernetes with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)
 - [NeMo Retriever Library — prerequisites / deployment](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) (supported Helm charts)
 - [Docker Compose (unsupported, developer)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md)
-- [Notebooks](notebooks.md)
+- [Notebooks](notebooks/index.md)
 - [NVIDIA AI Blueprints catalog](https://build.nvidia.com/explore/discover) — solution cards, enterprise RAG blueprints, and end-to-end patterns (including [Enterprise RAG — multimodal PDF data extraction](https://build.nvidia.com/nvidia/multimodal-pdf-data-extraction-for-enterprise-rag)); for integration pathways, refer to [Integrations](integrations-langchain-llamaindex-haystack.md).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -104,7 +104,7 @@ nav:
       - "NimClient and custom NIM endpoints": extraction/nimclient.md
   - "10. Integrations & ecosystem":
       - "Framework integrations": extraction/integrations-langchain-llamaindex-haystack.md
-      - "Starter kits": extraction/notebooks.md
+      - "Starter kits": extraction/notebooks/index.md
   - "11. Evaluation & benchmarks":
       - "Evaluate on your own documents": extraction/evaluate-on-your-data.md
   - "12. Reference":
@@ -159,6 +159,7 @@ plugins:
         extraction/hosted-nims-when-to-use.md: extraction/deployment-options.md
         extraction/releasenotes-nv-ingest.md: extraction/releasenotes.md
         extraction/ngc-api-key.md: extraction/api-keys.md
+        extraction/notebooks.md: extraction/notebooks/index.md
         extraction/data-store.md: extraction/vdbs.md
         extraction/nemoretriever-parse.md: extraction/multimodal-extraction.md#text-and-layout-extraction
         extraction/supported-file-types.md: extraction/multimodal-extraction.md#supported-file-types-and-formats


### PR DESCRIPTION
## Summary

Closes the remaining Randy review follow-up from [#1963](https://github.com/NVIDIA/NeMo-Retriever/pull/1963) (2026-05-05):

- Move the starter-kits notebooks page into `docs/docs/extraction/notebooks/`
- Point MkDocs **Starter kits** nav at the new path
- Add redirect from `extraction/notebooks.md` for old URLs
- Update in-tree cross-links
- Remove the **Related Topics** section (sidebar/nav covers discovery)

## Changes

| Area | Change |
|------|--------|
| `notebooks/index.md` | Relocated from `notebooks.md`; `overview.md` link uses `../overview.md` |
| `mkdocs.yml` | Nav + redirect |
| Cross-links | `concepts.md`, `deployment-options.md`, `overview.md`, `getting-started-about.md`, `integrations-langchain-llamaindex-haystack.md` |

## Test plan

- [ ] `mkdocs build` (strict) succeeds
- [ ] Sidebar **Starter kits** opens `extraction/notebooks/`
- [ ] Redirect from old `extraction/notebooks.html` works
- [ ] Internal links from overview / getting-started resolve

## Related

- PR #1963 — unified prerequisites, VDB nav (other follow-ups already on `main`)