### PR TITLE
docs(extraction): fix P0 26.3.0 GitHub and Helm links

### DIFF
--- a/docs/docs/extraction/air-gapped-deployment.md
+++ b/docs/docs/extraction/air-gapped-deployment.md
@@ -4,10 +4,10 @@ This guide consolidates what you need to run NeMo Retriever Library in a secured
 
 !!! note "Source of truth for versions"
 
-    Image repositories and default tags change between releases. Always verify pins against the Git branch that matches your stack (for 26.3.x self-hosted docs, use the NeMo Retriever **`26.03`** branch as the structural baseline):
+    Image repositories and default tags change between releases. Always verify pins against the Git branch that matches your stack (for 26.3.x self-hosted docs, check out the **`26.03`** branch that matches **26.3.0** in your environment; **`main`** moves forward for the current Helm chart under **`nemo_retriever/helm`**):
 
     - [NeMo Retriever `docker-compose.yaml`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/docker-compose.yaml) for self-hosted Compose
-    - [`helm/values.yaml`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/helm/values.yaml) and [`helm/README.md`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/helm/README.md) for Kubernetes / Helm
+    - [`helm/values.yaml`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/helm/values.yaml) and [`helm/README.md.gotmpl`](https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/helm/README.md.gotmpl) for Kubernetes / Helm
 
 ## End-to-end workflow
 
@@ -62,7 +62,7 @@ Again, take the exact repository and tag from your pinned `values.yaml` for 26.3
 
 ## Helm charts and packaging artifacts
 
-From a connected environment, download and version-control the chart archive you install, for example (see [NV-Ingest Helm README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/helm/README.md)):
+From a connected environment, download and version-control the chart archive you install, for example (see [NV-Ingest Helm README](https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/helm/README.md.gotmpl)):
 
 - `nv-ingest-26.3.0.tgz` from NGC Helm (`helm pull` with NGC credentials)
 

--- a/docs/docs/extraction/cli-reference.md
+++ b/docs/docs/extraction/cli-reference.md
@@ -20,7 +20,7 @@ retriever --help
 
 !!! tip
 
-    For CLI examples, see the [CLI section of the self-hosted quickstart](quickstart-guide.md#ingest_cli_example) or the [CLI companion notebook on the `26.03` branch](https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/client/client_examples/examples/cli_client_usage.ipynb).
+    For CLI examples, refer to the [CLI section of the self-hosted quickstart](quickstart-guide.md#ingest_cli_example) or the [CLI companion notebook on the `release/25.3.0` branch](https://github.com/NVIDIA/NeMo-Retriever/blob/release/25.3.0/client/client_examples/examples/cli_client_usage.ipynb).
 
 
 ## Parameter Reference

--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -12,7 +12,7 @@ Use the provided [docker-compose.yaml](https://github.com/NVIDIA/nv-ingest/blob/
     NIM containers on their first startup can take 10-15 minutes to pull and fully load models.
 
 
-If you prefer, you can run on Kubernetes by using [our Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/helm/README.md). Also, there are [additional environment variables](environment-config.md) you can configure.
+If you prefer, you can run on Kubernetes by using [our Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md). Also, there are [additional environment variables](environment-config.md) you can configure.
 
 a. Git clone the repo:
 
@@ -528,7 +528,7 @@ docker compose \
 
 ## Specify MIG slices for NIM models
 
-When you deploy NeMo Retriever Library with NIM models on MIG‑enabled GPUs, MIG device slices are requested and scheduled through the `values.yaml` file for the corresponding NIM microservice. For IBM Content-Aware Storage (CAS) deployments, this allows NeMo Retriever Library NIM pods to land only on nodes that expose the desired MIG profiles [raw.githubusercontent](https://raw.githubusercontent.com/NVIDIA/NeMo-Retriever/26.03/helm/README.md).
+When you deploy NeMo Retriever Library with NIM models on MIG‑enabled GPUs, MIG device slices are requested and scheduled through the `values.yaml` file for the corresponding NIM microservice. For IBM Content-Aware Storage (CAS) deployments, this allows NeMo Retriever Library NIM pods to land only on nodes that expose the desired MIG profiles [raw.githubusercontent](https://raw.githubusercontent.com/NVIDIA/NeMo-Retriever/main/nemo_retriever/helm/README.md).
 
 To target a specific MIG profile—for example, a 3g.20gb slice on an A100, which is a hardware-partitioned virtual GPU instance that gives your workload a fixed mid-sized share of the A100’s compute plus 20 GB of dedicated GPU memory and behaves like a smaller independent GPU—for a given NIM, configure the `resources` and `nodeSelector` under that NIM’s values path in `values.yaml`.
 


### PR DESCRIPTION
## Summary

- **air-gapped-deployment.md** — Point Helm references at \helm/README.md.gotmpl\ on the \26.03\ branch (replacing stale \helm/README.md\ and published \elease/26.3.0\ targets). Compose and \helm/values.yaml\ stay on \26.03\ because those root paths are not on \main\.
- **cli-reference.md** — CLI companion notebook now uses \elease/25.3.0\; tip CTA uses **refer to**.
- **quickstart-guide.md** — Helm chart and MIG raw GitHub links now target \main/nemo_retriever/helm/README.md\.

Other P0 rows from the link audit were already addressed in #2048 (in-tree quickstart anchors instead of broken \
v-ingest\ notebook URLs; support-matrix nemotron-parse API URL; UDF README on NeMo-Retriever \main\). This PR does **not** add third-party mirrors (Gitee) or fork URLs (AI-App) proposed by the audit tool.

## Test plan

- [ ] Confirm \https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/helm/README.md.gotmpl\ resolves.
- [ ] Confirm \https://github.com/NVIDIA/NeMo-Retriever/blob/release/25.3.0/client/client_examples/examples/cli_client_usage.ipynb\ resolves.
- [ ] Confirm \https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md\ resolves.
- [ ] \mkdocs build\ / docs CI passes for touched pages.