### PR TITLE
Add self-update guidance to nemo-retriever skill

### DIFF
--- a/skills/nemo-retriever/SKILL.md
+++ b/skills/nemo-retriever/SKILL.md
@@ -35,3 +35,18 @@ Before ingesting a mixed folder, inventory extensions (`find <dir> -name '*.*' |
 - **Banned**: `TodoWrite`, Glob, Grep, `Read` of whole PDFs, re-running setup, spawning subagents, speculative "confirmation" calls.
 
 Long query turns (5+ tool calls, 1M+ cache-read tokens) cost ~5× a disciplined turn and almost always still produce the wrong answer. **Answering partially beats timing out.**
+
+## Self-update
+
+The `retriever` CLI and output shape move. When a run exposes a durable gap in this skill, edit it.
+
+Update when:
+
+- A flag, command, default, output field, or `metadata` shape differs from this skill.
+- A supported input type, install extra, setup step, or backend requirement is missing.
+- A repeated failure mode or recovery path is not covered.
+- An eval miss reveals a workflow rule that would prevent future wrong answers.
+
+Put details in the narrowest reference: install/setup facts in `references/install.md` or `references/setup.md`; query/output/citation facts in `references/query.md`; failures in `references/troubleshooting.md`; CLI specifics in `references/cli/*.md`. Only always-on workflow rules belong here.
+
+Keep additions terse and evidence-backed. If a fact came from one corpus, one environment, or one transient failure, leave it out.


### PR DESCRIPTION
## Summary
- add a terse Self-update section to the nemo-retriever skill
- route durable CLI/output/failure discoveries into the narrowest reference doc

## NVSkills signature
- left `skills/nemo-retriever/skill.oms.sig` unchanged intentionally; I will request `/nvskills-ci` on this PR so the signature workflow can refresh it

## Testing
- `git diff --check`