### PR TITLE
docs: fix mkdocstrings paths after nemo_retriever reorg (#2215)

### DIFF
--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -73,7 +73,7 @@ Use the following procedure to run the NIM on your own infrastructure. Self-host
 
     ```python
     from nemo_retriever import create_ingestor
-    from nemo_retriever.params.models import ASRParams
+    from nemo_retriever.common.params.models import ASRParams
 
     ingestor = (
         create_ingestor(run_mode="batch")
@@ -102,7 +102,7 @@ Instead of running the pipeline locally, you can call Parakeet through [build.nv
 
     ```python
     from nemo_retriever import create_ingestor
-    from nemo_retriever.params.models import ASRParams
+    from nemo_retriever.common.params.models import ASRParams
 
     ingestor = (
         create_ingestor(run_mode="batch")

--- a/docs/docs/extraction/custom-metadata.md
+++ b/docs/docs/extraction/custom-metadata.md
@@ -94,7 +94,7 @@ table = db.open_table("nemo_retriever_collection")
 **`Retriever.query` + `where`:** LanceDB applies the predicate before ranking. For post-filter logic in Python, use a wider `top_k` first.
 
 ```python
-from nemo_retriever.retriever import Retriever
+from nemo_retriever.graph.retriever import Retriever
 
 retriever = Retriever(
     vdb_kwargs={"uri": "./lancedb_data", "table_name": "nemo_retriever_collection"},

--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -13,6 +13,6 @@ To tune splitter throughput from the CLI, use `--pdf-split-batch-size` (Ray acto
       filters:
         - "!^pdf_split_config$"
 
-::: nemo_retriever.retriever
+::: nemo_retriever.graph.retriever
 
-::: nemo_retriever.params
+::: nemo_retriever.common.params


### PR DESCRIPTION
## Summary
- Restore NRL GitHub Pages MkDocs build on main after PR #2215 moved `params` and `retriever` into new package buckets.
- Update mkdocstrings directives and doc code samples to `nemo_retriever.common.params` and `nemo_retriever.graph.retriever`.`n
## Test plan
- [ ] NRL documentation — GitHub Pages workflow passes on merge
- [ ] `mkdocs build -f mkdocs.yml --strict` succeeds locally from `docs/` with `pip install -e ./nemo_retriever`