### PR TITLE
docs(extraction): fix remaining NVBugs 6179241 links for 26.3.0

### DIFF
--- a/docs/docs/extraction/audio.md
+++ b/docs/docs/extraction/audio.md
@@ -27,7 +27,7 @@ to transcribe speech to text, which is then embedded by using the NeMo Retriever
 
 !!! important
 
-    Due to limitations in available VRAM controls in the current release, the RIVA ASR NIM microservice must run on a [dedicated additional GPU](support-matrix.md). For the full list of requirements, refer to [Support Matrix](https://docs.nvidia.com/deeplearning/riva/user-guide/docs/support-matrix/support-matrix.html).
+    Due to limitations in available VRAM controls in the current release, the RIVA ASR NIM microservice must run on a [dedicated additional GPU](support-matrix.md). For the full list of requirements, refer to [Support Matrix](https://docs.nvidia.com/deeplearning/riva/user-guide/docs/public/support-matrix/support-matrix.html).
 
 This pipeline enables users to retrieve speech files at the segment level.
 

--- a/docs/docs/extraction/quickstart-guide.md
+++ b/docs/docs/extraction/quickstart-guide.md
@@ -400,7 +400,7 @@ multimodal_test.pdf.metadata.json
 
 For the full metadata definitions, refer to [Content Metadata](content-metadata.md). 
 
-We also provide a script for inspecting [extracted images](https://github.com/NVIDIA/nv-ingest/blob/main/src/util/image_viewer.py).
+We also provide a script for inspecting [extracted images](https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/src/util/image_viewer.py).
 
 First, install `tkinter` by running the following code. Choose the code for your OS.
 

--- a/docs/docs/extraction/user-defined-functions.md
+++ b/docs/docs/extraction/user-defined-functions.md
@@ -304,7 +304,7 @@ UDFs can be executed at different stages of the pipeline by specifying the `targ
 - `broker_response` - Response message handling
 - `otel_tracer` - OpenTelemetry tracing
 
-> **Note:** For the complete and up-to-date list of pipeline stages, see the [default_pipeline.yaml](https://raw.githubusercontent.com/NVIDIA/NeMo-Retriever/26.03/config/default_pipeline.yaml) configuration file.
+> **Note:** For the complete and up-to-date list of pipeline stages, see the [default_pipeline.yaml](https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/config/default_pipeline.yaml) configuration file.
 
 #### Target Stage Selection Examples
 

--- a/docs/docs/extraction/user-defined-functions.md
+++ b/docs/docs/extraction/user-defined-functions.md
@@ -304,7 +304,7 @@ UDFs can be executed at different stages of the pipeline by specifying the `targ
 - `broker_response` - Response message handling
 - `otel_tracer` - OpenTelemetry tracing
 
-> **Note:** For the complete and up-to-date list of pipeline stages, see the [default_pipeline.yaml](https://github.com/NVIDIA/nv-ingest/blob/main/config/default_pipeline.yaml) configuration file.
+> **Note:** For the complete and up-to-date list of pipeline stages, see the [default_pipeline.yaml](https://raw.githubusercontent.com/NVIDIA/NeMo-Retriever/26.03/config/default_pipeline.yaml) configuration file.
 
 #### Target Stage Selection Examples
 


### PR DESCRIPTION
## Summary
- Fix `image_viewer.py` link in `quickstart-guide.md` to point at `NVIDIA/NeMo-Retriever` on the `26.03` branch instead of the renamed `nv-ingest` repo.
- Fix Riva support matrix URL in `audio.md` to use the current `/docs/public/support-matrix/` path.
- Fix `default_pipeline.yaml` link in `user-defined-functions.md` to the raw `26.03` config on `NeMo-Retriever`.

Closes remaining NVBugs **6179241** source edits for the 26.3.0 doc train after #2048. Republish 26.3.0 after merge to clear the crawler.

## Test plan
- [ ] Verify the three updated URLs resolve in a browser.
- [ ] Docs build succeeds for touched extraction pages.
- [ ] After republish, re-run the broken-link scan for `/nemo/retriever/26.3.0/extraction/`.