### PR TITLE
Fix service-mode harness PDF page counts

### DIFF
--- a/nemo_retriever/src/nemo_retriever/harness/run.py
+++ b/nemo_retriever/src/nemo_retriever/harness/run.py
@@ -243,6 +243,42 @@ def _safe_pdf_page_count(path: Path) -> int | None:
         return None
 
 
+def _service_failure_key(failure: Any) -> str:
+    if isinstance(failure, (list, tuple)) and failure:
+        return str(failure[0])
+    return str(failure)
+
+
+def _filename_page_counts(paths: list[Path], page_counts: list[int | None]) -> dict[str, int]:
+    filename_to_pages: dict[str, int] = {}
+    ambiguous_filenames: set[str] = set()
+    for path, page_count in zip(paths, page_counts):
+        if page_count is None:
+            continue
+        filename = path.name
+        if filename in filename_to_pages:
+            ambiguous_filenames.add(filename)
+            continue
+        filename_to_pages[filename] = page_count
+    for filename in ambiguous_filenames:
+        filename_to_pages.pop(filename, None)
+    return filename_to_pages
+
+
+def _count_failed_pdf_pages(
+    failures: list[Any],
+    document_filenames: dict[str, str],
+    filename_to_pages: dict[str, int],
+) -> int:
+    pages_failed = 0
+    for failure in failures:
+        failure_key = _service_failure_key(failure)
+        filename = document_filenames.get(failure_key, failure_key)
+        page_count = filename_to_pages.get(Path(filename).name)
+        pages_failed += page_count if page_count is not None else 1
+    return pages_failed
+
+
 def _resolve_summary_metrics(
     cfg: HarnessConfig,
     metrics_payload: dict[str, Any],
@@ -1191,13 +1227,23 @@ def _run_service_mode(
     elapsed = float(getattr(result_obj, "elapsed_s", 0.0))
     failures = list(getattr(result_obj, "failures", []))
     document_ids = list(getattr(result_obj, "document_ids", []))
+    raw_document_filenames = getattr(result_obj, "document_filenames", {})
+    if isinstance(raw_document_filenames, dict):
+        document_filenames = {
+            str(document_id): str(filename) for document_id, filename in raw_document_filenames.items()
+        }
+    else:
+        document_filenames = {}
+
     pages_failed = len(failures)
     counted_input_pages: int | None = None
+    input_page_counts: list[int | None] = []
     if cfg.input_type == "pdf":
         total_counted_pages = 0
         counted_any_pdf = False
         for path in input_files:
             page_count = _safe_pdf_page_count(path)
+            input_page_counts.append(page_count)
             if page_count is None:
                 continue
             counted_any_pdf = True
@@ -1207,6 +1253,8 @@ def _run_service_mode(
 
     if counted_input_pages is not None:
         total_pages = counted_input_pages
+        filename_to_pages = _filename_page_counts(input_files, input_page_counts)
+        pages_failed = _count_failed_pdf_pages(failures, document_filenames, filename_to_pages)
         pages_processed = max(total_pages - pages_failed, 0)
     else:
         pages_processed = len(result_obj)

--- a/nemo_retriever/src/nemo_retriever/harness/run.py
+++ b/nemo_retriever/src/nemo_retriever/harness/run.py
@@ -275,7 +275,11 @@ def _count_failed_pdf_pages(
         failure_key = _service_failure_key(failure)
         filename = document_filenames.get(failure_key, failure_key)
         page_count = filename_to_pages.get(Path(filename).name)
-        pages_failed += page_count if page_count is not None else 1
+        if page_count is None:
+            # Unknown failed PDFs can be unreadable or have ambiguous basenames; count one failed unit
+            # to preserve failure visibility, with pages_processed remaining an approximation.
+            page_count = 1
+        pages_failed += page_count
     return pages_failed
 
 

--- a/nemo_retriever/src/nemo_retriever/harness/run.py
+++ b/nemo_retriever/src/nemo_retriever/harness/run.py
@@ -251,15 +251,17 @@ def _service_failure_key(failure: Any) -> str:
 
 def _filename_page_counts(paths: list[Path], page_counts: list[int | None]) -> dict[str, int]:
     filename_to_pages: dict[str, int] = {}
+    seen_filenames: set[str] = set()
     ambiguous_filenames: set[str] = set()
     for path, page_count in zip(paths, page_counts):
-        if page_count is None:
-            continue
         filename = path.name
-        if filename in filename_to_pages:
+        if filename in seen_filenames:
             ambiguous_filenames.add(filename)
+            filename_to_pages.pop(filename, None)
             continue
-        filename_to_pages[filename] = page_count
+        seen_filenames.add(filename)
+        if page_count is not None:
+            filename_to_pages[filename] = page_count
     for filename in ambiguous_filenames:
         filename_to_pages.pop(filename, None)
     return filename_to_pages

--- a/nemo_retriever/src/nemo_retriever/harness/run.py
+++ b/nemo_retriever/src/nemo_retriever/harness/run.py
@@ -1191,9 +1191,26 @@ def _run_service_mode(
     elapsed = float(getattr(result_obj, "elapsed_s", 0.0))
     failures = list(getattr(result_obj, "failures", []))
     document_ids = list(getattr(result_obj, "document_ids", []))
-    pages_processed = len(result_obj)
     pages_failed = len(failures)
-    total_pages = pages_processed + pages_failed
+    counted_input_pages: int | None = None
+    if cfg.input_type == "pdf":
+        total_counted_pages = 0
+        counted_any_pdf = False
+        for path in input_files:
+            page_count = _safe_pdf_page_count(path)
+            if page_count is None:
+                continue
+            counted_any_pdf = True
+            total_counted_pages += page_count
+        if counted_any_pdf:
+            counted_input_pages = total_counted_pages
+
+    if counted_input_pages is not None:
+        total_pages = counted_input_pages
+        pages_processed = max(total_pages - pages_failed, 0)
+    else:
+        pages_processed = len(result_obj)
+        total_pages = pages_processed + pages_failed
 
     pps = round(total_pages / elapsed, 2) if elapsed and elapsed > 0 else None
 

--- a/nemo_retriever/src/nemo_retriever/service_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/service_ingestor.py
@@ -15,7 +15,8 @@ Three execution surfaces are exposed:
 1. :meth:`ServiceIngestor.ingest` — sync, blocks until every document has
    finished, returns a :class:`ServiceIngestResult` (a ``list`` subclass
    holding per-document completion events, plus ``job_id`` / ``failures``
-   / ``document_ids`` / ``elapsed_s`` / ``job_status`` / ``dataframe``
+   / ``document_ids`` / ``document_filenames`` / ``elapsed_s`` /
+   ``job_status`` / ``dataframe``
    attributes). By default ``return_results=True`` fetches each
    completed document's rows from the status endpoint into
    ``result.dataframe``. Each
@@ -119,6 +120,9 @@ class ServiceIngestResult(list):
         that failed during upload or pipeline processing.
     document_ids
         Document identifiers returned by the server, in upload order.
+    document_filenames
+        Mapping from server document id to the source filename submitted for
+        that document.
     elapsed_s
         Wall-clock seconds from first upload to last result.
     job_status
@@ -142,6 +146,7 @@ class ServiceIngestResult(list):
         self.job_id: str | None = None
         self.failures: list[tuple[str, str]] = []
         self.document_ids: list[str] = []
+        self.document_filenames: dict[str, str] = {}
         self.elapsed_s: float = 0.0
         self.job_status: str | None = None
         self.dataframe: Any = None
@@ -1098,6 +1103,10 @@ class ServiceIngestor(ingestor):
 
             if event_type == "upload_complete":
                 total_uploaded += 1
+                document_id = evt.get("document_id")
+                filename = evt.get("filename")
+                if document_id and filename:
+                    result.document_filenames[str(document_id)] = str(filename)
                 if result.job_id is None:
                     # Race: SSE delivered an upload_complete before the
                     # generator yielded job_created. Fall back to the

--- a/nemo_retriever/tests/test_harness_run.py
+++ b/nemo_retriever/tests/test_harness_run.py
@@ -1004,6 +1004,69 @@ def test_run_service_mode_counts_pdf_pages_not_completed_documents(monkeypatch, 
     assert result["summary_metrics"]["pages_per_sec_ingest"] == 3.5
 
 
+def test_run_service_mode_counts_failed_pdf_documents_as_pages(monkeypatch, tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    input_files = [dataset_dir / name for name in ("a.pdf", "b.pdf", "c.pdf")]
+    for input_file in input_files:
+        input_file.write_bytes(b"%PDF-1.4\n")
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+
+    cfg = HarnessConfig(
+        dataset_dir=str(dataset_dir),
+        dataset_label="tiny",
+        preset="base",
+        run_mode="service",
+        service_url="http://localhost:17670",
+    )
+
+    class FakeResult(list):
+        def __init__(self) -> None:
+            super().__init__(
+                [
+                    {"document_id": "doc-a", "status": "completed"},
+                    {"document_id": "doc-b", "status": "failed"},
+                    {"document_id": "doc-c", "status": "completed"},
+                ]
+            )
+            self.job_id = "job-1"
+            self.document_ids = ["doc-a", "doc-b", "doc-c"]
+            self.document_filenames = {"doc-a": "a.pdf", "doc-b": "b.pdf", "doc-c": "c.pdf"}
+            self.failures = [("doc-b", "boom")]
+            self.elapsed_s = 5.0
+            self.job_status = "partial_success"
+
+    class FakeServiceIngestor:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def ingest(self) -> FakeResult:
+            return FakeResult()
+
+    import nemo_retriever.service_ingestor as service_ingestor
+
+    monkeypatch.setattr(service_ingestor, "ServiceIngestor", FakeServiceIngestor)
+    monkeypatch.setattr(harness_run, "resolve_input_files", lambda *_args, **_kwargs: input_files)
+    monkeypatch.setattr(harness_run, "_safe_pdf_page_count", lambda path: 5 if path in input_files else None)
+    monkeypatch.setattr(harness_run, "last_commit", lambda: "abc123")
+    monkeypatch.setattr(harness_run, "now_timestr", lambda: "20260305_000000_UTC")
+    monkeypatch.setattr(harness_run, "_collect_run_metadata", lambda: {"host": "builder-01"})
+    monkeypatch.setattr(harness_run, "write_json", lambda _path, _payload: None)
+
+    result = harness_run._run_service_mode(cfg, artifact_dir, run_id="r1")
+
+    assert result["success"] is False
+    assert result["failure_reason"] == "5 page(s) failed during service ingestion"
+    assert result["metrics"]["files"] == 3
+    assert result["metrics"]["pages"] == 15
+    assert result["metrics"]["pages_processed"] == 10
+    assert result["metrics"]["pages_failed"] == 5
+    assert result["metrics"]["pages_per_sec_ingest"] == 3.0
+    assert result["summary_metrics"]["pages"] == 15
+    assert result["summary_metrics"]["pages_per_sec_ingest"] == 3.0
+
+
 def test_run_service_mode_evaluates_beir_recall_against_service(monkeypatch, tmp_path: Path) -> None:
     dataset_dir = tmp_path / "dataset"
     dataset_dir.mkdir()

--- a/nemo_retriever/tests/test_harness_run.py
+++ b/nemo_retriever/tests/test_harness_run.py
@@ -1067,6 +1067,70 @@ def test_run_service_mode_counts_failed_pdf_documents_as_pages(monkeypatch, tmp_
     assert result["summary_metrics"]["pages_per_sec_ingest"] == 3.0
 
 
+def test_run_service_mode_does_not_reuse_page_count_for_unreadable_duplicate_basename(
+    monkeypatch, tmp_path: Path
+) -> None:
+    dataset_dir = tmp_path / "dataset"
+    readable_dir = dataset_dir / "readable"
+    unreadable_dir = dataset_dir / "unreadable"
+    readable_dir.mkdir(parents=True)
+    unreadable_dir.mkdir(parents=True)
+    readable_pdf = readable_dir / "doc.pdf"
+    unreadable_pdf = unreadable_dir / "doc.pdf"
+    readable_pdf.write_bytes(b"%PDF-1.4\n")
+    unreadable_pdf.write_bytes(b"%PDF-1.4\n")
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+
+    cfg = HarnessConfig(
+        dataset_dir=str(dataset_dir),
+        dataset_label="tiny",
+        preset="base",
+        run_mode="service",
+        service_url="http://localhost:17670",
+    )
+
+    class FakeResult(list):
+        def __init__(self) -> None:
+            super().__init__(
+                [
+                    {"document_id": "doc-readable", "status": "completed"},
+                    {"document_id": "doc-unreadable", "status": "failed"},
+                ]
+            )
+            self.job_id = "job-1"
+            self.document_ids = ["doc-readable", "doc-unreadable"]
+            self.document_filenames = {"doc-readable": "doc.pdf", "doc-unreadable": "doc.pdf"}
+            self.failures = [("doc-unreadable", "boom")]
+            self.elapsed_s = 2.0
+            self.job_status = "partial_success"
+
+    class FakeServiceIngestor:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def ingest(self) -> FakeResult:
+            return FakeResult()
+
+    import nemo_retriever.service_ingestor as service_ingestor
+
+    input_files = [readable_pdf, unreadable_pdf]
+    monkeypatch.setattr(service_ingestor, "ServiceIngestor", FakeServiceIngestor)
+    monkeypatch.setattr(harness_run, "resolve_input_files", lambda *_args, **_kwargs: input_files)
+    monkeypatch.setattr(harness_run, "_safe_pdf_page_count", lambda path: 5 if path == readable_pdf else None)
+    monkeypatch.setattr(harness_run, "last_commit", lambda: "abc123")
+    monkeypatch.setattr(harness_run, "now_timestr", lambda: "20260305_000000_UTC")
+    monkeypatch.setattr(harness_run, "_collect_run_metadata", lambda: {"host": "builder-01"})
+    monkeypatch.setattr(harness_run, "write_json", lambda _path, _payload: None)
+
+    result = harness_run._run_service_mode(cfg, artifact_dir, run_id="r1")
+
+    assert result["metrics"]["pages"] == 5
+    assert result["metrics"]["pages_failed"] == 1
+    assert result["metrics"]["pages_processed"] == 4
+    assert result["failure_reason"] == "1 page(s) failed during service ingestion"
+
+
 def test_run_service_mode_evaluates_beir_recall_against_service(monkeypatch, tmp_path: Path) -> None:
     dataset_dir = tmp_path / "dataset"
     dataset_dir.mkdir()

--- a/nemo_retriever/tests/test_harness_run.py
+++ b/nemo_retriever/tests/test_harness_run.py
@@ -951,6 +951,59 @@ def test_run_service_mode_uses_finalized_service_ingest_result_contract(monkeypa
     assert payloads["result"]["service_job_id"] == "job-1"
 
 
+def test_run_service_mode_counts_pdf_pages_not_completed_documents(monkeypatch, tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset"
+    dataset_dir.mkdir()
+    input_file = dataset_dir / "doc.pdf"
+    input_file.write_bytes(b"%PDF-1.4\n")
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+
+    cfg = HarnessConfig(
+        dataset_dir=str(dataset_dir),
+        dataset_label="tiny",
+        preset="base",
+        run_mode="service",
+        service_url="http://localhost:17670",
+    )
+
+    class FakeResult(list):
+        def __init__(self) -> None:
+            super().__init__([{"document_id": "doc-1", "status": "completed"}])
+            self.job_id = "job-1"
+            self.document_ids = ["doc-1"]
+            self.failures = []
+            self.elapsed_s = 2.0
+            self.job_status = "completed"
+
+    class FakeServiceIngestor:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def ingest(self) -> FakeResult:
+            return FakeResult()
+
+    import nemo_retriever.service_ingestor as service_ingestor
+
+    monkeypatch.setattr(service_ingestor, "ServiceIngestor", FakeServiceIngestor)
+    monkeypatch.setattr(harness_run, "resolve_input_files", lambda *_args, **_kwargs: [input_file])
+    monkeypatch.setattr(harness_run, "_safe_pdf_page_count", lambda path: 7 if path == input_file else None)
+    monkeypatch.setattr(harness_run, "last_commit", lambda: "abc123")
+    monkeypatch.setattr(harness_run, "now_timestr", lambda: "20260305_000000_UTC")
+    monkeypatch.setattr(harness_run, "_collect_run_metadata", lambda: {"host": "builder-01"})
+    monkeypatch.setattr(harness_run, "write_json", lambda _path, _payload: None)
+
+    result = harness_run._run_service_mode(cfg, artifact_dir, run_id="r1")
+
+    assert result["metrics"]["files"] == 1
+    assert result["metrics"]["pages"] == 7
+    assert result["metrics"]["pages_processed"] == 7
+    assert result["metrics"]["pages_failed"] == 0
+    assert result["metrics"]["pages_per_sec_ingest"] == 3.5
+    assert result["summary_metrics"]["pages"] == 7
+    assert result["summary_metrics"]["pages_per_sec_ingest"] == 3.5
+
+
 def test_run_service_mode_evaluates_beir_recall_against_service(monkeypatch, tmp_path: Path) -> None:
     dataset_dir = tmp_path / "dataset"
     dataset_dir.mkdir()

--- a/nemo_retriever/tests/test_service_ingest_async.py
+++ b/nemo_retriever/tests/test_service_ingest_async.py
@@ -106,6 +106,7 @@ def test_ingest_default_returns_service_ingest_result(stub_ingestor: ServiceInge
     # ``.failures``.
     assert len(result) == 2
     assert result.failures == [("doc-b", "boom")]
+    assert result.document_filenames == {"doc-a": "a.pdf", "doc-b": "b.pdf"}
     assert result.dataframe is not None
     assert len(result.dataframe) == 1
     assert "document_id" not in result.dataframe.columns


### PR DESCRIPTION
## Description
Fix service-mode harness page metrics for PDF datasets.

Service-mode ingestion returns one completion event per uploaded document, not one event per PDF page. `_run_service_mode` was treating the completed-document count as `pages`, so a single multi-page PDF could be reported as `1` page and skew pages/sec. The harness now counts PDF input pages with the existing `_safe_pdf_page_count` helper when possible, and falls back to the existing completion-event count for non-PDF inputs or unreadable PDFs.

This also adds a regression test covering a single completed service document whose source PDF has multiple pages.

Validation:
- `uv run --project nemo_retriever --extra dev pytest -q nemo_retriever/tests/test_harness_run.py` → `48 passed`
- Managed Helm harness run with a generated single 3-page PDF fixture → PASS, recorded `metrics.pages=3`, `metrics.pages_processed=3`, and `summary_metrics.pages=3` in `/tmp/nemo-harness-artifacts/managed_pagecount_three_page_20260604_153511_UTC/results.json`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] If adjusting docker-compose.yaml environment variables have you ensured those are mimicked in the Helm values.yaml file.
