### PR TITLE
restore GitHub Pages build after notebooks subfolder move

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -209,8 +209,9 @@ markdown_extensions:
 
 # MkDocs 1.6+: exclude suite landing and legacy duplicate pages (still in repo for parity).
 # extraction/chunking.md — removed from nav; content is under concepts.md (redirect_maps keeps old URLs).
+# Use /index.md (docs root only); bare index.md would exclude every index.md (e.g. extraction/notebooks/index.md).
 exclude_docs: |
-  index.md
+  /index.md
   extraction/chunking.md
   extraction/helm.md
   extraction/choose-your-path.md


### PR DESCRIPTION
## Summary

Fixes the **NRL documentation — GitHub Pages** workflow failures introduced by #2159 (`move notebooks to subfolder`).

PR #2159 moved the Starter kits page from `extraction/notebooks.md` to `extraction/notebooks/index.md` and updated nav, internal links, and redirects correctly. The strict MkDocs build still failed because `exclude_docs` listed bare `index.md`, which MkDocs treats as a glob matching **every** file named `index.md` — including the new notebooks page.

That left `extraction/notebooks/index.md` excluded from the built site while still referenced in nav, doc links, and the redirect map (`extraction/notebooks.md` → `extraction/notebooks/index.md`), producing:

```
WARNING - Redirect target 'extraction/notebooks/index.md' does not exist!
Aborted with 1 warnings in strict mode!
```

**Change:** scope the exclusion to the docs root only (`/index.md`), so the legacy landing page remains excluded but `extraction/notebooks/index.md` is built again.

## Test plan

- [x] `mkdocs build -f mkdocs.yml --strict` succeeds locally
- [x] `docs/site/extraction/notebooks/index.html` is generated
- [ ] **NRL documentation — GitHub Pages** workflow passes on merge