### PR TITLE
ci(docs): default Akamai notify email for docs.nvidia.com auto-publish when notify list is empty

### DIFF
--- a/.github/workflows/nrl-docs-nvidia-publish.yml
+++ b/.github/workflows/nrl-docs-nvidia-publish.yml
@@ -134,6 +134,9 @@ jobs:
               EMAILS="${NOTIFY_INPUT}"
             fi
           fi
+          if [[ -z "${EMAILS}" ]]; then
+            EMAILS="kheiss@nvidia.com"
+          fi
           echo "emails_csv=${EMAILS}" >> "$GITHUB_OUTPUT"
 
   build:


### PR DESCRIPTION
## Summary
- For the **NRL automatic build and deployment to docs.nvidia.com** workflow (`nrl-docs-nvidia-publish.yml` — S3 sync to Brightspot + Akamai cache flush on merge to `main`), when `DOCS_RELEASE_EMAILS` and the manual notify input are both empty, default Akamai ECCU `statusUpdateEmails` to `kheiss@nvidia.com`.
- Prevents an empty `emails-csv` from overriding the FW-CI `publish-docs` default and dropping notifications entirely.

## Test plan
- [ ] Merge and run **NRL documentation — docs.nvidia.com publish** manually with notify field empty and no `DOCS_RELEASE_EMAILS` variable
- [ ] Confirm **Flush Akamai cache** step writes `["kheiss@nvidia.com"]` to the email list
- [ ] Confirm Akamai status email is received after live publish

Additional stakeholders will be added once automatic publish to docs.nvidia.com is validated end-to-end (S3 paths, `latest/`, live URLs, and Akamai notification to kheiss@nvidia.com).
