### PR TITLE
docs: crosslink Python API guide adjacent to python snippets

### DIFF
--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -100,6 +100,8 @@ Instead of running the pipeline locally, you can call Parakeet through [build.nv
 
 2. Run inference from Python with the hosted gRPC endpoint and credentials from that page (the example below uses the default hosted gRPC hostname; confirm values in the **Get API Key** flow for your deployment). Pass hosted endpoint, function ID, and API key through `ASRParams` (`audio_endpoints`, `function_id`, `auth_token`).
 
+    For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md).
+
     ```python
     from nemo_retriever import create_ingestor
     from nemo_retriever.common.params.models import ASRParams

--- a/docs/docs/extraction/custom-metadata.md
+++ b/docs/docs/extraction/custom-metadata.md
@@ -93,6 +93,8 @@ table = db.open_table("nemo_retriever_collection")
 
 **`Retriever.query` + `where`:** LanceDB applies the predicate before ranking. For post-filter logic in Python, use a wider `top_k` first.
 
+For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md).
+
 ```python
 from nemo_retriever.graph.retriever import Retriever
 

--- a/docs/docs/extraction/embedding.md
+++ b/docs/docs/extraction/embedding.md
@@ -12,14 +12,14 @@ The model can embed documents in the form of an image, text, or a combination of
 Documents can then be retrieved given a user query in text form. 
 The model supports images that contain text, tables, charts, and infographics.
 
-Parameter details for `.extract()` and `.embed()` appear in the [Python API guide](nemo-retriever-api-reference.md).
-
 ## Example with Default Text-Based Embedding
 
 When you use the multimodal model, by default, all extracted content (text, tables, charts) is treated as plain text. 
 The following example provides a strong baseline for retrieval.
 
 - The `embed` method is called with no arguments.
+
+For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md).
 
 ```python
 from nemo_retriever import create_ingestor
@@ -41,6 +41,8 @@ The following example enables the multimodal model to capture the spatial and st
 
 - The `embed` method is configured with `embed_modality="text_image"` to embed the extracted tables and charts as images.
 - This configuration is more accurate than text only, with a performance cost.
+
+For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md).
 
 ```python
 from nemo_retriever import create_ingestor
@@ -64,6 +66,8 @@ you can configure NeMo Retriever Library to treat every page as a single image.
 The following example extracts and embeds each page as an image.
 
 - The `embed` method processes the page images.
+
+For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md).
 
 ```python
 from nemo_retriever import create_ingestor

--- a/docs/docs/extraction/nimclient.md
+++ b/docs/docs/extraction/nimclient.md
@@ -64,6 +64,8 @@ client = create_inference_client(
 
 To integrate a new NIM, you need to create a custom `ModelInterface` subclass that implements the required methods.
 
+For ingest pipeline APIs used with custom NIMs, refer to the [Python API guide](nemo-retriever-api-reference.md).
+
 ### Basic Model Interface Template
 
 ```python
@@ -258,6 +260,8 @@ class MyCustomModelInterface(ModelInterface):
 
 ## Real-World Examples
 
+For parameter details on ingest and pipeline APIs, refer to the [Python API guide](nemo-retriever-api-reference.md).
+
 ### Text Generation Model Interface
 
 ```python
@@ -376,6 +380,8 @@ class ImageAnalysisModelInterface(ModelInterface):
 ```
 
 ## Using NimClient in UDFs
+
+For ingest pipeline APIs used in UDFs, refer to the [Python API guide](nemo-retriever-api-reference.md).
 
 ### Basic UDF with NimClient
 
@@ -513,6 +519,8 @@ export NIM_MAX_RETRIES=5
 
 ### Error Handling
 
+For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md).
+
 ```python
 def robust_nim_udf(control_message: IngestControlMessage) -> IngestControlMessage:
     """UDF with comprehensive error handling."""
@@ -563,6 +571,8 @@ If you encounter memory issues, try increasing the `NIM_TRITON_CUDA_MEMORY_POOL_
 If memory issues persist, you can reduce the `NIM_TRITON_RATE_LIMIT` value — even down to 1. However, lowering this parameter affects performance.
 
 ### Debugging Tips
+
+For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md).
 
 ```python
 import logging


### PR DESCRIPTION
## Summary

Apply reviewer guidance: every ` ```python ` fence on extraction doc pages should have a same-section crosslink to the [Python API guide](docs/docs/extraction/nemo-retriever-api-reference.md) (per `.cursor/rules/nrl-python-snippet-api-crosslinks.mdc`).

**Updated pages**
- `embedding.md` — one crosslink per example section (three `##` sections)
- `audio-video.md` — hosted Parakeet example (Helm section already had a link)
- `custom-metadata.md` — `Retriever.query` filter example (pseudocode block unchanged)
- `nimclient.md` — section-level crosslinks for ModelInterface, UDF, error-handling, and debugging sections

**Already compliant** (no changes): `workflow-document-ingestion.md`, `faq.md`, `vdbs.md`, `custom-metadata.md` (ingest snippet), `audio-video.md` (Helm snippet).

## Test plan

- [ ] Spot-check rendered pages: crosslink appears immediately above each runnable python fence
- [ ] `rg '```python' docs/docs/extraction -l` vs pages with `nemo-retriever-api-reference` in same section
