### PR TITLE
Codex/fail empty root ingest

### DIFF
--- a/.claude/skills/nemo-retriever/references/ingest.md
+++ b/.claude/skills/nemo-retriever/references/ingest.md
@@ -92,7 +92,7 @@ retriever ingest data/multimodal_test.pdf \
 | `--table-name` | `nemo-retriever` | LanceDB table to write into. Must match `retriever query`'s table on read. |
 | `--profile` | `auto` | `auto` is normal manifest-routed ingest. `fast-text` disables expensive PDF recall stages for a text-only fallback. |
 | `--caption` | `false` | Optional VLM captioning stage after extraction. Never enabled by profiles. |
-| `--caption-invoke-url` | unset | Remote VLM endpoint. If omitted with `--caption`, local VLM captioning is used. |
+| `--caption-invoke-url` | unset | Remote VLM endpoint. If omitted with `--caption`, GPU hosts use local captioning; CPU-only runs use the hosted default endpoint. |
 | `--caption-context-text-max-chars` | default | Include nearby extracted text in caption prompts. |
 | `--caption-infographics` | default | Caption infographic crops in addition to extracted images. |
 | `--run-mode` | `batch` | `batch` for the SDK batch ingestor; pass `inprocess` to skip Ray for local debug or CI. |

--- a/.claude/skills/nemo-retriever/references/ingest.md
+++ b/.claude/skills/nemo-retriever/references/ingest.md
@@ -92,7 +92,7 @@ retriever ingest data/multimodal_test.pdf \
 | `--table-name` | `nemo-retriever` | LanceDB table to write into. Must match `retriever query`'s table on read. |
 | `--profile` | `auto` | `auto` is normal manifest-routed ingest. `fast-text` disables expensive PDF recall stages for a text-only fallback. |
 | `--caption` | `false` | Optional VLM captioning stage after extraction. Never enabled by profiles. |
-| `--caption-invoke-url` | unset | Remote VLM endpoint. If omitted with `--caption`, GPU hosts use local captioning; CPU-only runs use the hosted default endpoint. |
+| `--caption-invoke-url` | unset | Remote VLM endpoint. If omitted with `--caption`, GPU hosts use local captioning; CPU-only runs use the hosted default endpoint with `NVIDIA_API_KEY` / `NGC_API_KEY`. |
 | `--caption-context-text-max-chars` | default | Include nearby extracted text in caption prompts. |
 | `--caption-infographics` | default | Caption infographic crops in addition to extracted images. |
 | `--run-mode` | `batch` | `batch` for the SDK batch ingestor; pass `inprocess` to skip Ray for local debug or CI. |

--- a/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
+++ b/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
@@ -27,6 +27,7 @@ from nemo_retriever.adapters.cli.sdk_workflow import (
     ingest_documents,
     query_documents,
 )
+from nemo_retriever.vdb.records import RetrievalHit
 from nemo_retriever.version import get_version_info
 
 logger = logging.getLogger(__name__)
@@ -66,6 +67,14 @@ for _name, _module, _attr in _LAZY_SUBAPPS:
         logger.debug("Skipping '%s' sub-command (import failed)", _name)
 
 _ROOT_CLI_ERRORS = (OSError, RuntimeError, ValueError, ValidationError)
+
+
+def _query_cli_hit(hit: RetrievalHit) -> dict[str, object]:
+    return {
+        "source": hit.get("source", ""),
+        "page_number": hit.get("page_number"),
+        "text": hit.get("text", ""),
+    }
 
 
 def _silence_noisy_libraries() -> None:
@@ -555,7 +564,7 @@ def query_command(
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(1) from exc
 
-    typer.echo(json.dumps(list(hits), indent=2, sort_keys=True, default=str))
+    typer.echo(json.dumps([_query_cli_hit(hit) for hit in hits], indent=2, sort_keys=True, default=str))
 
 
 @app.callback()

--- a/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
+++ b/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
@@ -480,10 +480,9 @@ def ingest_command(
 
     # Report input-file count alongside the actual landed-row count from the
     # LanceDB table — they diverge whenever one document explodes into multiple
-    # chunks (PDFs → page elements, video → audio_visual segments) or
-    # shrinks to zero rows when every NIM call failed. The previous message
-    # only reported inputs and hid both cases. ``n_rows`` is None when the
-    # table read itself failed (caller can still see file count + URI).
+    # chunks (PDFs → page elements, video → audio_visual segments). The SDK
+    # rejects known-empty ingests before we get here; ``n_rows`` is None when
+    # the table read itself failed (caller can still see file count + URI).
     n_files = len(summary["documents"])
     table_path = f"{summary['lancedb_uri']}/{summary['table_name']}"
     n_rows = summary.get("n_rows")

--- a/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
+++ b/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
@@ -265,7 +265,7 @@ def ingest_command(
         "--caption-invoke-url",
         help=(
             "VLM caption endpoint URL. If omitted with --caption, GPU hosts use local captioning; "
-            "CPU-only runs use the hosted default endpoint."
+            "CPU-only runs use the hosted default endpoint with NVIDIA_API_KEY/NGC_API_KEY."
         ),
     ),
     caption_model_name: str | None = typer.Option(
@@ -484,8 +484,8 @@ def ingest_command(
     # Report input-file count alongside the actual landed-row count from the
     # LanceDB table — they diverge whenever one document explodes into multiple
     # chunks (PDFs → page elements, video → audio_visual segments). The SDK
-    # rejects known-empty ingests before we get here; ``n_rows`` is None when
-    # the table read itself failed (caller can still see file count + URI).
+    # rejects empty or unverifiable ingests before we get here; the ``None``
+    # branch below is defensive for direct SDK callers.
     n_files = len(summary["documents"])
     table_path = f"{summary['lancedb_uri']}/{summary['table_name']}"
     n_rows = summary.get("n_rows")

--- a/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
+++ b/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
@@ -263,7 +263,10 @@ def ingest_command(
     caption_invoke_url: str | None = typer.Option(
         None,
         "--caption-invoke-url",
-        help="VLM caption endpoint URL. If omitted with --caption, local VLM captioning is used.",
+        help=(
+            "VLM caption endpoint URL. If omitted with --caption, GPU hosts use local captioning; "
+            "CPU-only runs use the hosted default endpoint."
+        ),
     ),
     caption_model_name: str | None = typer.Option(
         None,

--- a/nemo_retriever/src/nemo_retriever/adapters/cli/sdk_workflow.py
+++ b/nemo_retriever/src/nemo_retriever/adapters/cli/sdk_workflow.py
@@ -851,19 +851,58 @@ def ingest_documents(
     if dry_run:
         return plan.dry_run_data()
 
+    initial_n_rows = None if overwrite else _count_lancedb_rows(plan.lancedb_uri, plan.table_name)
     ingestor = create_ingestor(**plan.create_kwargs).files(plan.documents)
     ingestor = ingestor.extract(plan.extract_params, **plan.extract_call_kwargs())
     if plan.caption_params is not None:
         ingestor = ingestor.caption(plan.caption_params)
     ingestor = ingestor.embed(plan.embed_params) if plan.embed_params is not None else ingestor.embed()
     result = ingestor.vdb_upload(plan.vdb_params).ingest()
+    n_rows = _count_lancedb_rows(plan.lancedb_uri, plan.table_name)
+    _raise_for_empty_ingest(
+        documents=plan.documents,
+        lancedb_uri=plan.lancedb_uri,
+        table_name=plan.table_name,
+        n_rows=n_rows,
+        initial_n_rows=initial_n_rows,
+    )
     return {
         "documents": plan.documents,
         "lancedb_uri": plan.lancedb_uri,
         "result": result,
         "table_name": plan.table_name,
-        "n_rows": _count_lancedb_rows(plan.lancedb_uri, plan.table_name),
+        "n_rows": n_rows,
     }
+
+
+def _raise_for_empty_ingest(
+    *,
+    documents: Sequence[str],
+    lancedb_uri: str,
+    table_name: str,
+    n_rows: int | None,
+    initial_n_rows: int | None,
+) -> None:
+    if n_rows is None:
+        return
+    if n_rows > 0 and (initial_n_rows is None or n_rows > initial_n_rows):
+        return
+
+    target = f"{lancedb_uri}/{table_name}"
+    if initial_n_rows is not None:
+        raise RuntimeError(
+            f"retriever ingest did not add rows to LanceDB {target}; row count stayed at {n_rows} "
+            f"for {len(documents)} input file(s). This usually means extraction or embedding failed before "
+            "any rows were written; check the captured stage logs above, and verify NVIDIA_API_KEY/NGC_API_KEY "
+            "or the configured local/remote endpoints."
+        )
+
+    noun = "row" if n_rows == 1 else "rows"
+    raise RuntimeError(
+        f"retriever ingest produced {n_rows} {noun} in LanceDB {target} for {len(documents)} input file(s). "
+        "This usually means extraction or embedding failed before any rows were written; check the captured "
+        "stage logs above, and verify NVIDIA_API_KEY/NGC_API_KEY or the configured local/remote endpoints."
+    )
 
 
 def _count_lancedb_rows(lancedb_uri: str, table_name: str) -> int | None:

--- a/nemo_retriever/src/nemo_retriever/adapters/cli/sdk_workflow.py
+++ b/nemo_retriever/src/nemo_retriever/adapters/cli/sdk_workflow.py
@@ -902,9 +902,8 @@ def _raise_for_empty_ingest(
             "or the configured local/remote endpoints."
         )
 
-    noun = "row" if n_rows == 1 else "rows"
     raise RuntimeError(
-        f"retriever ingest produced {n_rows} {noun} in LanceDB {target} for {len(documents)} input file(s). "
+        f"retriever ingest produced 0 rows in LanceDB {target} for {len(documents)} input file(s). "
         "This usually means extraction or embedding failed before any rows were written; check the captured "
         "stage logs above, and verify NVIDIA_API_KEY/NGC_API_KEY or the configured local/remote endpoints."
     )

--- a/nemo_retriever/src/nemo_retriever/adapters/cli/sdk_workflow.py
+++ b/nemo_retriever/src/nemo_retriever/adapters/cli/sdk_workflow.py
@@ -883,12 +883,17 @@ def _raise_for_empty_ingest(
     n_rows: int | None,
     initial_n_rows: int | None,
 ) -> None:
+    target = f"{lancedb_uri}/{table_name}"
     if n_rows is None:
-        return
+        raise RuntimeError(
+            f"retriever ingest could not verify rows in LanceDB {target} for {len(documents)} input file(s). "
+            "This usually means the LanceDB table was not created or could not be read after ingestion; check "
+            "the captured stage logs above, and verify NVIDIA_API_KEY/NGC_API_KEY or the configured local/remote "
+            "endpoints."
+        )
     if n_rows > 0 and (initial_n_rows is None or n_rows > initial_n_rows):
         return
 
-    target = f"{lancedb_uri}/{table_name}"
     if initial_n_rows is not None:
         raise RuntimeError(
             f"retriever ingest did not add rows to LanceDB {target}; row count stayed at {n_rows} "
@@ -908,11 +913,9 @@ def _raise_for_empty_ingest(
 def _count_lancedb_rows(lancedb_uri: str, table_name: str) -> int | None:
     """Return the actual row count in ``<lancedb_uri>/<table_name>`` or ``None``.
 
-    Best-effort: the CLI surfaces the value purely as a more honest replacement
-    for the legacy "Ingested N document(s)" message (which counted *inputs*, not
-    landed rows). Failures here must never break ingestion — swallow any
-    exception and report ``None``. Tests stub this helper rather than poking a
-    real LanceDB.
+    The low-level reader is best-effort so callers can decide whether an
+    unknown count is acceptable. Root ingest treats an unknown final count as a
+    failure because agents need proof that rows landed.
     """
     try:
         import lancedb  # local import — keeps the CLI startup snappy

--- a/nemo_retriever/src/nemo_retriever/caption/caption.py
+++ b/nemo_retriever/src/nemo_retriever/caption/caption.py
@@ -25,6 +25,7 @@ from nemo_retriever.ocr.ocr import _crop_b64_image_by_norm_bbox
 from nemo_retriever.params import CaptionParams
 
 _DEFAULT_MODEL_NAME = "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"
+_DEFAULT_REMOTE_ENDPOINT_URL = "https://integrate.api.nvidia.com/v1/chat/completions"
 _MAX_CONTEXT_TEXT_CHARS = 4096
 _MIN_IMAGE_DIMENSION = 32
 _LOCAL_MODEL_CACHE_KEYS = (
@@ -118,9 +119,15 @@ class CaptionCPUActor(AbstractOperator, CPUOperator):
         super().__init__(params=params)
         self._params = params
         self._kwargs = params.model_dump(mode="python")
-        endpoint = (self._kwargs.get("endpoint_url") or "").strip()
-        if not endpoint:
-            raise ValueError("CaptionCPUActor requires params.endpoint_url to be set.")
+        configured_endpoint = (self._kwargs.get("endpoint_url") or "").strip()
+        endpoint = configured_endpoint or _DEFAULT_REMOTE_ENDPOINT_URL
+        if not configured_endpoint and not (self._kwargs.get("api_key") or "").strip():
+            raise ValueError(
+                "CaptionCPUActor defaulted to the hosted VLM endpoint but no API key is configured. "
+                "Set NVIDIA_API_KEY/NGC_API_KEY, pass --caption-invoke-url for a local endpoint, "
+                "or run on a GPU host for local captioning."
+            )
+        self._kwargs["endpoint_url"] = endpoint
         self._model = None
 
     def preprocess(self, data: Any, **kwargs: Any) -> Any:

--- a/nemo_retriever/src/nemo_retriever/caption/caption.py
+++ b/nemo_retriever/src/nemo_retriever/caption/caption.py
@@ -23,6 +23,7 @@ from nemo_retriever.graph.gpu_operator import GPUOperator
 from nemo_retriever.graph.operator_archetype import ArchetypeOperator
 from nemo_retriever.ocr.ocr import _crop_b64_image_by_norm_bbox
 from nemo_retriever.params import CaptionParams
+from nemo_retriever.utils.remote_auth import resolve_remote_api_key
 
 _DEFAULT_MODEL_NAME = "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"
 _DEFAULT_REMOTE_ENDPOINT_URL = "https://integrate.api.nvidia.com/v1/chat/completions"
@@ -121,7 +122,10 @@ class CaptionCPUActor(AbstractOperator, CPUOperator):
         self._kwargs = params.model_dump(mode="python")
         configured_endpoint = (self._kwargs.get("endpoint_url") or "").strip()
         endpoint = configured_endpoint or _DEFAULT_REMOTE_ENDPOINT_URL
-        if not configured_endpoint and not (self._kwargs.get("api_key") or "").strip():
+        api_key = resolve_remote_api_key(str(self._kwargs.get("api_key") or ""))
+        if api_key:
+            self._kwargs["api_key"] = api_key
+        if not configured_endpoint and not api_key:
             raise ValueError(
                 "CaptionCPUActor defaulted to the hosted VLM endpoint but no API key is configured. "
                 "Set NVIDIA_API_KEY/NGC_API_KEY, pass --caption-invoke-url for a local endpoint, "

--- a/nemo_retriever/src/nemo_retriever/infographic/infographic_detection.py
+++ b/nemo_retriever/src/nemo_retriever/infographic/infographic_detection.py
@@ -26,6 +26,9 @@ from nemo_retriever.graph.designer import designer_component
 from nemo_retriever.graph.operator_archetype import ArchetypeOperator
 from nemo_retriever.params import RemoteRetryParams
 from nemo_retriever.nim.nim import NIMClient, invoke_image_inference_batches
+from nemo_retriever.utils.remote_auth import resolve_remote_api_key
+
+_DEFAULT_INFOGRAPHIC_INVOKE_URL = "https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-graphic-elements-v1"
 
 try:
     import numpy as np
@@ -824,12 +827,15 @@ class InfographicDetectionCPUActor(AbstractOperator, CPUOperator):
         super().__init__(**detect_kwargs)
         self.detect_kwargs = dict(detect_kwargs)
         invoke_url = str(
-            self.detect_kwargs.get("infographic_invoke_url") or self.detect_kwargs.get("invoke_url") or ""
+            self.detect_kwargs.get("infographic_invoke_url")
+            or self.detect_kwargs.get("invoke_url")
+            or _DEFAULT_INFOGRAPHIC_INVOKE_URL
         ).strip()
-        if not invoke_url:
-            raise ValueError("InfographicDetectionCPUActor requires infographic_invoke_url or invoke_url.")
         if "invoke_url" not in self.detect_kwargs:
             self.detect_kwargs["invoke_url"] = invoke_url
+        api_key = resolve_remote_api_key(str(self.detect_kwargs.get("api_key") or ""))
+        if api_key:
+            self.detect_kwargs["api_key"] = api_key
         self._model = None
         self._nim_client = NIMClient(
             max_pool_workers=int(self.detect_kwargs.get("remote_max_pool_workers", 24)),

--- a/nemo_retriever/src/nemo_retriever/rerank/rerank.py
+++ b/nemo_retriever/src/nemo_retriever/rerank/rerank.py
@@ -70,12 +70,8 @@ logger = logging.getLogger(__name__)
 
 _render_warned = False
 _DEFAULT_MODEL = "nvidia/llama-nemotron-rerank-1b-v2"
-_DEFAULT_RERANK_INVOKE_URL = (
-    "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-1b-v2/reranking"
-)
-_DEFAULT_VL_RERANK_INVOKE_URL = (
-    "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-vl-1b-v2/reranking"
-)
+_DEFAULT_RERANK_INVOKE_URL = "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-1b-v2/reranking"
+_DEFAULT_VL_RERANK_INVOKE_URL = "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-vl-1b-v2/reranking"
 _DEFAULT_MAX_LENGTH = 512
 _DEFAULT_BATCH_SIZE = 32
 _SCORE_COLUMN = "rerank_score"

--- a/nemo_retriever/src/nemo_retriever/rerank/rerank.py
+++ b/nemo_retriever/src/nemo_retriever/rerank/rerank.py
@@ -63,15 +63,28 @@ from nemo_retriever.graph.cpu_operator import CPUOperator
 from nemo_retriever.model import is_vl_rerank_model
 from nemo_retriever.graph.gpu_operator import GPUOperator
 from nemo_retriever.graph.operator_archetype import ArchetypeOperator
+from nemo_retriever.utils.remote_auth import resolve_remote_api_key
 
 
 logger = logging.getLogger(__name__)
 
 _render_warned = False
 _DEFAULT_MODEL = "nvidia/llama-nemotron-rerank-1b-v2"
+_DEFAULT_RERANK_INVOKE_URL = (
+    "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-1b-v2/reranking"
+)
+_DEFAULT_VL_RERANK_INVOKE_URL = (
+    "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-vl-1b-v2/reranking"
+)
 _DEFAULT_MAX_LENGTH = 512
 _DEFAULT_BATCH_SIZE = 32
 _SCORE_COLUMN = "rerank_score"
+
+
+def _default_rerank_invoke_url(model_name: str | None) -> str:
+    if is_vl_rerank_model(model_name):
+        return _DEFAULT_VL_RERANK_INVOKE_URL
+    return _DEFAULT_RERANK_INVOKE_URL
 
 
 # ---------------------------------------------------------------------------
@@ -417,12 +430,17 @@ class NemotronRerankCPUActor(AbstractOperator, CPUOperator):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._kwargs = dict(kwargs)
-        rerank_invoke_url = str(self._kwargs.get("rerank_invoke_url") or "").strip()
-        if not rerank_invoke_url:
+        configured_url = str(self._kwargs.get("rerank_invoke_url") or "").strip()
+        rerank_invoke_url = configured_url or _default_rerank_invoke_url(
+            str(self._kwargs.get("model_name") or _DEFAULT_MODEL)
+        )
+        api_key = resolve_remote_api_key(str(self._kwargs.get("api_key") or ""))
+        if api_key:
+            self._kwargs["api_key"] = api_key
+        elif not configured_url:
             raise ValueError(
-                "NemotronRerankCPUActor requires an explicit `rerank_invoke_url` (no default endpoint). "
-                "For local GPU reranking, omit the URL and the ArchetypeOperator will dispatch to "
-                "NemotronRerankGPUActor."
+                "NemotronRerankCPUActor defaulted to the hosted rerank endpoint but no API key is configured. "
+                "Set NVIDIA_API_KEY/NGC_API_KEY or pass rerank_invoke_url for a local endpoint."
             )
         self._kwargs["rerank_invoke_url"] = rerank_invoke_url
         self._model = None

--- a/nemo_retriever/tests/test_caption.py
+++ b/nemo_retriever/tests/test_caption.py
@@ -412,6 +412,31 @@ def test_caption_cpu_actor_defaults_to_hosted_endpoint_when_api_key_is_configure
     assert infer_kwargs["model_name"] == "nvidia/nemotron-nano-12b-v2-vl"
 
 
+@patch("nemo_retriever.caption.caption._create_remote_client")
+def test_caption_cpu_actor_default_endpoint_reads_api_key_from_runtime_env(mock_create_client, monkeypatch):
+    from nemo_retriever.caption.caption import CaptionCPUActor
+    from nemo_retriever.params import CaptionParams
+
+    monkeypatch.delenv("NVIDIA_API_KEY", raising=False)
+    monkeypatch.delenv("NGC_API_KEY", raising=False)
+    params = CaptionParams()
+    assert params.api_key is None
+
+    monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-env")
+    mock_nim = MagicMock()
+    mock_nim.infer.return_value = ["remote cap"]
+    mock_create_client.return_value = mock_nim
+
+    actor = CaptionCPUActor(params)
+    actor.process(_make_page_df(num_images=1))
+
+    assert actor._kwargs["api_key"] == "nvapi-env"
+    mock_create_client.assert_called_once_with(
+        "https://integrate.api.nvidia.com/v1/chat/completions",
+        "nvapi-env",
+    )
+
+
 def test_caption_cpu_actor_default_endpoint_requires_api_key(monkeypatch):
     from nemo_retriever.caption.caption import CaptionCPUActor
     from nemo_retriever.params import CaptionParams

--- a/nemo_retriever/tests/test_caption.py
+++ b/nemo_retriever/tests/test_caption.py
@@ -394,6 +394,36 @@ def test_caption_cpu_actor_default_extra_body_does_not_repack_profile_extras(moc
 
 
 @patch("nemo_retriever.caption.caption._create_remote_client")
+def test_caption_cpu_actor_defaults_to_hosted_endpoint_when_api_key_is_configured(mock_create_client):
+    from nemo_retriever.caption.caption import CaptionCPUActor
+    from nemo_retriever.params import CaptionParams
+
+    mock_nim = MagicMock()
+    mock_nim.infer.return_value = ["remote cap"]
+    mock_create_client.return_value = mock_nim
+
+    actor = CaptionCPUActor(CaptionParams(api_key="nvapi-test"))
+    result = actor.process(_make_page_df(num_images=1))
+
+    assert result.iloc[0]["images"][0]["text"] == "remote cap"
+    mock_create_client.assert_called_once()
+    assert mock_create_client.call_args.args[0] == "https://integrate.api.nvidia.com/v1/chat/completions"
+    infer_kwargs = mock_nim.infer.call_args.kwargs
+    assert infer_kwargs["model_name"] == "nvidia/nemotron-nano-12b-v2-vl"
+
+
+def test_caption_cpu_actor_default_endpoint_requires_api_key(monkeypatch):
+    from nemo_retriever.caption.caption import CaptionCPUActor
+    from nemo_retriever.params import CaptionParams
+
+    monkeypatch.delenv("NVIDIA_API_KEY", raising=False)
+    monkeypatch.delenv("NGC_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="no API key is configured"):
+        CaptionCPUActor(CaptionParams())
+
+
+@patch("nemo_retriever.caption.caption._create_remote_client")
 def test_remote_omni_user_extra_body_overrides_profile_defaults(mock_create_client):
     from nemo_retriever.caption.caption import caption_images
 

--- a/nemo_retriever/tests/test_ingest_empty_validation.py
+++ b/nemo_retriever/tests/test_ingest_empty_validation.py
@@ -7,6 +7,26 @@ import pytest
 from nemo_retriever.adapters.cli.sdk_workflow import _raise_for_empty_ingest
 
 
+def test_empty_ingest_validation_accepts_rows_on_overwrite() -> None:
+    _raise_for_empty_ingest(
+        documents=["doc.pdf"],
+        lancedb_uri="lancedb",
+        table_name="nemo-retriever",
+        n_rows=3,
+        initial_n_rows=None,
+    )
+
+
+def test_empty_ingest_validation_accepts_new_rows_on_append() -> None:
+    _raise_for_empty_ingest(
+        documents=["doc.pdf"],
+        lancedb_uri="lancedb",
+        table_name="nemo-retriever",
+        n_rows=4,
+        initial_n_rows=3,
+    )
+
+
 def test_empty_ingest_validation_rejects_unknown_final_row_count() -> None:
     with pytest.raises(RuntimeError, match="could not verify rows"):
         _raise_for_empty_ingest(
@@ -17,3 +37,24 @@ def test_empty_ingest_validation_rejects_unknown_final_row_count() -> None:
             initial_n_rows=None,
         )
 
+
+def test_empty_ingest_validation_rejects_unchanged_append_count() -> None:
+    with pytest.raises(RuntimeError, match="did not add rows"):
+        _raise_for_empty_ingest(
+            documents=["doc.pdf"],
+            lancedb_uri="lancedb",
+            table_name="nemo-retriever",
+            n_rows=3,
+            initial_n_rows=3,
+        )
+
+
+def test_empty_ingest_validation_rejects_zero_rows_on_overwrite() -> None:
+    with pytest.raises(RuntimeError, match="produced 0 rows"):
+        _raise_for_empty_ingest(
+            documents=["doc.pdf"],
+            lancedb_uri="lancedb",
+            table_name="nemo-retriever",
+            n_rows=0,
+            initial_n_rows=None,
+        )

--- a/nemo_retriever/tests/test_ingest_empty_validation.py
+++ b/nemo_retriever/tests/test_ingest_empty_validation.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-25, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from nemo_retriever.adapters.cli.sdk_workflow import _raise_for_empty_ingest
+
+
+def test_empty_ingest_validation_rejects_unknown_final_row_count() -> None:
+    with pytest.raises(RuntimeError, match="could not verify rows"):
+        _raise_for_empty_ingest(
+            documents=["doc.pdf"],
+            lancedb_uri="lancedb",
+            table_name="nemo-retriever",
+            n_rows=None,
+            initial_n_rows=None,
+        )
+

--- a/nemo_retriever/tests/test_nemotron_rerank_v2.py
+++ b/nemo_retriever/tests/test_nemotron_rerank_v2.py
@@ -535,6 +535,41 @@ class TestRerankViaEndpoint:
 class TestNemotronRerankActor:
     """Test the Ray Data-compatible actor."""
 
+    def test_cpu_actor_defaults_to_hosted_text_endpoint(self, monkeypatch):
+        from nemo_retriever.rerank.rerank import NemotronRerankCPUActor
+
+        monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-test")
+        monkeypatch.delenv("NGC_API_KEY", raising=False)
+
+        actor = NemotronRerankCPUActor()
+
+        assert actor._model is None
+        assert actor._kwargs["api_key"] == "nvapi-test"
+        assert actor._kwargs["rerank_invoke_url"] == (
+            "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-1b-v2/reranking"
+        )
+
+    def test_cpu_actor_defaults_to_hosted_vl_endpoint(self, monkeypatch):
+        from nemo_retriever.rerank.rerank import NemotronRerankCPUActor
+
+        monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-test")
+        monkeypatch.delenv("NGC_API_KEY", raising=False)
+
+        actor = NemotronRerankCPUActor(model_name="nvidia/llama-nemotron-rerank-vl-1b-v2")
+
+        assert actor._kwargs["rerank_invoke_url"] == (
+            "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-vl-1b-v2/reranking"
+        )
+
+    def test_cpu_actor_default_endpoint_requires_api_key(self, monkeypatch):
+        from nemo_retriever.rerank.rerank import NemotronRerankCPUActor
+
+        monkeypatch.delenv("NVIDIA_API_KEY", raising=False)
+        monkeypatch.delenv("NGC_API_KEY", raising=False)
+
+        with pytest.raises(ValueError, match="hosted rerank endpoint"):
+            NemotronRerankCPUActor()
+
     def test_actor_with_rerank_invoke_url_skips_local_model(self):
         from nemo_retriever.rerank.rerank import NemotronRerankCPUActor
 

--- a/nemo_retriever/tests/test_operator_flags_and_cpu_actors.py
+++ b/nemo_retriever/tests/test_operator_flags_and_cpu_actors.py
@@ -286,6 +286,25 @@ class TestTableStructureCPUActor:
         pd.testing.assert_frame_equal(result, expected)
 
 
+class TestInfographicDetectionCPUActor:
+    def test_uses_default_invoke_url(self, monkeypatch):
+        from nemo_retriever.infographic.infographic_detection import InfographicDetectionCPUActor
+
+        monkeypatch.delenv("NVIDIA_API_KEY", raising=False)
+        monkeypatch.delenv("NGC_API_KEY", raising=False)
+        actor = InfographicDetectionCPUActor()
+        assert actor._model is None
+        assert "nemotron-graphic-elements-v1" in actor.detect_kwargs["invoke_url"]
+
+    def test_resolves_api_key_for_default_endpoint(self, monkeypatch):
+        from nemo_retriever.infographic.infographic_detection import InfographicDetectionCPUActor
+
+        monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-test")
+        monkeypatch.delenv("NGC_API_KEY", raising=False)
+        actor = InfographicDetectionCPUActor()
+        assert actor.detect_kwargs["api_key"] == "nvapi-test"
+
+
 class TestOCRCPUActor:
     def test_inherits_cpu_operator(self):
         from nemo_retriever.ocr.cpu_ocr import OCRCPUActor

--- a/nemo_retriever/tests/test_root_cli_workflow.py
+++ b/nemo_retriever/tests/test_root_cli_workflow.py
@@ -692,8 +692,24 @@ def test_root_query_passes_query_options_and_prints_json(monkeypatch) -> None:
     retriever_calls: list[dict[str, Any]] = []
     query_calls: list[str] = []
     hits = [
-        {"text": "passage", "page_number": 1, "_distance": 0.2},
-        {"text": "other", "page_number": 2, "_distance": 0.4},
+        {
+            "text": "passage",
+            "source": "doc.pdf",
+            "page_number": 1,
+            "metadata": {"type": "text"},
+            "_distance": 0.2,
+        },
+        {
+            "text": "other",
+            "source": "other.pdf",
+            "page_number": 2,
+            "metadata": {"type": "table"},
+            "_distance": 0.4,
+        },
+    ]
+    expected_output = [
+        {"source": "doc.pdf", "page_number": 1, "text": "passage"},
+        {"source": "other.pdf", "page_number": 2, "text": "other"},
     ]
 
     class FakeRetriever:
@@ -724,8 +740,8 @@ def test_root_query_passes_query_options_and_prints_json(monkeypatch) -> None:
     # No rerank flag passed → rerank is off (opt-in only).
     assert retriever_calls == [{"top_k": 3, "vdb_kwargs": {"uri": "/tmp/lancedb", "table_name": "docs"}}]
     assert query_calls == ["Which animal is responsible for typos?"]
-    assert json.loads(result.output) == hits
-    assert result.output == json.dumps(hits, indent=2, sort_keys=True, default=str) + "\n"
+    assert json.loads(result.output) == expected_output
+    assert result.output == json.dumps(expected_output, indent=2, sort_keys=True, default=str) + "\n"
 
 
 def test_root_query_passes_embed_options(monkeypatch) -> None:

--- a/nemo_retriever/tests/test_root_cli_workflow.py
+++ b/nemo_retriever/tests/test_root_cli_workflow.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import importlib
+import itertools
 import json
 import logging
 import os
@@ -34,6 +35,13 @@ from nemo_retriever.params import (
 
 RUNNER = CliRunner()
 cli_main = importlib.import_module("nemo_retriever.adapters.cli.main")
+
+
+@pytest.fixture(autouse=True)
+def _successful_row_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Most tests fake GraphIngestor; default row counts should look like a successful write.
+    counts = itertools.count(1)
+    monkeypatch.setattr(sdk_workflow, "_count_lancedb_rows", lambda *_, **__: next(counts))
 
 
 def _make_fake_ingestor() -> Any:

--- a/nemo_retriever/tests/test_root_cli_workflow.py
+++ b/nemo_retriever/tests/test_root_cli_workflow.py
@@ -142,6 +142,38 @@ def test_root_ingest_append_forwards_overwrite_false(monkeypatch, tmp_path) -> N
     }
 
 
+def test_root_ingest_fails_when_no_rows_landed(monkeypatch, tmp_path) -> None:
+    fake_ingestor = _make_fake_ingestor()
+    document = tmp_path / "silent-stage-failure.pdf"
+    document.write_bytes(b"%PDF-1.4\n")
+
+    monkeypatch.setattr(sdk_workflow, "create_ingestor", lambda **_kwargs: fake_ingestor)
+    monkeypatch.setattr(sdk_workflow, "_count_lancedb_rows", lambda *_, **__: 0)
+
+    result = RUNNER.invoke(cli_main.app, ["ingest", str(document)])
+
+    assert result.exit_code == 1
+    assert "retriever ingest produced 0 rows" in result.output
+    assert "NVIDIA_API_KEY/NGC_API_KEY" in result.output
+    assert "Ingested 1 file(s)" not in result.output
+
+
+def test_root_ingest_append_fails_when_row_count_does_not_increase(monkeypatch, tmp_path) -> None:
+    fake_ingestor = _make_fake_ingestor()
+    document = tmp_path / "silent-append-failure.pdf"
+    document.write_bytes(b"%PDF-1.4\n")
+    counts = iter([3, 3])
+
+    monkeypatch.setattr(sdk_workflow, "create_ingestor", lambda **_kwargs: fake_ingestor)
+    monkeypatch.setattr(sdk_workflow, "_count_lancedb_rows", lambda *_, **__: next(counts))
+
+    result = RUNNER.invoke(cli_main.app, ["ingest", str(document), "--append"])
+
+    assert result.exit_code == 1
+    assert "did not add rows" in result.output
+    assert "row count stayed at 3" in result.output
+
+
 def test_root_ingest_passes_nim_url_options(monkeypatch, tmp_path) -> None:
     fake_ingestor = _make_fake_ingestor()
     document = tmp_path / "nim-routed.pdf"


### PR DESCRIPTION
## Description
]- fail `retriever ingest` when no rows land, append writes no new rows, or the final LanceDB row count cannot be verified
- default CPU captioning to the hosted NVIDIA VLM endpoint when no caption URL is provided
- extend the same hosted-endpoint fallback to other remote CPU actors that lacked it
- clarify `--caption-invoke-url` help/docs for CPU-only hosted fallback auth

## Testing
- `python -m pytest nemo_retriever/tests/test_root_cli_workflow.py nemo_retriever/tests/test_ingest_empty_validation.py nemo_retriever/tests/test_ingest_manifest.py nemo_retriever/tests/test_ingest_plans.py nemo_retriever/tests/test_caption_model_profiles.py nemo_retriever/tests/test_caption.py nemo_retriever/tests/test_operator_flags_and_cpu_actors.py nemo_retriever/tests/test_nemotron_rerank_v2.py`
- `PYTHONPYCACHEPREFIX=/tmp/nemo-retriever-pyc python -m compileall -q ...`
- `git diff --check`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
