### PR TITLE
docs(extraction): pin UDF examples link to 26.03 branch

### DIFF
--- a/docs/docs/extraction/user-defined-functions.md
+++ b/docs/docs/extraction/user-defined-functions.md
@@ -940,6 +940,6 @@ def debug_udf(control_message: IngestControlMessage) -> IngestControlMessage:
 
 ## Related Topics
 
-- [NV-Ingest UDF Examples](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/udfs/README.md)
+- [NV-Ingest UDF Examples](https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/examples/udfs/README.md)
 - [User-Defined Stages for NeMo Retriever Library](user-defined-stages.md)
 - [NimClient Usage](nimclient.md)


### PR DESCRIPTION
## Summary
- Fix the last NVBugs 6179241 broken GitHub link on the 26.3.0 extraction docs by pointing the UDF examples README at \NeMo-Retriever\ branch \26.03\ instead of \main\ (404).

## Test plan
- [ ] Confirm \https://github.com/NVIDIA/NeMo-Retriever/blob/26.03/examples/udfs/README.md\ returns 200
- [ ] Rebuild/publish 26.3.0 extraction docs and verify the link on \user-defined-functions\
