### PR TITLE
Support inference hub rerank endpoint

### DIFF
--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -115,6 +115,21 @@ retriever query "What is in this document?" \
   --reranker-invoke-url https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-nemotron-rerank-vl-1b-v2/reranking
 ```
 
+For NVIDIA inference hub rerank models that expose the Cohere-style rerank
+route, pass the full `/v1/rerank` URL and the model name shown in the hub
+snippet:
+
+```bash
+export NGC_INFERENCE_API_KEY=...
+
+retriever query "What is in this document?" \
+  --embed-invoke-url https://integrate.api.nvidia.com/v1/embeddings \
+  --embed-model-name nvidia/llama-nemotron-embed-1b-v2 \
+  --reranker-invoke-url https://inference-api.nvidia.com/v1/rerank \
+  --reranker-model-name nvidia/nvidia/llama-3.2-nv-rerankqa-1b-v2 \
+  --reranker-api-key-env NGC_INFERENCE_API_KEY
+```
+
 ### Query result controls
 
 `retriever query` returns compact JSON hits with `source`, `page_number`, and `text`.

--- a/nemo_retriever/src/nemo_retriever/cli/main.py
+++ b/nemo_retriever/src/nemo_retriever/cli/main.py
@@ -187,6 +187,16 @@ def _version_callback(value: bool) -> None:
     raise typer.Exit()
 
 
+def _api_key_from_env_option(env_key: str | None) -> str | None:
+    key = (env_key or "").strip()
+    if not key:
+        return None
+    value = os.environ.get(key, "").strip()
+    if not value:
+        raise ValueError(f"{key} is not set or is empty.")
+    return value
+
+
 def main() -> None:
     app()
 
@@ -783,7 +793,15 @@ def query_command(
         "--embed-model-name",
         help="Optional embedding model name override.",
     ),
-    reranker_invoke_url: str | None = typer.Option(None, "--reranker-invoke-url", help="Reranker NIM endpoint URL."),
+    reranker_invoke_url: str | None = typer.Option(None, "--reranker-invoke-url", help="Reranker endpoint URL."),
+    reranker_api_key_env: str | None = typer.Option(
+        None,
+        "--reranker-api-key-env",
+        help=(
+            "Environment variable containing the bearer token for --reranker-invoke-url. "
+            "If omitted, NVIDIA_API_KEY / NGC_API_KEY is used when set."
+        ),
+    ),
     reranker_model_name: str | None = typer.Option(
         None,
         "--reranker-model-name",
@@ -841,35 +859,38 @@ def query_command(
     rerank = rerank or bool(reranker_invoke_url) or bool(reranker_model_name) or bool(reranker_backend)
     _silence_noisy_libraries()
 
-    def _run(use_hybrid: bool) -> list:
-        return query_documents(
-            QueryRequest(
-                query=query,
-                retrieval=QueryRetrievalOptions(
-                    top_k=top_k,
-                    candidate_k=candidate_k,
-                    page_dedup=page_dedup,
-                    content_types=content_types,
-                    hybrid=use_hybrid,
-                ),
-                embed=QueryEmbedOptions(
-                    embed_invoke_url=embed_invoke_url,
-                    embed_model_name=embed_model_name,
-                ),
-                rerank=QueryRerankOptions(
-                    enabled=rerank,
-                    reranker_invoke_url=reranker_invoke_url,
-                    reranker_model_name=reranker_model_name,
-                    reranker_backend=reranker_backend,
-                ),
-                storage=QueryStorageOptions(
-                    lancedb_uri=lancedb_uri,
-                    table_name=table_name,
-                ),
-            )
-        )
-
     try:
+        reranker_api_key = _api_key_from_env_option(reranker_api_key_env) if reranker_invoke_url else None
+
+        def _run(use_hybrid: bool) -> list:
+            return query_documents(
+                QueryRequest(
+                    query=query,
+                    retrieval=QueryRetrievalOptions(
+                        top_k=top_k,
+                        candidate_k=candidate_k,
+                        page_dedup=page_dedup,
+                        content_types=content_types,
+                        hybrid=use_hybrid,
+                    ),
+                    embed=QueryEmbedOptions(
+                        embed_invoke_url=embed_invoke_url,
+                        embed_model_name=embed_model_name,
+                    ),
+                    rerank=QueryRerankOptions(
+                        enabled=rerank,
+                        reranker_invoke_url=reranker_invoke_url,
+                        reranker_model_name=reranker_model_name,
+                        reranker_backend=reranker_backend,
+                        reranker_api_key=reranker_api_key,
+                    ),
+                    storage=QueryStorageOptions(
+                        lancedb_uri=lancedb_uri,
+                        table_name=table_name,
+                    ),
+                )
+            )
+
         with _quiet_capture():
             if hybrid:
                 try:

--- a/nemo_retriever/src/nemo_retriever/harness/portal/app.py
+++ b/nemo_retriever/src/nemo_retriever/harness/portal/app.py
@@ -34,10 +34,7 @@ from fastapi.responses import FileResponse, Response, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
-from apscheduler.triggers.cron import CronTrigger
-
 from nemo_retriever.harness import history
-from nemo_retriever.harness import scheduler as sched_module
 from nemo_retriever.harness.config import VALID_EVALUATION_MODES
 
 mimetypes.add_type("text/javascript", ".jsx")
@@ -56,6 +53,13 @@ if not STATIC_DIR.is_dir():
 
 GITHUB_WEBHOOK_SECRET = os.environ.get("RETRIEVER_HARNESS_GITHUB_SECRET", "")
 GITHUB_REPO_URL_OVERRIDE = os.environ.get("RETRIEVER_HARNESS_GITHUB_REPO_URL", "")
+
+
+def _scheduler_module() -> Any:
+    """Import the scheduler only for code paths that use it."""
+    from nemo_retriever.harness import scheduler
+
+    return scheduler
 
 
 def _url_to_github_web(raw_url: str) -> str:
@@ -148,13 +152,14 @@ async def _runner_health_check_loop():
 async def _lifespan(app: FastAPI):
     _seed_default_run_code_ref()
     _init_mcp_server()
-    sched_module.start_scheduler()
+    scheduler = _scheduler_module()
+    scheduler.start_scheduler()
     global _runner_health_task
     _runner_health_task = asyncio.create_task(_runner_health_check_loop())
     yield
     if _runner_health_task:
         _runner_health_task.cancel()
-    sched_module.stop_scheduler()
+    scheduler.stop_scheduler()
 
 
 def _seed_default_run_code_ref() -> None:
@@ -2853,7 +2858,9 @@ def _compute_next_run(cron_expression: str, count: int = 1) -> list[str]:
     Returns ISO-8601 UTC strings.
     """
     try:
-        cron_kwargs = sched_module._parse_cron_expression(cron_expression)
+        from apscheduler.triggers.cron import CronTrigger
+
+        cron_kwargs = _scheduler_module()._parse_cron_expression(cron_expression)
         trigger = CronTrigger(**cron_kwargs)
         now = datetime.now(timezone.utc)
         times: list[str] = []
@@ -2917,7 +2924,7 @@ async def list_upcoming(count: int = Query(10, ge=1, le=50)):
 async def create_schedule(req: ScheduleCreateRequest):
     data = req.model_dump(exclude_unset=True)
     schedule = history.create_schedule(data)
-    sched_module.sync_schedule(schedule["id"])
+    _scheduler_module().sync_schedule(schedule["id"])
     return schedule
 
 
@@ -2935,7 +2942,7 @@ async def update_schedule_endpoint(schedule_id: int, req: ScheduleUpdateRequest)
         raise HTTPException(status_code=404, detail="Schedule not found")
     data = req.model_dump(exclude_unset=True)
     schedule = history.update_schedule(schedule_id, data)
-    sched_module.sync_schedule(schedule_id)
+    _scheduler_module().sync_schedule(schedule_id)
     return schedule
 
 
@@ -2943,14 +2950,14 @@ async def update_schedule_endpoint(schedule_id: int, req: ScheduleUpdateRequest)
 async def delete_schedule_endpoint(schedule_id: int):
     if not history.delete_schedule(schedule_id):
         raise HTTPException(status_code=404, detail="Schedule not found")
-    sched_module.sync_schedule(schedule_id)
+    _scheduler_module().sync_schedule(schedule_id)
     return {"ok": True}
 
 
 @app.post("/api/schedules/{schedule_id}/trigger")
 async def trigger_schedule(schedule_id: int):
     """Manually fire a schedule now, bypassing the cron timer."""
-    job = sched_module.trigger_schedule_now(schedule_id)
+    job = _scheduler_module().trigger_schedule_now(schedule_id)
     if job is None:
         raise HTTPException(status_code=404, detail="Schedule not found")
     return job
@@ -2993,7 +3000,7 @@ async def github_webhook(request: Request):
     if not repo_full or not branch:
         return {"ok": True, "skipped": True, "reason": "missing repo or branch"}
 
-    dispatched = sched_module.handle_github_webhook(repo_full, branch, commit_sha)
+    dispatched = _scheduler_module().handle_github_webhook(repo_full, branch, commit_sha)
     return {"ok": True, "dispatched": len(dispatched), "jobs": [j["id"] for j in dispatched]}
 
 
@@ -3541,7 +3548,7 @@ async def deploy_latest(req: DeployRequest):
         time.sleep(2)
         logger.info("Restarting portal process after deploy…")
         try:
-            sched_module.stop_scheduler()
+            _scheduler_module().stop_scheduler()
         except Exception:
             pass
         os.execv(sys.executable, [sys.executable] + sys.argv)

--- a/nemo_retriever/src/nemo_retriever/operators/rerank.py
+++ b/nemo_retriever/src/nemo_retriever/operators/rerank.py
@@ -12,9 +12,9 @@ Provides:
 Remote endpoint
 ---------------
 When ``rerank_invoke_url`` is set the actor/function calls a vLLM (>=0.14) or NIM
-server that exposes the NIM ranking REST API. The helper accepts
-either a fully qualified ``.../reranking`` URL or a base URL and appends
-``/v1/ranking`` automatically::
+server that exposes a ranking REST API. The helper accepts fully qualified
+``.../reranking``, ``.../v1/ranking``, or ``.../v1/rerank`` URLs. Other base
+URLs append ``/v1/ranking`` automatically::
 
     POST /v1/ranking
     {
@@ -89,6 +89,91 @@ def _default_rerank_invoke_url(model_name: str | None) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _normalize_rerank_endpoint(endpoint: str) -> str:
+    cleaned_endpoint = endpoint.rstrip("/")
+    if cleaned_endpoint.endswith(("/reranking", "/ranking", "/rerank")):
+        return cleaned_endpoint
+    return f"{cleaned_endpoint}/v1/ranking"
+
+
+def _uses_v1_rerank_schema(url: str) -> bool:
+    return url.rstrip("/").endswith("/rerank")
+
+
+def _set_score(scores: List[float], index: Any, score: Any) -> None:
+    if index is None or score is None:
+        return
+    try:
+        i = int(index)
+        parsed_score = float(score)
+    except (TypeError, ValueError):
+        return
+    if 0 <= i < len(scores):
+        scores[i] = parsed_score
+
+
+def _nim_ranking_payload(
+    query: str,
+    documents: List[str],
+    model_name: str,
+    images_b64: Optional[List[Optional[str]]],
+) -> dict[str, Any]:
+    passages = []
+    for i, d in enumerate(documents):
+        entry: Dict[str, Any] = {"text": d}
+        if images_b64 and i < len(images_b64) and images_b64[i]:
+            entry["image"] = images_b64[i]
+        passages.append(entry)
+    return {
+        "model": model_name,
+        "query": {"text": query},
+        "passages": passages,
+        "truncate": "END",
+    }
+
+
+def _v1_rerank_payload(
+    query: str,
+    documents: List[str],
+    model_name: str,
+    images_b64: Optional[List[Optional[str]]],
+) -> dict[str, Any]:
+    if images_b64 and any(images_b64):
+        raise ValueError("The /v1/rerank endpoint only supports text documents; use a /reranking endpoint for images.")
+    return {
+        "model": model_name,
+        "query": query,
+        "documents": documents,
+        "top_n": len(documents),
+    }
+
+
+def _nim_ranking_scores(data: Any, n_documents: int) -> List[float]:
+    scores = [float("-inf")] * n_documents
+    if not isinstance(data, dict):
+        return scores
+    rankings = data.get("rankings")
+    if not isinstance(rankings, list):
+        return scores
+    for item in rankings:
+        if isinstance(item, dict):
+            _set_score(scores, item.get("index"), item.get("logit"))
+    return scores
+
+
+def _v1_rerank_scores(data: Any, n_documents: int) -> List[float]:
+    scores = [float("-inf")] * n_documents
+    if not isinstance(data, dict):
+        return scores
+    results = data.get("results")
+    if not isinstance(results, list):
+        return scores
+    for item in results:
+        if isinstance(item, dict):
+            _set_score(scores, item.get("index"), item.get("relevance_score"))
+    return scores
+
+
 def _rerank_via_endpoint(
     query: str,
     documents: List[str],
@@ -101,12 +186,15 @@ def _rerank_via_endpoint(
     """
     Call a vLLM / NIM ranking endpoint and return per-document scores.
 
-    The server must expose the ranking API used by NeMo Retriever and NIM. Pass
-    either a full ``.../reranking`` URL or a base URL; base URLs are
-    normalized to ``.../v1/ranking``::
+    The server must expose a supported ranking API. Pass a full
+    ``.../reranking``, ``.../v1/ranking``, or ``.../v1/rerank`` URL. Base URLs
+    are normalized to ``.../v1/ranking``::
 
         POST {endpoint}/v1/ranking
         {"model": ..., "query": {"text": ...}, "passages": [{"text": ...}]}
+
+        POST https://inference-api.nvidia.com/v1/rerank
+        {"model": ..., "query": "...", "documents": ["..."], "top_n": N}
 
     Parameters
     ----------
@@ -117,7 +205,7 @@ def _rerank_via_endpoint(
     endpoint:
         Base URL of the reranking endpoint (e.g. ``http://localhost:8015
         ``). The function will append ``/v1/ranking`` if the URL does not
-        already end with ``/reranking``.
+        already end with ``/reranking``, ``/ranking``, or ``/rerank``.
     model_name:
         Model identifier sent to the remote endpoint (default
         ``"nvidia/llama-nemotron-rerank-1b-v2"``).
@@ -132,36 +220,21 @@ def _rerank_via_endpoint(
     """
     import requests
 
-    cleaned_endpoint = endpoint.rstrip("/")
-    if not cleaned_endpoint.endswith("/reranking"):
-        cleaned_endpoint = endpoint.rstrip("/") + "/v1/ranking"
-    url = cleaned_endpoint
+    url = _normalize_rerank_endpoint(endpoint)
+    use_v1_rerank_schema = _uses_v1_rerank_schema(url)
     headers = {"accept": "application/json", "Content-Type": "application/json"}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
-    passages = []
-    for i, d in enumerate(documents):
-        entry: Dict[str, Any] = {"text": d}
-        if images_b64 and i < len(images_b64) and images_b64[i]:
-            entry["image"] = images_b64[i]
-        passages.append(entry)
-    payload = {
-        "model": model_name,
-        "query": {"text": query},
-        "passages": passages,
-        "truncate": "END",
-    }
+    if use_v1_rerank_schema:
+        payload = _v1_rerank_payload(query, documents, model_name, images_b64)
+    else:
+        payload = _nim_ranking_payload(query, documents, model_name, images_b64)
     response = requests.post(url, json=payload, headers=headers)
     response.raise_for_status()
     data = response.json()
-    # Build score list aligned with input document order.
-    scores = [float("-inf")] * len(documents)
-    for item in data.get("rankings", []):
-        idx = item.get("index")
-        score = item.get("logit")
-        if idx is not None and score is not None:
-            scores[idx] = float(score)
-    return scores
+    if use_v1_rerank_schema:
+        return _v1_rerank_scores(data, len(documents))
+    return _nim_ranking_scores(data, len(documents))
 
 
 # ---------------------------------------------------------------------------

--- a/nemo_retriever/src/nemo_retriever/query/options.py
+++ b/nemo_retriever/src/nemo_retriever/query/options.py
@@ -31,6 +31,7 @@ class QueryRerankOptions:
     reranker_invoke_url: str | None = None
     reranker_model_name: str | None = None
     reranker_backend: str | None = None
+    reranker_api_key: str | None = None
 
 
 @dataclass(frozen=True)

--- a/nemo_retriever/src/nemo_retriever/query/workflow.py
+++ b/nemo_retriever/src/nemo_retriever/query/workflow.py
@@ -22,7 +22,7 @@ def _build_rerank_kwargs(options: QueryRerankOptions) -> dict[str, str]:
         rerank_kwargs: dict[str, str] = {"rerank_invoke_url": reranker_url}
         if options.reranker_model_name:
             rerank_kwargs["model_name"] = options.reranker_model_name
-        api_key = resolve_remote_api_key()
+        api_key = resolve_remote_api_key(options.reranker_api_key)
         if api_key is not None:
             rerank_kwargs["api_key"] = api_key
         return rerank_kwargs

--- a/nemo_retriever/tests/test_nemotron_rerank_v2.py
+++ b/nemo_retriever/tests/test_nemotron_rerank_v2.py
@@ -482,6 +482,36 @@ class TestRerankViaEndpoint:
         assert scores[1] == 0.5  # index 1
         assert scores[2] == 0.1  # index 2
 
+    def test_posts_to_inference_api_rerank_url(self):
+        from nemo_retriever.operators.rerank import _rerank_via_endpoint
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "results": [
+                {"index": 1, "relevance_score": 0.7},
+                {"index": 0, "relevance_score": 0.2},
+            ]
+        }
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            scores = _rerank_via_endpoint(
+                "What is ML?",
+                ["Machine learning is...", "Paris is..."],
+                endpoint="https://inference-api.nvidia.com/v1/rerank",
+                model_name="nvidia/nvidia/llama-3.2-nv-rerankqa-1b-v2",
+            )
+
+        call_args = mock_post.call_args
+        assert call_args[0][0] == "https://inference-api.nvidia.com/v1/rerank"
+        assert call_args[1]["json"] == {
+            "model": "nvidia/nvidia/llama-3.2-nv-rerankqa-1b-v2",
+            "query": "What is ML?",
+            "documents": ["Machine learning is...", "Paris is..."],
+            "top_n": 2,
+        }
+        assert scores == [0.2, 0.7]
+
     def test_authorization_header_sent_when_api_key_provided(self):
         from nemo_retriever.operators.rerank import _rerank_via_endpoint
 

--- a/nemo_retriever/tests/test_retriever_queries.py
+++ b/nemo_retriever/tests/test_retriever_queries.py
@@ -104,6 +104,41 @@ class TestQueriesGraphExecution:
         retriever.queries(["q"])
         assert resolved.execute.call_args.kwargs["top_k"] == 12
 
+    def test_rerank_dataframe_output_orders_hits_by_score(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        vector_hits = [
+            {"text": "vector retrieval winner", "source": "vector.pdf", "page_number": 1},
+            {"text": "reranker winner", "source": "rerank.pdf", "page_number": 2},
+        ]
+        execute_kwargs: list[dict[str, Any]] = []
+
+        class FakeResolvedGraph:
+            def execute(self, _df: pd.DataFrame, **kwargs: Any) -> list[Any]:
+                execute_kwargs.append(kwargs)
+                return [
+                    pd.DataFrame(
+                        [
+                            {
+                                "query": "q",
+                                "text": "vector retrieval winner",
+                                "_hit": vector_hits[0],
+                                "rerank_score": 0.1,
+                            },
+                            {"query": "q", "text": "reranker winner", "_hit": vector_hits[1], "rerank_score": 0.9},
+                        ]
+                    )
+                ]
+
+        class FakeGraph:
+            def resolve_for_local_execution(self) -> FakeResolvedGraph:
+                return FakeResolvedGraph()
+
+        monkeypatch.setattr(Retriever, "_build_default_graph", lambda self, *, embed_extra=None: FakeGraph())
+
+        out = _make_retriever(top_k=1, rerank=True).query("q")
+
+        assert out == [{"text": "reranker winner", "source": "rerank.pdf", "page_number": 2, "_rerank_score": 0.9}]
+        assert [call["top_k"] for call in execute_kwargs] == [4]
+
     def test_query_delegates_to_queries(self) -> None:
         retriever = _make_retriever()
         expected = _make_hits(2)

--- a/nemo_retriever/tests/test_root_query_cli.py
+++ b/nemo_retriever/tests/test_root_query_cli.py
@@ -197,6 +197,61 @@ def test_root_query_passes_reranker_url(monkeypatch) -> None:
     assert json.loads(result.output) == []
 
 
+def test_root_query_passes_reranker_api_key_env(monkeypatch) -> None:
+    retriever_calls: list[dict[str, Any]] = []
+    monkeypatch.delenv("NVIDIA_API_KEY", raising=False)
+    monkeypatch.delenv("NGC_API_KEY", raising=False)
+    monkeypatch.setenv("NGC_INFERENCE_API_KEY", "inference-secret")
+
+    class FakeRetriever:
+        def __init__(self, **kwargs: Any) -> None:
+            retriever_calls.append(kwargs)
+
+        def query(self, query: str, **_kwargs: Any) -> list[dict[str, Any]]:
+            return []
+
+    monkeypatch.setattr(query_core, "Retriever", FakeRetriever)
+
+    result = RUNNER.invoke(
+        cli_main.app,
+        [
+            "query",
+            "Which passages mention deployment?",
+            "--reranker-invoke-url",
+            "https://inference-api.nvidia.com/v1/rerank",
+            "--reranker-model-name",
+            "nvidia/nvidia/llama-3.2-nv-rerankqa-1b-v2",
+            "--reranker-api-key-env",
+            "NGC_INFERENCE_API_KEY",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert retriever_calls[0]["rerank_kwargs"] == {
+        "rerank_invoke_url": "https://inference-api.nvidia.com/v1/rerank",
+        "model_name": "nvidia/nvidia/llama-3.2-nv-rerankqa-1b-v2",
+        "api_key": "inference-secret",
+    }
+
+
+def test_root_query_reports_missing_reranker_api_key_env() -> None:
+    result = RUNNER.invoke(
+        cli_main.app,
+        [
+            "query",
+            "Which passages mention deployment?",
+            "--reranker-invoke-url",
+            "https://inference-api.nvidia.com/v1/rerank",
+            "--reranker-api-key-env",
+            "NGC_INFERENCE_API_KEY",
+        ],
+        env={"NVIDIA_API_KEY": "", "NGC_API_KEY": "", "NGC_INFERENCE_API_KEY": ""},
+    )
+
+    assert result.exit_code == 1
+    assert "Error: NGC_INFERENCE_API_KEY is not set or is empty." in result.output
+
+
 def test_root_query_rerank_flag_enables_local_rerank(monkeypatch) -> None:
     """``--rerank`` alone enables rerank with the local VL default model."""
     retriever_calls: list[dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- Preserve fully qualified `/v1/rerank` URLs instead of appending `/v1/ranking`.
- Use the inference-hub rerank request/response schema for `/v1/rerank`.
- Add explicit `--reranker-api-key-env` so root query can use `NGC_INFERENCE_API_KEY` without global auth fallback.

## CI note
- Fixed a pre-existing `upstream/main` portal import boundary issue exposed by CI: `harness.portal.app` eagerly imported scheduler-only APScheduler modules during test collection. The PR now lazy-loads those scheduler dependencies only on scheduler code paths.

## Validation
- `uv run --no-dev --extra dev pytest tests/test_remote_auth.py tests/test_query_workflow_options.py tests/test_nemotron_rerank_v2.py::TestRerankViaEndpoint tests/test_nemotron_rerank_vl_v2_hf.py::TestRerankViaEndpointVL tests/test_retriever_queries.py::TestQueriesGraphExecution tests/test_retriever_queries.py::TestRerankLongDataframe tests/test_root_query_cli.py`
- `uv run --no-dev --extra dev pytest tests/test_harness_config.py -q`
- `uv tool run pre-commit run --all-files`
- Live JP20 query against `https://inference-api.nvidia.com/v1/rerank` returned reranked pages `[13, 53, 14, 60, 15, 52, 62, 35, 36, 62]`.