### PR TITLE
fix Docs Hub /latest/ 404 and canonicalize retriever doc links

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -207,11 +207,11 @@ markdown_extensions:
   - admonition
   - footnotes
 
-# MkDocs 1.6+: exclude suite landing and legacy duplicate pages (still in repo for parity).
+# MkDocs 1.6+: exclude legacy duplicate pages (still in repo for parity).
 # extraction/chunking.md — removed from nav; content is under concepts.md (redirect_maps keeps old URLs).
-# Use /index.md (docs root only); bare index.md would exclude every index.md (e.g. extraction/notebooks/index.md).
+# Root index.md is not in nav; redirect_maps sends index.md → extraction/overview.md so /latest/ (Docs Hub tile) resolves.
+# Use /index.md in exclude_docs only (bare index.md would exclude every index.md, e.g. extraction/notebooks/index.md).
 exclude_docs: |
-  /index.md
   extraction/chunking.md
   extraction/helm.md
   extraction/choose-your-path.md


### PR DESCRIPTION
## Summary

Fixes the **Page Not Found** error when users click the **NVIDIA NeMo Retriever Documentation** tile on the [Docs Hub Overview](https://docs.nvidia.com/nemo/retriever/) (`Browse` → `https://docs.nvidia.com/nemo/retriever/latest/`).

Stop excluding `docs/docs/index.md` from the MkDocs build so existing `redirect_maps` publishes `index.html` → `extraction/overview/`. After the next docs publish, bare `/nemo/retriever/latest/` should redirect instead of 404.

**Single file:** `docs/mkdocs.yml`

## Root cause

The Docs Hub tile links to `/nemo/retriever/latest/`, but no version-root index page was published because `/index.md` was in `exclude_docs`. The redirect rule (`index.md` → `extraction/overview.md`) never took effect.

## Test plan

- [ ] `mkdocs build -f docs/mkdocs.yml --strict` passes in CI
- [ ] After docs publish to docs.nvidia.com, `https://docs.nvidia.com/nemo/retriever/latest/` redirects to overview