### PR TITLE
docs hygiene and reconciliation: sync 26.05 product docs with main 

### DIFF
--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -2,7 +2,7 @@
 
 Use this page for speech and audio extraction with Parakeet ASR and for video workflows that combine audio with OCR on frames or derived images.
 
-For air-gapped or disconnected deployments, see [Air-gapped and disconnected deployment](deployment-options.md#air-gapped-deployment).
+For air-gapped or disconnected deployments, refer to [Air-gapped and disconnected deployment](deployment-options.md#air-gapped-deployment).
 
 **Sections:** [Speech and audio (Parakeet)](#speech-and-audio-extraction) · [Run Parakeet on the cluster (Helm)](#run-parakeet-on-the-cluster-helm) · [Parakeet with hosted inference (build.nvidia.com)](#parakeet-hosted-inference-build-nvidia) · [Video and frame OCR](#video-and-frame-ocr)
 
@@ -18,7 +18,7 @@ Supported file types for speech extraction today:
 - `mp3`, `wav`
 - `mp4`, `mov`, `mkv`, `avi` — common video containers; the audio track is transcribed (same extensions as in [What is NeMo Retriever Library?](overview.md))
 
-[NeMo Retriever Library](overview.md) supports extracting speech from audio for Retrieval Augmented Generation (RAG). Similar to how the multimodal document pipeline uses detection and OCR microservices, NeMo Retriever Library uses the [parakeet-1-1b-ctc-en-us ASR NIM](https://docs.nvidia.com/nim/speech/latest/asr/deploy-asr-models/parakeet-ctc-en-us.html) to transcribe speech to text, then embeddings via the NeMo Retriever embedding path.
+[NeMo Retriever Library](overview.md) supports extracting speech from audio for Retrieval Augmented Generation (RAG). Similar to how the multimodal document pipeline uses detection and OCR microservices, NeMo Retriever Library uses the [parakeet-1-1b-ctc-en-us ASR NIM](https://docs.nvidia.com/nim/speech/latest/asr/deploy-asr-models/parakeet-ctc-en-us.html) to transcribe speech to text, then embeddings through the NeMo Retriever embedding path.
 
 Before running audio extraction from Python with either self-hosted or hosted Parakeet, install the multimedia extra so the Parakeet ASR client can decode and resample audio:
 
@@ -48,44 +48,49 @@ For Kubernetes deployments with network access to package repositories, set
 [Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#1-service-image)
 to install ffmpeg/ffprobe at service startup. This runtime path requires
 package-repository network egress, a writable root filesystem, and a security
-policy that allows the image's scoped sudo use. For air-gapped clusters, see
+policy that allows the image's scoped sudo use. For air-gapped clusters, refer to
 [Air-gapped and disconnected deployment](deployment-options.md#air-gapped-deployment).
 
 !!! important
 
     Due to limitations in available VRAM controls in the current release, the parakeet-1-1b-ctc-en-us ASR NIM must run on a [dedicated additional GPU](prerequisites-support-matrix.md#model-hardware-requirements). For the full list of requirements, refer to the [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md#model-hardware-requirements).
 
-This pipeline enables retrieval at the speech segment level when you enable segmenting (see examples below).
+This pipeline enables retrieval at the speech segment level when you enable segmenting (refer to the examples below).
 
 ![Overview diagram](images/audio.png)
 
 ## Run Parakeet on the cluster (Helm) { #run-parakeet-on-the-cluster-helm }
 
-Use the following procedure for self-hosted Parakeet on your cluster. For chart enablement, GPU placement, ffmpeg, and endpoint wiring, see [Optional Helm NIMs](prerequisites-support-matrix.md#optional-helm-nims-not-auto-wired-by-default) and [Audio and video (Parakeet ASR)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#audio-video-parakeet) in the Helm chart README, plus [Deployment options](deployment-options.md).
+Use the following procedure to run the NIM on your own infrastructure. Self-hosted Parakeet runs on Kubernetes through the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md). Enable the ASR NIM per [Optional Helm NIMs](prerequisites-support-matrix.md#optional-helm-nims-not-auto-wired-by-default). GPU pinning and endpoint wiring are documented in [Parakeet ASR](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#audio-video-parakeet).
 
-1. Deploy or upgrade per that Helm guide and [Deployment options](deployment-options.md).
+1. Deploy or upgrade with the [NeMo Retriever Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) and enable Parakeet for your release (refer to [Optional Helm NIMs](prerequisites-support-matrix.md#optional-helm-nims-not-auto-wired-by-default)). Follow [Deployment options](deployment-options.md).
 
-2. After the services are running, interact with the pipeline from Python.
+2. If the service will process audio or video files, set `service.installFfmpeg=true` in the Helm chart when your cluster allows runtime package installation; for air-gapped clusters, refer to [Air-gapped and disconnected deployment](deployment-options.md#air-gapped-deployment) and the [Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#1-service-image) for `service.image` overrides.
 
-    - The `Ingestor` object initializes the ingestion process.
-    - The `files` method specifies the input files to process.
-    - The `extract_audio` method runs audio extraction.
+3. After the services are running, interact with the pipeline from Python (refer to the [Python API guide](nemo-retriever-api-reference.md) for parameter details).
+
+    - In `batch` mode, pass the in-cluster Parakeet gRPC endpoint through `ASRParams.audio_endpoints` (for example `audio:50051` from your Helm release). The retriever service auto-wires this endpoint; graph ingest does not.
 
     ```python
+    from nemo_retriever import create_ingestor
     from nemo_retriever.params.models import ASRParams
 
     ingestor = (
-        Ingestor()
+        create_ingestor(run_mode="batch")
         .files("./data/*.wav")
         .extract_audio(
-            asr_params=ASRParams(segment_audio=True),
+            asr_params=ASRParams(
+                audio_endpoints=("audio:50051", None),  # (grpc_endpoint, http_endpoint)
+                segment_audio=True,
+            ),
         )
     )
+    results = ingestor.ingest()
     ```
 
-To generate one extracted element for each sentence-like ASR segment, pass `asr_params=ASRParams(segment_audio=True)` to `.extract_audio(...)`. This option applies when audio extraction runs with a self-hosted Parakeet NIM or using build.nvidia.com hosted inference, but has no effect when using the local Hugging Face Parakeet model.
+    To generate one extracted element for each sentence-like ASR segment, pass `asr_params=ASRParams(segment_audio=True)` to `.extract_audio(...)`. This option applies when audio extraction runs with a self-hosted Parakeet NIM or using build.nvidia.com hosted inference, but has no effect when using the local Hugging Face Parakeet model.
 
-For more Python examples, refer to [Python Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/python_client_usage.ipynb).
+    For more runnable examples, refer to [Workflow: Ingest documents](workflow-document-ingestion.md).
 
 ## Parakeet with hosted inference (build.nvidia.com) { #parakeet-hosted-inference-build-nvidia }
 
@@ -93,18 +98,14 @@ Instead of running the pipeline locally, you can call Parakeet through [build.nv
 
 1. On the Parakeet model page on [build.nvidia.com](https://build.nvidia.com/), create or copy an API key and note the function ID for hosted access. You need both before making API calls.
 
-2. Run inference from Python with the hosted gRPC endpoint and credentials from that page (the example below uses the default hosted gRPC hostname; confirm values in the **Get API Key** flow for your deployment).
-
-    - The `Ingestor` object initializes the ingestion process.
-    - The `files` method specifies the input files to process.
-    - The `extract_audio` method runs audio extraction.
-    - The hosted gRPC endpoint, function ID, and API key are routed through `ASRParams`. Pass them via `asr_params=ASRParams(...)`; the ASR actor reads `audio_endpoints`, `function_id`, and `auth_token` from that object.
+2. Run inference from Python with the hosted gRPC endpoint and credentials from that page (the example below uses the default hosted gRPC hostname; confirm values in the **Get API Key** flow for your deployment). Pass hosted endpoint, function ID, and API key through `ASRParams` (`audio_endpoints`, `function_id`, `auth_token`).
 
     ```python
+    from nemo_retriever import create_ingestor
     from nemo_retriever.params.models import ASRParams
 
     ingestor = (
-        Ingestor()
+        create_ingestor(run_mode="batch")
         .files("./data/*.mp3")
         .extract_audio(
             asr_params=ASRParams(
@@ -115,21 +116,22 @@ Instead of running the pipeline locally, you can call Parakeet through [build.nv
             ),
         )
     )
+    results = ingestor.ingest()
     ```
 
     !!! tip
 
-        For more Python examples, refer to [Python Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/python_client_usage.ipynb).
+        For more runnable examples, refer to [Workflow: Ingest documents](workflow-document-ingestion.md).
 
 ## Video and frame OCR { #video-and-frame-ocr }
 
-For video assets, NeMo Retriever Library can combine audio or speech processing (see [Speech and audio extraction](#speech-and-audio-extraction) above) with visual text extraction when OCR applies to frames or derived images.
+For video assets, NeMo Retriever Library can combine audio or speech processing (refer to [Speech and audio extraction](#speech-and-audio-extraction) above) with visual text extraction when OCR applies to frames or derived images.
 
-For OCR-oriented extract methods on scanned or image-heavy content, see [OCR and scanned documents](multimodal-extraction.md#ocr-and-scanned-documents), [text and layout extraction](multimodal-extraction.md#text-and-layout-extraction), and [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse) for advanced visual parsing.
+For OCR-oriented extract methods on scanned or image-heavy content, refer to [OCR and scanned documents](multimodal-extraction.md#ocr-and-scanned-documents), [text and layout extraction](multimodal-extraction.md#text-and-layout-extraction), and [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse) for advanced visual parsing.
 
-Container formats and early-access video types are listed under [supported file types and formats](multimodal-extraction.md#supported-file-types-and-formats) (see [What is NeMo Retriever Library?](overview.md) for the full list).
+Container formats and early-access video types are listed under [supported file types and formats](multimodal-extraction.md#supported-file-types-and-formats) (refer to [What is NeMo Retriever Library?](overview.md) for the full list).
 
-For end-to-end RAG stacks that include multimodal ingestion, see the [NVIDIA AI Blueprints catalog](https://build.nvidia.com/explore/discover) and related solution pages on [NVIDIA Build](https://build.nvidia.com/).
+For end-to-end RAG stacks that include multimodal ingestion, refer to the [NVIDIA AI Blueprints catalog](https://build.nvidia.com/explore/discover) and related solution pages on [NVIDIA Build](https://build.nvidia.com/).
 
 ## Related topics { #related-topics }
 

--- a/docs/docs/extraction/custom-metadata.md
+++ b/docs/docs/extraction/custom-metadata.md
@@ -35,6 +35,10 @@ meta_df = pd.DataFrame(
     }
 )
 
+hostname = "localhost"
+table_name = "nemo_retriever_collection"
+lancedb_uri = "s3://your-bucket/lancedb"
+
 ingestor = (
     create_ingestor(run_mode="service", base_url=f"http://{hostname}:7670")
         .files(["data/woods_frost.pdf", "data/multimodal_test.pdf"])

--- a/docs/docs/extraction/custom-metadata.md
+++ b/docs/docs/extraction/custom-metadata.md
@@ -5,13 +5,9 @@ Use this documentation to attach per-document metadata during ingestion and to n
 ## On this page { #on-this-page }
 
 - [Attach metadata at ingestion](#attach-metadata-at-ingestion)
+- [Best practices](#best-practices)
+- [Filter results during retrieval](#filter-results-during-retrieval)
 - [How metadata is stored](#how-metadata-is-stored)
-- [Filter results at query time](#filter-results-at-query-time)
-- [Writing `where` predicates](#writing-where-predicates)
-- [Server-side vs client-side filters](#server-side-vs-client-side-filters)
-- [Inspect hit metadata](#inspect-hit-metadata)
-- [Limitations](#limitations)
-- [Related content](#related-content)
 
 ## Attach metadata at ingestion { #attach-metadata-at-ingestion }
 
@@ -25,6 +21,8 @@ Pass a **sidecar metadata table** on `vdb_upload` so selected columns are merged
 
 Optional `meta_join_key` controls how rows are matched to documents: `auto` (try full path then basename), `source_id` (full path), or `source_name` (basename only).
 
+For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md).
+
 ```python
 import pandas as pd
 from nemo_retriever import create_ingestor
@@ -36,10 +34,6 @@ meta_df = pd.DataFrame(
         "meta_b": [10, 20],
     }
 )
-
-hostname = "localhost"
-table_name = "nemo_retriever_collection"
-lancedb_uri = "./lancedb_data"
 
 ingestor = (
     create_ingestor(run_mode="service", base_url=f"http://{hostname}:7670")
@@ -54,22 +48,18 @@ ingestor = (
         .embed()
         .vdb_upload(
             vdb_op="lancedb",
-            uri=lancedb_uri,
-            table_name=table_name,
+            vdb_kwargs={"lancedb_uri": lancedb_uri, "table_name": table_name},
+            meta_dataframe=meta_df,
+            meta_source_field="source",
+            meta_fields=["meta_a", "meta_b"],
         )
 )
 results = ingestor.ingest_async().result()
 ```
 
-Merge values from `meta_df` (or `file_path`) into each document's `content_metadata` before `vdb_upload`, or follow the step-by-step pattern in [metadata_and_filtered_search.ipynb](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/metadata_and_filtered_search.ipynb), so category, department, and timestamp are present on the chunks LanceDB indexes.
+Set `hostname`, `table_name`, and a **remote** `lancedb_uri` (for example `s3://bucket/path`) to match your deployment—the retriever service rejects local filesystem paths. The client uploads in-memory sidecar metadata to the service before ingest; do not pass a raw local file path as `meta_dataframe` on the REST spec. For local LanceDB directories, use `run_mode="batch"` instead (refer to [Vector databases](vdbs.md)). For a step-by-step walkthrough with additional fields such as category, department, and timestamp, refer to [Vector DB operators and LanceDB — Metadata filtering](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/vdb#metadata-filtering).
 
-## How metadata is stored { #how-metadata-is-stored }
-
-During ingestion, each chunk's `content_metadata` is serialized as a **compact JSON string** (no spaces after `:` or `,`) in the LanceDB table's `metadata` column. Sidecar columns from `meta_dataframe`, `meta_source_field`, and `meta_fields` are merged into that JSON object before upload, so custom keys live in the same string—not separate columns. That is why `Retriever.query` filters often use `metadata LIKE '%\"key\":\"value\"%'`. For operator behavior and predicate examples, see [Vector DB operators and LanceDB — Metadata filtering](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/vdb#metadata-filtering).
-
-## Best Practices
-
-The following are the best practices when you work with custom metadata:
+## Best practices { #best-practices }
 
 - Plan metadata structure before ingestion.
 - Test filter expressions with small datasets first.
@@ -78,13 +68,9 @@ The following are the best practices when you work with custom metadata:
 - Handle missing metadata fields gracefully.
 - Log invalid filter expressions.
 
+## Filter results during retrieval { #filter-results-during-retrieval }
 
-
-## Use Custom Metadata to Filter Results During Retrieval
-
-You can use custom metadata to filter documents during retrieval operations.
-For **predicate pushdown**, pass a `where` SQL predicate through [`Retriever.query`](nemo-retriever-api-reference.md) (see [Vector databases](vdbs.md)) or chain `.where(...)` on a native LanceDB `table.search(...)` query. Application-side filtering on returned hits does not change what the database evaluates—raise `top_k` if matches might sit outside the first neighbors.
-
+You can use custom metadata to filter documents during retrieval operations. For **predicate pushdown**, pass a `where` SQL predicate through [`Retriever.query`](nemo-retriever-api-reference.md) (refer to [Vector databases](vdbs.md)) or chain `.where(...)` on a native LanceDB `table.search(...)` query. Application-side filtering on returned hits does not change what the database evaluates—raise `top_k` if matches might sit outside the first neighbors.
 
 ### Example filter ideas
 
@@ -92,15 +78,14 @@ Typical keys to filter on include `category`, `department`, `priority`, and `tim
 
 ### Example: Use a Filter Expression in Search
 
-After ingestion is complete, and documents are uploaded to LanceDB with metadata,
-you can narrow results in the database with a **`where`** clause, or in Python on the returned hits.
+After ingestion is complete and documents are uploaded to LanceDB with metadata, you can narrow results in the database with a **`where`** clause, or in Python on the returned hits.
 
-**Native LanceDB (SQL pushdown):** connect, embed the query yourself (same model as ingestion), then chain `.where("<LanceDB SQL predicate>")` on `table.search(...)` so filtering happens before the `limit`. Exact SQL depends on how `metadata` is stored; see [LanceDB SQL](https://lancedb.github.io/lancedb/sql/).
+**Native LanceDB (SQL pushdown):** connect, embed the query yourself (same model as ingestion), then chain `.where("<LanceDB SQL predicate>")` on `table.search(...)` so filtering happens before the `limit`. Exact SQL depends on how `metadata` is stored; refer to [LanceDB metadata filtering](https://docs.lancedb.com/search/filtering#filtering-with-sql).
 
 ```python
 import lancedb
 
-# Pseudocode sketch — replace YOUR_VECTOR and YOUR_PREDICATE with real values.
+# pseudocode — replace YOUR_VECTOR and YOUR_PREDICATE with real values.
 db = lancedb.connect("./lancedb_data")
 table = db.open_table("nemo_retriever_collection")
 # table.search(YOUR_VECTOR, vector_column_name="vector").where(YOUR_PREDICATE).limit(10).to_list()
@@ -126,11 +111,11 @@ hits = retriever.query(
 )
 ```
 
-For a runnable end-to-end flow (ingest, `Retriever.query`, and both filter modes), see [nemo_retriever_retriever_query_metadata_filter.ipynb](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/nemo_retriever_retriever_query_metadata_filter.ipynb).
+For a runnable end-to-end flow (ingest, `Retriever.query`, and both filter modes), refer to [nemo_retriever_retriever_query_metadata_filter.ipynb](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/nemo_retriever_retriever_query_metadata_filter.ipynb).
 
 When you ingest through the **retriever service**, upload the sidecar with [`POST /v1/ingest/sidecar`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/src/nemo_retriever/service/routers/ingest.py#L1040-L1129) (multipart file; response [`SidecarUploadResponse`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/src/nemo_retriever/service/models/responses.py#L60-L68)), then pass the returned `sidecar_id` as `meta_dataframe_id` with `meta_source_field` and `meta_fields` in `pipeline.vdb_upload_params` on [`POST /v1/ingest`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/src/nemo_retriever/service/models/requests.py#L15-L32) ([`PipelineSpec`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/src/nemo_retriever/service/models/pipeline_spec.py#L55-L78)). Request and response shapes, form fields, and auth headers are in the service OpenAPI UI at `/docs` (or `/openapi.json`) on your retriever base URL (for example `http://localhost:7670/docs` after `retriever service start`). Do not send a raw local path as `meta_dataframe` on the service spec.
 
-## Related content { #related-content }
+## How metadata is stored { #how-metadata-is-stored }
 
 - [Vector databases](vdbs.md) — canonical LanceDB upload and retrieval guide
-- [metadata_and_filtered_search.ipynb](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/metadata_and_filtered_search.ipynb) — CLI and graph ingest with sidecar metadata
+- [nemo_retriever_retriever_query_metadata_filter.ipynb](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/nemo_retriever_retriever_query_metadata_filter.ipynb) — runnable notebook for sidecar metadata at ingest and filtered `Retriever.query`

--- a/docs/docs/extraction/deployment-options.md
+++ b/docs/docs/extraction/deployment-options.md
@@ -11,6 +11,10 @@ Use the sections below to pick documentation and deployment options that match y
 1. [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
 2. [Use the Python API](nemo-retriever-api-reference.md) or [Use the CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli) — install and run the [`nemo_retriever`](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever) package in your environment
 
+### I want a standalone Docker service container
+
+Build and run the NeMo Retriever service image with the [Docker service image guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md). Use this for local service-container validation; use Helm for multi-service Kubernetes deployments.
+
 ### I want a Kubernetes / Helm deployment
 
 1. [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
@@ -20,7 +24,6 @@ Use the sections below to pick documentation and deployment options that match y
 
 **Core NIMs for the default extraction pipeline** (26.05): `page_elements`, `table_structure`, `ocr`, and `vlm_embed` (`llama-nemotron-embed-vl-1b-v2:1.12.0`). These four are auto-wired into the retriever service. **Nemotron Parse**, **Nemotron 3 Nano Omni**, the **VL reranker**, and **Parakeet ASR** are optional and not auto-wired. For a minimal GPU footprint, disable optional keys you do not need (see [Recommended minimal install (26.05)](https://github.com/NVIDIA/NeMo-Retriever/blob/26.05/nemo_retriever/helm/README.md#recommended-minimal-install-2605)). See [Pre-Requisites & Support Matrix — Default Helm NIMs](prerequisites-support-matrix.md#default-helm-nims).
 
-**Docker Compose (unsupported, developer-only):** [Docker Compose for local development](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md) — **not** a substitute for Helm or the published Library charts.
 
 For audio and video extraction in Kubernetes, set `service.installFfmpeg=true`
 so the service container installs `ffmpeg` and `ffprobe` at startup. This
@@ -46,7 +49,7 @@ environments), use a custom service image that already contains `ffmpeg` and
 2. [Throughput is dataset-dependent](multimodal-extraction.md#extraction-limitations-and-quality)
 3. [Evaluate on your data](evaluate-on-your-data.md)
 
-## When to use NVIDIA-hosted NIMs { #when-to-use-nvidia-hosted-nims }
+## When to use NVIDIA-hosted NIMs
 
 [NVIDIA-hosted NIMs](https://build.nvidia.com/) run inference on NVIDIA-managed infrastructure. You call models with API keys (refer to [Get your API key](api-keys.md)) without operating GPU nodes yourself.
 
@@ -58,7 +61,7 @@ Consider hosted NIMs when:
 
 **Also refer to:** [NVIDIA NIM catalog](https://build.nvidia.com/)
 
-## When to self-host NIMs { #when-to-self-host-nims }
+## When to self-host NIMs
 
 Self-hosted NIMs run on your GPUs or air-gapped hardware, typically with Kubernetes and the [NIM Operator](https://docs.nvidia.com/nim-operator/latest/index.html).
 
@@ -88,4 +91,3 @@ For offline image captioning, deploy the in-cluster [Nemotron 3 Nano Omni](prere
 - [NeMo Retriever Library — prerequisites / deployment](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) (supported **Helm** handoff)
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
 - [Audio and video](audio-video.md)
-- **Docker Compose (unsupported):** [docker.md](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md) — local developer tooling only

--- a/docs/docs/extraction/embedding.md
+++ b/docs/docs/extraction/embedding.md
@@ -2,7 +2,7 @@
 
 !!! note "Text-only NeMo Retriever embedding NIM"
 
-    You can still use the NeMo Retriever text embedding NIM (OpenAI-compatible embeddings for passage and query vectors) alongside or instead of the multimodal flows on this page. Product and deployment details are in the [NeMo Retriever Text Embedding NIM documentation](https://docs.nvidia.com/nim/nemo-retriever/text-embedding/latest/overview.html). In library and CLI pipelines, route embedding to that NIM with your configured `embed` / invoke URL and model name (see the [graph pipeline examples](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/README.md) for environment-based remote inference).
+    You can still use the NeMo Retriever text embedding NIM (OpenAI-compatible embeddings for passage and query vectors) alongside or instead of the multimodal flows on this page. Product and deployment details are in the [NeMo Retriever Text Embedding NIM documentation](https://docs.nvidia.com/nim/nemo-retriever/text-embedding/latest/overview.html). In library and CLI pipelines, route embedding to that NIM with your configured embed endpoint and model name (refer to the [graph pipeline examples](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/README.md) for environment-based remote inference).
 
 This documentation describes how to use [NeMo Retriever Library](overview.md) 
 with the multimodal embedding model [Llama Nemotron Embed VL 1B v2](https://build.nvidia.com/nvidia/llama-nemotron-embed-vl-1b-v2).
@@ -12,6 +12,7 @@ The model can embed documents in the form of an image, text, or a combination of
 Documents can then be retrieved given a user query in text form. 
 The model supports images that contain text, tables, charts, and infographics.
 
+Parameter details for `.extract()` and `.embed()` appear in the [Python API guide](nemo-retriever-api-reference.md).
 
 ## Example with Default Text-Based Embedding
 
@@ -21,11 +22,13 @@ The following example provides a strong baseline for retrieval.
 - The `embed` method is called with no arguments.
 
 ```python
+from nemo_retriever import create_ingestor
+
 ingestor = (
-    Ingestor()
+    create_ingestor(run_mode="batch")
     .files("./data/*.pdf")
     .extract()
-    .embed() # Default behavior embeds all content as text
+    .embed()  # Default behavior embeds all content as text
 )
 results = ingestor.ingest()
 ```
@@ -33,15 +36,17 @@ results = ingestor.ingest()
 
 ## Example with Embedding Structured Elements as Text + Images
 
-It is common to process PDFs by embedding standard text as text, and embed visual elements like tables and charts as images. 
+It is common to process PDFs by embedding standard text as text and embed visual elements such as tables and charts as images. 
 The following example enables the multimodal model to capture the spatial and structural information of the visual content.
 
 - The `embed` method is configured with `embed_modality="text_image"` to embed the extracted tables and charts as images.
-- This configuration is more accurate than text only with a performance cost
+- This configuration is more accurate than text only, with a performance cost.
 
 ```python
+from nemo_retriever import create_ingestor
+
 ingestor = (
-    Ingestor()
+    create_ingestor(run_mode="batch")
     .files("./data/*.pdf")
     .extract()
     .embed(
@@ -58,16 +63,18 @@ For documents where the entire page layout is important (such as infographics, c
 you can configure NeMo Retriever Library to treat every page as a single image.
 The following example extracts and embeds each page as an image.
 
-- The `embed method` processes the page images.
+- The `embed` method processes the page images.
 
 ```python
+from nemo_retriever import create_ingestor
+
 ingestor = (
-    Ingestor()
+    create_ingestor(run_mode="batch")
     .files("./data/*.pdf")
     .extract()
     .embed(
         embed_modality="image",
-        embed_granularity="page"
+        embed_granularity="page",
     )
 )
 results = ingestor.ingest()
@@ -78,4 +85,3 @@ results = ingestor.ingest()
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
 - [Troubleshoot Nemo Retriever Extraction](troubleshoot.md)
 - [Use the Python API](nemo-retriever-api-reference.md)
-- [Extract Captions from Images](nemo-retriever-api-reference.md)

--- a/docs/docs/extraction/environment-config.md
+++ b/docs/docs/extraction/environment-config.md
@@ -3,8 +3,6 @@
 The following are the environment variables that you can use to configure [NeMo Retriever Library](overview.md).
 You can specify these in a .env file in your working directory or directly as shell environment variables.
 
-For **Docker Compose** `.env` files at the **NeMo-Retriever repository root** (unsupported developer tooling only), refer to [`docker.md`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md).
-
 
 ## General Environment Variables
 

--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -25,7 +25,7 @@ For chart-labeled PDF regions and other caption scope limits, see [Are PDF chart
 
 ## Are PDF chart or figure regions captioned when Omni is enabled?
 
-No. Chart-labeled PDF regions are not routed through Omni captioning. See [Charts and infographics](multimodal-extraction.md#charts-and-infographics) and [Image captioning](multimodal-extraction.md#image-captioning) for scope, validation, and what the caption stage covers.
+No. Chart-labeled PDF regions are not routed through Omni captioning. See [Image captioning](prerequisites-support-matrix.md#image-captioning-2605) for scope, validation, and what the caption stage covers.
 
 ## When should I consider advanced visual parsing?
 
@@ -40,7 +40,7 @@ For more information, refer to [Nemotron Parse](https://build.nvidia.com/nvidia/
 For [self-hosted deployments](deployment-options.md#when-to-self-host-nims), you should set the environment variables `NGC_API_KEY` and `NIM_NGC_API_KEY`.
 For more information, refer to [Authentication and API keys](api-keys.md).
 
-For advanced scenarios, you might want to set environment variables for NIM container paths, tags, and batch sizes on the ingestion runtime. Configure them in your Helm values, Kubernetes `Secret`/`ConfigMap`, or follow [Environment variables](environment-config.md). If you use **Docker Compose** locally for experiments only, see the unsupported developer page [docker.md](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md) — **not** a supported deployment substitute for Helm.
+For advanced scenarios, you might want to set environment variables for NIM container paths, tags, and batch sizes on the ingestion runtime. Configure them in your Helm values, Kubernetes `Secret`/`ConfigMap`, or follow [Environment variables](environment-config.md).
 
 ### Library Mode
 

--- a/docs/docs/extraction/getting-started-about.md
+++ b/docs/docs/extraction/getting-started-about.md
@@ -9,7 +9,6 @@ Typical order:
 3. Deploy using one of:
     - [Deployment options](deployment-options.md) for how to run NeMo Retriever Library
     - **Supported:** [Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) for Kubernetes, plus [NeMo Retriever Library install docs](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the published charts
-    - **Unsupported (developer-only):** [Docker Compose (local)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md) — not a supported NIM deployment path
 4. Explore [Jupyter Notebooks](notebooks/index.md) for end-to-end examples.
 
 If you are new to the product, read [What is NeMo Retriever Library?](overview.md) and [Concepts](concepts.md) under **Introduction** first.

--- a/docs/docs/extraction/multimodal-extraction.md
+++ b/docs/docs/extraction/multimodal-extraction.md
@@ -49,7 +49,7 @@ NeMo Retriever Library detects tables as structured page elements, processes the
 
 Charts and infographic regions are classified with other page layout elements (tables, text blocks, titles) and processed through layout detection and OCR. `extract_charts` and `extract_infographics` are enabled by default. Outputs use the same metadata schema as other extracted objects.
 
-Chart-labeled PDF regions are **not** routed through the Omni caption stage; they remain on the layout-and-OCR path. For caption scope and validation, see [Image captioning](#image-captioning).
+Chart-labeled PDF regions are **not** routed through the Omni caption stage; they remain on the layout-and-OCR path. For scope and validation guidance, see [Image captioning](prerequisites-support-matrix.md#image-captioning-2605).
 
 For natural-language infographic descriptions, optionally enable [image captioning](#image-captioning) and set `caption_infographics=True` when you need VLM captions on infographic regions.
 
@@ -63,7 +63,7 @@ For natural-language infographic descriptions, optionally enable [image captioni
 
 Scanned PDFs and image-only pages rely on OCR and hybrid paths that combine native text extraction with OCR when needed. For extract methods such as `ocr` and `pdfium_hybrid`, refer to the [Python API reference](nemo-retriever-api-reference.md).
 
-When you run extraction locally with Hugging Face weights, the default OCR engine is **Nemotron OCR v2**, which operates in **multilingual** mode by default. For CLI flags and API parameters, see [Nemotron OCR v2 — language mode](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docs/cli/README.md#nemotron-ocr-v2-language-mode). For Kubernetes deployment, see [OCR NIM configuration](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#ocr-nim-configuration) in the Helm chart README.
+OCR artifacts depend on how you deploy. **Helm / NIM:** the production chart uses **Nemotron OCR v1** (`nvcr.io/nim/nvidia/nemotron-ocr-v1:1.3.0`). **Local Hugging Face inference:** the default engine is **Nemotron OCR v2**, which operates in **multilingual** mode by default. For CLI flags and API parameters, see [Nemotron OCR v2 — language mode](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docs/cli/README.md#nemotron-ocr-v2-language-mode). For Kubernetes defaults and the Helm-vs-local split, see [OCR artifacts (Helm vs local Hugging Face)](prerequisites-support-matrix.md#nemotron-ocr-v2-language-mode) in the support matrix.
 
 **Related**
 
@@ -77,22 +77,11 @@ Image captioning generates natural-language descriptions for unstructured image 
 
 **Captioning is optional** — enable it in your ingest configuration (for example, the `caption` API or pipeline flag) when you need natural-language descriptions of image content. Reasoning traces are disabled by default for captioning.
 
-!!! important "PDF chart regions are not captioned by Omni"
-
-    When **nemotron-page-elements-v3** classifies a PDF region as **chart**, that region is processed through layout detection and OCR—not the Omni caption stage. Enabling the caption NIM and the `caption` pipeline stage does **not** send chart-labeled figures to `/v1/chat/completions`.
-
-    The caption stage covers:
-
-    - Unstructured content in the `images` column (standalone image files and page-element regions **not** classified as table, chart, or infographic)
-    - Optional infographic regions when you set `caption_infographics=True` on `CaptionParams` (the VLM caption is stored in `caption`, separate from OCR `text`)
-
-    To validate caption traffic during ingest, inspect metadata such as `page_elements_v3_counts_by_label`. If the figure is labeled `chart`, expect no Omni chat-completions requests for that region even when captioning is enabled.
-
 **Related**
 
 - [Multimodal embeddings (VLM)](embedding.md)
 - [Metadata reference](content-metadata.md)
-- [Image captioning — NIM and hardware](prerequisites-support-matrix.md#image-captioning-2605)
+- [Image captioning](prerequisites-support-matrix.md#image-captioning-2605)
 
 ## Metadata and content schema { #metadata-and-content-schema }
 

--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -1,6 +1,6 @@
 # NeMo Retriever API Reference
 
-## PDF pre-splitting for parallel ingest { #pdf-pre-splitting-for-parallel-ingest }
+## PDF pre-splitting for parallel ingest
 
 Large PDFs are split into page batches before Ray processing so extraction can run in parallel. This happens on the default ingest path; you do not need extra configuration for typical workloads.
 

--- a/docs/docs/extraction/nimclient.md
+++ b/docs/docs/extraction/nimclient.md
@@ -13,6 +13,8 @@ For advanced usage patterns, refer to the existing model interfaces in `nemo_ret
 
 ## Quick Start
 
+For ingest and pipeline APIs used with NimClient in UDFs, refer to the [Python API guide](nemo-retriever-api-reference.md).
+
 ### Basic NimClient Creation
 
 ```python

--- a/docs/docs/extraction/notebooks/index.md
+++ b/docs/docs/extraction/notebooks/index.md
@@ -8,18 +8,17 @@ If you plan to run benchmarking or evaluation tests, you must download the [Benc
 
 ## Getting Started
 
-To get started with the basics, try one of the following notebooks:
+To get started with the basics, try one of the following guides or notebooks:
 
-- [CLI Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/cli_client_usage.ipynb)
-- [Python Quick Start Guide](https://github.com/NVIDIA/NeMo-Retriever/blob/main/client/client_examples/examples/python_client_usage.ipynb)
-- [How to add metadata to your documents and filter searches](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/metadata_and_filtered_search.ipynb)
-- [How to reindex a collection](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/reindex_example.ipynb)
+- [Quickstart: retriever CLI](../../reference/retriever-cli-quickstart.md)
+- [Workflow: Ingest documents](../workflow-document-ingestion.md)
+- [How to add metadata to your documents and filter searches](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/nemo_retriever_retriever_query_metadata_filter.ipynb)
 
 
 For more advanced scenarios, try one of the following notebooks:
 
 - [Build a Custom Vector Database Operator](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/building_vdb_operator.ipynb)
-- [Try Enterprise RAG Blueprint](https://github.com/NVIDIA/NeMo-Retriever/blob/main/deploy/pdf-blueprint.ipynb)
+- [Try Enterprise RAG Blueprint](https://build.nvidia.com/nvidia/multimodal-pdf-data-extraction-for-enterprise-rag)
 - [Evaluate bo767 retrieval recall accuracy with NeMo Retriever Library](https://github.com/NVIDIA/NeMo-Retriever/blob/main/evaluation/bo767_recall.ipynb)
 - [Multimodal RAG with LangChain](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/langchain_multimodal_rag.ipynb)
 - [Multimodal RAG with LlamaIndex](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/llama_index_multimodal_rag.ipynb)

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -49,6 +49,5 @@ NeMo Retriever Library supports the following file types:
 - [Deployment options](deployment-options.md) — library, Helm, hosted vs self-hosted NIMs in one place
 - [Deploy on Kubernetes with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)
 - [NeMo Retriever Library — prerequisites / deployment](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) (supported Helm charts)
-- [Docker Compose (unsupported, developer)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md)
 - [Notebooks](notebooks/index.md)
 - [NVIDIA AI Blueprints catalog](https://build.nvidia.com/explore/discover) — solution cards, enterprise RAG blueprints, and end-to-end patterns (including [Enterprise RAG — multimodal PDF data extraction](https://build.nvidia.com/nvidia/multimodal-pdf-data-extraction-for-enterprise-rag)); for integration pathways, refer to [Integrations](integrations-langchain-llamaindex-haystack.md).

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -2,7 +2,7 @@
 
 Before you begin using [NeMo Retriever Library](overview.md), confirm your software stack, deployment hardware, and—if you use them—advanced features (audio and video, Nemotron Parse, VLM image captioning, reranking) against the guidance in this page.
 
-## Software Requirements { #software-requirements }
+## Software Requirements
 
 - Linux operating systems (Ubuntu 22.04 or later recommended)
 - [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads) (NVIDIA Driver >= `580`, CUDA >= `13.0`)
@@ -64,7 +64,7 @@ Ensure your deployment environment meets these specifications before running the
 
 The NeMo Retriever Library extraction core pipeline features run on a single A10G or better GPU.
 
-### Default Helm NIMs { #default-helm-nims }
+### Default Helm NIMs
 
 The production Helm chart enables these NIM microservices **by default** (for example via `nimOperator.*.enabled=true`):
 
@@ -107,11 +107,22 @@ These NIM microservices are **optional** for the default extraction pipeline. Th
 
 For 26.05, use **`nemotron_3_nano_omni_30b_a3b_reasoning`** when you enable the caption stage (hosted model ID `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`). The Helm key is in the [optional NIMs](#optional-helm-nims-not-auto-wired-by-default) table above.
 
+!!! important "PDF chart regions are not captioned by Omni"
+
+    When **nemotron-page-elements-v3** classifies a PDF region as **chart**, that region is processed through layout detection and OCR—not the Omni caption stage. Enabling the caption NIM and the `caption` pipeline stage does **not** send chart-labeled figures to `/v1/chat/completions`.
+
+    The caption stage covers:
+
+    - Unstructured content in the `images` column (standalone image files and page-element regions **not** classified as table, chart, or infographic)
+    - Optional infographic regions when you set `caption_infographics=True` on `CaptionParams` (the VLM caption is stored in `caption`, separate from OCR `text`)
+
+    To validate caption traffic during ingest, inspect metadata such as `page_elements_v3_counts_by_label`. If the figure is labeled `chart`, expect no Omni chat-completions requests for that region even when captioning is enabled.
+
 Optional features listed in the table above require additional GPU support, disk space, and feature-specific system dependencies beyond the four default NIMs.
 
 For published NIM model IDs and deployment-specific constraints, use the product support matrices linked under [Related Topics](#related-topics) below.
 
-## Model Hardware Requirements { #model-hardware-requirements }
+## Model Hardware Requirements
 
 NeMo Retriever Library supports the following GPU hardware given system constraints in the table.
 

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -64,6 +64,7 @@ Highlights for the 26.05 release include:
 
 ### Packaging and platform
 
+- GA PyPI install: `uv pip install nemo-retriever==26.5.0` (refer to the library [quickstart](https://github.com/NVIDIA/NeMo-Retriever/tree/26.05/nemo_retriever#setup-your-environment))
 - Optional install extras (`[local]`, `[multimedia]`, `[llm]`, `[tabular]`, `[nemotron-parse]`, `[service]`, and others), including slim remote/NIM-only installs on Mac and Windows  
 
 ### Helm chart

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -64,7 +64,6 @@ Highlights for the 26.05 release include:
 
 ### Packaging and platform
 
-- GA PyPI install: `uv pip install nemo-retriever==26.5.0` (see the library [quickstart](https://github.com/NVIDIA/NeMo-Retriever/tree/26.05/nemo_retriever#setup-your-environment))
 - Optional install extras (`[local]`, `[multimedia]`, `[llm]`, `[tabular]`, `[nemotron-parse]`, `[service]`, and others), including slim remote/NIM-only installs on Mac and Windows  
 
 ### Helm chart
@@ -73,21 +72,21 @@ Highlights for the 26.05 release include:
 
 ### Documentation
 
-- Documentation aligned to a Helm-first supported path; [Docker Compose for local development](https://github.com/NVIDIA/NeMo-Retriever/blob/26.05/nemo_retriever/docker.md) documented as unsupported developer tooling (not a production NIM deployment path)  
+- Documentation aligned to a Helm-first supported path for NIM and service deployment
 - Documentation consolidates extraction concepts, ingest workflow, embeddings, audio/video guides, prerequisites and support matrix, and UDF/custom stages in the [graph README](https://github.com/NVIDIA/NeMo-Retriever/tree/26.05/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph)  
 
 ## Release Notes for Previous Versions
 
-| [26.03](https://docs.nvidia.com/nemo/retriever/26.3.0/extraction/releasenotes/)
-| [26.1.2](https://docs.nvidia.com/nemo/retriever/26.1.2/extraction/releasenotes/)
-| [26.1.1](https://docs.nvidia.com/nemo/retriever/26.1.1/extraction/releasenotes/)
-| [25.9.0](https://docs.nvidia.com/nemo/retriever/25.9.0/extraction/releasenotes/) 
-| [25.6.3](https://docs.nvidia.com/nemo/retriever/25.6.3/extraction/releasenotes/) 
-| [25.6.2](https://docs.nvidia.com/nemo/retriever/25.6.2/extraction/releasenotes/) 
-| [25.4.2](https://docs.nvidia.com/nemo/retriever/25.4.2/extraction/releasenotes/) 
-| [25.3.0](https://docs.nvidia.com/nemo/retriever/25.3.0/extraction/releasenotes/) 
-| [24.12.1](https://docs.nvidia.com/nemo/retriever/25.3.0/extraction/releasenotes/#release-24121) 
-| [24.12.0](https://docs.nvidia.com/nemo/retriever/25.3.0/extraction/releasenotes/#release-2412) 
+| [26.03](https://docs.nvidia.com/nemo/retriever/26.3.0/extraction/releasenotes-nv-ingest/)
+| [26.1.2](https://docs.nvidia.com/nemo/retriever/26.1.2/extraction/releasenotes-nv-ingest/)
+| [26.1.1](https://docs.nvidia.com/nemo/retriever/26.1.1/extraction/releasenotes-nv-ingest/)
+| [25.9.0](https://docs.nvidia.com/nemo/retriever/25.9.0/extraction/releasenotes-nv-ingest/) 
+| [25.6.3](https://docs.nvidia.com/nemo/retriever/25.6.3/extraction/releasenotes-nv-ingest/) 
+| [25.6.2](https://docs.nvidia.com/nemo/retriever/25.6.2/extraction/releasenotes-nv-ingest/) 
+| [25.4.2](https://docs.nvidia.com/nemo/retriever/25.4.2/extraction/releasenotes-nv-ingest/) 
+| [25.3.0](https://docs.nvidia.com/nemo/retriever/25.3.0/extraction/releasenotes-nv-ingest/) 
+| [24.12.1](https://docs.nvidia.com/nemo/retriever/25.3.0/extraction/releasenotes-nv-ingest/#release-24121) 
+| [24.12.0](https://docs.nvidia.com/nemo/retriever/25.3.0/extraction/releasenotes-nv-ingest/#release-2412) 
 
 ## Related Topics
 

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -186,4 +186,3 @@ ERROR 2025-04-24 22:49:44.434 nimutils.py:68] }
 - [Deployment options](deployment-options.md)
 - [Deploy with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)
 - [NeMo Retriever Library — prerequisites / deployment](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) (supported **Helm** charts)
-- [Docker Compose (unsupported, developer)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/docker.md)

--- a/docs/docs/extraction/vdbs.md
+++ b/docs/docs/extraction/vdbs.md
@@ -32,7 +32,7 @@ It does not store the embeddings for images.
 
     To persist extracted images, tables, and chart renderings to disk or object storage, use the `store` task in addition to `vdb_upload`. The `store` task supports any fsspec-compatible backend (local filesystem, S3, GCS, and other object stores). For details, refer to [Store Extracted Images](nemo-retriever-api-reference.md).
 
-NeMo Retriever Library supports uploading data by using the [Ingestor.vdb_upload API](nemo-retriever-api-reference.md).
+NeMo Retriever Library supports uploading data through `.vdb_upload()` on `create_ingestor(...)` ([Python API guide](nemo-retriever-api-reference.md)).
 Currently, data upload is not supported through the [CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli).
 
 
@@ -51,11 +51,13 @@ This combination of file format, index strategy, and in-process runtime supports
 
 ## Upload to LanceDB { #upload-to-lancedb }
 
-LanceDB uses the `LanceDB` operator class from the client library. You can configure it via the Python API.
+LanceDB uses the `LanceDB` operator class from the client library. You can configure it through the Python API.
 
 ### Programmatic API (Python)
 
-Pass `vdb_op="lancedb"` to `vdb_upload`, or construct a `LanceDB` instance and pass it as `vdb_op`:
+Pass `vdb_op="lancedb"` to `vdb_upload`, or construct a `LanceDB` instance and pass it as `vdb_op`.
+
+For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md).
 
 ```python
 from nemo_retriever.vdb.lancedb import LanceDB
@@ -108,13 +110,13 @@ This page covers LanceDB upload and retrieval. **Metadata is not duplicated here
 
 ## Upload to a Custom Data Store { #upload-to-a-custom-data-store }
 
-You can ingest to other data stores by using the `Ingestor.vdb_upload` method;
+You can ingest to other data stores through `.vdb_upload()` on `create_ingestor(...)`;
 however, you must configure other data stores and connections yourself.
 NeMo Retriever Library does not provide connections to other data sources.
 
 ## Vector database partners { #vector-database-partners }
 
-NeMo Retriever Library integrates with vector databases used for RAG collections. The sections above focus on LanceDB as the shipped backend. This section lists that backend and how partner or custom `VDB` subclasses plug into graph operators. For chunking behavior, see [Chunking](concepts.md#chunking).
+NeMo Retriever Library integrates with vector databases used for RAG collections. The sections above focus on LanceDB as the shipped backend. This section lists that backend and how partner or custom `VDB` subclasses plug into graph operators. For chunking behavior, refer to [Chunking](concepts.md#chunking).
 
 ### Backends with `VDB` implementations (retriever adapters) { #vdb-backends-implementations }
 
@@ -124,9 +126,9 @@ NeMo Retriever graph operators [`IngestVdbOperator`](https://github.com/NVIDIA/N
 |---------|---------|----------------|
 | **LanceDB** | [LanceDB](https://lancedb.com/) · [documentation](https://lancedb.github.io/lancedb/) | [`lancedb.py`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/src/nemo_retriever/vdb/lancedb.py) — pass `vdb_op="lancedb"` (recommended). |
 
-On the ingestion Python client's `Ingestor.vdb_upload`, omitting `vdb_op` does not select LanceDB; see [Upload to LanceDB](#upload-to-lancedb).
+On `GraphIngestor.vdb_upload`, omitting `vdb_op` does not select LanceDB; refer to [Upload to LanceDB](#upload-to-lancedb).
 
-Pass `vdb_op="lancedb"` or a `LanceDB` instance. To integrate another vector database, subclass [`VDB`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/src/nemo_retriever/vdb/adt_vdb.py) and pass your operator instance as `vdb` (see [Build a Custom Vector Database Operator](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/building_vdb_operator.ipynb)).
+Pass `vdb_op="lancedb"` or a `LanceDB` instance. To integrate another vector database, subclass [`VDB`](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/src/nemo_retriever/vdb/adt_vdb.py) and pass your operator instance as `vdb` (refer to [Build a Custom Vector Database Operator](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/building_vdb_operator.ipynb)).
 
 ### RAG Blueprint and partner vector stores { #rag-blueprint-and-partner-vector-stores }
 

--- a/docs/docs/extraction/workflow-document-ingestion.md
+++ b/docs/docs/extraction/workflow-document-ingestion.md
@@ -9,12 +9,12 @@ Document ingestion is the step where NeMo Retriever Library reads your files (PD
 Follow these steps:
 
 1. **Choose how you call the library.** Use the [Python API](nemo-retriever-api-reference.md) or [CLI](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/docs/cli) from application code, or run a deployment (for example [NeMo Retriever Library on GitHub](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever), [Deployment options](deployment-options.md), or [Quickstart: Kubernetes (Helm)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)) and send jobs over the network. Runnable examples appear in [Choose how you call the library](#choose-how-you-call-the-library) below.
-2. **Use parallel PDF handling.** The default ingest path splits large PDFs before Ray processing; see [API guide — PDF pre-splitting](nemo-retriever-api-reference.md#pdf-pre-splitting-for-parallel-ingest).
+2. **Use parallel PDF handling.** The default ingest path splits large PDFs before Ray processing; refer to [API guide — PDF pre-splitting](nemo-retriever-api-reference.md#pdf-pre-splitting-for-parallel-ingest).
 3. **Tune extraction for your content.** Refer to [Multimodal extraction](multimodal-extraction.md) for formats, [text and layout](multimodal-extraction.md#text-and-layout-extraction), [tables](multimodal-extraction.md#tables), [OCR](multimodal-extraction.md#ocr-and-scanned-documents), and related subsections on that page.
 
 Pipeline concepts and stage overview appear in [Key concepts](concepts.md). Default chunking behavior is summarized under [Chunking](concepts.md#chunking).
 
-`create_ingestor(...)` returns a `GraphIngestor`, which chains `.extract()` and `.embed()` but does **not** implement `.vdb_upload()` yet (the base method records the intent only and raises `NotImplementedError` if you call it). To write embeddings into LanceDB after graph ingest, use the `graph_pipeline` CLI below (it performs upload via an internal helper, not the fluent builder) or follow the storage patterns in [Vector databases](vdbs.md). The Python example stops after `.embed()` and returns a dataset you can index in a separate step.
+`create_ingestor(...)` returns a `GraphIngestor`, which chains `.extract()`, `.embed()`, and `.vdb_upload()` into one graph. The Python example below stops after `.embed()` so you can inspect chunks first; append `.vdb_upload(vdb_op="lancedb", vdb_kwargs={...})` before `.ingest()` to write directly to LanceDB (refer to [Vector databases](vdbs.md)). For directory-scale corpus ingest, the `graph_pipeline` CLI below is the canonical path used in evaluation workflows.
 
 ## Choose how you call the library
 
@@ -22,7 +22,7 @@ The following examples match the [NeMo Retriever Library README](https://github.
 
 ### Ingest a test PDF (Python)
 
-The [test PDF](https://github.com/NVIDIA/NeMo-Retriever/blob/main/data/multimodal_test.pdf) contains text, tables, charts, and images. The pipeline below chains `.extract()` and `.embed()` only—**do not** append `.vdb_upload()` on `GraphIngestor`; it is not implemented on this code path.
+The [test PDF](https://github.com/NVIDIA/NeMo-Retriever/blob/main/data/multimodal_test.pdf) contains text, tables, charts, and images. The pipeline below chains `.extract()` and `.embed()` only so you can inspect embedded chunks before indexing. To upload in the same run, append `.vdb_upload(...)` before `.ingest()` (parameter details in the [Python API guide](nemo-retriever-api-reference.md)).
 
 ```python
 from nemo_retriever import create_ingestor
@@ -42,7 +42,7 @@ ingestor = (
     .embed()
 )
 
-chunks = ingestor.ingest()  # ``pandas.DataFrame`` (batch and inprocess)
+result = ingestor.ingest()  # ``pandas.DataFrame`` (``batch`` and ``inprocess``)
 ```
 
 Run the above with your working directory at the repository root (so `data/multimodal_test.pdf` resolves), or adjust `documents` to the absolute path of the test PDF.
@@ -63,4 +63,4 @@ python -m nemo_retriever.examples.graph_pipeline \
 
 For build.nvidia.com hosted inference, set [`NVIDIA_API_KEY`](api-keys.md#nvidia-api-key) and pass the `--*-invoke-url` / `--embed-invoke-url` options shown in the [README remote inference section](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/README.md#ingest-a-test-corpus-cli).
 
-**Next:** [Semantic retrieval](vdbs.md#semantic-retrieval) when serving queries (see also [Evaluate on your data](evaluate-on-your-data.md) for reranking and quality checks).
+**Next:** [Semantic retrieval](vdbs.md#semantic-retrieval) when serving queries (also refer to [Evaluate on your data](evaluate-on-your-data.md) for reranking and quality checks).

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -44,18 +44,10 @@ For **local GPU inference** (Nemotron models running on your GPU), install with 
 ```bash
 uv venv retriever --python 3.12
 source retriever/bin/activate
-uv pip install "nemo-retriever[local]"
+uv pip install "nemo-retriever[local]==26.5.0"
 ```
 
-The `[local]` extra resolves stable Nemotron extraction packages by default. To
-try prerelease/nightly Nemotron packages from PyPI within the same supported
-major-version windows, opt in with `--pre`:
-
-```bash
-uv pip install --pre "nemo-retriever[local]==26.05-RC1"
-```
-
-Install matching **ingestion client** and **ingestion runtime** wheels at the same version when your workflow expects them (see the [NeMo Retriever Library prerequisites](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the exact PyPI coordinates for your release).
+Install matching **ingestion client** and **ingestion runtime** wheels at the same version when your workflow expects them (refer to the [NeMo Retriever Library prerequisites](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the exact PyPI coordinates for your release).
 
 For **remote NIM inference only** (no local GPU required), the base package is sufficient:
 
@@ -63,17 +55,17 @@ For **remote NIM inference only** (no local GPU required), the base package is s
 uv python install 3.12
 uv venv retriever --python 3.12
 source retriever/bin/activate
-uv pip install nemo-retriever
+uv pip install nemo-retriever==26.5.0
 ```
 
-Install matching **ingestion client** and **ingestion runtime** wheels at the same version when your workflow expects them (see the [NeMo Retriever Library prerequisites](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the exact PyPI coordinates for your release).
+Install matching **ingestion client** and **ingestion runtime** wheels at the same version when your workflow expects them (refer to the [NeMo Retriever Library prerequisites](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the exact PyPI coordinates for your release).
 
 This creates a dedicated Python environment and installs the `nemo-retriever` PyPI package, the canonical distribution for the NeMo Retriever Library.
 
 If your PDF pipeline uses `extract_method="nemotron_parse"`, install the Nemotron Parse client dependencies with the `nemotron-parse` extra:
 
 ```bash
-uv pip install "nemo-retriever[nemotron-parse]"
+uv pip install "nemo-retriever[nemotron-parse]==26.5.0"
 ```
 
 For local GPU inference with Nemotron Parse, combine the extras as `nemo-retriever[local,nemotron-parse]`.

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -10,8 +10,9 @@ You’ll set up a CUDA 13–compatible environment, install the library and its 
 
 ## Deployment at a glance
 
-- **Supported (Kubernetes / Helm):** deploy the retriever **service** and optional in-cluster **NIM** workloads with the **[`nemo_retriever/helm` chart](helm/README.md)**. Published **Helm** install and upgrade flows for the full extraction stack are documented in the **[NeMo Retriever Library](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/)** (use together with the chart README for your release).
-- **Unsupported (Docker Compose):** looking for local **Docker Compose** workflows? See **[`docker.md`](docker.md)** — **unsupported developer tooling** for experimentation only, **not** a supported NIM deployment path.
+For Kubernetes deployments, use the **[`nemo_retriever/helm` chart](helm/README.md)** to deploy the retriever **service** and optional in-cluster **NIM** workloads. Published Helm install and upgrade flows for the full extraction stack are documented in the **[NeMo Retriever Library](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/)**; use those docs together with the chart README for your release.
+
+For standalone service-image builds and local container runs, see **[`docker.md`](docker.md)**.
 
 ## Prerequisites
 
@@ -43,7 +44,15 @@ For **local GPU inference** (Nemotron models running on your GPU), install with 
 ```bash
 uv venv retriever --python 3.12
 source retriever/bin/activate
-uv pip install "nemo-retriever[local]==26.5.0"
+uv pip install "nemo-retriever[local]"
+```
+
+The `[local]` extra resolves stable Nemotron extraction packages by default. To
+try prerelease/nightly Nemotron packages from PyPI within the same supported
+major-version windows, opt in with `--pre`:
+
+```bash
+uv pip install --pre "nemo-retriever[local]==26.05-RC1"
 ```
 
 Install matching **ingestion client** and **ingestion runtime** wheels at the same version when your workflow expects them (see the [NeMo Retriever Library prerequisites](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the exact PyPI coordinates for your release).
@@ -54,7 +63,7 @@ For **remote NIM inference only** (no local GPU required), the base package is s
 uv python install 3.12
 uv venv retriever --python 3.12
 source retriever/bin/activate
-uv pip install nemo-retriever==26.5.0
+uv pip install nemo-retriever
 ```
 
 Install matching **ingestion client** and **ingestion runtime** wheels at the same version when your workflow expects them (see the [NeMo Retriever Library prerequisites](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the exact PyPI coordinates for your release).
@@ -64,7 +73,7 @@ This creates a dedicated Python environment and installs the `nemo-retriever` Py
 If your PDF pipeline uses `extract_method="nemotron_parse"`, install the Nemotron Parse client dependencies with the `nemotron-parse` extra:
 
 ```bash
-uv pip install "nemo-retriever[nemotron-parse]==26.5.0"
+uv pip install "nemo-retriever[nemotron-parse]"
 ```
 
 For local GPU inference with Nemotron Parse, combine the extras as `nemo-retriever[local,nemotron-parse]`.
@@ -131,9 +140,7 @@ uv run python nemo_retriever/src/nemo_retriever/examples/batch_pipeline.py /path
 
 ```python
 # ingestor.ingest() actually executes the pipeline
-# batch run_mode returns a ray.data.Dataset; inprocess returns a pandas DataFrame
-dataset = ingestor.ingest()
-chunks = dataset.take_all()  # Ray Dataset API (batch mode)
+chunks = ingestor.ingest()  # pandas.DataFrame (batch and inprocess)
 ```
 
 ### Ingest a test corpus (CLI)
@@ -189,31 +196,27 @@ When you use the remote embedder, pair the `Retriever` with matching
 You can inspect how recall accuracy optimized text chunks for various content types were extracted into text representations:
 ```text
 # page 1 raw text:
->>> chunks[0]["text"]
+>>> chunks.iloc[0]["text"]
 'TestingDocument\r\nA sample document with headings and placeholder text\r\nIntroduction\r\nThis is a placeholder document that can be used for any purpose...'
 
 # markdown formatted table from the first page
 '| Table | 1 |\n| This | table | describes | some | animals, | and | some | activities | they | might | be | doing | in | specific |\n| locations. |\n| Animal | Activity | Place |\n| Giraffe | Driving | a | car | At | the | beach |\n| Lion | Putting | on | sunscreen | At | the | park |\n| Cat | Jumping | onto | a | laptop | In | a | home | office |\n| Dog | Chasing | a | squirrel | In | the | front | yard |\n| Chart | 1 |'
 
 # a chart from the first page
->>> chunks[2]["text"]
+>>> chunks.iloc[2]["text"]
 'Chart 1\nThis chart shows some gadgets, and some very fictitious costs.\nGadgets and their cost\n$160.00\n$140.00\n$120.00\n$100.00\nDollars\n$80.00\n$60.00\n$40.00\n$20.00\n$-\nPowerdrill\nBluetooth speaker\nMinifridge\nPremium desk fan\nHammer\nCost'
 
 # markdown formatting for full pages or documents:
-# document results are keyed by source filename
+# per-page markdown is keyed by page number
 >>> to_markdown_by_page(chunks).keys()
-dict_keys(['multimodal_test.pdf'])
-
-# results per document are keyed by page number
->>> to_markdown_by_page(chunks)["multimodal_test.pdf"].keys()
 dict_keys([1, 2, 3])
 
->>> to_markdown_by_page(chunks)["multimodal_test.pdf"][1]
+>>> to_markdown_by_page(chunks)[1]
 'TestingDocument\r\nA sample document with headings and placeholder text\r\nIntroduction\r\nThis is a placeholder document that can be used for any purpose. It contains some \r\nheadings and some placeholder text to fill the space. The text is not important and contains \r\nno real value, but it is useful for testing. Below, we will have some simple tables and charts \r\nthat we can use to confirm Ingest is working as expected.\r\nTable 1\r\nThis table describes some animals, and some activities they might be doing in specific \r\nlocations.\r\nAnimal Activity Place\r\nGira@e Driving a car At the beach\r\nLion Putting on sunscreen At the park\r\nCat Jumping onto a laptop In a home o@ice\r\nDog Chasing a squirrel In the front yard\r\nChart 1\r\nThis chart shows some gadgets, and some very fictitious costs.\n\n| This | table | describes | some | animals, | and | some | activities | they | might | be | doing | in | specific |\n| locations. |\n| Animal | Activity | Place |\n| Giraffe | Driving | a | car | At | the | beach |\n| Lion | Putting | on | sunscreen | At | the | park |\n| Cat | Jumping | onto | a | laptop | In | a | home | office |\n| Dog | Chasing | a | squirrel | In | the | front | yard |\n| Chart | 1 |\n\nChart 1 This chart shows some gadgets, and some very fictitious costs. Gadgets and their cost $160.00 $140.00 $120.00 $100.00 Dollars $80.00 $60.00 $40.00 $20.00 $- Powerdrill Bluetooth speaker Minifridge Premium desk fan Hammer Cost\n\n### Table 1\n\n| This | table | describes | some | animals, | and | some | activities | they | might | be | doing | in | specific |\n| locations. |\n| Animal | Activity | Place |\n| Giraffe | Driving | a | car | At | the | beach |\n| Lion | Putting | on | sunscreen | At | the | park |\n| Cat | Jumping | onto | a | laptop | In | a | home | office |\n| Dog | Chasing | a | squirrel | In | the | front | yard |\n| Chart | 1 |\n\n### Chart 1\n\nChart 1 This chart shows some gadgets, and some very fictitious costs. Gadgets and their cost $160.00 $140.00 $120.00 $100.00 Dollars $80.00 $60.00 $40.00 $20.00 $- Powerdrill Bluetooth speaker Minifridge Premium desk fan Hammer Cost\n\n### Table 2\n\n| This | table | describes | some | animals, | and | some | activities | they | might | be | doing | in | specific |\n| locations. |\n| Animal | Activity | Place |\n| Giraffe | Driving | a | car | At | the | beach |\n| Lion | Putting | on | sunscreen | At | the | park |\n| Cat | Jumping | onto | a | laptop | In | a | home | office |\n| Dog | Chasing | a | squirrel | In | the | front | yard |\n| Chart | 1 |\n\n### Chart 2\n\nChart 1 This chart shows some gadgets, and some very fictitious costs. Gadgets and their cost $160.00 $140.00 $120.00 $100.00 Dollars $80.00 $60.00 $40.00 $20.00 $- Powerdrill Bluetooth speaker Minifridge Premium desk fan Hammer Cost\n\n### Table 3\n\n| This | table | describes | some | animals, | and | some | activities | they | might | be | doing | in | specific |\n| locations. |\n| Animal | Activity | Place |\n| Giraffe | Driving | a | car | At | the | beach |\n| Lion | Putting | on | sunscreen | At | the | park |\n| Cat | Jumping | onto | a | laptop | In | a | home | office |\n| Dog | Chasing | a | squirrel | In | the | front | yard |\n| Chart | 1 |\n\n### Chart 3\n\nChart 1 This chart shows some gadgets, and some very fictitious costs. Gadgets and their cost $160.00 $140.00 $120.00 $100.00 Dollars $80.00 $60.00 $40.00 $20.00 $- Powerdrill Bluetooth speaker Minifridge Premium desk fan Hammer Cost'
 
-# full document markdown also keyed by source filename
->>> to_markdown(chunks).keys()
-dict_keys(['multimodal_test.pdf'])
+# full document markdown is a single string (or None if empty)
+>>> to_markdown(chunks)[:50]
+'# Extracted Content\n\n## Page 1\n\nTestingDocument\r\nA s'
 ```
 
 Since the ingestion job automatically populated a lancedb table with all these chunks, you can use queries to retrieve semantically relevant chunks for feeding directly into an LLM:
@@ -359,7 +362,11 @@ Live RAG with scoring and an LLM judge (requires a ground-truth `reference`):
 ```python
 from nemo_retriever.llm import LLMJudge
 
-judge = LLMJudge.from_kwargs(model="nvidia_nim/mistralai/mixtral-8x22b-instruct-v0.1")
+judge = LLMJudge.from_kwargs(
+    model="nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5",
+    temperature=0.1,
+    max_tokens=4096,
+)
 result = retriever.answer(
     "What is RAG?",
     llm=llm,
@@ -389,7 +396,7 @@ Scoring tiers on `AnswerResult`:
 
 - **Tier 1** (`answer_in_context`) -- whether retrieval surfaced the evidence; requires `reference`.
 - **Tier 2** (`token_f1`, `exact_match`) -- token-level overlap; requires `reference`.
-- **Tier 3** (`judge_score`, `judge_reasoning`) -- LLM-as-judge 1-5 score; requires `reference` and `judge`.
+- **Tier 3** (`judge_score`) -- dual-judge `AnswerAccuracy` LLM-as-judge score (0.0-1.0), ported from ragas onto `litellm`; requires `reference` and `judge`. `judge_reasoning` is always empty (the metric emits only a rating).
 - `failure_mode` -- derived classification (`correct`, `partial`, `retrieval_miss`, `generation_miss`, `refused_*`, `thinking_truncated`).
 
 If only `reference` is supplied, Tier 1 + 2 run. If only `judge` is supplied (without `reference`), a `ValueError` is raised. On generation error, scoring and judge are skipped and `AnswerResult.error` is populated.
@@ -426,10 +433,12 @@ ingestor = (
 *Note:* the `split_config` keyword on `.extract()` uses a tokenizer to split texts by a max_token length
 ### Render results as markdown
 
-If you want a readable markdown view of extracted results, pass the full in-process result list
-to `nemo_retriever.io.to_markdown`. The helper now returns a `dict[str, str]` keyed by input
-filename, where each value is the document collapsed into one markdown string without per-page
-headers, so both single-document and multi-document runs follow the same contract.
+If you want a readable markdown view of extracted results, pass a single document's extraction
+records to `nemo_retriever.io.to_markdown`. The helper returns one markdown string (or `None`
+if there is no content), with per-page sections joined under a single document heading.
+
+For multi-document runs, pass one document at a time—for example, `to_markdown(results[0])`.
+To build a filename-keyed index across many documents, use `build_page_index`.
 
 PDF text is split at the page level.
 
@@ -443,12 +452,12 @@ ingestor = (
   .extract(split_config={"text": {"max_tokens": 5}, "html": {"max_tokens": 5}}) # 1024 by default, set low here to demonstrate chunking
 )
 results = ingestor.ingest()
-markdown_docs = to_markdown(results)
-print(markdown_docs["multimodal_test.pdf"])
+markdown_doc = to_markdown(results[0])
+print(markdown_doc)
 ```
 
-Use `to_markdown_by_page(results)` when you want a nested
-`dict[str, dict[int, str]]` instead, where each filename maps to its per-page markdown strings.
+Use `to_markdown_by_page(results[0])` when you want a `dict[int, str]` keyed by page
+number instead, where each value is the rendered markdown for that page.
 For audio and video files, ensure ffmpeg is installed by your system's package manager.
 
 For example, with apt-get on Ubuntu:
@@ -592,14 +601,10 @@ This means defaults are deterministic but easy to override when you need fixed b
 |---|---|---|
 | `override_cpu_count`, `override_gpu_count` | function args | Highest-priority CPU/GPU override |
 
-## NIM containers and Docker Compose (unsupported)
+## NIM containers
 
-Looking for local **Docker Compose** workflows (including multi-GPU NIM
-stacks)? See **[`docker.md`](docker.md)** — **unsupported developer tooling**
-only.
-
-For **supported** deployment of NeMo Retriever / **NIM** containers, use
-**Helm**: **[`helm/README.md`](helm/README.md)** and the **NeMo Retriever Library**
+For deployment of NeMo Retriever / **NIM** containers, use **Helm**:
+**[`helm/README.md`](helm/README.md)** and the **NeMo Retriever Library**
 documentation linked from that guide and the
 [NeMo Retriever Library](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/).
 

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -358,8 +358,10 @@ write concurrency.
 
 ### Where results live
 
-- **LanceDB** — `--lancedb-uri lancedb` (default), table `nv-ingest`. Query via
-  `retriever recall vdb-recall …` or `nemo_retriever.retriever.Retriever`.
+- **LanceDB** — `--lancedb-uri lancedb` (default). Default table name depends on the
+  subcommand: `retriever ingest` and `retriever query` use `nemo-retriever`; `retriever
+  pipeline run` still uses `nv-ingest`. Query via `retriever recall vdb-recall …` or
+  `nemo_retriever.retriever.Retriever`.
 - **Parquet** — `--save-intermediate <dir>` writes `<dir>/extraction.parquet`.
 - **Images** — `--store-images-uri <uri>` (local path or fsspec URI). Storage follows
   `--embed-granularity` (page vs element images).
@@ -420,6 +422,10 @@ retriever pipeline run "${PDF_DIR}" \
 - Tune throughput with `--pdf-split-batch-size`, `--pdf-extract-batch-size`, etc.
 
 ### Inspect results
+
+The batch walk-through above uses `retriever pipeline run`, which writes LanceDB table
+`nv-ingest` by default. After `retriever ingest`, use `nemo-retriever` instead (see
+[Inspect the results](#inspect-the-results)).
 
 ```python
 import pyarrow.parquet as pq

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -10,64 +10,67 @@ alongside it as a new-CLI counterpart you can link to or migrate to.
 ## Supported vs development / experimental subcommands
 
 For product use and published examples, treat only these top-level subcommands as
-**supported**:
+the **supported public path**:
 
 - **`retriever ingest`** — ingest documents into LanceDB
 - **`retriever query`** — query an existing LanceDB table
-- **`retriever pipeline`** — run the graph ingestion pipeline (for example `retriever pipeline run`)
 
-Any other top-level `retriever` subcommand — including but not limited to `pdf`, `html`,
-`txt`, `audio`, `chart`, `benchmark`, `harness`, `eval`, `recall`, `service`, `local`,
-`compare`, `image`, and `skill-eval` — is **development and experimental**. These commands
-may change or be removed without notice and **carry no compatibility, stability, or
-behavior guarantees**.
+`retriever pipeline` remains available as a **development / compatibility**
+wrapper, including `retriever pipeline run`, while ingestion behavior migrates
+onto the same implementation used by `retriever ingest`. Prefer `retriever
+ingest` and `retriever query` for user-facing workflows.
+
+Any other top-level `retriever` subcommand — including but not limited to
+`pipeline`, `pdf`, `html`, `txt`, `audio`, `chart`, `benchmark`, `harness`,
+`eval`, `recall`, `service`, `local`, `compare`, `image`, and `skill-eval` —
+is **development and experimental**. These commands may change without public
+compatibility guarantees.
 
 ## Key shape difference
 
 The legacy **ingestion-service** CLI was a **single command that talks to a running REST service on
 `localhost:7670`** and composes work via repeated `--task extract|split|caption|embed|dedup|filter|udf`.
 
-`retriever` is a **multi-subcommand Typer app**. Most of the old CLI examples
-map to `retriever pipeline run INPUT_PATH`, which runs the graph pipeline
-locally (in-process or via Ray) and writes results to LanceDB and, optionally,
-to Parquet / object storage. Other subcommands cover focused tasks:
+`retriever` is a **multi-subcommand Typer app**. Public ingest/query examples
+should map to `retriever ingest INPUT_PATH` followed by `retriever query ...`.
+`retriever pipeline run INPUT_PATH` is still present for development workflows
+that need pipeline-only evaluation, runtime summaries, Parquet export, or
+service-mode compatibility.
 
 | Old intent | New subcommand |
 |------------|----------------|
-| Extract + embed + store a batch of documents | `retriever pipeline run` |
+| Extract + embed + store a batch of documents | `retriever ingest` |
 | Run an ad-hoc PDF extraction stage | `retriever pdf stage` |
 | Run an HTML / text / audio / chart stage | `retriever html run`, `retriever txt run`, `retriever audio extract`, `retriever chart run` |
-| Upload stage output to LanceDB | `retriever ingest` or `retriever pipeline run` |
+| Upload stage output to LanceDB | `retriever ingest` |
 | Query LanceDB + compute recall@k | `retriever recall vdb-recall` |
 | Run a QA evaluation sweep | `retriever eval run` |
 | Serve / submit to the online REST API | `retriever online serve` / `retriever online stream-pdf` |
 | Benchmark stage throughput | `retriever benchmark {split,extract,audio-extract,page-elements,ocr,all}` |
 | Benchmark orchestration | `retriever harness {run,sweep,nightly,summary,compare}` |
 
-Rows that use subcommands other than `ingest`, `query`, or `pipeline` are
+Rows that use subcommands other than `ingest` or `query` are
 [development and experimental](#supported-vs-development--experimental-subcommands).
 
 ## Contents
 
 | Topic | Location | Replaces example(s) in |
 |-------|----------|------------------------|
-| Quick start | [below](#quick-start) | Legacy service quickstart; **Helm** + [NeMo Retriever Library](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/); **Docker Compose** (unsupported): [`docker.md`](https://github.com/NVIDIA/NeMo-Retriever/blob/HEAD/nemo_retriever/docker.md) |
+| Quick start | [below](#quick-start) | Legacy service quickstart; **Helm** + [NeMo Retriever Library](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) |
 | CLI reference | [below](#cli-reference) | Prior `cli-reference` pages under `docs/docs/extraction/` |
 | Client usage walk-through | [below](#client-usage-walk-through) | `client/client_examples/examples/cli_client_usage.ipynb` |
 | PDF pre-splitting | [API guide](../../../docs/docs/extraction/nemo-retriever-api-reference.md#pdf-pre-splitting-for-parallel-ingest); [Large PDF page batches](#large-pdf-page-batches) below | Prior extraction docs |
-| Benchmarking | [`benchmarking.md`](benchmarking.md) | `docs/docs/extraction/benchmarking.md` and `tools/harness/README.md` |
+| Benchmarking | [`benchmarking.md`](benchmarking.md) | `docs/docs/extraction/benchmarking.md` and `nemo_retriever/harness/HANDOFF.md` |
 
 <!-- --8<-- [start:quickstart] -->
 
-> Only `retriever ingest`, `retriever query`, and `retriever pipeline` are supported for
-> product use; see [Supported vs development / experimental subcommands](#supported-vs-development--experimental-subcommands).
+> Use `retriever ingest` and `retriever query` for product-facing workflows.
+> `retriever pipeline` is development / compatibility only; see
+> [Supported vs development / experimental subcommands](#supported-vs-development--experimental-subcommands).
 
 ## Quick start
 
-Local **Docker Compose** workflows are **unsupported developer tooling** only — see
-[`docker.md`](https://github.com/NVIDIA/NeMo-Retriever/blob/HEAD/nemo_retriever/docker.md) (GitHub `HEAD` = default branch; pin to your release tag when not on `main`).
-
-For **supported** deployment of NeMo Retriever / **NIM** containers, use
+For deployment of NeMo Retriever / **NIM** containers, use
 [nemo_retriever/helm](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/helm)
 and the [NeMo Retriever Library](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/)
 Helm install guides.
@@ -75,20 +78,23 @@ Helm install guides.
 ### Ingest a PDF
 
 ```bash
-retriever pipeline run ./data/multimodal_test.pdf \
-  --input-type pdf \
+retriever ingest ./data/multimodal_test.pdf \
   --method pdfium \
   --extract-text --extract-tables --extract-charts \
-  --store-images-uri ./processed_docs/images \
-  --save-intermediate ./processed_docs
+  --use-table-structure \
+  --embed-model-name nvidia/llama-nemotron-embed-1b-v2
 ```
 
-For a lightweight PDF-only workflow:
+Then query the LanceDB table:
 
 ```bash
-retriever ingest ./data/multimodal_test.pdf
-retriever query "What is in this document?"
+retriever query "What is in this document?" \
+  --embed-model-name nvidia/llama-nemotron-embed-1b-v2
 ```
+
+Development-only pipeline features such as `--save-intermediate`, runtime
+summaries, and post-ingest evaluation remain on `retriever pipeline run` while
+the public path is restricted to ingest/query.
 
 Route stages to self-hosted or hosted NIM endpoints by passing only the URLs you
 want to override:
@@ -109,6 +115,44 @@ retriever query "What is in this document?" \
   --reranker-invoke-url https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-vl-1b-v2/reranking
 ```
 
+### Query result controls
+
+`retriever query` returns compact JSON hits with `source`, `page_number`, and `text`.
+By default it retrieves and returns `--top-k` rows. Use these controls when you
+need a wider candidate pool or a narrower result shape:
+
+```bash
+# Retrieve 30 candidates, then return the best 10.
+retriever query "where is the warranty limitation discussed?" \
+  --candidate-k 30
+
+# Keep only the first hit from each document page.
+retriever query "which pages discuss operating costs?" \
+  --top-k 5 \
+  --candidate-k 30 \
+  --page-dedup
+
+# Search a wider pool, then keep only table rows.
+retriever query "annual revenue by region" \
+  --top-k 5 \
+  --candidate-k 40 \
+  --content-types table
+```
+
+`--top-k` is the final number of hits returned. `--candidate-k` is the wider
+candidate pool retrieved before page deduplication, content-type filtering, and
+final truncation. It must be greater than or equal to `--top-k`, and should
+usually be larger when page deduplication or content-type filtering might
+otherwise remove too many of the top retrieved rows. Page deduplication and
+content-type filtering are applied after vector retrieval, preserving the
+retriever's ranking order and truncating the final output to `--top-k`.
+When querying a table ingested with an explicit embedding model, pass the same
+`--embed-model-name` to `retriever query`.
+`--content-types` accepts comma-separated content types such as `text`, `table`,
+`chart`, `image`, and `infographic`. `images` is accepted as an alias for
+captioned image rows emitted by ingest. Hits with missing or unknown content
+types are excluded while `--content-types` is active.
+
 `NVIDIA_API_KEY` is required only when those URLs point at hosted
 build.nvidia.com endpoints. `NGC_API_KEY` is used separately when pulling or
 running self-hosted NIM containers.
@@ -116,28 +160,27 @@ running self-hosted NIM containers.
 ### What you get
 
 - Extracted text, tables, and charts as rows in LanceDB at `./lancedb` (default
-  table name `nv-ingest`).
-- Per-document Parquet under `./processed_docs/` (`--save-intermediate`).
-- Image assets under `./processed_docs/images/` (`--store-images-uri`).
+  table name `nemo-retriever`).
+- Compact JSON retrieval hits from `retriever query`, including source, page,
+  and text fields.
+- Extracted image assets when `retriever ingest` is run with
+  `--store-images-uri`.
+- Pipeline-only development artifacts such as extraction Parquet, runtime
+  summaries, and evaluation reports remain available through
+  `retriever pipeline run`.
 - Progress and stage logs on stderr.
 
 ### Inspect the results
 
 ```bash
-ls ./processed_docs
-ls ./processed_docs/images
 ls ./lancedb
 ```
 
 ```python
-import pyarrow.parquet as pq
 import lancedb
 
-df = pq.read_table("./processed_docs").to_pandas()
-print(df.head())
-
 db = lancedb.connect("./lancedb")
-tbl = db.open_table("nv-ingest")
+tbl = db.open_table("nemo-retriever")
 print(tbl.to_pandas().head())
 ```
 
@@ -146,7 +189,14 @@ Or query via the Retriever Python client (`nemo_retriever/README.md`):
 ```python
 from nemo_retriever.retriever import Retriever
 
-retriever = Retriever(vdb_kwargs={"uri": "lancedb", "table_name": "nv-ingest"}, top_k=5)
+retriever = Retriever(
+    vdb_kwargs={"uri": "lancedb", "table_name": "nemo-retriever"},
+    embed_kwargs={
+        "model_name": "nvidia/llama-nemotron-embed-1b-v2",
+        "embed_model_name": "nvidia/llama-nemotron-embed-1b-v2",
+    },
+    top_k=5,
+)
 hits = retriever.query(
     "Given their activities, which animal is responsible for the typos?"
 )
@@ -167,27 +217,27 @@ hits = retriever.query(
 `retriever` is the Typer app installed with the `nemo-retriever` package. Subcommand
 support policy: [Supported vs development / experimental subcommands](#supported-vs-development--experimental-subcommands).
 
-Document ingestion is usually `retriever pipeline run INPUT_PATH`, which runs the graph pipeline
-locally (in-process or Ray) and writes rows to LanceDB and optional Parquet.
+Document ingestion for users is `retriever ingest INPUT_PATH`, followed by
+`retriever query` for retrieval. `retriever pipeline run INPUT_PATH` is retained
+as a development / compatibility wrapper for pipeline-only behavior.
 
 ```bash
 retriever --version
 retriever --help
-retriever pipeline run --help
+retriever ingest --help
+retriever query --help
 ```
 
 ### Extract a PDF with defaults
 
 ```bash
-retriever pipeline run ./data/test.pdf \
-  --input-type pdf \
-  --run-mode inprocess \
-  --save-intermediate ./processed_docs
+retriever ingest ./data/test.pdf \
+  --run-mode inprocess
 ```
 
-Results go to LanceDB (`./lancedb`, table `nv-ingest` by default) and, with
-`--save-intermediate`, to Parquet under `./processed_docs`. Inspect rows with
-`pyarrow.parquet` or LanceDB queries (not per-content-type `*.metadata.json` files).
+Results go to LanceDB (`./lancedb`, table `nemo-retriever` by default). Use
+`retriever pipeline run --save-intermediate` only when you need development
+Parquet artifacts.
 
 ### Text chunking and PDF page batches
 
@@ -310,7 +360,7 @@ write concurrency.
 
 - **LanceDB** — `--lancedb-uri lancedb` (default), table `nv-ingest`. Query via
   `retriever recall vdb-recall …` or `nemo_retriever.retriever.Retriever`.
-- **Parquet** — `--save-intermediate <dir>` for the extraction DataFrame.
+- **Parquet** — `--save-intermediate <dir>` writes `<dir>/extraction.parquet`.
 - **Images** — `--store-images-uri <uri>` (local path or fsspec URI). Storage follows
   `--embed-granularity` (page vs element images).
 
@@ -375,7 +425,7 @@ retriever pipeline run "${PDF_DIR}" \
 import pyarrow.parquet as pq
 import lancedb
 
-df = pq.read_table(OUTPUT_DIRECTORY_BATCH).to_pandas()
+df = pq.read_table(f"{OUTPUT_DIRECTORY_BATCH}/extraction.parquet").to_pandas()
 print(df[["source_id", "text", "content_type"]].head())
 
 db = lancedb.connect("./lancedb")
@@ -404,8 +454,9 @@ for these cases:
 
 - Input paths assume you invoke `retriever` from the `nemo_retriever/`
   directory (or point at absolute paths).
-- `--save-intermediate <dir>` writes the extraction DataFrame as Parquet for
-  inspection. LanceDB output goes to `--lancedb-uri` (defaults to `./lancedb`).
+- `--save-intermediate <dir>` writes the extraction DataFrame as
+  `<dir>/extraction.parquet` for inspection. LanceDB output goes to `--lancedb-uri`
+  (defaults to `./lancedb`).
 - `--store-images-uri <uri>` stores extracted image assets to a local path or
   an fsspec URI (e.g. `s3://bucket/prefix`). Page granularity stores page
   images; element granularity stores element images.

--- a/nemo_retriever/docs/cli/benchmarking.md
+++ b/nemo_retriever/docs/cli/benchmarking.md
@@ -4,23 +4,17 @@
 with no guarantees — see [Supported vs development / experimental subcommands](README.md#supported-vs-development--experimental-subcommands).
 
 This page covers benchmark workflows for NeMo Retriever Library. See also
-`docs/docs/extraction/benchmarking.md`, [`tools/harness/README.md`](../../../tools/harness/README.md)
-(legacy integration harness), and [`nemo_retriever/harness/HANDOFF.md`](../../harness/HANDOFF.md)
-(the harness behind `retriever harness`).
+`docs/docs/extraction/benchmarking.md` for published extraction benchmark notes and
+[`nemo_retriever/harness/HANDOFF.md`](../../harness/HANDOFF.md) for operator-oriented
+notes on `retriever harness`.
 
-There are two harness stacks:
+Use `retriever harness` for benchmark orchestration and `retriever benchmark` for
+per-stage micro-benchmarks.
 
-| Stack | How you run it | Config |
-|-------|----------------|--------|
-| **Legacy** (`tools/harness/`) | `python -m nv_ingest_harness.cli.run` from `tools/harness/` | `tools/harness/test_configs.yaml` |
-| **Retriever CLI** (`nemo_retriever.harness`) | `retriever harness run` | `nemo_retriever/harness/test_configs.yaml` |
-
-The `retriever` CLI also exposes per-stage `retriever benchmark …` micro-benchmarks.
-
-## Retriever harness (development / experimental)
+## Harness (development / experimental)
 
 Run from the repository root (or any directory; pass `--config` if needed). Uses
-`--dataset` and `--preset` — there is no `--case` flag on this harness.
+`--dataset` and `--preset` against `nemo_retriever/harness/test_configs.yaml`.
 
 ```bash
 # Named dataset from nemo_retriever/harness/test_configs.yaml
@@ -60,28 +54,6 @@ Image persistence is configured on `retriever pipeline run`, not on the harness.
 Use `--store-images-uri <uri>` (local path or fsspec URI). Stored assets follow
 `--embed-granularity` (page vs element images).
 
-## Legacy `tools/harness` (nv_ingest_harness)
-
-Unsupported developer tooling; kept for older CI and compose/helm managed runs.
-After `cd tools/harness`, omit `--project tools/harness` — uv finds `pyproject.toml`
-in the current directory.
-
-```bash
-cd tools/harness
-uv sync
-uv pip install -e .
-
-uv run python -m nv_ingest_harness.cli.run --case=e2e --dataset=bo767
-uv run python -m nv_ingest_harness.cli.run --case=e2e --dataset=/path/to/your/data
-uv run python -m nv_ingest_harness.cli.run --case=e2e --dataset=bo767 --managed
-```
-
-From the **repo root** without `cd`, use the project flag:
-
-```bash
-uv run --project tools/harness python -m nv_ingest_harness.cli.run --case=e2e --dataset=bo767
-```
-
 ## Per-stage micro-benchmarks
 
 Stage throughput benchmarks on the main CLI (no full harness required):
@@ -106,16 +78,12 @@ retriever benchmark extract ./data/pdf_corpus \
 
 Each benchmark reports rows/sec (or chunk rows/sec for audio) for its actor.
 
-## Parity notes
+## Notes
 
-- **Not a drop-in flag map:** legacy harness uses `--case=e2e`; `retriever harness`
-  uses `--dataset` / `--preset` / `--override KEY=VALUE` against
+- **Configuration:** `retriever harness` uses `--dataset` / `--preset` /
+  `--override KEY=VALUE` against
   `nemo_retriever/harness/test_configs.yaml`.
-- **Datasets:** names like `bo767` and `jp20` exist in both configs but paths and
-  defaults may differ; check the YAML for each stack.
 - **Launcher:** for internal benchmarking, `retriever harness run …` is the
-  retriever-CLI entry point (development / experimental; no guarantees). Use
-  `nv_ingest_harness` when you still depend on `--case` or `--managed` behavior in
-  `tools/harness/README.md`.
+  benchmark orchestration entry point (development / experimental; no guarantees).
 - **Stage benchmarks:** `retriever benchmark …` is specific to the retriever CLI and
-  has no legacy service-CLI equivalent.
+  covers per-stage throughput rather than full harness orchestration.

--- a/nemo_retriever/helm/README.md
+++ b/nemo_retriever/helm/README.md
@@ -6,8 +6,6 @@ streams uploads through a set of NVIDIA NIM microservices
 (page-elements, table-structure, OCR, VLM embed by default) and exposes
 result + status APIs over HTTP / SSE.
 
-**Unsupported developer path:** ad-hoc **Docker Compose** workflows (not
-chart-managed) are documented separately in [`../docker.md`](../docker.md).
 Use **Helm** (this chart and/or the **additional Library charts** documented in the
 [NeMo Retriever Library](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/))
 for supported NIM and service deployment.
@@ -936,6 +934,155 @@ kubectl get hpa <release>-realtime -o jsonpath='{.metadata.annotations.nemo-retr
 The dashboard's *Worker Pool Capacity* card on the **Overview** page
 mirrors the same signal Prometheus is seeing, so it's a quick eyeball
 sanity check before opening Grafana.
+
+---
+
+## OpenShift deployment { #openshift-deployment }
+
+The chart defaults target generic Kubernetes clusters that allow fixed numeric
+UIDs (`runAsUser` / `runAsGroup` / `fsGroup` **1000**). **OpenShift 4.x**
+namespaces under the default **restricted-v2** Security Context Constraint (SCC)
+and **Pod Security Admission (PSA) `restricted`** profile assign a per-namespace
+UID/GID range instead. A stock `helm install` without overrides therefore fails
+SCC validation, emits PSA warnings, or crashes on log paths the random UID cannot
+write.
+
+We do **not** change chart defaults for OpenShift-only behavior (that would affect
+other platforms). Use the overrides below on OpenShift, or save the YAML block
+into a local values file and pass `-f <file>`.
+
+### Cluster posture (typical QA / hardened namespaces)
+
+| Control | Typical default on a new OpenShift project |
+| --- | --- |
+| SCC | **restricted-v2** (first match in priority order) |
+| PSA | `pod-security.kubernetes.io/warn=restricted` (and often `audit=restricted`; `enforce` may be unset on dev clusters) |
+| UID assignment | SCC injects `runAsUser` / `fsGroup` from the namespace range (for example `1000750000–1000759999`) |
+
+On clusters with **PSA `enforce=restricted`**, missing container `securityContext`
+fields become hard rejections, not warnings.
+
+### Override reference (maps to chart limitations)
+
+| Symptom on stock install | Cause | Helm override |
+| --- | --- | --- |
+| `FailedCreate`: UID/GID **1000** not in namespace range | Hardcoded `service.podSecurityContext` UID/GID/fsGroup | Omit `runAsUser`, `runAsGroup`, and `fsGroup`; keep only `runAsNonRoot: true` |
+| PSA warning: `allowPrivilegeEscalation`, capabilities, `seccompProfile` | Empty `service.securityContext` | Set restricted baseline on `service.securityContext` (see sample below) |
+| `PermissionError` on `/var/lib/nemo-retriever/retriever-service.log` when `persistence.enabled=false` | Default log path is image-owned; random UID cannot write without a PVC | Point `serviceConfig.logging.file` at `/tmp/...` (chart mounts `emptyDir` at `/tmp`) |
+| `CreateContainerConfigError`: non-numeric image `USER nemo` on **vectordb** | Vectordb container has no `securityContext` block for SCC to annotate | Disable vectordb for smoke tests, or patch the vectordb Deployment after install (below) |
+| PSA warnings on **otel-collector** | Otel Deployment has no `securityContext` in the chart | `topology.otel.enabled=false` unless you patch that Deployment |
+
+### Recommended value overrides
+
+```yaml
+# OpenShift overrides for nemo-retriever Helm chart (restricted-v2 / PSA restricted).
+# Save locally, then: helm install retriever ./nemo_retriever/helm -f <your-file>.yaml ...
+
+service:
+  podSecurityContext:
+    runAsNonRoot: true
+    # Do NOT set runAsUser, runAsGroup, or fsGroup — OpenShift SCC assigns them.
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop: ["ALL"]
+    seccompProfile:
+      type: RuntimeDefault
+
+serviceConfig:
+  logging:
+    # Writable without persistence PVC (chart always mounts emptyDir at /tmp).
+    file: /tmp/retriever-service.log
+  vectordb:
+    # Set false for minimal service-only validation; see vectordb patch below if enabled.
+    enabled: false
+
+topology:
+  otel:
+    enabled: false
+```
+
+When **`persistence.enabled=true`**, you can keep the default log path under
+`persistence.mountPath` (`/var/lib/nemo-retriever`) because the PVC is mounted and
+SCC-assigned `fsGroup` applies. When persistence is off, always relocate logs to
+`/tmp` (or another path backed by `service.extraVolumes`).
+
+### Example install on OpenShift 4.20 (service-only smoke test)
+
+Matches QA validation with external NIMs disabled, no persistence, and no results
+PVC:
+
+```bash
+oc new-project nemo-retriever
+
+oc create secret docker-registry ngc-secret -n nemo-retriever \
+  --docker-server=nvcr.io --docker-username='$oauthtoken' \
+  --docker-password="$NGC_API_KEY"
+
+oc create secret generic ngc-api -n nemo-retriever \
+  --from-literal=NGC_API_KEY="$NGC_API_KEY" \
+  --from-literal=NGC_CLI_API_KEY="$NGC_API_KEY"
+
+helm install retriever ./nemo_retriever/helm -n nemo-retriever \
+  -f <your-openshift-overrides>.yaml \
+  --set ngcImagePullSecret.create=false \
+  --set ngcApiSecret.create=false \
+  --set nims.enabled=false \
+  --set persistence.enabled=false \
+  --set retrieverResults.enabled=false
+```
+
+Verify pods:
+
+```bash
+oc get pods -n nemo-retriever
+oc describe pod -l app.kubernetes.io/name=nemo-retriever -n nemo-retriever
+```
+
+You should see SCC-assigned numeric `runAsUser` on containers that declare a
+`securityContext` block, and no PSA warnings once overrides are applied.
+
+### Enabling the vectordb Deployment on OpenShift
+
+`serviceConfig.vectordb.enabled=true` renders a **vectordb** container from the
+same image (`USER nemo`, non-numeric). The chart does not yet expose a
+`securityContext` value for that container. After `helm install`, patch the
+Deployment so OpenShift can inject a numeric UID into the container spec:
+
+```bash
+RELEASE=retriever
+NS=nemo-retriever
+VDB_DEPLOY="${RELEASE}-nemo-retriever-vectordb"
+
+oc patch deployment "$VDB_DEPLOY" -n "$NS" --type=json -p='[
+  {"op": "add", "path": "/spec/template/spec/containers/0/securityContext", "value": {
+    "allowPrivilegeEscalation": false,
+    "capabilities": {"drop": ["ALL"]},
+    "runAsNonRoot": true,
+    "seccompProfile": {"type": "RuntimeDefault"}
+  }}
+]'
+```
+
+Re-apply the patch after `helm upgrade` if the Deployment is recreated. A future
+chart release may add first-class `topology.vectordb.securityContext` values.
+
+### Enabling the OpenTelemetry collector on OpenShift
+
+The chart’s otel-collector Deployment likewise lacks `securityContext` fields.
+Prefer `topology.otel.enabled=false` (as in the sample values) unless you operate
+your own collector or patch `*-otel` the same way as vectordb.
+
+### What we intentionally do not require on OpenShift
+
+Do **not** bind the namespace to **anyuid** SCC or set PSA `enforce=privileged`
+unless your security team explicitly approves it. The overrides above are intended
+to keep **restricted-v2** / PSA **restricted** posture.
+
+### Related documentation
+
+- [Pre-Requisites & Support Matrix](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/prerequisites-support-matrix.md)
+- [Deployment options](https://github.com/NVIDIA/NeMo-Retriever/blob/main/docs/docs/extraction/deployment-options.md)
 
 ---
 


### PR DESCRIPTION
## Summary

- Reconcile product documentation drift between `main` and `26.05` after several NVBugs doc fixes landed on `26.05` before `main`.
- Establishes `main` as the canonical source for extraction docs, package README, CLI docs, and Helm README on the release branch.
- Includes CLI quickstart fix for default LanceDB table `nemo-retriever` (NVBug 6262625) and latest `releasenotes.md` from `main`.

## Why this happened

During the 26.05 GA push, many doc fixes were merged directly to `26.05` while `main` continued to receive post-GA doc and code changes independently. This PR is a one-shot realignment: copy the current product-doc trees from `main` onto `26.05` rather than replaying individual cherry-picks.

## Scope

21 files only (no code, CI, or agent artifacts):

- `docs/docs/extraction/**`
- `nemo_retriever/docs/**`
- `nemo_retriever/README.md`
- `nemo_retriever/helm/README.md`
