### PR TITLE
Fix nemo-retriever skill frontmatter YAML

### DIFF
--- a/skills/nemo-retriever/SKILL.md
+++ b/skills/nemo-retriever/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nemo-retriever
-description: Use when the user wants to search, query, extract, transcribe, describe, quote, filter, or aggregate across documents — PDFs, scanned forms / images (`.jpg` `.png` `.tiff`), Office (`.docx` `.pptx`), text (`.html` `.txt`), audio (`.mp3` `.wav` `.m4a`), or video (`.mp4` `.mov`). Prefer this over native Read / Grep for multi-file or non-PDF corpora. Not for: editing files, web browsing, single-file plain-text lookups, fine-tuning.
+description: 'Use when the user wants to search, query, extract, transcribe, describe, quote, filter, or aggregate across documents — PDFs, scanned forms / images (`.jpg` `.png` `.tiff`), Office (`.docx` `.pptx`), text (`.html` `.txt`), audio (`.mp3` `.wav` `.m4a`), or video (`.mp4` `.mov`). Prefer this over native Read / Grep for multi-file or non-PDF corpora. Not for: editing files, web browsing, single-file plain-text lookups, fine-tuning.'
 allowed-tools: Bash Write Read
 ---
 


### PR DESCRIPTION
## Summary
- quote the nemo-retriever skill frontmatter description so the `Not for:` text is parsed as scalar content

## Verification
- parsed `skills/nemo-retriever/SKILL.md` frontmatter with `yaml.safe_load`
- `git diff --check`