### PR TITLE
docs: add explicit section link anchors on cross-linked pages

### DIFF
--- a/docs/docs/extraction/concepts.md
+++ b/docs/docs/extraction/concepts.md
@@ -2,19 +2,19 @@
 
 These terms appear throughout NeMo Retriever Library documentation.
 
-## Job
+## Job { #job }
 
 An **ingestion job** is a unit of work you run on input content (documents, audio, video, and other supported types). You submit jobs through the **ingestor Python API** (for example `Ingestor` task chains such as `.extract(...)`) or the **`retriever ingest` CLI**—not by posting a standalone JSON job document. Default tasks target strong recall; customize behavior with task keyword arguments (including chunking and splitting on `.extract()`) or custom UDF-style operations ([NeMo Retriever graph](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph)). Results are structured metadata and annotations (Ray Dataset, pandas `DataFrame`, or similar).
 
-## Pipeline and tasks
+## Pipeline and tasks { #pipeline-and-tasks }
 
 NeMo Retriever Library does **not** run one static pipeline on every document. You configure **tasks** such as parsing, chunking, embedding, storage, and filtering per job. Related topics: [Extending/Customizing NeMo Retriever Library with custom code](https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph).
 
-## Extraction metadata
+## Extraction metadata { #extraction-metadata }
 
 Output is a **Ray Dataset** (Ray Data) or **pandas** `DataFrame` listing extracted objects (text regions, tables, images, and so on), processing notes, and timing or trace data. Field-level detail is in the [metadata reference](content-metadata.md).
 
-## Embeddings and retrieval
+## Embeddings and retrieval { #embeddings-and-retrieval }
 
 Optionally, the library can compute **embeddings** for extracted content and store vectors in [LanceDB](https://lancedb.com/) for downstream semantic search in your application. For upload and retrieval APIs, see [Vector databases](vdbs.md). For multimodal (VLM) embedding options, see [Multimodal embeddings (VLM)](embedding.md).
 
@@ -32,7 +32,7 @@ For PDF parallelism before Ray processing (large files), see [PDF pre-splitting 
 
 Token-based splitting uses the Llama 3.2 1B tokenizer (default `meta-llama/Llama-3.2-1B`) with configurable `max_tokens` and `overlap_tokens` when you add an explicit `.split(...)` stage or when the pipeline applies the default text segmentation for unstructured text. In the shipped NeMo Retriever container, tokenizer assets are included locally, so you do not need `HF_ACCESS_TOKEN` for this default path. If your runtime loads the tokenizer from the Hugging Face Hub instead (for example, some library-only installs), set `HF_ACCESS_TOKEN` or pass `hf_access_token` in task params when the Hub requires it. Details appear in the [Python API guide](nemo-retriever-api-reference.md).
 
-## Deployment modes
+## Deployment modes { #deployment-modes }
 
 - **Library mode** — Run without the full container stack where appropriate; see [Deployment options](deployment-options.md).
 - **Kubernetes / Helm (self-hosted)** — See [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) and [deployment options](deployment-options.md) for running the full microservices pipeline on your infrastructure.

--- a/docs/docs/extraction/deployment-options.md
+++ b/docs/docs/extraction/deployment-options.md
@@ -49,7 +49,7 @@ environments), use a custom service image that already contains `ffmpeg` and
 2. [Throughput is dataset-dependent](multimodal-extraction.md#extraction-limitations-and-quality)
 3. [Evaluate on your data](evaluate-on-your-data.md)
 
-## When to use NVIDIA-hosted NIMs
+## When to use NVIDIA-hosted NIMs { #when-to-use-nvidia-hosted-nims }
 
 [NVIDIA-hosted NIMs](https://build.nvidia.com/) run inference on NVIDIA-managed infrastructure. You call models with API keys (refer to [Get your API key](api-keys.md)) without operating GPU nodes yourself.
 
@@ -61,7 +61,7 @@ Consider hosted NIMs when:
 
 **Also refer to:** [NVIDIA NIM catalog](https://build.nvidia.com/)
 
-## When to self-host NIMs
+## When to self-host NIMs { #when-to-self-host-nims }
 
 Self-hosted NIMs run on your GPUs or air-gapped hardware, typically with Kubernetes and the [NIM Operator](https://docs.nvidia.com/nim-operator/latest/index.html).
 

--- a/docs/docs/extraction/nemo-retriever-api-reference.md
+++ b/docs/docs/extraction/nemo-retriever-api-reference.md
@@ -1,6 +1,6 @@
 # NeMo Retriever API Reference
 
-## PDF pre-splitting for parallel ingest
+## PDF pre-splitting for parallel ingest { #pdf-pre-splitting-for-parallel-ingest }
 
 Large PDFs are split into page batches before Ray processing so extraction can run in parallel. This happens on the default ingest path; you do not need extra configuration for typical workloads.
 

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -2,7 +2,19 @@
 
 Before you begin using [NeMo Retriever Library](overview.md), confirm your software stack, deployment hardware, and—if you use them—advanced features (audio and video, Nemotron Parse, VLM image captioning, reranking) against the guidance in this page.
 
-## Software Requirements
+## On this page { #on-this-page }
+
+- [Software Requirements](#software-requirements)
+- [Hardware Requirements](#hardware-requirements)
+- [Core and Advanced Pipeline Features](#core-and-advanced-pipeline-features)
+    - [Default Helm NIMs](#default-helm-nims)
+    - [OCR artifacts (Helm vs local Hugging Face)](#nemotron-ocr-v2-language-mode)
+    - [Optional Helm NIMs (not auto-wired)](#optional-helm-nims-not-auto-wired-by-default)
+    - [Image captioning (26.05)](#image-captioning-2605)
+- [Model Hardware Requirements](#model-hardware-requirements)
+- [Related Topics](#related-topics)
+
+## Software Requirements { #software-requirements }
 
 - Linux operating systems (Ubuntu 22.04 or later recommended)
 - [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads) (NVIDIA Driver >= `580`, CUDA >= `13.0`)
@@ -23,7 +35,7 @@ Before you begin using [NeMo Retriever Library](overview.md), confirm your softw
 
     When you use UV, create the environment with Python 3.12 — for example, `uv venv --python 3.12`. This matches the `requires-python` metadata in the library packages.
 
-## Hardware Requirements
+## Hardware Requirements { #hardware-requirements }
 
 The full ingestion pipeline is designed to consume significant CPU and memory resources to achieve maximal parallelism. 
 Resource usage scales up to the limits of your deployed system.
@@ -60,11 +72,11 @@ For production deployments processing large volumes of documents, consider:
 
 Ensure your deployment environment meets these specifications before running the full pipeline. Resource-constrained environments may experience performance degradation.
 
-## Core and Advanced Pipeline Features
+## Core and Advanced Pipeline Features { #core-and-advanced-pipeline-features }
 
 The NeMo Retriever Library extraction core pipeline features run on a single A10G or better GPU.
 
-### Default Helm NIMs
+### Default Helm NIMs { #default-helm-nims }
 
 The production Helm chart enables these NIM microservices **by default** (for example via `nimOperator.*.enabled=true`):
 
@@ -122,7 +134,7 @@ Optional features listed in the table above require additional GPU support, disk
 
 For published NIM model IDs and deployment-specific constraints, use the product support matrices linked under [Related Topics](#related-topics) below.
 
-## Model Hardware Requirements
+## Model Hardware Requirements { #model-hardware-requirements }
 
 NeMo Retriever Library supports the following GPU hardware given system constraints in the table.
 
@@ -158,7 +170,7 @@ Model repositories and NIM references are linked in [Core and Advanced Pipeline 
 To perform recall testing with the reranker on these GPUs, shut down the core pipeline NIM microservices 
 and run only the embedder, reranker, and your vector database.
 
-## Related Topics
+## Related Topics { #related-topics }
 
 - [Troubleshooting](troubleshoot.md)
 - [Release Notes](releasenotes.md)

--- a/docs/docs/extraction/workflow-document-ingestion.md
+++ b/docs/docs/extraction/workflow-document-ingestion.md
@@ -2,7 +2,7 @@
 
 This page covers extracting content from documents and turning that content into a searchable vector collection in one place so you can scroll and search (for example with Ctrl+F) instead of jumping across multiple short workflow stubs.
 
-## Ingest and extract
+## Ingest and extract { #ingest-and-extract }
 
 Document ingestion is the step where NeMo Retriever Library reads your files (PDFs, Office documents, images, and other [supported formats](multimodal-extraction.md#supported-file-types-and-formats)), runs extraction and optional enrichment, and returns structured content you can embed and index.
 
@@ -16,7 +16,7 @@ Pipeline concepts and stage overview appear in [Key concepts](concepts.md). Defa
 
 `create_ingestor(...)` returns a `GraphIngestor`, which chains `.extract()`, `.embed()`, and `.vdb_upload()` into one graph. The Python example below stops after `.embed()` so you can inspect chunks first; append `.vdb_upload(vdb_op="lancedb", vdb_kwargs={...})` before `.ingest()` to write directly to LanceDB (refer to [Vector databases](vdbs.md)). For directory-scale corpus ingest, the `graph_pipeline` CLI below is the canonical path used in evaluation workflows.
 
-## Choose how you call the library
+## Choose how you call the library { #choose-how-you-call-the-library }
 
 The following examples match the [NeMo Retriever Library README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/README.md). They assume a checkout of the [NeMo Retriever](https://github.com/NVIDIA/NeMo-Retriever) repository and the `batch` run mode with local GPU inference unless you configure remote NIMs.
 


### PR DESCRIPTION
## Summary

- Add stable `{ #anchor }` IDs to heavily cross-linked sections on the support matrix, deployment options, API reference, concepts, and document-ingestion workflow pages
- Add an "On this page" mini-TOC to `prerequisites-support-matrix.md`, matching the pattern already used on `vdbs.md` and `multimodal-extraction.md`
- Follow-up to reviewer feedback to generally add more link anchors so cross-page fragments survive heading edits

## Test plan

- [ ] `cd docs && mkdocs build -f mkdocs.yml --strict` (optional local verify)
- [ ] Confirm inbound links still resolve: `#software-requirements`, `#default-helm-nims`, `#model-hardware-requirements`, `#when-to-self-host-nims`, `#when-to-use-nvidia-hosted-nims`, `#pdf-pre-splitting-for-parallel-ingest`, `#choose-how-you-call-the-library`
- [ ] Spot-check support matrix "On this page" links in built HTML
