### PR TITLE
Support `return_failures` for all ingest modes (inprocess, batch)

### DIFF
--- a/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
@@ -339,6 +339,22 @@ def _summarize_error_payload(error: Any) -> str:
     return _sanitize_error_text(error) or type(error).__name__
 
 
+def _format_public_failure_message(record: dict[str, Any]) -> str:
+    return "row {row_index}, column {column}, path {path}: {summary}".format(
+        row_index=record.get("row_index"),
+        column=record.get("column"),
+        path=record.get("path"),
+        summary=_summarize_error_payload(record.get("error")),
+    )
+
+
+def _coerce_source_identifier(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
 def _sanitize_error_text(value: Any, *, limit: int = _ERROR_MESSAGE_LIMIT) -> str | None:
     if value is None:
         return None
@@ -711,7 +727,7 @@ class GraphIngestor(ingestor):
             A ``pandas.DataFrame``.
         ``return_failures=True``
             ``(result, failures)`` where ``failures`` is a list of
-            structured row-level stage error records.
+            service-style ``(source, error)`` tuples.
         """
         return_failures = self._resolve_return_failures(params, kwargs)
         default_branches = self._plan_default_extraction_branches()
@@ -1045,6 +1061,59 @@ class GraphIngestor(ingestor):
                 child_path = f"{path}[{i}]" if path else f"[{i}]"
                 yield from cls._iter_stage_errors_from_value(child, path=child_path)
 
+    @staticmethod
+    def _row_value(row: Any, key: str) -> Any:
+        if isinstance(row, dict):
+            return row.get(key)
+        getter = getattr(row, "get", None)
+        if callable(getter):
+            try:
+                return getter(key)
+            except Exception:
+                return None
+        return None
+
+    @staticmethod
+    def _nested_mapping_value(value: Any, path: tuple[str, ...]) -> Any:
+        current = value
+        for key in path:
+            if not isinstance(current, dict):
+                return None
+            current = current.get(key)
+        return current
+
+    @classmethod
+    def _source_identifier_from_row(cls, row: Any, row_index: Any) -> str:
+        for field in ("document_id", "path", "source_path"):
+            identifier = _coerce_source_identifier(cls._row_value(row, field))
+            if identifier is not None:
+                return identifier
+
+        metadata = cls._row_value(row, "metadata")
+        for nested_path in (
+            ("source_path",),
+            ("source_metadata", "source_id"),
+            ("source_metadata", "source_name"),
+        ):
+            identifier = _coerce_source_identifier(cls._nested_mapping_value(metadata, nested_path))
+            if identifier is not None:
+                return identifier
+
+        for field in ("source_id", "source_name"):
+            identifier = _coerce_source_identifier(cls._row_value(row, field))
+            if identifier is not None:
+                return identifier
+
+        return f"row {row_index}" if row_index is not None else "row ?"
+
+    @staticmethod
+    def _public_failure_tuple(record: dict[str, Any]) -> tuple[str, str]:
+        identifier = _coerce_source_identifier(record.get("source_identifier"))
+        if identifier is None:
+            row_index = record.get("row_index")
+            identifier = f"row {row_index}" if row_index is not None else "row ?"
+        return identifier, _format_public_failure_message(record)
+
     @classmethod
     def _stage_error_records(cls, batch: Any, *, columns: Iterable[str] | None = None) -> list[dict[str, Any]]:
         iter_batches = getattr(batch, "iter_batches", None)
@@ -1068,11 +1137,13 @@ class GraphIngestor(ingestor):
                 else [c for c in requested_columns if c in available_columns]
             )
             for row_index, row in batch_df.iterrows():
+                source_identifier = cls._source_identifier_from_row(row, row_index)
                 for column in target_columns:
                     for record in cls._iter_stage_errors_from_value(row[column]):
                         records.append(
                             {
                                 "row_index": row_index,
+                                "source_identifier": source_identifier,
                                 "column": column,
                                 **record,
                             }
@@ -1205,9 +1276,12 @@ class GraphIngestor(ingestor):
         columns = set(diagnostics.keys()) if diagnostics else None
         return self._stage_error_records(result, columns=columns)
 
+    def _collect_failure_tuples(self, result: Any) -> list[tuple[str, str]]:
+        return [self._public_failure_tuple(record) for record in self._collect_failure_records(result)]
+
     def _finalize_ingest_result(self, result: Any, *, return_failures: bool) -> Any:
         if return_failures:
-            return result, self._collect_failure_records(result)
+            return result, self._collect_failure_tuples(result)
         self._raise_for_stage_errors(result)
         return result
 

--- a/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
@@ -54,6 +54,7 @@ from nemo_retriever.common.params import (
     EmbedParams,
     ExtractParams,
     HtmlChunkParams,
+    IngestExecuteParams,
     StoreParams,
     TextChunkParams,
     VideoFrameParams,
@@ -708,7 +709,11 @@ class GraphIngestor(ingestor):
             A materialized ``ray.data.Dataset``.
         ``run_mode='inprocess'``
             A ``pandas.DataFrame``.
+        ``return_failures=True``
+            ``(result, failures)`` where ``failures`` is a list of
+            structured row-level stage error records.
         """
+        return_failures = self._resolve_return_failures(params, kwargs)
         default_branches = self._plan_default_extraction_branches()
         if default_branches is None:
             single_effective = self._resolve_effective_extraction_inputs()
@@ -739,8 +744,7 @@ class GraphIngestor(ingestor):
                 raise RuntimeError("Internal error: extraction inputs were not resolved.")
             result = self._execute_single_graph(single_effective, post_extract_order=post_extract_order)
 
-        self._raise_for_stage_errors(result)
-        return result
+        return self._finalize_ingest_result(result, return_failures=return_failures)
 
     def _execute_single_graph(
         self,
@@ -1185,6 +1189,27 @@ class GraphIngestor(ingestor):
         records = self._stage_error_records(result, columns=set(diagnostics.keys()))
         if records:
             raise GraphIngestionError(records, stage_diagnostics=diagnostics)
+
+    @staticmethod
+    def _resolve_return_failures(params: Any, kwargs: dict[str, Any]) -> bool:
+        if "return_failures" in kwargs:
+            return bool(kwargs["return_failures"])
+        if isinstance(params, IngestExecuteParams):
+            return bool(params.return_failures)
+        if isinstance(params, dict) and "return_failures" in params:
+            return bool(params["return_failures"])
+        return False
+
+    def _collect_failure_records(self, result: Any) -> list[dict[str, Any]]:
+        diagnostics = self._remote_stage_diagnostics()
+        columns = set(diagnostics.keys()) if diagnostics else None
+        return self._stage_error_records(result, columns=columns)
+
+    def _finalize_ingest_result(self, result: Any, *, return_failures: bool) -> Any:
+        if return_failures:
+            return result, self._collect_failure_records(result)
+        self._raise_for_stage_errors(result)
+        return result
 
     @staticmethod
     def extract_error_rows(batch: Any) -> Any:

--- a/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py
@@ -719,6 +719,22 @@ class GraphIngestor(ingestor):
     def ingest(self, params: Any = None, **kwargs: Any) -> Any:
         """Build the operator graph and run it through the configured executor.
 
+        Parameters
+        ----------
+        params
+            Optional :class:`IngestExecuteParams` (or plain ``dict``) carrying
+            execute-time flags. Graph run modes honor ``return_failures``.
+        **kwargs
+            Execute-time flags passed directly. ``return_failures`` may be
+            passed here and takes precedence over the value in ``params``.
+        return_failures
+            When ``True`` (default ``False``), return ``(result, failures)``
+            instead of raising collected row-level stage errors. If no explicit
+            remote-stage diagnostics are configured, all output columns are
+            scanned for populated error fields so local collected failures can
+            still be returned; the default raise path remains scoped to
+            explicitly configured remote stages.
+
         Returns
         -------
         ``run_mode='batch'``
@@ -1069,7 +1085,14 @@ class GraphIngestor(ingestor):
         if callable(getter):
             try:
                 return getter(key)
-            except Exception:
+            except Exception as exc:  # noqa: BLE001 - row metadata lookup is best-effort diagnostic context.
+                logger.debug(
+                    "Failed to read source identifier field %r from row type %s: %s",
+                    key,
+                    type(row).__name__,
+                    exc,
+                    exc_info=True,
+                )
                 return None
         return None
 
@@ -1273,6 +1296,9 @@ class GraphIngestor(ingestor):
 
     def _collect_failure_records(self, result: Any) -> list[dict[str, Any]]:
         diagnostics = self._remote_stage_diagnostics()
+        # With explicit remote stages, report only their diagnostic columns.
+        # Without them, scan all columns so ``return_failures=True`` can expose
+        # local collected failures instead of silently returning an empty list.
         columns = set(diagnostics.keys()) if diagnostics else None
         return self._stage_error_records(result, columns=columns)
 

--- a/nemo_retriever/tests/test_ingest_interface.py
+++ b/nemo_retriever/tests/test_ingest_interface.py
@@ -331,8 +331,7 @@ def test_graph_ingestor_return_failures_returns_service_tuples_from_path(monkeyp
     assert failures == [
         (
             "doc-a.pdf",
-            "row 0, column page_elements_v3, path error: "
-            "remote_inference: ConnectionError: connection refused",
+            "row 0, column page_elements_v3, path error: " "remote_inference: ConnectionError: connection refused",
         )
     ]
 

--- a/nemo_retriever/tests/test_ingest_interface.py
+++ b/nemo_retriever/tests/test_ingest_interface.py
@@ -463,6 +463,17 @@ def test_graph_ingestor_return_failures_falls_back_to_row_index(monkeypatch) -> 
     assert "row failed" in failures[0][1]
 
 
+def test_graph_ingestor_row_value_logs_best_effort_lookup_failures(caplog) -> None:
+    class BrokenRow:
+        def get(self, key):
+            raise RuntimeError(f"cannot read {key}")
+
+    with caplog.at_level("DEBUG", logger="nemo_retriever.ingestor.graph_ingestor"):
+        assert GraphIngestor._row_value(BrokenRow(), "path") is None
+
+    assert "Failed to read source identifier field 'path'" in caplog.text
+
+
 @pytest.mark.integration
 def test_graph_ingestor_raises_for_explicit_remote_stage_errors() -> None:
     ingestor = GraphIngestor(

--- a/nemo_retriever/tests/test_ingest_interface.py
+++ b/nemo_retriever/tests/test_ingest_interface.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pandas as pd
 import pytest
 from PIL import Image
@@ -14,6 +16,7 @@ from nemo_retriever.common.params import (
     EmbedParams,
     ExtractParams,
     HtmlChunkParams,
+    IngestExecuteParams,
     RemoteRetryParams,
     TextChunkParams,
 )
@@ -47,6 +50,23 @@ def _effective_graph_node_names(ingestor: GraphIngestor) -> list[str]:
         split_config=ingestor._split_config,
     )
     return _graph_node_names(graph)
+
+
+def _run_graph_ingest_with_result(ingestor: GraphIngestor, result, monkeypatch, **ingest_kwargs):
+    monkeypatch.setattr(ingestor, "_plan_default_extraction_branches", lambda: None)
+    monkeypatch.setattr(
+        ingestor,
+        "_resolve_effective_extraction_inputs",
+        lambda: SimpleNamespace(extraction_mode="pdf"),
+    )
+
+    def _execute_single_graph(effective_extraction, *, post_extract_order):
+        assert effective_extraction.extraction_mode == "pdf"
+        assert isinstance(post_extract_order, tuple)
+        return result
+
+    monkeypatch.setattr(ingestor, "_execute_single_graph", _execute_single_graph)
+    return ingestor.ingest(**ingest_kwargs)
 
 
 def test_merge_params_none_returns_kwargs() -> None:
@@ -265,6 +285,150 @@ def test_typed_shortcuts_preserve_legacy_no_default_chunking() -> None:
     txt_ingestor = GraphIngestor(run_mode="inprocess").extract_txt(custom)
     assert txt_ingestor._split_config["text"] is None
     assert txt_ingestor._text_params is custom
+
+
+def test_graph_ingestor_return_failures_returns_structured_records(monkeypatch) -> None:
+    result = pd.DataFrame(
+        {
+            "page_elements_v3": [
+                {
+                    "timing": None,
+                    "error": {
+                        "stage": "remote_inference",
+                        "type": "ConnectionError",
+                        "message": "connection refused",
+                    },
+                }
+            ],
+            "metadata": [
+                {
+                    "error": {
+                        "stage": "local_postprocess",
+                        "message": "ignored because diagnostics narrow the scan",
+                    }
+                }
+            ],
+        }
+    )
+    ingestor = GraphIngestor(run_mode="inprocess").extract(
+        page_elements_invoke_url="http://remote.example/v1/page-elements",
+        extract_text=False,
+        extract_images=True,
+        extract_tables=False,
+        extract_charts=False,
+        extract_infographics=False,
+    )
+
+    returned, failures = _run_graph_ingest_with_result(
+        ingestor,
+        result,
+        monkeypatch,
+        return_failures=True,
+    )
+
+    assert returned is result
+    assert len(failures) == 1
+    assert failures[0]["row_index"] == 0
+    assert failures[0]["column"] == "page_elements_v3"
+    assert failures[0]["path"] == "error"
+    assert failures[0]["error"]["type"] == "ConnectionError"
+
+
+def test_graph_ingestor_return_failures_params_model(monkeypatch) -> None:
+    result = pd.DataFrame(
+        {
+            "metadata": [
+                {
+                    "error": {
+                        "stage": "local_postprocess",
+                        "message": "boom",
+                    }
+                }
+            ],
+        }
+    )
+    ingestor = GraphIngestor(run_mode="inprocess")
+
+    returned, failures = _run_graph_ingest_with_result(
+        ingestor,
+        result,
+        monkeypatch,
+        params=IngestExecuteParams(return_failures=True),
+    )
+
+    assert returned is result
+    assert len(failures) == 1
+    assert failures[0]["column"] == "metadata"
+    assert failures[0]["error"]["message"] == "boom"
+
+
+def test_graph_ingestor_return_failures_kwargs_override_params(monkeypatch) -> None:
+    result = pd.DataFrame({"text": ["ok"]})
+    ingestor = GraphIngestor(run_mode="inprocess")
+
+    returned = _run_graph_ingest_with_result(
+        ingestor,
+        result,
+        monkeypatch,
+        params=IngestExecuteParams(return_failures=True),
+        return_failures=False,
+    )
+
+    assert returned is result
+    assert not isinstance(returned, tuple)
+
+
+def test_graph_ingestor_return_failures_empty_when_no_row_errors(monkeypatch) -> None:
+    result = pd.DataFrame({"page_elements_v3": [{"detections": [], "error": None}], "text": ["ok"]})
+    ingestor = GraphIngestor(run_mode="inprocess").extract(
+        page_elements_invoke_url="http://remote.example/v1/page-elements",
+        extract_text=False,
+        extract_images=True,
+        extract_tables=False,
+        extract_charts=False,
+        extract_infographics=False,
+    )
+
+    returned, failures = _run_graph_ingest_with_result(
+        ingestor,
+        result,
+        monkeypatch,
+        return_failures=True,
+    )
+
+    assert returned is result
+    assert failures == []
+
+
+def test_graph_ingestor_return_failures_batch_mode(monkeypatch) -> None:
+    result = pd.DataFrame(
+        {
+            "metadata": [
+                {
+                    "errors": [
+                        {
+                            "stage": "batch_stage",
+                            "message": "row failed",
+                        }
+                    ]
+                }
+            ],
+        }
+    )
+    ingestor = GraphIngestor(run_mode="batch")
+
+    returned, failures = _run_graph_ingest_with_result(
+        ingestor,
+        result,
+        monkeypatch,
+        params={"return_failures": True},
+    )
+
+    assert returned is result
+    assert len(failures) == 1
+    assert failures[0]["column"] == "metadata"
+    assert failures[0]["path"] == "errors"
+    assert failures[0]["error"][0]["message"] == "row failed"
 
 
 @pytest.mark.integration

--- a/nemo_retriever/tests/test_ingest_interface.py
+++ b/nemo_retriever/tests/test_ingest_interface.py
@@ -287,9 +287,10 @@ def test_typed_shortcuts_preserve_legacy_no_default_chunking() -> None:
     assert txt_ingestor._text_params is custom
 
 
-def test_graph_ingestor_return_failures_returns_structured_records(monkeypatch) -> None:
+def test_graph_ingestor_return_failures_returns_service_tuples_from_path(monkeypatch) -> None:
     result = pd.DataFrame(
         {
+            "path": ["doc-a.pdf"],
             "page_elements_v3": [
                 {
                     "timing": None,
@@ -327,22 +328,25 @@ def test_graph_ingestor_return_failures_returns_structured_records(monkeypatch) 
     )
 
     assert returned is result
-    assert len(failures) == 1
-    assert failures[0]["row_index"] == 0
-    assert failures[0]["column"] == "page_elements_v3"
-    assert failures[0]["path"] == "error"
-    assert failures[0]["error"]["type"] == "ConnectionError"
+    assert failures == [
+        (
+            "doc-a.pdf",
+            "row 0, column page_elements_v3, path error: "
+            "remote_inference: ConnectionError: connection refused",
+        )
+    ]
 
 
-def test_graph_ingestor_return_failures_params_model(monkeypatch) -> None:
+def test_graph_ingestor_return_failures_params_model_uses_metadata_source_path(monkeypatch) -> None:
     result = pd.DataFrame(
         {
             "metadata": [
                 {
+                    "source_path": "nested-doc.pdf",
                     "error": {
                         "stage": "local_postprocess",
                         "message": "boom",
-                    }
+                    },
                 }
             ],
         }
@@ -357,9 +361,7 @@ def test_graph_ingestor_return_failures_params_model(monkeypatch) -> None:
     )
 
     assert returned is result
-    assert len(failures) == 1
-    assert failures[0]["column"] == "metadata"
-    assert failures[0]["error"]["message"] == "boom"
+    assert failures == [("nested-doc.pdf", "row 0, column metadata, path error: local_postprocess: boom")]
 
 
 def test_graph_ingestor_return_failures_kwargs_override_params(monkeypatch) -> None:
@@ -400,17 +402,18 @@ def test_graph_ingestor_return_failures_empty_when_no_row_errors(monkeypatch) ->
     assert failures == []
 
 
-def test_graph_ingestor_return_failures_batch_mode(monkeypatch) -> None:
+def test_graph_ingestor_return_failures_batch_mode_uses_source_metadata(monkeypatch) -> None:
     result = pd.DataFrame(
         {
             "metadata": [
                 {
+                    "source_metadata": {"source_id": "batch-doc.pdf"},
                     "errors": [
                         {
                             "stage": "batch_stage",
                             "message": "row failed",
                         }
-                    ]
+                    ],
                 }
             ],
         }
@@ -426,9 +429,39 @@ def test_graph_ingestor_return_failures_batch_mode(monkeypatch) -> None:
 
     assert returned is result
     assert len(failures) == 1
-    assert failures[0]["column"] == "metadata"
-    assert failures[0]["path"] == "errors"
-    assert failures[0]["error"][0]["message"] == "row failed"
+    assert failures[0][0] == "batch-doc.pdf"
+    assert "row 0, column metadata, path errors" in failures[0][1]
+    assert "row failed" in failures[0][1]
+
+
+def test_graph_ingestor_return_failures_falls_back_to_row_index(monkeypatch) -> None:
+    result = pd.DataFrame(
+        {
+            "metadata": [
+                {
+                    "errors": [
+                        {
+                            "stage": "batch_stage",
+                            "message": "row failed",
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    ingestor = GraphIngestor(run_mode="inprocess")
+
+    returned, failures = _run_graph_ingest_with_result(
+        ingestor,
+        result,
+        monkeypatch,
+        return_failures=True,
+    )
+
+    assert returned is result
+    assert len(failures) == 1
+    assert failures[0][0] == "row 0"
+    assert "row failed" in failures[0][1]
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Description
Add `return_failures=True` support to graph-mode ingestors so `run_mode="inprocess"` and `run_mode="batch"` can return `(result, failures)` instead of requiring service mode for failure collection.

This reuses the existing row-level stage error scanner and keeps default behavior unchanged: graph ingestion still raises `GraphIngestionError` for recognized remote-stage row errors unless `return_failures=True` is requested.

Validation:
- `.venv/bin/pytest nemo_retriever/tests/test_ingest_interface.py`
- `.venv/bin/pytest nemo_retriever/tests/test_service_ingest_async.py`
- `git diff --check -- nemo_retriever/src/nemo_retriever/ingestor/graph_ingestor.py nemo_retriever/tests/test_ingest_interface.py`

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.