### PR TITLE
fix(ci): restore GitHub Pages deploy for NRL docs

### DIFF
--- a/.github/workflows/nrl-docs-github-pages.yml
+++ b/.github/workflows/nrl-docs-github-pages.yml
@@ -1,6 +1,10 @@
 # NeMo Retriever Library (NRL) documentation — sole publisher to GitHub Pages for this repo.
 # Does not run the full Docker + Sphinx pipeline (no nv-ingest / nv-ingest-api HTML API dump).
 # Full-pipeline doc builds run in docs-deploy.yml (CI only, no deploy).
+#
+# If deploy fails with HTTP 401, verify repo Settings → Pages → Build and deployment
+# source is "GitHub Actions" (not "Deploy from a branch") and that workflow permissions
+# allow pages:write + id-token:write (Settings → Actions → General).
 name: NRL documentation — GitHub Pages
 
 on:
@@ -29,6 +33,11 @@ jobs:
   build:
     name: Build NRL docs
     runs-on: ubuntu-latest
+    # upload-pages-artifact requires pages + id-token on the build job (not only workflow-level).
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -84,6 +93,14 @@ jobs:
         with:
           path: docs/site
 
+      # Long-lived download (90 days) for S3/staging; survives GitHub Pages deploy failures.
+      - name: Upload docs artifact (nrl-docs-site)
+        if: ${{ github.repository == 'NVIDIA/NeMo-Retriever' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: nrl-docs-site
+          path: docs/site
+
       - name: Upload docs artifact (non-Pages repos)
         if: ${{ github.repository != 'NVIDIA/NeMo-Retriever' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -96,10 +113,16 @@ jobs:
     if: ${{ github.repository == 'NVIDIA/NeMo-Retriever' }}
     needs: build
     runs-on: ubuntu-latest
+    # deploy-pages needs pages + id-token (+ actions: read for artifact fetch) on this job.
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      actions: read
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Summary
- Fixes the **Deploy to GitHub Pages** step failing with HTTP 401 (Requires authentication) after PR #2226 and manual re-runs.
- The MkDocs **build was already succeeding**; only the deploy job failed.
- Adds **job-level** `pages: write`, `id-token: write`, and `actions: read` permissions on the build and deploy jobs, as required by `actions/deploy-pages` and `actions/upload-pages-artifact`.
- Uploads the long-lived `nrl-docs-site` artifact (90 days) from the GitHub Pages workflow too, so doc HTML remains downloadable even if deploy flakes.

## Root cause
`deploy-pages` must mint an OIDC token and call the Pages API from the **deploy** job. Org/repo defaults can prevent workflow-level permissions from applying to split build/deploy jobs, which surfaces as `401 Requires authentication` even when the site artifact uploaded successfully.

## If deploy still fails after merge
Ask a repo admin to confirm:
1. **Settings → Pages → Build and deployment → Source** = **GitHub Actions** (not deploy from branch)
2. **Settings → Actions → General → Workflow permissions** = **Read and write**

## Test plan
- [ ] Merge and re-run **NRL documentation — GitHub Pages** on `main` (or push a trivial `docs/**` change)
- [ ] Confirm **Build NRL docs** and **Deploy to GitHub Pages** both succeed
- [ ] Confirm `nrl-docs-site` artifact appears on the workflow run
- [ ] Verify https://nvidia.github.io/NeMo-Retriever/extraction/overview/ shows PR #2226 link fixes