### PR TITLE
Lower bound numba for Python 3.12 installs

### DIFF
--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -99,6 +99,8 @@ service = [
   "apscheduler>=3.10",
   # Audio resampling used by ParakeetClient
   "librosa>=0.10.2",
+  # Explicitly avoid pulling older numba/llvmlite versions that precede python 3.12
+  "numba>=0.59",
 ]
 
 # ── Local model inference (GPU assumed; torch resolves to CUDA on Linux) ─────
@@ -146,6 +148,8 @@ multimedia = [
   "scipy>=1.11.0",
   "cairosvg>=2.7.0",
   "librosa>=0.10.2",
+  # Explicitly avoid pulling older numba/llvmlite versions that precede python 3.12
+  "numba>=0.59",
 ]
 
 # ── Nemotron Parse NIM client support ────────────────────────────────────────

--- a/nemo_retriever/uv.lock
+++ b/nemo_retriever/uv.lock
@@ -2491,6 +2491,8 @@ all = [
     { name = "nemotron-page-elements-v3" },
     { name = "nemotron-table-structure-v1" },
     { name = "neo4j" },
+    { name = "numba", version = "0.61.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "numba", version = "0.65.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "nvidia-ml-py" },
     { name = "open-clip-torch" },
     { name = "opencv-python-headless" },
@@ -2550,6 +2552,8 @@ local = [
 multimedia = [
     { name = "cairosvg" },
     { name = "librosa" },
+    { name = "numba", version = "0.61.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "numba", version = "0.65.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "scipy" },
     { name = "soundfile" },
 ]
@@ -2563,6 +2567,8 @@ service = [
     { name = "easydict" },
     { name = "glom" },
     { name = "librosa" },
+    { name = "numba", version = "0.61.2", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "numba", version = "0.65.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
     { name = "psutil" },
     { name = "scikit-learn" },
 ]
@@ -2625,6 +2631,8 @@ requires-dist = [
     { name = "nemotron-table-structure-v1", marker = "extra == 'local'", specifier = ">=1.0.0,<2" },
     { name = "neo4j", marker = "extra == 'tabular'", specifier = ">=5.0" },
     { name = "nltk", specifier = "==3.9.4" },
+    { name = "numba", marker = "extra == 'multimedia'", specifier = ">=0.59" },
+    { name = "numba", marker = "extra == 'service'", specifier = ">=0.59" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "nvidia-ml-py", marker = "extra == 'local'" },
     { name = "nvidia-riva-client", specifier = ">=2.25.1" },


### PR DESCRIPTION
## Description
Add explicit `numba>=0.59` lower bounds to the `service` and `multimedia` extras that pull in `librosa`. This prevents dependency resolution from falling back to the pre-Python-3.12 `numba==0.53.1` / `llvmlite==0.36.0` stack when latest package metadata allows `numpy==2.5.0` to enter the solve.

The lockfile is updated so the affected extras carry the new direct `numba` requirement. With this bound, Python 3.12 Linux resolution selects the compatible `numba==0.65.1` / `llvmlite==0.47.0` stack.

Validation performed:

- `uv pip compile nemo_retriever/pyproject.toml --extra service --python-version 3.12 --python-platform x86_64-manylinux2014 --refresh --no-header --no-annotate`
- `uv pip compile nemo_retriever/pyproject.toml --extra multimedia --python-version 3.12 --python-platform x86_64-manylinux2014 --refresh --no-header --no-annotate`
- `uv pip compile nemo_retriever/pyproject.toml --extra service --extra multimedia --python-version 3.12 --python-platform x86_64-manylinux2014 --refresh --no-header --no-annotate`
- `uv pip install --dry-run --target /tmp/nr-service-dryrun --python-version 3.12 --python-platform x86_64-manylinux2014 --refresh -e './nemo_retriever[service]'`
- `uv pip install --dry-run --target /tmp/nr-multimedia-dryrun --python-version 3.12 --python-platform x86_64-manylinux2014 --refresh -e './nemo_retriever[multimedia]'`
- `uv pip install --dry-run --target /tmp/nr-service-multimedia-dryrun --python-version 3.12 --python-platform x86_64-manylinux2014 --refresh -e './nemo_retriever[service,multimedia]'`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
