### PR TITLE
Remove redundant dedupe of relevant_tables in CandidatePreparationAgent

### DIFF
--- a/nemo_retriever/src/nemo_retriever/tabular_data/retrieval/text_to_sql/agents/candidates_preparation.py
+++ b/nemo_retriever/src/nemo_retriever/tabular_data/retrieval/text_to_sql/agents/candidates_preparation.py
@@ -157,7 +157,6 @@ class CandidatePreparationAgent(BaseAgent):
         additional_tables = dedupe_merge_relevant_tables(additional_tables)[:10]
         relevant_tables.extend(additional_tables)
 
-        relevant_tables = dedupe_merge_relevant_tables(relevant_tables)[:20]
         self.logger.info(
             "Found %d relevant tables (after dedupe, capped at 20): %s",
             len(relevant_tables),


### PR DESCRIPTION
The additional_tables list was already deduped + capped before being appended to relevant_tables, and the downstream log message still states "capped at 20" — but the outer dedupe/cap was masking the true count carried forward. Drop the second dedupe so all retrieved candidates are preserved.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title may be reflected in release notes. -->

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
