### PR TITLE
Add query filters for service-backed retrieval

### DIFF
--- a/nemo_retriever/src/nemo_retriever/cli/query/app.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query/app.py
@@ -25,6 +25,7 @@ from nemo_retriever.common.vdb.records import RetrievalHit
 from nemo_retriever.query.options import (
     QueryAgenticOptions,
     QueryEmbedOptions,
+    QueryFilterOptions,
     QueryRerankOptions,
     QueryRequest,
     QueryRetrievalOptions,
@@ -155,6 +156,21 @@ def _retrieval_options(
     )
 
 
+def _filter_options(
+    *,
+    source_id: str | None,
+    source: str | None,
+    page_number: int | None,
+    where: str | None,
+) -> QueryFilterOptions:
+    return QueryFilterOptions(
+        source_id=source_id,
+        source=source,
+        page_number=page_number,
+        where=where,
+    )
+
+
 @app.command(
     "_local",
     hidden=True,
@@ -170,6 +186,10 @@ def _local_command(
     candidate_k: opts.CandidateKOption = None,
     page_dedup: opts.PageDedupOption = False,
     content_types: opts.ContentTypesOption = None,
+    source_id: opts.SourceIdOption = None,
+    source: opts.SourceOption = None,
+    page_number: opts.PageNumberOption = None,
+    where: opts.WhereOption = None,
     lancedb_uri: opts.LanceDbUriOption = "lancedb",
     table_name: opts.TableNameOption = "nemo-retriever",
     embed_invoke_url: opts.EmbedInvokeUrlOption = None,
@@ -258,6 +278,12 @@ def _local_command(
                     content_types=content_types,
                     retrieval_mode=effective_retrieval_mode,
                 ),
+                filters=_filter_options(
+                    source_id=source_id,
+                    source=source,
+                    page_number=page_number,
+                    where=where,
+                ),
                 embed=QueryEmbedOptions(
                     embed_invoke_url=embed_invoke_url,
                     embed_model_name=embed_model_name,
@@ -295,6 +321,10 @@ def _service_command(
     candidate_k: opts.CandidateKOption = None,
     page_dedup: opts.PageDedupOption = False,
     content_types: opts.ContentTypesOption = None,
+    source_id: opts.SourceIdOption = None,
+    source: opts.SourceOption = None,
+    page_number: opts.PageNumberOption = None,
+    where: opts.WhereOption = None,
     output_format: opts.OutputFormatOption = "hits",
     max_text_chars: opts.MaxTextCharsOption = None,
 ) -> None:
@@ -310,6 +340,12 @@ def _service_command(
                         candidate_k=candidate_k,
                         page_dedup=page_dedup,
                         content_types=content_types,
+                    ),
+                    filters=_filter_options(
+                        source_id=source_id,
+                        source=source,
+                        page_number=page_number,
+                        where=where,
                     ),
                     service=QueryServiceOptions(
                         service_url=service_url,

--- a/nemo_retriever/src/nemo_retriever/cli/query/app.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query/app.py
@@ -22,6 +22,7 @@ from nemo_retriever.cli.shared import (
     silence_noisy_libraries,
 )
 from nemo_retriever.common.vdb.records import RetrievalHit
+from nemo_retriever.query.filters import has_query_filters
 from nemo_retriever.query.options import (
     QueryAgenticOptions,
     QueryEmbedOptions,
@@ -226,8 +227,16 @@ def _local_command(
     try:
         reranker_api_key = _api_key_from_env_option(reranker_api_key_env) if reranker_invoke_url else None
         effective_retrieval_mode = _query_retrieval_mode(ctx, retrieval_mode, hybrid)
+        filters = _filter_options(
+            source_id=source_id,
+            source=source,
+            page_number=page_number,
+            where=where,
+        )
 
         if agentic:
+            if has_query_filters(filters):
+                raise ValueError("--source-id, --source, --page-number, and --where are not supported with --agentic.")
             request = QueryRequest(
                 query=query,
                 retrieval=_retrieval_options(
@@ -278,12 +287,7 @@ def _local_command(
                     content_types=content_types,
                     retrieval_mode=effective_retrieval_mode,
                 ),
-                filters=_filter_options(
-                    source_id=source_id,
-                    source=source,
-                    page_number=page_number,
-                    where=where,
-                ),
+                filters=filters,
                 embed=QueryEmbedOptions(
                     embed_invoke_url=embed_invoke_url,
                     embed_model_name=embed_model_name,

--- a/nemo_retriever/src/nemo_retriever/cli/query/options.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query/options.py
@@ -73,7 +73,7 @@ WhereOption = Annotated[
     str | None,
     typer.Option(
         "--where",
-        help="Advanced: raw LanceDB SQL predicate appended to structured query filters.",
+        help="Advanced/trusted-caller: raw LanceDB SQL predicate appended to structured query filters.",
     ),
 ]
 LanceDbUriOption = Annotated[

--- a/nemo_retriever/src/nemo_retriever/cli/query/options.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query/options.py
@@ -47,6 +47,35 @@ ContentTypesOption = Annotated[
         ),
     ),
 ]
+SourceIdOption = Annotated[
+    str | None,
+    typer.Option(
+        "--source-id",
+        help="Only search chunks from this source identifier.",
+    ),
+]
+SourceOption = Annotated[
+    str | None,
+    typer.Option(
+        "--source",
+        help="Only search chunks from this source name or identifier.",
+    ),
+]
+PageNumberOption = Annotated[
+    int | None,
+    typer.Option(
+        "--page-number",
+        min=0,
+        help="Only search chunks from this page number.",
+    ),
+]
+WhereOption = Annotated[
+    str | None,
+    typer.Option(
+        "--where",
+        help="Advanced: raw LanceDB SQL predicate appended to structured query filters.",
+    ),
+]
 LanceDbUriOption = Annotated[
     str,
     typer.Option(

--- a/nemo_retriever/src/nemo_retriever/query/filters.py
+++ b/nemo_retriever/src/nemo_retriever/query/filters.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Translate root query filter options into LanceDB's native ``where`` predicate.
+
+LanceDB owns predicate execution. This module only maps stable root query
+options such as source and page filters onto the table columns used by both
+older local indexes and the VectorDB service, where ``metadata`` and ``source``
+are JSON strings at rest.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from nemo_retriever.query.options import QueryFilterOptions
+
+
+def _clean_str(value: str | None) -> str | None:
+    cleaned = (value or "").strip()
+    return cleaned or None
+
+
+def _sql_string(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _like_clause(column: str, pattern: str, *, escape: bool = False) -> str:
+    clause = f"{column} LIKE {_sql_string(pattern)}"
+    if escape:
+        clause += " ESCAPE '\\'"
+    return clause
+
+
+def _like_pattern_literal(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _json_member_patterns(key: str, value: str) -> list[str]:
+    encoded_value = _like_pattern_literal(json.dumps(value, ensure_ascii=False))
+    return [
+        f'%"{key}":{encoded_value}%',
+        f'%"{key}": {encoded_value}%',
+    ]
+
+
+def _source_json_member_clause(key: str, value: str) -> str:
+    return " OR ".join(_like_clause("source", pattern, escape=True) for pattern in _json_member_patterns(key, value))
+
+
+def _source_id_clause(source_id: str) -> str:
+    clauses = [
+        _source_json_member_clause("source_id", source_id),
+        f"source = {_sql_string(source_id)}",
+    ]
+    return "(" + " OR ".join(clauses) + ")"
+
+
+def _source_clause(source: str) -> str:
+    clauses = [
+        _source_json_member_clause("source_id", source),
+        _source_json_member_clause("source_name", source),
+        f"source = {_sql_string(source)}",
+    ]
+    return "(" + " OR ".join(clauses) + ")"
+
+
+def _page_number_clause(page_number: int) -> str:
+    page = int(page_number)
+    if page < 0:
+        raise ValueError("page_number must be greater than or equal to 0.")
+    patterns = [
+        f'%"page_number":{page},%',
+        f'%"page_number":{page}}}%',
+        f'%"page_number": {page},%',
+        f'%"page_number": {page}}}%',
+        f'%"page_number":"{page}"%',
+        f'%"page_number": "{page}"%',
+    ]
+    return "(" + " OR ".join(_like_clause("metadata", pattern) for pattern in patterns) + ")"
+
+
+def build_query_where_clause(options: QueryFilterOptions) -> str | None:
+    """Build the LanceDB predicate for root query filters."""
+    clauses: list[str] = []
+
+    source_id = _clean_str(options.source_id)
+    if source_id is not None:
+        clauses.append(_source_id_clause(source_id))
+
+    source = _clean_str(options.source)
+    if source is not None:
+        clauses.append(_source_clause(source))
+
+    if options.page_number is not None:
+        clauses.append(_page_number_clause(options.page_number))
+
+    where = _clean_str(options.where)
+    if where is not None:
+        clauses.append(where if not clauses else f"({where})")
+
+    if not clauses:
+        return None
+    return " AND ".join(clauses)
+
+
+def query_filter_payload(options: QueryFilterOptions) -> dict[str, Any]:
+    """Return the public service query filter payload for non-empty fields."""
+    payload: dict[str, Any] = {}
+
+    source_id = _clean_str(options.source_id)
+    if source_id is not None:
+        payload["source_id"] = source_id
+
+    source = _clean_str(options.source)
+    if source is not None:
+        payload["source"] = source
+
+    if options.page_number is not None:
+        page_number = int(options.page_number)
+        if page_number < 0:
+            raise ValueError("page_number must be greater than or equal to 0.")
+        payload["page_number"] = page_number
+
+    where = _clean_str(options.where)
+    if where is not None:
+        payload["where"] = where
+
+    return payload

--- a/nemo_retriever/src/nemo_retriever/query/filters.py
+++ b/nemo_retriever/src/nemo_retriever/query/filters.py
@@ -106,6 +106,11 @@ def build_query_where_clause(options: QueryFilterOptions) -> str | None:
     return " AND ".join(clauses)
 
 
+def has_query_filters(options: QueryFilterOptions) -> bool:
+    """Return whether any query filter option is set."""
+    return build_query_where_clause(options) is not None
+
+
 def query_filter_payload(options: QueryFilterOptions) -> dict[str, Any]:
     """Return the public service query filter payload for non-empty fields."""
     payload: dict[str, Any] = {}

--- a/nemo_retriever/src/nemo_retriever/query/options.py
+++ b/nemo_retriever/src/nemo_retriever/query/options.py
@@ -23,6 +23,14 @@ class QueryRetrievalOptions:
 
 
 @dataclass(frozen=True)
+class QueryFilterOptions:
+    source_id: str | None = None
+    source: str | None = None
+    page_number: int | None = None
+    where: str | None = None
+
+
+@dataclass(frozen=True)
 class QueryEmbedOptions:
     embed_invoke_url: str | None = None
     embed_model_name: str | None = None
@@ -67,6 +75,7 @@ class QueryAgenticOptions:
 class QueryRequest:
     query: str
     retrieval: QueryRetrievalOptions = field(default_factory=QueryRetrievalOptions)
+    filters: QueryFilterOptions = field(default_factory=QueryFilterOptions)
     embed: QueryEmbedOptions = field(default_factory=QueryEmbedOptions)
     rerank: QueryRerankOptions = field(default_factory=QueryRerankOptions)
     storage: QueryStorageOptions = field(default_factory=QueryStorageOptions)
@@ -77,4 +86,5 @@ class QueryRequest:
 class ServiceQueryRequest:
     query: str
     retrieval: QueryRetrievalOptions = field(default_factory=QueryRetrievalOptions)
+    filters: QueryFilterOptions = field(default_factory=QueryFilterOptions)
     service: QueryServiceOptions = field(default_factory=QueryServiceOptions)

--- a/nemo_retriever/src/nemo_retriever/query/service.py
+++ b/nemo_retriever/src/nemo_retriever/query/service.py
@@ -27,7 +27,7 @@ def query_documents(request: ServiceQueryRequest) -> list[RetrievalHit]:
         base_url=request.service.service_url,
         api_token=request.service.service_api_token,
     )
-    raw_result_sets = client.query(request.query, top_k=retrieval_top_k)
+    raw_result_sets = client.query(request.query, top_k=retrieval_top_k, filters=request.filters)
     raw_hits = raw_result_sets[0]
     return shape_query_hits(
         raw_hits,

--- a/nemo_retriever/src/nemo_retriever/query/workflow.py
+++ b/nemo_retriever/src/nemo_retriever/query/workflow.py
@@ -13,6 +13,7 @@ from nemo_retriever.common.vdb.lancedb_capabilities import LanceRetrievalMode
 from nemo_retriever.common.vdb.records import RetrievalHit
 from nemo_retriever.graph.retriever import Retriever
 from nemo_retriever.models import VL_RERANK_MODEL
+from nemo_retriever.query.filters import build_query_where_clause
 from nemo_retriever.query.options import QueryRequest, QueryRerankOptions
 
 _LOCAL_VL_RERANK_MODEL = VL_RERANK_MODEL
@@ -62,6 +63,7 @@ class ResolvedQueryPlan:
     candidate_k: int | None
     page_dedup: bool
     content_types: str | None
+    where: str | None
     lancedb_uri: str
     table_name: str
     retrieval_mode: str
@@ -93,11 +95,14 @@ class ResolvedQueryPlan:
         return Retriever(**self.retriever_kwargs())
 
     def query_kwargs(self) -> dict[str, Any]:
-        return {
+        kwargs: dict[str, Any] = {
             "candidate_k": self.candidate_k,
             "page_dedup": self.page_dedup,
             "content_types": self.content_types,
         }
+        if self.where is not None:
+            kwargs["vdb_kwargs"] = {"where": self.where}
+        return kwargs
 
 
 def resolve_query_plan(request: QueryRequest) -> ResolvedQueryPlan:
@@ -112,6 +117,7 @@ def resolve_query_plan(request: QueryRequest) -> ResolvedQueryPlan:
         candidate_k=request.retrieval.candidate_k,
         page_dedup=bool(request.retrieval.page_dedup),
         content_types=content_types,
+        where=build_query_where_clause(request.filters),
         lancedb_uri=str(request.storage.lancedb_uri),
         table_name=str(request.storage.table_name),
         retrieval_mode=str(request.retrieval.retrieval_mode),

--- a/nemo_retriever/src/nemo_retriever/service/client.py
+++ b/nemo_retriever/src/nemo_retriever/service/client.py
@@ -50,6 +50,8 @@ from rich.progress import (
     TimeRemainingColumn,
 )
 
+from nemo_retriever.query.filters import query_filter_payload
+from nemo_retriever.query.options import QueryFilterOptions
 from nemo_retriever.service.query_schema import QueryResponse
 
 logger = logging.getLogger(__name__)
@@ -216,11 +218,19 @@ class RetrieverServiceClient:
     # Query
     # ------------------------------------------------------------------
 
-    def query(self, query: str | list[str], *, top_k: int) -> list[list[dict[str, Any]]]:
+    def query(
+        self,
+        query: str | list[str],
+        *,
+        top_k: int,
+        filters: QueryFilterOptions | None = None,
+    ) -> list[list[dict[str, Any]]]:
         """Search ingested documents through ``POST /v1/query``."""
         url = f"{self._base_url}/v1/query"
         expected_results = len(query) if isinstance(query, list) else 1
         payload: dict[str, Any] = {"query": query, "top_k": int(top_k)}
+        if filters is not None:
+            payload.update(query_filter_payload(filters))
         try:
             with httpx.Client(
                 timeout=httpx.Timeout(300.0, connect=30.0),

--- a/nemo_retriever/src/nemo_retriever/service/query_schema.py
+++ b/nemo_retriever/src/nemo_retriever/service/query_schema.py
@@ -15,7 +15,16 @@ class QueryRequest(BaseModel):
     source_id: str | None = None
     source: str | None = None
     page_number: int | None = Field(default=None, ge=0)
-    where: str | None = None
+    where: str | None = Field(
+        default=None,
+        description=(
+            "Advanced trusted-caller LanceDB/DataFusion predicate. The VectorDB service "
+            "passes this to table.search(...).where(...) as a read-only pre-filter before "
+            "limit(). Prefer source_id, source, and page_number for common filtering. "
+            "Deployers should expose this only inside the same auth/trust boundary as "
+            "unfiltered /v1/query access."
+        ),
+    )
 
 
 class QueryResult(BaseModel):

--- a/nemo_retriever/src/nemo_retriever/service/query_schema.py
+++ b/nemo_retriever/src/nemo_retriever/service/query_schema.py
@@ -12,6 +12,10 @@ from pydantic import BaseModel, Field
 class QueryRequest(BaseModel):
     query: str | list[str]
     top_k: int = Field(default=10, ge=1, le=1000)
+    source_id: str | None = None
+    source: str | None = None
+    page_number: int | None = Field(default=None, ge=0)
+    where: str | None = None
 
 
 class QueryResult(BaseModel):

--- a/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
+++ b/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
@@ -41,6 +41,8 @@ import uvicorn
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
+from nemo_retriever.query.filters import build_query_where_clause
+from nemo_retriever.query.options import QueryFilterOptions
 from nemo_retriever.service.query_schema import QueryRequest, QueryResponse, QueryResult
 
 logger = logging.getLogger(__name__)
@@ -195,7 +197,12 @@ class VectorDBState:
         except Exception:
             return 0
 
-    def search(self, vectors: list[list[float]], top_k: int) -> list[list[dict[str, Any]]]:
+    def search(
+        self,
+        vectors: list[list[float]],
+        top_k: int,
+        where: str | None = None,
+    ) -> list[list[dict[str, Any]]]:
         """Search the LanceDB table with precomputed query vectors."""
         if not self._table_exists:
             return [[] for _ in vectors]
@@ -203,9 +210,13 @@ class VectorDBState:
         from nemo_retriever.common.vdb.records import normalize_retrieval_results
 
         table = self._db.open_table(self.table_name)
+        where_clause = str(where).strip() if where is not None else None
         raw_results = []
         for vector in vectors:
-            results = table.search(vector).limit(top_k).to_list()
+            query = table.search(vector)
+            if where_clause:
+                query = query.where(where_clause)
+            results = query.limit(top_k).to_list()
             raw_results.append(results)
 
         return normalize_retrieval_results(raw_results)
@@ -351,7 +362,15 @@ def create_vectordb_app(
 
         async with _query_semaphore:
             vectors = await asyncio.to_thread(_state.embed_queries, queries)
-            hits_per_query = await asyncio.to_thread(_state.search, vectors, req.top_k)
+            where_clause = build_query_where_clause(
+                QueryFilterOptions(
+                    source_id=req.source_id,
+                    source=req.source,
+                    page_number=req.page_number,
+                    where=req.where,
+                )
+            )
+            hits_per_query = await asyncio.to_thread(_state.search, vectors, req.top_k, where_clause)
 
         results = [QueryResult(hits=hits) for hits in hits_per_query]
         return QueryResponse(results=results)

--- a/nemo_retriever/tests/test_lancedb_retrieval_where.py
+++ b/nemo_retriever/tests/test_lancedb_retrieval_where.py
@@ -97,6 +97,45 @@ def test_retrieval_metadata_like_predicate() -> None:
     assert cm["doc_id"] == "x"
 
 
+def test_retrieval_metadata_like_matches_compact_sidecar_metadata() -> None:
+    d = tempfile.mkdtemp()
+    schema = pa.schema(
+        [
+            pa.field("vector", pa.list_(pa.float32(), 2)),
+            pa.field("text", pa.string()),
+            pa.field("metadata", pa.string()),
+            pa.field("source", pa.string()),
+        ]
+    )
+    rows = [
+        {
+            "vector": [1.0, 0.0],
+            "text": "alpha chunk",
+            "metadata": json.dumps({"meta_a": "alpha", "page_number": 1}, separators=(",", ":")),
+            "source": "{}",
+        },
+        {
+            "vector": [0.0, 1.0],
+            "text": "bravo chunk",
+            "metadata": json.dumps({"meta_a": "bravo", "page_number": 2}, separators=(",", ":")),
+            "source": "{}",
+        },
+    ]
+    lancedb.connect(d).create_table("t", rows, schema=schema, mode="overwrite")
+    op = LanceDB(uri=d, table_name="t", overwrite=False, vector_dim=2, validate_vector_length=False, hybrid=False)
+
+    filtered = op.retrieval(
+        [[1.0, 0.0]],
+        top_k=10,
+        table_path=d,
+        table_name="t",
+        where='metadata LIKE \'%"meta_a":"alpha"%\'',
+    )
+
+    assert [hit["text"] for hit in filtered[0]] == ["alpha chunk"]
+    assert json.loads(filtered[0][0]["metadata"])["meta_a"] == "alpha"
+
+
 def test_retrieval_search_kwargs_must_be_dict() -> None:
     d = tempfile.mkdtemp()
     _tiny_table(d)

--- a/nemo_retriever/tests/test_query_filters.py
+++ b/nemo_retriever/tests/test_query_filters.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import pytest
 
-from nemo_retriever.query.filters import build_query_where_clause, query_filter_payload
+from nemo_retriever.query.filters import build_query_where_clause, has_query_filters, query_filter_payload
 from nemo_retriever.query.options import QueryFilterOptions
 
 
@@ -54,6 +54,12 @@ def test_advanced_where_is_pass_through_and_combines_with_structured_filters() -
         'OR metadata LIKE \'%"page_number": "2"%\') '
         "AND (text = 'alpha')"
     )
+
+
+def test_has_query_filters_reports_non_empty_options() -> None:
+    assert not has_query_filters(QueryFilterOptions())
+    assert has_query_filters(QueryFilterOptions(source_id="docs/a.pdf"))
+    assert has_query_filters(QueryFilterOptions(where="text = 'alpha'"))
 
 
 def test_negative_page_filter_is_rejected() -> None:

--- a/nemo_retriever/tests/test_query_filters.py
+++ b/nemo_retriever/tests/test_query_filters.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import pytest
+
+from nemo_retriever.query.filters import build_query_where_clause, query_filter_payload
+from nemo_retriever.query.options import QueryFilterOptions
+
+
+def test_structured_source_id_and_page_filters_build_lancedb_predicate() -> None:
+    assert build_query_where_clause(QueryFilterOptions(source_id="docs/a.pdf", page_number=3)) == (
+        "(source LIKE '%\"source_id\":\"docs/a.pdf\"%' ESCAPE '\\' "
+        "OR source LIKE '%\"source_id\": \"docs/a.pdf\"%' ESCAPE '\\' "
+        "OR source = 'docs/a.pdf') "
+        "AND (metadata LIKE '%\"page_number\":3,%' "
+        "OR metadata LIKE '%\"page_number\":3}%' "
+        "OR metadata LIKE '%\"page_number\": 3,%' "
+        "OR metadata LIKE '%\"page_number\": 3}%' "
+        'OR metadata LIKE \'%"page_number":"3"%\' '
+        'OR metadata LIKE \'%"page_number": "3"%\')'
+    )
+
+
+def test_source_filter_matches_source_identifier_name_or_raw_source() -> None:
+    assert build_query_where_clause(QueryFilterOptions(source="a.pdf")) == (
+        "(source LIKE '%\"source_id\":\"a.pdf\"%' ESCAPE '\\' "
+        "OR source LIKE '%\"source_id\": \"a.pdf\"%' ESCAPE '\\' "
+        "OR source LIKE '%\"source_name\":\"a.pdf\"%' ESCAPE '\\' "
+        "OR source LIKE '%\"source_name\": \"a.pdf\"%' ESCAPE '\\' "
+        "OR source = 'a.pdf')"
+    )
+
+
+def test_source_filters_escape_lancedb_like_wildcards() -> None:
+    where = build_query_where_clause(QueryFilterOptions(source_id="my_report%2026.pdf"))
+
+    assert where is not None
+    assert "my\\_report\\%2026.pdf" in where
+    assert "ESCAPE '\\'" in where
+    assert "source = 'my_report%2026.pdf'" in where
+
+
+def test_advanced_where_is_pass_through_and_combines_with_structured_filters() -> None:
+    assert build_query_where_clause(QueryFilterOptions(where="text = 'alpha'")) == "text = 'alpha'"
+    assert build_query_where_clause(QueryFilterOptions(page_number=2, where="text = 'alpha'")) == (
+        "(metadata LIKE '%\"page_number\":2,%' "
+        "OR metadata LIKE '%\"page_number\":2}%' "
+        "OR metadata LIKE '%\"page_number\": 2,%' "
+        "OR metadata LIKE '%\"page_number\": 2}%' "
+        'OR metadata LIKE \'%"page_number":"2"%\' '
+        'OR metadata LIKE \'%"page_number": "2"%\') '
+        "AND (text = 'alpha')"
+    )
+
+
+def test_negative_page_filter_is_rejected() -> None:
+    with pytest.raises(ValueError, match="page_number must be greater than or equal to 0"):
+        build_query_where_clause(QueryFilterOptions(page_number=-1))
+
+    with pytest.raises(ValueError, match="page_number must be greater than or equal to 0"):
+        query_filter_payload(QueryFilterOptions(page_number=-1))

--- a/nemo_retriever/tests/test_query_workflow_options.py
+++ b/nemo_retriever/tests/test_query_workflow_options.py
@@ -10,8 +10,10 @@ import pytest
 
 import nemo_retriever.query.service as query_service
 import nemo_retriever.query.workflow as query_workflow
+from nemo_retriever.query.filters import build_query_where_clause
 from nemo_retriever.query.options import (
     QueryEmbedOptions,
+    QueryFilterOptions,
     QueryRerankOptions,
     QueryRequest,
     QueryRetrievalOptions,
@@ -182,6 +184,36 @@ def test_query_documents_with_metadata_reports_resolved_strategy(monkeypatch, mo
     assert result.strategies == strategies
 
 
+def test_query_documents_threads_filter_options_into_vdb_kwargs(monkeypatch) -> None:
+    query_calls: list[tuple[str, dict[str, Any]]] = []
+
+    class FakeRetriever:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        def query(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+            query_calls.append((query, kwargs))
+            return []
+
+    monkeypatch.setattr(query_workflow, "Retriever", FakeRetriever)
+
+    filters = QueryFilterOptions(source_id="docs/a.pdf", page_number=3)
+    request = QueryRequest(query="deployment?", filters=filters)
+
+    assert query_workflow.query_documents(request) == []
+    assert query_calls == [
+        (
+            "deployment?",
+            {
+                "candidate_k": None,
+                "page_dedup": False,
+                "content_types": None,
+                "vdb_kwargs": {"where": build_query_where_clause(filters)},
+            },
+        )
+    ]
+
+
 def test_service_query_uses_candidate_pool_and_preserves_local_shaping(monkeypatch) -> None:
     client_calls: list[dict[str, Any]] = []
 
@@ -189,8 +221,14 @@ def test_service_query_uses_candidate_pool_and_preserves_local_shaping(monkeypat
         def __init__(self, *, base_url: str, api_token: str | None = None, **_kwargs: Any) -> None:
             client_calls.append({"base_url": base_url, "api_token": api_token})
 
-        def query(self, query: str, *, top_k: int) -> list[list[dict[str, Any]]]:
-            client_calls.append({"query": query, "top_k": top_k})
+        def query(
+            self,
+            query: str,
+            *,
+            top_k: int,
+            filters: QueryFilterOptions | None = None,
+        ) -> list[list[dict[str, Any]]]:
+            client_calls.append({"query": query, "top_k": top_k, "filters": filters})
             return [
                 [
                     {"text": "keep", "source": "doc.pdf", "page_number": 1, "metadata": {"type": "text"}},
@@ -209,6 +247,7 @@ def test_service_query_uses_candidate_pool_and_preserves_local_shaping(monkeypat
             page_dedup=True,
             content_types="text",
         ),
+        filters=QueryFilterOptions(source="doc.pdf"),
         service=QueryServiceOptions(service_url="http://svc:7670", service_api_token="secret"),
     )
 
@@ -217,7 +256,7 @@ def test_service_query_uses_candidate_pool_and_preserves_local_shaping(monkeypat
     ]
     assert client_calls == [
         {"base_url": "http://svc:7670", "api_token": "secret"},
-        {"query": "deployment?", "top_k": 3},
+        {"query": "deployment?", "top_k": 3, "filters": QueryFilterOptions(source="doc.pdf")},
     ]
 
 

--- a/nemo_retriever/tests/test_root_query_cli.py
+++ b/nemo_retriever/tests/test_root_query_cli.py
@@ -12,6 +12,8 @@ from typer.testing import CliRunner
 
 import nemo_retriever.query.workflow as query_core
 from nemo_retriever.models import VL_EMBED_MODEL, VL_RERANK_MODEL
+from nemo_retriever.query.filters import build_query_where_clause
+from nemo_retriever.query.options import QueryFilterOptions
 
 RUNNER = CliRunner()
 cli_main = importlib.import_module("nemo_retriever.cli.main")
@@ -110,6 +112,66 @@ def test_root_query_passes_candidate_dedup_and_content_filters(monkeypatch) -> N
     assert query_kwargs == [{"candidate_k": 3, "page_dedup": True, "content_types": "text,table"}]
     assert json.loads(result.output) == [
         {"page_number": 1, "source": "doc.pdf", "text": "text row", "modality": "text", "score": None},
+    ]
+
+
+def test_root_query_passes_source_page_filters_without_changing_output_shape(monkeypatch) -> None:
+    query_kwargs: list[dict[str, Any]] = []
+
+    class FakeRetriever:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        def query(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+            query_kwargs.append(kwargs)
+            return [
+                {
+                    "text": "text row",
+                    "metadata": {"type": "text"},
+                    "page_number": 3,
+                    "source": "docs/a.pdf",
+                    "_distance": 0.2,
+                },
+            ]
+
+    monkeypatch.setattr(query_core, "Retriever", FakeRetriever)
+
+    result = RUNNER.invoke(
+        cli_main.app,
+        [
+            "query",
+            "deployment?",
+            "--source-id",
+            "docs/a.pdf",
+            "--page-number",
+            "3",
+            "--where",
+            "text != ''",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == [
+        {
+            "modality": "text",
+            "page_number": 3,
+            "score": 0.2,
+            "source": "docs/a.pdf",
+            "text": "text row",
+        },
+    ]
+    assert set(json.loads(result.output)[0]) == {"modality", "page_number", "score", "source", "text"}
+    assert query_kwargs == [
+        {
+            "candidate_k": None,
+            "page_dedup": False,
+            "content_types": None,
+            "vdb_kwargs": {
+                "where": build_query_where_clause(
+                    QueryFilterOptions(source_id="docs/a.pdf", page_number=3, where="text != ''")
+                )
+            },
+        }
     ]
 
 
@@ -587,6 +649,10 @@ def test_root_query_service_help_hides_local_only_options() -> None:
     assert "--top-k" in result.output
     assert "--candidate-k" in result.output
     assert "--content-types" in result.output
+    assert "--source-id" in result.output
+    assert "--source" in result.output
+    assert "--page-number" in result.output
+    assert "--where" in result.output
     assert "--format" in result.output
     assert "--max-text-chars" in result.output
     assert "--run-mode" not in result.output
@@ -630,6 +696,12 @@ def test_root_query_service_mode_uses_service_options_and_prints_json(monkeypatc
             "--page-dedup",
             "--content-types",
             "text",
+            "--source-id",
+            "docs/a.pdf",
+            "--page-number",
+            "3",
+            "--where",
+            "text != ''",
         ],
     )
 
@@ -642,6 +714,7 @@ def test_root_query_service_mode_uses_service_options_and_prints_json(monkeypatc
     assert request.retrieval.candidate_k == 5
     assert request.retrieval.page_dedup is True
     assert request.retrieval.content_types == "text"
+    assert request.filters == QueryFilterOptions(source_id="docs/a.pdf", page_number=3, where="text != ''")
     assert json.loads(result.output) == [
         {"modality": "text", "page_number": 3, "score": 0.2, "source": "doc.pdf", "text": "service passage"},
     ]

--- a/nemo_retriever/tests/test_root_query_cli.py
+++ b/nemo_retriever/tests/test_root_query_cli.py
@@ -470,6 +470,24 @@ def test_root_query_agentic_requires_llm_model() -> None:
     assert "requires --agentic-llm-model" in result.output
 
 
+def test_root_query_agentic_rejects_filter_flags() -> None:
+    result = RUNNER.invoke(
+        cli_main.app,
+        [
+            "query",
+            "hello",
+            "--agentic",
+            "--agentic-llm-model",
+            "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+            "--source-id",
+            "docs/a.pdf",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "not supported with --agentic" in result.output
+
+
 def test_root_query_agentic_plumbs_rerank_into_config(monkeypatch) -> None:
     """`--rerank` with `--agentic` wires the reranker config into AgenticRetrievalConfig
     (reranker model + endpoint + backend), so the agent's retrieval backend reranks."""

--- a/nemo_retriever/tests/test_service_query_client.py
+++ b/nemo_retriever/tests/test_service_query_client.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 
 import nemo_retriever.service.client as service_client_module
+from nemo_retriever.query.options import QueryFilterOptions
 from nemo_retriever.service.client import RetrieverServiceClient
 
 
@@ -58,6 +59,39 @@ def test_service_client_query_posts_to_v1_query_with_auth(monkeypatch) -> None:
     assert calls[1] == {
         "url": "http://svc:7670/v1/query",
         "json": {"query": "deployment?", "top_k": 2},
+    }
+
+
+def test_service_client_query_posts_filters_to_v1_query(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+    _install_query_response(
+        monkeypatch,
+        {"results": [{"hits": [{"text": "passage", "source": "doc.pdf"}]}]},
+        calls,
+    )
+
+    client = RetrieverServiceClient(base_url="http://svc:7670", api_token="secret")
+
+    assert client.query(
+        "deployment?",
+        top_k=2,
+        filters=QueryFilterOptions(
+            source_id="docs/a.pdf",
+            source="a.pdf",
+            page_number=3,
+            where="text != ''",
+        ),
+    ) == [[{"text": "passage", "source": "doc.pdf"}]]
+    assert calls[1] == {
+        "url": "http://svc:7670/v1/query",
+        "json": {
+            "query": "deployment?",
+            "top_k": 2,
+            "source_id": "docs/a.pdf",
+            "source": "a.pdf",
+            "page_number": 3,
+            "where": "text != ''",
+        },
     }
 
 

--- a/nemo_retriever/tests/test_service_vectordb_app.py
+++ b/nemo_retriever/tests/test_service_vectordb_app.py
@@ -82,3 +82,57 @@ def test_vector_db_state_local_embed_queries() -> None:
 
     assert vectors == [[1.0, 2.0]]
     mock_embedder.embed_queries.assert_called_once_with(["hello"])
+
+
+def test_query_rejects_negative_page_filter(tmp_path) -> None:
+    app = create_vectordb_app(
+        lancedb_uri=str(tmp_path),
+        table_name="test_table",
+        embed_endpoint="http://embed.example/v1/embeddings",
+        embed_model="nvidia/llama-nemotron-embed-vl-1b-v2",
+    )
+    with TestClient(app) as client:
+        resp = client.post("/v1/query", json={"query": "hello", "top_k": 3, "page_number": -1})
+
+    assert resp.status_code == 422
+
+
+def test_vectordb_search_applies_where_before_limit() -> None:
+    calls: list[tuple[str, object]] = []
+
+    class FakeQuery:
+        def where(self, where: str) -> "FakeQuery":
+            calls.append(("where", where))
+            return self
+
+        def limit(self, top_k: int) -> "FakeQuery":
+            calls.append(("limit", top_k))
+            return self
+
+        def to_list(self) -> list[dict[str, object]]:
+            return [{"text": "match", "metadata": "{}", "source": "{}"}]
+
+    class FakeTable:
+        def search(self, vector: list[float]) -> FakeQuery:
+            calls.append(("search", vector))
+            return FakeQuery()
+
+    class FakeDB:
+        def open_table(self, table_name: str) -> FakeTable:
+            calls.append(("open_table", table_name))
+            return FakeTable()
+
+    state = object.__new__(VectorDBState)
+    state._table_exists = True
+    state._db = FakeDB()
+    state.table_name = "docs"
+
+    result = state.search([[1.0, 0.0]], 2, "metadata LIKE '%\"page_number\":3%'")
+
+    assert result[0][0]["text"] == "match"
+    assert calls == [
+        ("open_table", "docs"),
+        ("search", [1.0, 0.0]),
+        ("where", "metadata LIKE '%\"page_number\":3%'"),
+        ("limit", 2),
+    ]

--- a/nemo_retriever/tests/test_service_vectordb_app.py
+++ b/nemo_retriever/tests/test_service_vectordb_app.py
@@ -8,6 +8,9 @@ from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
 
+import nemo_retriever.service.vectordb_app as vectordb_app_module
+from nemo_retriever.query.filters import build_query_where_clause
+from nemo_retriever.query.options import QueryFilterOptions
 from nemo_retriever.service.vectordb_app import (
     VectorDBState,
     _tensor_to_embedding_rows,
@@ -135,4 +138,69 @@ def test_vectordb_search_applies_where_before_limit() -> None:
         ("search", [1.0, 0.0]),
         ("where", "metadata LIKE '%\"page_number\":3%'"),
         ("limit", 2),
+    ]
+
+
+def test_query_route_accepts_filters_and_applies_where(monkeypatch, tmp_path) -> None:
+    calls: list[tuple[str, object]] = []
+
+    class FakeState:
+        table_exists = True
+        embed_endpoint = "http://embed.example/v1/embeddings"
+        embed_mode = "remote"
+
+        def total_rows(self) -> int:
+            return 1
+
+        def embed_queries(self, texts: list[str]) -> list[list[float]]:
+            calls.append(("embed", texts))
+            return [[1.0, 0.0]]
+
+        def search(
+            self,
+            vectors: list[list[float]],
+            top_k: int,
+            where: str | None = None,
+        ) -> list[list[dict[str, object]]]:
+            calls.append(("search", {"vectors": vectors, "top_k": top_k, "where": where}))
+            return [[{"text": "match", "metadata": '{"meta_a":"alpha"}', "source": "{}"}]]
+
+    monkeypatch.setattr(vectordb_app_module, "VectorDBState", lambda **_kwargs: FakeState())
+
+    app = vectordb_app_module.create_vectordb_app(
+        lancedb_uri=str(tmp_path),
+        table_name="test_table",
+        embed_endpoint="http://embed.example/v1/embeddings",
+        embed_model="nvidia/llama-nemotron-embed-vl-1b-v2",
+    )
+    with TestClient(app) as client:
+        resp = client.post(
+            "/v1/query",
+            json={
+                "query": "hello",
+                "top_k": 3,
+                "source_id": "docs/a.pdf",
+                "page_number": 1,
+                "where": 'metadata LIKE \'%"meta_a":"alpha"%\'',
+            },
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["results"][0]["hits"][0]["text"] == "match"
+    assert calls == [
+        ("embed", ["hello"]),
+        (
+            "search",
+            {
+                "vectors": [[1.0, 0.0]],
+                "top_k": 3,
+                "where": build_query_where_clause(
+                    QueryFilterOptions(
+                        source_id="docs/a.pdf",
+                        page_number=1,
+                        where='metadata LIKE \'%"meta_a":"alpha"%\'',
+                    )
+                ),
+            },
+        ),
     ]


### PR DESCRIPTION
## Summary
- add typed root query filters for source id, source, page number, and advanced LanceDB `where` predicates
- make service query filtering work end to end: `RetrieverServiceClient.query(..., filters=...)` -> gateway `/v1/query` -> VectorDB `/v1/query` -> LanceDB `.where(...)`
- preserve existing local `Retriever.query(..., vdb_kwargs={"where": ...})` behavior and root query JSON output shape
- add notebook-prerequisite coverage for compact sidecar metadata predicates such as `metadata LIKE '%"meta_a":"alpha"%'`

## Scope / Follow-Up
- This PR is the service/query filtering prerequisite for the metadata-filtering notebook follow-up (#2261).
- It does not edit the notebook and does not move docs prose back into `vdbs.md`.
- The Helm notebook example stays in #2261 once this query/filter API behavior lands.
- Agentic root query rejects filter flags for now rather than silently ignoring them; agentic pre-filter semantics should be handled separately if that new path needs scoped retrieval.

## Raw `where` Contract
- `where` is intentionally advanced/trusted-caller pass-through to LanceDB/DataFusion, applied as a read-only pre-filter before `limit()`.
- Common filtering should use structured `source_id`, `source`, and `page_number` fields.
- Service deployers should expose raw `where` only inside the same auth/trust boundary as unfiltered `/v1/query` access. The public service schema now documents that posture.

## Design Lineage
- This builds on Julio's #1966 metadata/filtering work, which already added local `Retriever.query(..., vdb_kwargs={"where": ...})` and LanceDB `_filter`/`where` support.
- #2258 does not change LanceDB predicate execution; it threads the existing local capability through root query and service query for parity.

## Validation
- Focused local suite: `/localhome/local-jioffe/retriever-skills/nemo_retriever/.venv/bin/python -m pytest nemo_retriever/tests/test_lancedb_retrieval_where.py nemo_retriever/tests/test_query_filters.py nemo_retriever/tests/test_query_workflow_options.py nemo_retriever/tests/test_root_query_cli.py nemo_retriever/tests/test_service_query_client.py nemo_retriever/tests/test_service_vectordb_app.py nemo_retriever/tests/test_retriever_queries.py nemo_retriever/tests/test_root_cli_workflow.py -q` (`157 passed`)
- Touched-file pre-commit: `/localhome/local-jioffe/.local/venvs/pre-commit/bin/pre-commit run --files nemo_retriever/src/nemo_retriever/cli/query/options.py nemo_retriever/src/nemo_retriever/service/query_schema.py nemo_retriever/tests/test_lancedb_retrieval_where.py nemo_retriever/tests/test_service_vectordb_app.py`
- Local Retriever query threading is covered by `test_retriever_queries.py::TestQueriesGraphExecution::test_queries_thread_top_k_and_vdb_kwargs` and LanceDB predicate execution is covered by `test_lancedb_retrieval_where.py`, including the compact sidecar metadata predicate.
- Service client payload is covered by `test_service_query_client.py::test_service_client_query_posts_filters_to_v1_query`.
- VectorDB `/v1/query` route filter application is covered by `test_service_vectordb_app.py::test_query_route_accepts_filters_and_applies_where`.
- Root service query JSON shape/filter pass-through is covered by `test_root_query_cli.py::test_root_query_service_mode_uses_service_options_and_prints_json`.

## Live Helm Smoke With Real Embed NIM
Environment:
- MicroK8s namespace/release: `nrl-real-filter-smoke`
- Helm chart: `./nemo_retriever/helm`
- Service image used for smoke: `nrl-service:2258-filter-smoke-fullsrc`, built from `nvcr.io/nvidia/nemo-microservices/nrl-service:26.5.0` with this branch's `nemo_retriever/src/nemo_retriever` overlaid
- Real embed NIM: scaled existing `nv-ingest/llama-nemotron-embed-vl-1b-v2` deployment from 0 to 1; pod became `Ready`, using `nvcr.io/nim/nvidia/llama-nemotron-embed-vl-1b-v2:1.12.0`
- VectorDB embed endpoint: `http://llama-nemotron-embed-vl-1b-v2.nv-ingest.svc.cluster.local:8000/v1/embeddings`
- Direct real embed probe returned 2048-dimensional embeddings from `nvidia/llama-nemotron-embed-vl-1b-v2`
- VectorDB seeded through `/internal/vectordb/write` with two rows whose vectors were generated by the real embed NIM:
  - `alpha sidecar metadata chunk`, `metadata={"meta_a":"alpha","page_number":1}`
  - `bravo sidecar metadata chunk`, `metadata={"meta_a":"bravo","page_number":2}`

Real embed probe:
```bash
curl -fsS -X POST http://127.0.0.1:18000/v1/embeddings \
  -H 'Content-Type: application/json' \
  --data-binary '{"model":"nvidia/llama-nemotron-embed-vl-1b-v2","input":["metadata smoke"],"encoding_format":"float","input_type":"query","truncate":"NONE"}'
```

Probe summary:
- `model`: `nvidia/llama-nemotron-embed-vl-1b-v2`
- `count`: `1`
- `dim`: `2048`

Gateway request:
```bash
curl -fsS -X POST http://127.0.0.1:18670/v1/query \
  -H 'Content-Type: application/json' \
  --data-binary '{"query":"metadata smoke","top_k":5,"where":"metadata LIKE '\''%\"meta_a\":\"alpha\"%'\''"}'
```

Gateway result summary:
- Control request without `where` returned 2 hits: alpha and bravo.
- Filtered request returned 1 hit: `alpha sidecar metadata chunk` from `notebook-alpha.pdf`, page `1`, with `metadata.meta_a == "alpha"`.

Root CLI service smoke against the same real-NIM Helm gateway:
```bash
PYTHONPATH=nemo_retriever/src /localhome/local-jioffe/retriever-skills/nemo_retriever/.venv/bin/python -c 'from nemo_retriever.__main__ import main; main()' \
  query service 'metadata smoke' \
  --service-url http://127.0.0.1:18670 \
  --top-k 5 \
  --where 'metadata LIKE '\''%"meta_a":"alpha"%'\'''
```

Root CLI result summary:
- 1 JSON hit, preserving the root query hit shape: `source=notebook-alpha.pdf`, `page_number=1`, `text="alpha sidecar metadata chunk"`, `modality=text`, real-service score `1.435014009475708`.

