### PR TITLE
fix broken links from 26.05 doc audit

### DIFF
--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -90,7 +90,7 @@ Use the following procedure to run the NIM on your own infrastructure. Self-host
 
     To generate one extracted element for each sentence-like ASR segment, pass `asr_params=ASRParams(segment_audio=True)` to `.extract_audio(...)`. This option applies when audio extraction runs with a self-hosted Parakeet NIM or using build.nvidia.com hosted inference, but has no effect when using the local Hugging Face Parakeet model.
 
-    For more runnable examples, refer to the [Python Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/python_client_usage.ipynb).
+    For more runnable examples, refer to [Workflow: Ingest documents](workflow-document-ingestion.md).
 
 ## Parakeet with hosted inference (build.nvidia.com) { #parakeet-hosted-inference-build-nvidia }
 
@@ -121,7 +121,7 @@ Instead of running the pipeline locally, you can call Parakeet through [build.nv
 
     !!! tip
 
-        For more runnable examples, refer to the [Python Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/python_client_usage.ipynb).
+        For more runnable examples, refer to [Workflow: Ingest documents](workflow-document-ingestion.md).
 
 ## Video and frame OCR { #video-and-frame-ocr }
 

--- a/docs/docs/extraction/custom-metadata.md
+++ b/docs/docs/extraction/custom-metadata.md
@@ -57,7 +57,7 @@ ingestor = (
 results = ingestor.ingest_async().result()
 ```
 
-Set `hostname`, `table_name`, and a **remote** `lancedb_uri` (for example `s3://bucket/path`) to match your deployment—the retriever service rejects local filesystem paths. The client uploads in-memory sidecar metadata to the service before ingest; do not pass a raw local file path as `meta_dataframe` on the REST spec. For local LanceDB directories, use `run_mode="batch"` instead (refer to [Vector databases](vdbs.md)). For a step-by-step walkthrough with additional fields such as category, department, and timestamp, refer to [metadata_and_filtered_search.ipynb](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/metadata_and_filtered_search.ipynb).
+Set `hostname`, `table_name`, and a **remote** `lancedb_uri` (for example `s3://bucket/path`) to match your deployment—the retriever service rejects local filesystem paths. The client uploads in-memory sidecar metadata to the service before ingest; do not pass a raw local file path as `meta_dataframe` on the REST spec. For local LanceDB directories, use `run_mode="batch"` instead (refer to [Vector databases](vdbs.md)). For a step-by-step walkthrough with additional fields such as category, department, and timestamp, refer to [Vector DB operators and LanceDB — Metadata filtering](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/vdb#metadata-filtering).
 
 ## Best practices { #best-practices }
 
@@ -80,7 +80,7 @@ Typical keys to filter on include `category`, `department`, `priority`, and `tim
 
 After ingestion is complete and documents are uploaded to LanceDB with metadata, you can narrow results in the database with a **`where`** clause, or in Python on the returned hits.
 
-**Native LanceDB (SQL pushdown):** connect, embed the query yourself (same model as ingestion), then chain `.where("<LanceDB SQL predicate>")` on `table.search(...)` so filtering happens before the `limit`. Exact SQL depends on how `metadata` is stored; refer to [LanceDB SQL](https://lancedb.github.io/lancedb/sql/).
+**Native LanceDB (SQL pushdown):** connect, embed the query yourself (same model as ingestion), then chain `.where("<LanceDB SQL predicate>")` on `table.search(...)` so filtering happens before the `limit`. Exact SQL depends on how `metadata` is stored; refer to [LanceDB metadata filtering](https://docs.lancedb.com/search/filtering#filtering-with-sql).
 
 ```python
 import lancedb
@@ -118,4 +118,4 @@ When you ingest through the **retriever service**, upload the sidecar with [`POS
 ## How metadata is stored { #how-metadata-is-stored }
 
 - [Vector databases](vdbs.md) — canonical LanceDB upload and retrieval guide
-- [metadata_and_filtered_search.ipynb](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/metadata_and_filtered_search.ipynb) — CLI and graph ingest with sidecar metadata
+- [nemo_retriever_retriever_query_metadata_filter.ipynb](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/nemo_retriever_retriever_query_metadata_filter.ipynb) — runnable notebook for sidecar metadata at ingest and filtered `Retriever.query`

--- a/docs/docs/extraction/notebooks/index.md
+++ b/docs/docs/extraction/notebooks/index.md
@@ -8,18 +8,17 @@ If you plan to run benchmarking or evaluation tests, you must download the [Benc
 
 ## Getting Started
 
-To get started with the basics, try one of the following notebooks:
+To get started with the basics, try one of the following guides or notebooks:
 
-- [CLI Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/cli_client_usage.ipynb)
-- [Python Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/python_client_usage.ipynb)
-- [How to add metadata to your documents and filter searches](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/metadata_and_filtered_search.ipynb)
-- [How to reindex a collection](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/reindex_example.ipynb)
+- [Quickstart: retriever CLI](../../reference/retriever-cli-quickstart.md)
+- [Workflow: Ingest documents](../workflow-document-ingestion.md)
+- [How to add metadata to your documents and filter searches](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/nemo_retriever_retriever_query_metadata_filter.ipynb)
 
 
 For more advanced scenarios, try one of the following notebooks:
 
 - [Build a Custom Vector Database Operator](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/building_vdb_operator.ipynb)
-- [Try Enterprise RAG Blueprint](https://github.com/NVIDIA/NeMo-Retriever/blob/main/deploy/pdf-blueprint.ipynb)
+- [Try Enterprise RAG Blueprint](https://build.nvidia.com/nvidia/multimodal-pdf-data-extraction-for-enterprise-rag)
 - [Evaluate bo767 retrieval recall accuracy with NeMo Retriever Library](https://github.com/NVIDIA/NeMo-Retriever/blob/main/evaluation/bo767_recall.ipynb)
 - [Multimodal RAG with LangChain](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/langchain_multimodal_rag.ipynb)
 - [Multimodal RAG with LlamaIndex](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/llama_index_multimodal_rag.ipynb)

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -77,16 +77,16 @@ Highlights for the 26.05 release include:
 
 ## Release Notes for Previous Versions
 
-| [26.03](https://docs.nvidia.com/nemo/retriever/26.3.0/extraction/releasenotes/)
-| [26.1.2](https://docs.nvidia.com/nemo/retriever/26.1.2/extraction/releasenotes/)
-| [26.1.1](https://docs.nvidia.com/nemo/retriever/26.1.1/extraction/releasenotes/)
-| [25.9.0](https://docs.nvidia.com/nemo/retriever/25.9.0/extraction/releasenotes/) 
-| [25.6.3](https://docs.nvidia.com/nemo/retriever/25.6.3/extraction/releasenotes/) 
-| [25.6.2](https://docs.nvidia.com/nemo/retriever/25.6.2/extraction/releasenotes/) 
-| [25.4.2](https://docs.nvidia.com/nemo/retriever/25.4.2/extraction/releasenotes/) 
-| [25.3.0](https://docs.nvidia.com/nemo/retriever/25.3.0/extraction/releasenotes/) 
-| [24.12.1](https://docs.nvidia.com/nemo/retriever/25.3.0/extraction/releasenotes/#release-24121) 
-| [24.12.0](https://docs.nvidia.com/nemo/retriever/25.3.0/extraction/releasenotes/#release-2412) 
+| [26.03](https://docs.nvidia.com/nemo/retriever/26.3.0/extraction/releasenotes-nv-ingest/)
+| [26.1.2](https://docs.nvidia.com/nemo/retriever/26.1.2/extraction/releasenotes-nv-ingest/)
+| [26.1.1](https://docs.nvidia.com/nemo/retriever/26.1.1/extraction/releasenotes-nv-ingest/)
+| [25.9.0](https://docs.nvidia.com/nemo/retriever/25.9.0/extraction/releasenotes-nv-ingest/) 
+| [25.6.3](https://docs.nvidia.com/nemo/retriever/25.6.3/extraction/releasenotes-nv-ingest/) 
+| [25.6.2](https://docs.nvidia.com/nemo/retriever/25.6.2/extraction/releasenotes-nv-ingest/) 
+| [25.4.2](https://docs.nvidia.com/nemo/retriever/25.4.2/extraction/releasenotes-nv-ingest/) 
+| [25.3.0](https://docs.nvidia.com/nemo/retriever/25.3.0/extraction/releasenotes-nv-ingest/) 
+| [24.12.1](https://docs.nvidia.com/nemo/retriever/25.3.0/extraction/releasenotes-nv-ingest/#release-24121) 
+| [24.12.0](https://docs.nvidia.com/nemo/retriever/25.3.0/extraction/releasenotes-nv-ingest/#release-2412) 
 
 ## Related Topics
 


### PR DESCRIPTION
## Summary

Fixes broken outbound links identified by a crawl of the published NeMo Retriever Library docs (`latest` / 26.5.0):

## Link map (old → new, verified on `main`)

| Location | Old target | Status | New target | Verified |
|----------|------------|--------|------------|----------|
| `releasenotes.md` | `…/extraction/releasenotes/` (archived versions) | 404 on docs.nvidia.com | `…/extraction/releasenotes-nv-ingest/` | 200 |
| `custom-metadata.md` (ingest walkthrough) | `examples/metadata_and_filtered_search.ipynb` | Not on `main` | [VDB README — Metadata filtering](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/vdb#metadata-filtering) | 200 |
| `custom-metadata.md` (query section) | *(unchanged)* | — | `examples/nemo_retriever_retriever_query_metadata_filter.ipynb` | Exists on `main` |
| `custom-metadata.md` (LanceDB SQL) | `lancedb.github.io/lancedb/sql/` | 404 | [LanceDB metadata filtering](https://docs.lancedb.com/search/filtering#filtering-with-sql) | 200 |
| `custom-metadata.md` (related topics) | `examples/metadata_and_filtered_search.ipynb` | Not on `main` | `examples/nemo_retriever_retriever_query_metadata_filter.ipynb` | Exists on `main` |
| `audio-video.md` | `client/client_examples/examples/python_client_usage.ipynb` | Not on `main` (removed #1975) | [Workflow: Ingest documents](workflow-document-ingestion.md) | Exists on `main` |
| `notebooks/index.md` | `client/client_examples/examples/cli_client_usage.ipynb` | Not on `main` | [Quickstart: retriever CLI](../../reference/retriever-cli-quickstart.md) | Exists on `main` |
| `notebooks/index.md` | `client/client_examples/examples/python_client_usage.ipynb` | Not on `main` | [Workflow: Ingest documents](../workflow-document-ingestion.md) | Exists on `main` |
| `notebooks/index.md` | `examples/metadata_and_filtered_search.ipynb` | Not on `main` | `examples/nemo_retriever_retriever_query_metadata_filter.ipynb` | Exists on `main` |
| `notebooks/index.md` | `examples/reindex_example.ipynb` | Not on `main` | *(removed — no replacement on `main`)* | — |
| `notebooks/index.md` | `deploy/pdf-blueprint.ipynb` | Not on `main` (removed #2139) | [Enterprise RAG blueprint](https://build.nvidia.com/nvidia/multimodal-pdf-data-extraction-for-enterprise-rag) | 308→200 |
