### PR TITLE
remove 26.05 RC doc references

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 **Important: The default branch is main, which tracks active development and may be ahead of the latest supported release.**
 
-For the latest release line use the [26.05 branch](https://github.com/NVIDIA/NeMo-Retriever/tree/26.05) (RC builds are tagged `26.05-RC1`, `26.05-RC2`, …). The previous stable line is [26.03](https://github.com/NVIDIA/NeMo-Retriever/tree/26.03).
+For the latest supported release, use the [26.05 branch](https://github.com/NVIDIA/NeMo-Retriever/tree/26.05) (GA PyPI and Helm chart version `26.5.0`). The previous stable line is [26.03](https://github.com/NVIDIA/NeMo-Retriever/tree/26.03).
 
 See the corresponding [NeMo Retriever Library documentation](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/).
 

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -6,7 +6,7 @@ This documentation contains the release notes for [NeMo Retriever Library](overv
 
 NVIDIA® NeMo Retriever Library version 26.05 builds on the 26.03 foundation with a graph-based ingest architecture, expanded multimodal and tabular capabilities, production-oriented service deployment, and documentation aligned to a Helm-first supported path.
 
-To upgrade the Helm charts for this release, refer to the [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/26.05/nemo_retriever/helm/README.md).
+To upgrade the Helm charts for this release, refer to the [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/26.05/nemo_retriever/helm/README.md) and pin chart version `26.5.0`.
 
 Highlights for the 26.05 release include:
 
@@ -64,6 +64,7 @@ Highlights for the 26.05 release include:
 
 ### Packaging and platform
 
+- GA PyPI install: `uv pip install nemo-retriever==26.5.0` (see the library [quickstart](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever#setup-your-environment))
 - Optional install extras (`[local]`, `[multimedia]`, `[llm]`, `[tabular]`, `[nemotron-parse]`, `[service]`, and others), including slim remote/NIM-only installs on Mac and Windows  
 
 ### Helm chart

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -6,7 +6,7 @@ This documentation contains the release notes for [NeMo Retriever Library](overv
 
 NVIDIA® NeMo Retriever Library version 26.05 builds on the 26.03 foundation with a graph-based ingest architecture, expanded multimodal and tabular capabilities, production-oriented service deployment, and documentation aligned to a Helm-first supported path.
 
-To upgrade the Helm charts for this release, refer to the [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/26.05/nemo_retriever/helm/README.md) and pin chart version `26.5.0`.
+To upgrade the Helm charts for this release, refer to the [NeMo Retriever Library Helm Charts](https://github.com/NVIDIA/NeMo-Retriever/blob/26.05/nemo_retriever/helm/README.md).
 
 Highlights for the 26.05 release include:
 

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -64,7 +64,7 @@ Highlights for the 26.05 release include:
 
 ### Packaging and platform
 
-- GA PyPI install: `uv pip install nemo-retriever==26.5.0` (see the library [quickstart](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever#setup-your-environment))
+- GA PyPI install: `uv pip install nemo-retriever==26.5.0` (see the library [quickstart](https://github.com/NVIDIA/NeMo-Retriever/tree/26.05/nemo_retriever#setup-your-environment))
 - Optional install extras (`[local]`, `[multimedia]`, `[llm]`, `[tabular]`, `[nemotron-parse]`, `[service]`, and others), including slim remote/NIM-only installs on Mac and Windows  
 
 ### Helm chart

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -43,7 +43,7 @@ For **local GPU inference** (Nemotron models running on your GPU), install with 
 ```bash
 uv venv retriever --python 3.12
 source retriever/bin/activate
-uv pip install "nemo-retriever[local]==26.05-RC1"
+uv pip install "nemo-retriever[local]==26.5.0"
 ```
 
 Install matching **ingestion client** and **ingestion runtime** wheels at the same version when your workflow expects them (see the [NeMo Retriever Library prerequisites](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the exact PyPI coordinates for your release).
@@ -54,7 +54,7 @@ For **remote NIM inference only** (no local GPU required), the base package is s
 uv python install 3.12
 uv venv retriever --python 3.12
 source retriever/bin/activate
-uv pip install nemo-retriever==26.05-RC1
+uv pip install nemo-retriever==26.5.0
 ```
 
 Install matching **ingestion client** and **ingestion runtime** wheels at the same version when your workflow expects them (see the [NeMo Retriever Library prerequisites](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the exact PyPI coordinates for your release).
@@ -64,7 +64,7 @@ This creates a dedicated Python environment and installs the `nemo-retriever` Py
 If your PDF pipeline uses `extract_method="nemotron_parse"`, install the Nemotron Parse client dependencies with the `nemotron-parse` extra:
 
 ```bash
-uv pip install "nemo-retriever[nemotron-parse]==26.05-RC1"
+uv pip install "nemo-retriever[nemotron-parse]==26.5.0"
 ```
 
 For local GPU inference with Nemotron Parse, combine the extras as `nemo-retriever[local,nemotron-parse]`.

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -946,7 +946,7 @@ See [Deployment options — Air-gapped and disconnected deployment](https://docs
 ### Container images to mirror (26.05 chart defaults)
 
 Verify tags on the Git branch or tag you ship (for example `26.05` or
-`26.05-RC1`). Defaults below match
+`26.5.0`). Defaults below match
 [`values.yaml`](./values.yaml) on the current chart.
 
 | Role | `nimOperator` key | Default image (`repository:tag`) |


### PR DESCRIPTION
## Summary

Backport of #2213 to the `26.05` release branch — same GA doc updates:

- `nemo_retriever/README.md` install pins → `26.5.0`
- Helm air-gap mirroring example → `26.5.0`
- Repo `README.md` — GA wording instead of RC build tags
- `docs/docs/extraction/releasenotes.md` — GA PyPI/Helm pin guidance (quickstart link targets this branch)

## Test plan

- [x] Cherry-picked from #2213 with branch-appropriate quickstart link
- [ ] Randy quick review / merge