### PR TITLE
Make inprocess the default implementation for the GraphIngestor, batc…

### DIFF
--- a/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
+++ b/nemo_retriever/src/nemo_retriever/adapters/cli/main.py
@@ -165,9 +165,9 @@ def ingest_command(
     lancedb_uri: str = typer.Option(DEFAULT_LANCEDB_URI, "--lancedb-uri", help="LanceDB database URI."),
     table_name: str = typer.Option(DEFAULT_TABLE_NAME, "--table-name", help="LanceDB table name."),
     run_mode: IngestRunModeValue = typer.Option(
-        "batch",
+        "inprocess",
         "--run-mode",
-        help="Execution mode for the SDK ingestor. Defaults to batch; use inprocess to skip Ray for local debug/CI.",
+        help="Execution mode for the SDK ingestor. Defaults to inprocess; use batch for Ray Data scale-out.",
     ),
     dry_run: bool = typer.Option(
         False,

--- a/nemo_retriever/src/nemo_retriever/adapters/cli/sdk_workflow.py
+++ b/nemo_retriever/src/nemo_retriever/adapters/cli/sdk_workflow.py
@@ -505,7 +505,7 @@ def resolve_ingest_plan(
     *,
     profile: IngestProfileValue = "auto",
     input_type: IngestInputTypeValue = "auto",
-    run_mode: IngestRunModeValue = "batch",
+    run_mode: IngestRunModeValue = "inprocess",
     method: str | None = None,
     dpi: int | None = None,
     extract_text: bool | None = None,
@@ -567,9 +567,8 @@ def resolve_ingest_plan(
 ) -> ResolvedIngestPlan:
     """Resolve root ingest options into ordinary params for one extract call.
 
-    Root ``retriever ingest`` intentionally defaults to ``run_mode="batch"``.
-    Programmatic callers that need Ray-free local execution should pass
-    ``run_mode="inprocess"`` explicitly. ``input_type`` remains a private
+    Root ``retriever ingest`` defaults to ``run_mode="inprocess"`` (no Ray).
+    Pass ``run_mode="batch"`` for Ray Data scale-out. ``input_type`` remains a private
     expansion/validation constraint; extraction still routes from the manifest.
     """
 
@@ -706,7 +705,7 @@ def ingest_documents(
     *,
     profile: IngestProfileValue = "auto",
     input_type: IngestInputTypeValue = "auto",
-    run_mode: IngestRunModeValue = "batch",
+    run_mode: IngestRunModeValue = "inprocess",
     dry_run: bool = False,
     method: str | None = None,
     dpi: int | None = None,
@@ -778,9 +777,8 @@ def ingest_documents(
     Batch tuning arguments are opt-in and are translated into
     ``BatchTuningParams`` for extraction or embedding; they are meaningful for
     ``run_mode="batch"`` and ignored by callers that leave them unset.
-    Root ``retriever ingest`` intentionally defaults to ``run_mode="batch"``;
-    pass ``run_mode="inprocess"`` explicitly for local debug or CI callers
-    that need to skip Ray startup.
+    Root ``retriever ingest`` defaults to ``run_mode="inprocess"``; pass
+    ``run_mode="batch"`` for Ray Data scale-out.
     The legacy ``input_type`` argument constrains directory expansion and file
     validation only; extraction routing remains manifest-planned.
     """

--- a/nemo_retriever/src/nemo_retriever/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/graph_ingestor.py
@@ -16,7 +16,7 @@ Usage::
     from nemo_retriever.params import ExtractParams, EmbedParams
 
     result_ds = (
-        GraphIngestor(run_mode="batch")
+        GraphIngestor(run_mode="inprocess")
         .files(["/data/*.pdf"])
         .extract(ExtractParams(method="pdfium"))
         .embed(EmbedParams(model_name="nvidia/llama-nemotron-embed-1b-v2"))
@@ -387,8 +387,8 @@ class GraphIngestor(ingestor):
     Parameters
     ----------
     run_mode
-        ``"batch"`` (Ray Data, default) or ``"inprocess"`` (single-process
-        pandas).
+        ``"inprocess"`` (single-process pandas, default) or ``"batch"`` (Ray
+        Data).
     ray_address
         Ray cluster address. ``None`` starts a local cluster.
     batch_size
@@ -415,7 +415,7 @@ class GraphIngestor(ingestor):
     def __init__(
         self,
         *,
-        run_mode: str = "batch",
+        run_mode: str = "inprocess",
         documents: Optional[List[str]] = None,
         ray_address: Optional[str] = None,
         ray_log_to_driver: bool = True,

--- a/nemo_retriever/src/nemo_retriever/harness/config.py
+++ b/nemo_retriever/src/nemo_retriever/harness/config.py
@@ -73,7 +73,7 @@ class HarnessConfig:
     dataset_dir: str
     dataset_label: str
     preset: str
-    run_mode: str = "batch"
+    run_mode: str = "inprocess"
 
     query_csv: str | None = None
     input_type: str = "pdf"

--- a/nemo_retriever/src/nemo_retriever/pipeline/__main__.py
+++ b/nemo_retriever/src/nemo_retriever/pipeline/__main__.py
@@ -8,15 +8,14 @@ Registered on the ``retriever`` CLI as the ``pipeline`` subcommand.
 
 Examples::
 
-    # Batch mode (Ray) with PDF extraction + embedding
+    # In-process mode (default; no Ray) for local extraction + embedding
+    retriever pipeline run /data/pdfs \\
+        --ocr-invoke-url http://localhost:9000/v1
+
+    # Batch mode (Ray) for large-scale throughput
     retriever pipeline run /data/pdfs \\
         --run-mode batch \\
         --embed-invoke-url http://localhost:8000/v1
-
-    # In-process mode (no Ray) for quick local testing
-    retriever pipeline run /data/pdfs \\
-        --run-mode inprocess \\
-        --ocr-invoke-url http://localhost:9000/v1
 
     # Service mode (delegate to a running retriever service)
     retriever pipeline run /data/pdfs \\
@@ -979,10 +978,10 @@ def run(
     ),
     # --- I/O and execution ------------------------------------------------
     run_mode: str = typer.Option(
-        "batch",
+        "inprocess",
         "--run-mode",
         help=(
-            "Execution mode: 'batch' (Ray Data), 'inprocess' (pandas, no Ray), "
+            "Execution mode: 'inprocess' (pandas, no Ray, default), 'batch' (Ray Data), "
             "or 'service' (remote retriever service)."
         ),
         rich_help_panel=_PANEL_IO,

--- a/nemo_retriever/tests/test_harness_run.py
+++ b/nemo_retriever/tests/test_harness_run.py
@@ -171,7 +171,7 @@ def test_build_command_uses_hidden_detection_file_by_default(tmp_path: Path) -> 
     )
     cmd, runtime_dir, detection_file, effective_query_csv = _build_command(cfg, tmp_path, run_id="r1")
     assert "--run-mode" in cmd
-    assert cmd[cmd.index("--run-mode") + 1] == "batch"
+    assert cmd[cmd.index("--run-mode") + 1] == "inprocess"
     assert "--detection-summary-file" in cmd
     assert "--evaluation-mode" in cmd
     assert cmd[cmd.index("--evaluation-mode") + 1] == "beir"
@@ -1090,7 +1090,7 @@ def test_run_single_writes_results_with_run_metadata(monkeypatch, tmp_path: Path
             "dataset_label": "jp20",
             "dataset_dir": str(dataset_dir),
             "preset": "single_gpu",
-            "run_mode": "batch",
+            "run_mode": "inprocess",
             "query_csv": str(query_csv),
             "effective_query_csv": str(query_csv),
             "input_type": cfg.input_type,

--- a/nemo_retriever/tests/test_ingest_manifest.py
+++ b/nemo_retriever/tests/test_ingest_manifest.py
@@ -154,7 +154,7 @@ def test_ingest_plan_auto_profile_preserves_manifest_defaults(tmp_path) -> None:
     assert plan.extract_params.extract_charts is True
     assert plan.extract_params.extract_infographics is True
     assert plan.extract_params.use_page_elements is True
-    assert plan.create_kwargs == {"run_mode": "batch"}
+    assert plan.create_kwargs == {"run_mode": "inprocess"}
 
 
 def test_ingest_plan_fast_text_profile_is_pdf_text_only(tmp_path) -> None:

--- a/nemo_retriever/tests/test_root_cli_workflow.py
+++ b/nemo_retriever/tests/test_root_cli_workflow.py
@@ -71,7 +71,7 @@ def test_root_ingest_runs_default_sdk_chain(monkeypatch, tmp_path) -> None:
     result = RUNNER.invoke(cli_main.app, ["ingest", str(document)])
 
     assert result.exit_code == 0
-    assert create_calls == [{"run_mode": "batch"}]
+    assert create_calls == [{"run_mode": "inprocess"}]
     assert [method_call[0] for method_call in fake_ingestor.method_calls] == [
         "files",
         "extract",
@@ -425,8 +425,8 @@ def test_root_ingest_help_does_not_expose_input_type() -> None:
     assert "[auto|fast-text]" in result.output
     assert "--extract-images" in result.output
     assert "--caption" in result.output
-    assert "Defaults to" in result.output
-    assert "[default: batch]" in result.output
+    assert "--run-mode" in result.output
+    assert "[inprocess|batch" in result.output
     assert re.search(r"--no-caption(?!-)", result.output) is None
 
 
@@ -445,7 +445,7 @@ def test_root_ingest_dry_run_prints_plan_without_creating_ingestor(monkeypatch, 
     payload = json.loads(result.output)
     assert payload["dry_run"] is True
     assert payload["profile"] == "fast-text"
-    assert payload["create_ingestor"] == {"run_mode": "batch"}
+    assert payload["create_ingestor"] == {"run_mode": "inprocess"}
     assert payload["extract"]["method"] == "pdfium"
     assert payload["extract"]["extract_images"] is False
     assert payload["extract"]["use_page_elements"] is False


### PR DESCRIPTION
…h can still be used with a configuration

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
