### PR TITLE
docs: save_to_disk cleanup and run-mode default fixes (NVBugs 6187338, 6262715)

### DIFF
--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -12,7 +12,11 @@ To tune splitter throughput from the CLI, use `--pdf-split-batch-size` (Ray acto
     options:
       filters:
         - "!^pdf_split_config$"
+        - "!^save_to_disk$"
 
 ::: nemo_retriever.retriever
 
 ::: nemo_retriever.params
+    options:
+      filters:
+        - "!^save_to_disk$"

--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -10,17 +10,9 @@ To tune splitter throughput from the CLI, use `--pdf-split-batch-size` (Ray acto
 
 ::: nemo_retriever.ingestor
     options:
-      show_source: false
       filters:
-        - "!^_[^_]"
         - "!^pdf_split_config$"
-        - "!^save_to_disk$"
 
 ::: nemo_retriever.retriever
 
 ::: nemo_retriever.params
-    options:
-      show_source: false
-      filters:
-        - "!^_[^_]"
-        - "!^save_to_disk$"

--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -10,7 +10,9 @@ To tune splitter throughput from the CLI, use `--pdf-split-batch-size` (Ray acto
 
 ::: nemo_retriever.ingestor
     options:
+      show_source: false
       filters:
+        - "!^_[^_]"
         - "!^pdf_split_config$"
         - "!^save_to_disk$"
 
@@ -18,5 +20,7 @@ To tune splitter throughput from the CLI, use `--pdf-split-batch-size` (Ray acto
 
 ::: nemo_retriever.params
     options:
+      show_source: false
       filters:
+        - "!^_[^_]"
         - "!^save_to_disk$"

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -33,7 +33,7 @@ VideoFrameActor requires media dependencies; missing: ffprobe.
 The `ffmpeg-python` wrapper and `nemo-retriever[multimedia]` do not install the
 `ffmpeg` or `ffprobe` binaries the pipeline executes.
 
-For air-gapped or locked-down clusters, see [Air-gapped and disconnected deployment](deployment-options.md#air-gapped-deployment).
+For air-gapped or locked-down clusters, refer to [Air-gapped and disconnected deployment](deployment-options.md#air-gapped-deployment).
 
 **Connected environments:**
 
@@ -126,7 +126,7 @@ For local GPU inference with Nemotron Parse, combine extras:
 pip install "nemo-retriever[local,nemotron-parse]"
 ```
 
-See also [What is NeMo Retriever Library?](overview.md) and [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md#software-requirements).
+Also refer to [What is NeMo Retriever Library?](overview.md) and [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md#software-requirements).
 
 ## Extract method nemotron-parse doesn't support image files
 

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -77,11 +77,15 @@ ulimit -u 10000
 ## Out-of-Memory (OOM) Error when Processing Large Datasets
 
 When you process a very large dataset with thousands of documents, you might encounter an Out-of-Memory (OOM) error. 
-This happens because, by default, NeMo Retriever Library stores the results from every document in system memory (RAM). 
+This happens because NeMo Retriever Library materializes extraction results in system memory (RAM) while the job runs. 
 If the total size of the results exceeds the available memory, the process fails.
 
-To resolve this issue, use the `save_to_disk` method. 
-For details, refer to [Working with Large Datasets: Saving to Disk](nemo-retriever-api-reference.md).
+To reduce memory pressure, try one or more of the following:
+
+- Process documents in smaller batches instead of submitting the entire corpus in one job.
+- Route outputs to a sink (for example, `.vdb_upload(...)`, `.webhook(...)`, or `.store(...)`) so results are written out instead of held in memory until the job finishes.
+- In `run_mode="service"`, pass `return_results=False` to `.ingest(...)` when you do not need the full result payload returned to the client. For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md).
+- Increase available host or pod memory for the ingest workload.
 
 
 

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -95,7 +95,7 @@ Skip this step if you are using remote NIM inference only.
 
 The [test PDF](../data/multimodal_test.pdf) contains text, tables, charts, and images. Additional test data resides [here](../data/).
 
-> **Note:** `batch` is the primary intended run_mode of operation for this library. Other modes are experimental and subject to change or removal.
+> **Note:** `retriever ingest` and `retriever pipeline run` default to `--run-mode inprocess` (single-process pandas). Pass `--run-mode batch` for Ray Data scale-out on larger workloads. Other modes are experimental and subject to change or removal.
 
 The examples below use default local GPU inference (no `invoke_url` specified) and require the `[local]` extra and the CUDA 13 torch override from the setup steps above. For remote NIM inference without a local GPU, see [Run with remote inference](#run-with-remote-inference-no-local-gpu-required).
 

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -55,7 +55,7 @@ major-version windows, opt in with `--pre`:
 uv pip install --pre "nemo-retriever[local]==26.05-RC1"
 ```
 
-Install matching **ingestion client** and **ingestion runtime** wheels at the same version when your workflow expects them (see the [NeMo Retriever Library prerequisites](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the exact PyPI coordinates for your release).
+Install matching **ingestion client** and **ingestion runtime** wheels at the same version when your workflow expects them (refer to the [NeMo Retriever Library prerequisites](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the exact PyPI coordinates for your release).
 
 For **remote NIM inference only** (no local GPU required), the base package is sufficient:
 
@@ -66,7 +66,7 @@ source retriever/bin/activate
 uv pip install nemo-retriever
 ```
 
-Install matching **ingestion client** and **ingestion runtime** wheels at the same version when your workflow expects them (see the [NeMo Retriever Library prerequisites](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the exact PyPI coordinates for your release).
+Install matching **ingestion client** and **ingestion runtime** wheels at the same version when your workflow expects them (refer to the [NeMo Retriever Library prerequisites](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the exact PyPI coordinates for your release).
 
 This creates a dedicated Python environment and installs the `nemo-retriever` PyPI package, the canonical distribution for the NeMo Retriever Library.
 
@@ -97,7 +97,7 @@ The [test PDF](../data/multimodal_test.pdf) contains text, tables, charts, and i
 
 > **Note:** `retriever ingest` and `retriever pipeline run` default to `--run-mode inprocess` (single-process pandas). Pass `--run-mode batch` for Ray Data scale-out on larger workloads. Other modes are experimental and subject to change or removal.
 
-The examples below use default local GPU inference (no `invoke_url` specified) and require the `[local]` extra and the CUDA 13 torch override from the setup steps above. For remote NIM inference without a local GPU, see [Run with remote inference](#run-with-remote-inference-no-local-gpu-required).
+The examples below use default local GPU inference (no `invoke_url` specified) and require the `[local]` extra and the CUDA 13 torch override from the setup steps above. For remote NIM inference without a local GPU, refer to [Run with remote inference](#run-with-remote-inference-no-local-gpu-required).
 
 ### Ingest a test pdf
 ```python
@@ -167,7 +167,7 @@ used in [Run a recall query](#run-a-recall-query) below. With the
 and embedding. For a realistic retrieval corpus, see
 [QA evaluation -- Step 1](./src/nemo_retriever/evaluation/README.md#step-1-ingest-and-embed-pdfs-nemo-retriever).
 
-**No local GPU?** Set [`NVIDIA_API_KEY`](https://nvidia.github.io/NeMo-Retriever/extraction/api-keys/#nvidia-api-key) (see [Authentication and API keys](https://nvidia.github.io/NeMo-Retriever/extraction/api-keys/)) and route extraction and embedding
+**No local GPU?** Set [`NVIDIA_API_KEY`](https://nvidia.github.io/NeMo-Retriever/extraction/api-keys/#nvidia-api-key) (refer to [Authentication and API keys](https://nvidia.github.io/NeMo-Retriever/extraction/api-keys/)) and route extraction and embedding
 through [build.nvidia.com](https://build.nvidia.com/) NIMs instead:
 
 ```bash
@@ -528,7 +528,7 @@ ingestor = ingestor.files(documents).extract(method="nemotron_parse")
 
 ## Run with remote inference, no local GPU required:
 
-For build.nvidia.com hosted inference, set [`NVIDIA_API_KEY`](https://nvidia.github.io/NeMo-Retriever/extraction/api-keys/#nvidia-api-key) as an environment variable (see [Authentication and API keys](https://nvidia.github.io/NeMo-Retriever/extraction/api-keys/)). 
+For build.nvidia.com hosted inference, set [`NVIDIA_API_KEY`](https://nvidia.github.io/NeMo-Retriever/extraction/api-keys/#nvidia-api-key) as an environment variable (refer to [Authentication and API keys](https://nvidia.github.io/NeMo-Retriever/extraction/api-keys/)). 
 
 ```python
 ingestor = (

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -204,11 +204,11 @@ hits = retriever.query(
 
 ### Larger datasets
 
-- Batch ingest: `retriever ingest ./data/pdf_corpus --run-mode batch`.
+- Omitting `--run-mode` defaults to `inprocess` (single-process pandas; no Ray startup).
+- Ray Data scale-out: `retriever ingest ./data/pdf_corpus --run-mode batch`.
 - Tune throughput with `--pdf-extract-workers`, `--pdf-extract-batch-size`,
   `--page-elements-workers`, `--page-elements-batch-size`, `--ocr-workers`,
   `--ocr-batch-size`, `--embed-workers`, and `--embed-batch-size`.
-- For CI or debugging: `--run-mode inprocess` skips Ray startup.
 
 <!-- --8<-- [end:quickstart] -->
 
@@ -231,8 +231,7 @@ retriever query --help
 ### Extract a PDF with defaults
 
 ```bash
-retriever ingest ./data/test.pdf \
-  --run-mode inprocess
+retriever ingest ./data/test.pdf
 ```
 
 Results go to LanceDB (`./lancedb`, table `nemo-retriever` by default). Use
@@ -460,7 +459,7 @@ for these cases:
 - `--store-images-uri <uri>` stores extracted image assets to a local path or
   an fsspec URI (e.g. `s3://bucket/prefix`). Page granularity stores page
   images; element granularity stores element images.
-- `--run-mode inprocess` skips Ray and is ideal for single-file demos and CI;
-  `--run-mode batch` (the default) uses Ray Data for throughput.
+- `--run-mode inprocess` (the default) runs single-process pandas without Ray; ideal for single-file demos and CI.
+- `--run-mode batch` uses Ray Data for throughput on larger corpora.
 
 Run `retriever pipeline run --help` for the authoritative flag list.

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -282,7 +282,7 @@ ingest API) in Python.
 Remote OCR NIM endpoints choose their own model and language behavior. Local
 `--ocr-lang` and `--ocr-version` are not sent on remote requests. For hosted
 examples until OCR v2 is published on build.nvidia.com, keep
-`--ocr-invoke-url` pointed at `nemotron-ocr-v1` (see [Quick start](#quick-start)).
+`--ocr-invoke-url` pointed at `nemotron-ocr-v1` (refer to [Quick start](#quick-start)).
 
 ### PDF and Office documents
 

--- a/nemo_retriever/src/nemo_retriever/evaluation/README.md
+++ b/nemo_retriever/src/nemo_retriever/evaluation/README.md
@@ -289,7 +289,7 @@ python -m nemo_retriever.examples.graph_pipeline /path/to/bo767 \
 Output:
 - `lancedb/nemo-retriever/` (~84k chunks) -- used by step 3 for retrieval queries.
 
-**Note:** `graph_pipeline.py` defaults to `--run-mode inprocess`. Pass `--run-mode batch` for Ray Data scale-out. Both modes produce the same output schema.
+**Note:** `graph_pipeline.py` defaults to `--run-mode inprocess`. Pass `--run-mode batch` for Ray Data scale-out. Both modes produce compatible chunk records for downstream evaluation (return type differs: `pandas.DataFrame` vs `ray.data.Dataset`).
 
 ### Step 2: Build page markdown index (NeMo Retriever)
 

--- a/nemo_retriever/src/nemo_retriever/evaluation/README.md
+++ b/nemo_retriever/src/nemo_retriever/evaluation/README.md
@@ -256,8 +256,8 @@ ls /path/to/bo767/*.pdf | wc -l   # should be 767
 ### Step 1: Ingest and embed PDFs (NeMo Retriever)
 
 `graph_pipeline.py` builds an operator graph (`AbstractOperator` nodes connected via `>>`) and
-executes it through either a `RayDataExecutor` (batch mode, default) or `InprocessExecutor`
-(single-process pandas). The pipeline extracts, embeds, and uploads chunks to LanceDB in a
+executes it through either an `InprocessExecutor` (inprocess mode, default) or `RayDataExecutor`
+(batch mode). The pipeline extracts, embeds, and uploads chunks to LanceDB in a
 single pass.
 
 Run from the **repo root**. **Estimated time: ~45-90 min** (767 PDFs, GPU-accelerated
@@ -289,8 +289,7 @@ python -m nemo_retriever.examples.graph_pipeline /path/to/bo767 \
 Output:
 - `lancedb/nemo-retriever/` (~84k chunks) -- used by step 3 for retrieval queries.
 
-**Note:** `graph_pipeline.py` uses `--run-mode batch` (Ray Data) by default. For local testing
-without Ray, pass `--run-mode inprocess`. Both modes produce the same output.
+**Note:** `graph_pipeline.py` defaults to `--run-mode inprocess`. Pass `--run-mode batch` for Ray Data scale-out. Both modes produce the same output schema.
 
 ### Step 2: Build page markdown index (NeMo Retriever)
 

--- a/nemo_retriever/src/nemo_retriever/evaluation/README.md
+++ b/nemo_retriever/src/nemo_retriever/evaluation/README.md
@@ -289,7 +289,7 @@ python -m nemo_retriever.examples.graph_pipeline /path/to/bo767 \
 Output:
 - `lancedb/nemo-retriever/` (~84k chunks) -- used by step 3 for retrieval queries.
 
-**Note:** `graph_pipeline.py` defaults to `--run-mode inprocess`. Pass `--run-mode batch` for Ray Data scale-out. Both modes produce compatible chunk records for downstream evaluation (return type differs: `pandas.DataFrame` vs `ray.data.Dataset`).
+**Note:** `graph_pipeline.py` defaults to `--run-mode inprocess`. Pass `--run-mode batch` for Ray Data scale-out. Both modes return a `pandas.DataFrame` and produce compatible chunk records for downstream evaluation.
 
 ### Step 2: Build page markdown index (NeMo Retriever)
 

--- a/nemo_retriever/src/nemo_retriever/ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor.py
@@ -195,15 +195,6 @@ class ingestor:
         """Record intermediate results persistence configuration."""
         self._not_implemented("save_intermediate_results")
 
-    def save_to_disk(
-        self,
-        output_directory: Optional[str] = None,
-        cleanup: bool = True,
-        compression: Optional[str] = "gzip",
-    ) -> "ingestor":
-        """Record result persistence configuration (execution TBD)."""
-        self._not_implemented("save_to_disk")
-
     def caption(self, params: "CaptionParams | None" = None, **kwargs: Any) -> "ingestor":
         """Record a caption task configuration."""
         _ = _merge_params(params, kwargs)

--- a/nemo_retriever/src/nemo_retriever/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/params/models.py
@@ -117,7 +117,6 @@ class IngestorCreateParams(_ParamsModel):
 class IngestExecuteParams(_ParamsModel):
     show_progress: bool = False
     return_failures: bool = False
-    save_to_disk: bool = False
     return_traces: bool = False
     return_results: bool = True
     parallel: bool = False


### PR DESCRIPTION
## Summary

Fixes two doc-vs-implementation regressions on the 26.5.0 line.

### NVBugs 6187338 — `save_to_disk` documentation defect

- Remove the troubleshooting recommendation to call `save_to_disk()` for OOM relief; replace with supported mitigations (smaller batches, sinks, `return_results=False` in service mode, more memory).
- Drop the unimplemented `save_to_disk()` stub from `ingestor.py` and the unused `IngestExecuteParams.save_to_disk` field so mkdocstrings no longer documents it on the API reference page.
- `ServiceIngestor.save_to_disk()` remains implemented for service mode but is intentionally not documented (dev backlog for graph path).

### NVBugs 6262715 — CLI `--run-mode` default mismatch

- Align docs with shipped behavior after commit 2be38bde: `retriever ingest` and `retriever pipeline run` default to `--run-mode inprocess`, not `batch`.
- Update `nemo_retriever/docs/cli/README.md`, package `README.md`, and `graph_pipeline` evaluation notes.
- Clarify that inprocess vs batch return types differ (`pandas.DataFrame` vs `ray.data.Dataset`) while chunk records remain compatible for evaluation.

### Style / quality

- Fix `refer to` link CTAs in touched doc files (`check-nrl-doc-leakage.ps1` pass).
- Deep doc audit (`::a-2`) on PR files: critical claims verified against CLI source, ingest plan defaults, and tests.

## Files changed

| File | Change |
|------|--------|
| `docs/docs/extraction/troubleshoot.md` | OOM guidance without `save_to_disk` |
| `nemo_retriever/src/nemo_retriever/ingestor.py` | Remove unimplemented stub |
| `nemo_retriever/src/nemo_retriever/params/models.py` | Remove unused field |
| `nemo_retriever/docs/cli/README.md` | `inprocess` CLI default |
| `nemo_retriever/README.md` | CLI default note + link CTAs |
| `nemo_retriever/src/nemo_retriever/evaluation/README.md` | `graph_pipeline` default + return-type note |

## Test plan

- [ ] Confirm `docs/docs/extraction/troubleshoot.md` has no `save_to_disk` references.
- [ ] Rebuild docs; confirm API reference omits `save_to_disk` on `ingestor` / `IngestExecuteParams`.
- [ ] `retriever ingest --help` and `retriever pipeline run --help` show default `[default: inprocess]`, matching updated CLI README.
- [ ] `grep save_to_disk docs/docs/extraction/` returns no user-facing hits.
- [ ] `.\.cursor\scripts\check-nrl-doc-leakage.ps1 -Base main` passes on scoped doc files.