### PR TITLE
Add LanceDB retrieval mode autodetection

### DIFF
--- a/nemo_retriever/src/nemo_retriever/cli/ingest/graph_commands.py
+++ b/nemo_retriever/src/nemo_retriever/cli/ingest/graph_commands.py
@@ -21,6 +21,7 @@ from nemo_retriever.ingest.plan import (
     IngestExtractBatchOptions,
     IngestExtractOptions,
     IngestImageStoreOptions,
+    IngestIndexModeValue,
     IngestMediaOptions,
     IngestPlanRequest,
     IngestRunModeValue,
@@ -28,6 +29,7 @@ from nemo_retriever.ingest.plan import (
     IngestSourceOptions,
     IngestStorageOptions,
     resolve_ingest_plan,
+    validate_ingest_index_mode,
 )
 
 
@@ -79,6 +81,41 @@ def _validate_graph_ingest_mode_options(values: Mapping[str, Any], *, run_mode: 
     if batch_only_flags:
         joined_flags = ", ".join(batch_only_flags)
         raise ValueError(f"Batch-only option(s) require `retriever ingest batch`: {joined_flags}")
+
+
+def _parameter_was_provided(ctx: typer.Context, parameter_name: str) -> bool:
+    source = ctx.get_parameter_source(parameter_name)
+    return source is not None and getattr(source, "name", "") != "DEFAULT"
+
+
+def _resolve_index_mode_option(
+    ctx: typer.Context,
+    *,
+    index_mode: str,
+    hybrid: bool,
+    sparse: bool,
+) -> IngestIndexModeValue:
+    try:
+        resolved = validate_ingest_index_mode(index_mode)
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1) from exc
+
+    has_index_mode = _parameter_was_provided(ctx, "index_mode")
+    has_hybrid_alias = _parameter_was_provided(ctx, "hybrid")
+    has_sparse_alias = _parameter_was_provided(ctx, "sparse")
+    provided_modes = [has_index_mode, has_hybrid_alias, has_sparse_alias]
+    if sum(provided_modes) > 1:
+        typer.echo(
+            "Error: pass only one index mode option: --index-mode, deprecated --hybrid, or deprecated --sparse.",
+            err=True,
+        )
+        raise typer.Exit(1)
+    if has_hybrid_alias and hybrid:
+        return "hybrid"
+    if has_sparse_alias and sparse:
+        return "sparse"
+    return resolved
 
 
 def _matching_option_values(values: Mapping[str, Any], options_type: type[Any]) -> dict[str, Any]:
@@ -215,6 +252,7 @@ def _graph_ingest_command(
     dedup_iou_threshold: opts.DedupIouThresholdOption = None,
     store_images_uri: opts.StoreImagesUriOption = None,
     overwrite: opts.OverwriteOption = True,
+    index_mode: opts.IndexModeOption = "dense",
     hybrid: opts.HybridOption = False,
     sparse: opts.SparseOption = False,
     ray_address: opts.RayAddressOption = None,
@@ -261,4 +299,6 @@ def _graph_ingest_command(
     embed_gpus_per_actor: opts.EmbedGpusPerActorOption = None,
     quiet: opts.QuietOption = True,
 ) -> None:
-    _run_graph_ingest_from_parsed_options(ctx.params, run_mode=_graph_run_mode_for_command(ctx))
+    parsed_options = dict(ctx.params)
+    parsed_options["index_mode"] = _resolve_index_mode_option(ctx, index_mode=index_mode, hybrid=hybrid, sparse=sparse)
+    _run_graph_ingest_from_parsed_options(parsed_options, run_mode=_graph_run_mode_for_command(ctx))

--- a/nemo_retriever/src/nemo_retriever/cli/ingest/graph_commands.py
+++ b/nemo_retriever/src/nemo_retriever/cli/ingest/graph_commands.py
@@ -216,6 +216,7 @@ def _graph_ingest_command(
     store_images_uri: opts.StoreImagesUriOption = None,
     overwrite: opts.OverwriteOption = True,
     hybrid: opts.HybridOption = False,
+    sparse: opts.SparseOption = False,
     ray_address: opts.RayAddressOption = None,
     ray_log_to_driver: opts.RayLogToDriverOption = None,
     page_elements_invoke_url: opts.PageElementsInvokeUrlOption = None,

--- a/nemo_retriever/src/nemo_retriever/cli/ingest/options.py
+++ b/nemo_retriever/src/nemo_retriever/cli/ingest/options.py
@@ -209,11 +209,18 @@ OverwriteOption = Annotated[
 HybridOption = Annotated[
     bool,
     typer.Option(
-        "--hybrid/--no-hybrid",
+        "--hybrid",
         help=(
             "Also build a full-text (BM25) index over ingested text so query --hybrid can fuse "
             "lexical and vector retrieval. Disabled by default."
         ),
+    ),
+]
+SparseOption = Annotated[
+    bool,
+    typer.Option(
+        "--sparse",
+        help="Skip dense embedding and build a LanceDB full-text-search-only table. Disabled by default.",
     ),
 ]
 RayAddressOption = Annotated[

--- a/nemo_retriever/src/nemo_retriever/cli/ingest/options.py
+++ b/nemo_retriever/src/nemo_retriever/cli/ingest/options.py
@@ -10,6 +10,7 @@ import typer
 
 from nemo_retriever.ingest.plan import (
     AudioSplitTypeValue,
+    IngestIndexModeValue,
     IngestProfileValue,
     LocalIngestEmbedBackendValue,
     OcrLangValue,
@@ -206,21 +207,30 @@ OverwriteOption = Annotated[
         ),
     ),
 ]
+IndexModeOption = Annotated[
+    IngestIndexModeValue,
+    typer.Option(
+        "--index-mode",
+        help=(
+            "LanceDB index mode: dense, hybrid, or sparse. Dense is vector-only; hybrid also builds "
+            "BM25/FTS; sparse skips dense embedding and writes an FTS-only table."
+        ),
+    ),
+]
 HybridOption = Annotated[
     bool,
     typer.Option(
         "--hybrid",
-        help=(
-            "Also build a full-text (BM25) index over ingested text so query --hybrid can fuse "
-            "lexical and vector retrieval. Disabled by default."
-        ),
+        help="Deprecated alias for --index-mode hybrid.",
+        hidden=True,
     ),
 ]
 SparseOption = Annotated[
     bool,
     typer.Option(
         "--sparse",
-        help="Skip dense embedding and build a LanceDB full-text-search-only table. Disabled by default.",
+        help="Deprecated alias for --index-mode sparse.",
+        hidden=True,
     ),
 ]
 RayAddressOption = Annotated[

--- a/nemo_retriever/src/nemo_retriever/cli/query/app.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query/app.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import os
+from typing import cast
 
 import click
 import typer
@@ -27,6 +28,7 @@ from nemo_retriever.query.options import (
     QueryRerankOptions,
     QueryRequest,
     QueryRetrievalOptions,
+    QueryRetrievalMode,
     QueryServiceOptions,
     QueryStorageOptions,
     ServiceQueryRequest,
@@ -35,6 +37,7 @@ from nemo_retriever.query.service import query_documents as query_service_docume
 
 _DEFAULT_COMMAND = "_local"
 _GROUP_OPTIONS = {"--help", "-h", "--install-completion", "--show-completion"}
+_RETRIEVAL_MODES: set[str] = {"auto", "dense", "hybrid", "sparse"}
 
 
 class DefaultLocalQueryGroup(TyperGroup):
@@ -94,6 +97,31 @@ def _validate_output_options(output_format: str, max_text_chars: int | None) -> 
         raise typer.Exit(1)
 
 
+def _validate_retrieval_mode(retrieval_mode: str) -> QueryRetrievalMode:
+    normalized = retrieval_mode.strip().lower()
+    if normalized not in _RETRIEVAL_MODES:
+        typer.echo(
+            "Error: unknown --retrieval-mode " f"{retrieval_mode!r} (use 'auto', 'dense', 'hybrid', or 'sparse').",
+            err=True,
+        )
+        raise typer.Exit(1)
+    return cast(QueryRetrievalMode, normalized)
+
+
+def _query_retrieval_mode(ctx: typer.Context, retrieval_mode: str, hybrid: bool) -> QueryRetrievalMode:
+    resolved = _validate_retrieval_mode(retrieval_mode)
+    hybrid_source = ctx.get_parameter_source("hybrid")
+    has_hybrid_alias = hybrid_source is not None and getattr(hybrid_source, "name", "") != "DEFAULT"
+    retrieval_mode_source = ctx.get_parameter_source("retrieval_mode")
+    has_retrieval_mode = retrieval_mode_source is not None and getattr(retrieval_mode_source, "name", "") != "DEFAULT"
+    if has_hybrid_alias and has_retrieval_mode:
+        typer.echo("Error: pass only one of --retrieval-mode or deprecated --hybrid.", err=True)
+        raise typer.Exit(1)
+    if has_hybrid_alias and hybrid:
+        return "hybrid"
+    return resolved
+
+
 def _emit_query_output(
     hits: list[RetrievalHit],
     *,
@@ -116,14 +144,14 @@ def _retrieval_options(
     candidate_k: int | None,
     page_dedup: bool,
     content_types: str | None,
-    hybrid: bool | None = None,
+    retrieval_mode: QueryRetrievalMode = "auto",
 ) -> QueryRetrievalOptions:
     return QueryRetrievalOptions(
         top_k=top_k,
         candidate_k=candidate_k,
         page_dedup=page_dedup,
         content_types=content_types,
-        hybrid=hybrid,
+        retrieval_mode=retrieval_mode,
     )
 
 
@@ -144,6 +172,7 @@ def _local_command(
     reranker_model_name: opts.RerankerModelNameOption = None,
     reranker_backend: opts.RerankerBackendOption = None,
     rerank: opts.RerankOption = False,
+    retrieval_mode: opts.RetrievalModeOption = "auto",
     hybrid: opts.HybridOption = False,
     output_format: opts.OutputFormatOption = "hits",
     max_text_chars: opts.MaxTextCharsOption = None,
@@ -169,6 +198,7 @@ def _local_command(
 
     try:
         reranker_api_key = _api_key_from_env_option(reranker_api_key_env) if reranker_invoke_url else None
+        effective_retrieval_mode = _query_retrieval_mode(ctx, retrieval_mode, hybrid)
 
         if agentic:
             request = QueryRequest(
@@ -178,6 +208,7 @@ def _local_command(
                     candidate_k=candidate_k,
                     page_dedup=page_dedup,
                     content_types=content_types,
+                    retrieval_mode=effective_retrieval_mode,
                 ),
                 embed=QueryEmbedOptions(
                     embed_invoke_url=embed_invoke_url,
@@ -210,12 +241,7 @@ def _local_command(
             typer.echo(json.dumps(ranked, indent=2, sort_keys=True, default=str))
             return
 
-        hybrid_source = ctx.get_parameter_source("hybrid")
-        hybrid_override = (
-            hybrid if hybrid_source is not None and getattr(hybrid_source, "name", "") != "DEFAULT" else None
-        )
-
-        def _request(use_hybrid: bool | None) -> QueryRequest:
+        def _request() -> QueryRequest:
             return QueryRequest(
                 query=query,
                 retrieval=_retrieval_options(
@@ -223,7 +249,7 @@ def _local_command(
                     candidate_k=candidate_k,
                     page_dedup=page_dedup,
                     content_types=content_types,
-                    hybrid=use_hybrid,
+                    retrieval_mode=effective_retrieval_mode,
                 ),
                 embed=QueryEmbedOptions(
                     embed_invoke_url=embed_invoke_url,
@@ -243,7 +269,7 @@ def _local_command(
             )
 
         with quiet_capture():
-            result = query_local_documents_with_metadata(_request(hybrid_override))
+            result = query_local_documents_with_metadata(_request())
             hits = result.hits
             strategies = result.strategies
     except ROOT_CLI_ERRORS as exc:

--- a/nemo_retriever/src/nemo_retriever/cli/query/app.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query/app.py
@@ -14,7 +14,7 @@ from typer.core import TyperGroup
 from nemo_retriever.cli.evidence import build_evidence_result
 from nemo_retriever.cli.query import options as opts
 from nemo_retriever.cli.query_workflow import agentic_query_documents as query_agentic_documents
-from nemo_retriever.cli.query_workflow import query_documents as query_local_documents
+from nemo_retriever.cli.query_workflow import query_documents_with_metadata as query_local_documents_with_metadata
 from nemo_retriever.cli.shared import (
     ROOT_CLI_ERRORS,
     quiet_capture,
@@ -46,7 +46,10 @@ class DefaultLocalQueryGroup(TyperGroup):
 
 app = typer.Typer(
     cls=DefaultLocalQueryGroup,
-    help="Query Retriever indexes. Omitting a mode queries local LanceDB.",
+    help=(
+        "Query Retriever indexes. The local root CLI supports LanceDB indexes; "
+        "use the SDK VDB interface for other backends."
+    ),
     no_args_is_help=True,
 )
 
@@ -113,7 +116,7 @@ def _retrieval_options(
     candidate_k: int | None,
     page_dedup: bool,
     content_types: str | None,
-    hybrid: bool = False,
+    hybrid: bool | None = None,
 ) -> QueryRetrievalOptions:
     return QueryRetrievalOptions(
         top_k=top_k,
@@ -126,6 +129,7 @@ def _retrieval_options(
 
 @app.command("_local", hidden=True)
 def _local_command(
+    ctx: typer.Context,
     query: opts.QueryArgument,
     top_k: opts.TopKOption = 10,
     candidate_k: opts.CandidateKOption = None,
@@ -206,7 +210,12 @@ def _local_command(
             typer.echo(json.dumps(ranked, indent=2, sort_keys=True, default=str))
             return
 
-        def _request(use_hybrid: bool) -> QueryRequest:
+        hybrid_source = ctx.get_parameter_source("hybrid")
+        hybrid_override = (
+            hybrid if hybrid_source is not None and getattr(hybrid_source, "name", "") != "DEFAULT" else None
+        )
+
+        def _request(use_hybrid: bool | None) -> QueryRequest:
             return QueryRequest(
                 query=query,
                 retrieval=_retrieval_options(
@@ -234,16 +243,9 @@ def _local_command(
             )
 
         with quiet_capture():
-            if hybrid:
-                try:
-                    hits = query_local_documents(_request(True))
-                    strategies = ["semantic", "lexical"]
-                except Exception:  # noqa: BLE001 - preserve root query's vector fallback on missing FTS.
-                    hits = query_local_documents(_request(False))
-                    strategies = ["semantic"]
-            else:
-                hits = query_local_documents(_request(False))
-                strategies = ["semantic"]
+            result = query_local_documents_with_metadata(_request(hybrid_override))
+            hits = result.hits
+            strategies = result.strategies
     except ROOT_CLI_ERRORS as exc:
         typer.echo(f"Error: {exc}", err=True)
         raise typer.Exit(1) from exc

--- a/nemo_retriever/src/nemo_retriever/cli/query/options.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query/options.py
@@ -106,14 +106,22 @@ RerankOption = Annotated[
         ),
     ),
 ]
+RetrievalModeOption = Annotated[
+    str,
+    typer.Option(
+        "--retrieval-mode",
+        help=(
+            "Expert LanceDB retrieval mode: auto, dense, hybrid, or sparse. Default auto inspects the table "
+            "and chooses the supported mode."
+        ),
+    ),
+]
 HybridOption = Annotated[
     bool,
     typer.Option(
         "--hybrid",
-        help=(
-            "Override automatic LanceDB retrieval-mode detection for vector tables. By default, "
-            "query inspects the table and chooses dense, hybrid, or sparse retrieval."
-        ),
+        help="Deprecated alias for --retrieval-mode hybrid.",
+        hidden=True,
     ),
 ]
 OutputFormatOption = Annotated[

--- a/nemo_retriever/src/nemo_retriever/cli/query/options.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query/options.py
@@ -109,10 +109,10 @@ RerankOption = Annotated[
 HybridOption = Annotated[
     bool,
     typer.Option(
-        "--hybrid/--no-hybrid",
+        "--hybrid",
         help=(
-            "Fused vector + full-text (BM25) retrieval; falls back to vector-only if the table "
-            "has no FTS index. Opt-in (default off) preserves the legacy vector-only default."
+            "Override automatic LanceDB retrieval-mode detection for vector tables. By default, "
+            "query inspects the table and chooses dense, hybrid, or sparse retrieval."
         ),
     ),
 ]

--- a/nemo_retriever/src/nemo_retriever/cli/query_workflow.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query_workflow.py
@@ -7,14 +7,21 @@ from __future__ import annotations
 from typing import Any
 
 from nemo_retriever.query.options import QueryRequest
+from nemo_retriever.query.workflow import QueryDocumentsResult
 from nemo_retriever.query.workflow import agentic_query_documents as run_agentic_query_documents
 from nemo_retriever.query.workflow import query_documents as run_query_documents
+from nemo_retriever.query.workflow import query_documents_with_metadata as run_query_documents_with_metadata
 from nemo_retriever.common.vdb.records import RetrievalHit
 
 
 def query_documents(request: QueryRequest) -> list[RetrievalHit]:
     """Run the typed root query workflow."""
     return run_query_documents(request)
+
+
+def query_documents_with_metadata(request: QueryRequest) -> QueryDocumentsResult:
+    """Run the typed root query workflow and return hits plus retrieval metadata."""
+    return run_query_documents_with_metadata(request)
 
 
 def agentic_query_documents(request: QueryRequest) -> list[dict[str, Any]]:

--- a/nemo_retriever/src/nemo_retriever/common/vdb/README.md
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/README.md
@@ -7,6 +7,8 @@ This package wraps **vector database backends** behind a small `VDB` interface (
 
 The only built-in backend key today is **`lancedb`**, resolved by `get_vdb_op_cls()` in `factory.py` to the concrete **`LanceDB`** class in `lancedb.py`.
 
+The root CLI is intentionally LanceDB-first: `retriever ingest ...` writes LanceDB tables, and `retriever query ...` queries LanceDB tables. Other VDB backends should plug in through the SDK/operator layer by implementing `VDB` and registering a backend key in `factory.py`; the root CLI does not currently expose a generic `--vdb-op` / `--vdb-kwargs-json` query surface.
+
 ---
 
 ## `IngestVdbOperator` (ingestion)
@@ -127,6 +129,8 @@ hits_per_query = op.process(
 ## `Retriever` and `RetrieveVdbOperator`
 
 The high-level **`Retriever`** class (`retriever.py`) uses **`RetrieveVdbOperator`** internally. Pass a flat LanceDB **`vdb_kwargs`** dict with `uri`, `table_name`, filters, etc., or the explicit nested shape `{"vdb_op": "lancedb", "vdb_kwargs": {...}}`.
+
+For non-LanceDB backends, implement the `VDB` interface in a backend module, register the backend in `factory.py`, and construct `Retriever` through the SDK with `{"vdb_op": "<backend>", "vdb_kwargs": {...}}` or a concrete `{"vdb": backend_instance}`. The root `retriever query` CLI remains LanceDB-only.
 
 It **lazy-builds** the operator:
 

--- a/nemo_retriever/src/nemo_retriever/common/vdb/lancedb.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/lancedb.py
@@ -23,6 +23,8 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_VECTOR_DIM: Final[int] = 2048
 _VALID_ON_BAD_VECTORS: Final[FrozenSet[str]] = frozenset({"drop", "fill", "null", "error"})
+_RETRIEVAL_MODE_METADATA_KEY: Final[bytes] = b"retrieval_mode"
+_NEMO_RETRIEVER_RETRIEVAL_MODE_METADATA_KEY: Final[bytes] = b"nemo_retriever.retrieval_mode"
 
 
 def _normalize_on_bad_vectors(value: str) -> str:
@@ -114,8 +116,18 @@ def _effective_ivf_num_partitions(num_rows: int, requested: int) -> int | None:
     return min(int(requested), max(1, cap))
 
 
-def _lancedb_arrow_schema(vector_dim: int) -> pa.Schema:
-    return pa.schema(
+def _with_retrieval_mode_metadata(schema: pa.Schema, retrieval_mode: str | None) -> pa.Schema:
+    if retrieval_mode is None:
+        return schema
+    metadata = dict(schema.metadata or {})
+    encoded_mode = str(retrieval_mode).encode("utf-8")
+    metadata[_RETRIEVAL_MODE_METADATA_KEY] = encoded_mode
+    metadata[_NEMO_RETRIEVER_RETRIEVAL_MODE_METADATA_KEY] = encoded_mode
+    return schema.with_metadata(metadata)
+
+
+def _lancedb_arrow_schema(vector_dim: int, *, retrieval_mode: str | None = None) -> pa.Schema:
+    schema = pa.schema(
         [
             pa.field("vector", pa.list_(pa.float32(), int(vector_dim))),
             pa.field("text", pa.string()),
@@ -124,6 +136,19 @@ def _lancedb_arrow_schema(vector_dim: int) -> pa.Schema:
             pa.field("id", pa.string()),
         ]
     )
+    return _with_retrieval_mode_metadata(schema, retrieval_mode)
+
+
+def _sparse_lancedb_arrow_schema(*, retrieval_mode: str | None = "sparse") -> pa.Schema:
+    schema = pa.schema(
+        [
+            pa.field("text", pa.string()),
+            pa.field("metadata", pa.string()),
+            pa.field("source", pa.string()),
+            pa.field("id", pa.string()),
+        ]
+    )
+    return _with_retrieval_mode_metadata(schema, retrieval_mode)
 
 
 def _table_schema(table: Any) -> pa.Schema:
@@ -316,6 +341,49 @@ def _create_lancedb_results(
     return lancedb_rows, counts
 
 
+def _create_sparse_lancedb_results(results) -> tuple[list, dict[str, int]]:
+    """Transform NRL records into LanceDB rows for FTS-only sparse retrieval."""
+    lancedb_rows: list = []
+    accepted = 0
+    dropped_no_text = 0
+
+    for result in results:
+        for element in result:
+            metadata = element.get("metadata", {})
+            content_meta = metadata.get("content_metadata", {})
+            text = _get_text_for_element(element)
+
+            if not text:
+                dropped_no_text += 1
+                source_name = metadata.get("source_metadata", {}).get("source_name", "unknown")
+                pg_num = content_meta.get("page_number") if isinstance(content_meta, dict) else None
+                logger.debug("No text found for sparse entity: %s page: %s", source_name, pg_num)
+                continue
+
+            row_id = content_meta.get("id") if isinstance(content_meta, dict) else None
+            if row_id is None and isinstance(metadata, dict):
+                row_id = metadata.get("id")
+            row_id_str = str(row_id) if row_id is not None else ""
+
+            lancedb_rows.append(
+                {
+                    "text": text,
+                    "metadata": _json_str(content_meta),
+                    "source": _json_str(metadata.get("source_metadata", {})),
+                    "id": row_id_str,
+                }
+            )
+            accepted += 1
+
+    counts: dict[str, int] = {
+        "accepted": accepted,
+        "dropped_no_text": dropped_no_text,
+    }
+    if dropped_no_text:
+        logger.warning("_create_sparse_lancedb_results: accepted=%d dropped_no_text=%d", accepted, dropped_no_text)
+    return lancedb_rows, counts
+
+
 class LanceDB(VDB):
     """LanceDB operator implementing the VDB interface."""
 
@@ -329,6 +397,7 @@ class LanceDB(VDB):
         num_partitions: int = 16,
         num_sub_vectors: int = 256,
         hybrid: bool = False,
+        sparse: bool = False,
         fts_language: str = "English",
         vector_dim: int = _DEFAULT_VECTOR_DIM,
         on_bad_vectors: str = "drop",
@@ -345,6 +414,8 @@ class LanceDB(VDB):
 
         if int(vector_dim) <= 0:
             raise ValueError(f"vector_dim must be positive; got {vector_dim}")
+        if sparse and hybrid:
+            raise ValueError("LanceDB sparse ingest cannot also be hybrid; pass only one retrieval mode.")
         self.uri = uri or "lancedb"
         self.overwrite = bool(overwrite)
         self.table_name = table_name
@@ -354,6 +425,7 @@ class LanceDB(VDB):
         self.num_partitions = num_partitions
         self.num_sub_vectors = num_sub_vectors
         self.hybrid = hybrid
+        self.sparse = bool(sparse)
         self.fts_language = fts_language
         self.vector_dim = int(vector_dim)
         self.on_bad_vectors = _normalize_on_bad_vectors(on_bad_vectors)
@@ -377,19 +449,24 @@ class LanceDB(VDB):
         db = lancedb.connect(uri=self.uri)
         _record_timing("lancedb.connect", time.perf_counter() - connect_start)
 
-        if self.validate_vector_length and self.on_bad_vectors != "error":
-            expected_dim: int | None = self.vector_dim
+        if self.sparse:
+            results, counts = _create_sparse_lancedb_results(records or [])
+            schema = _sparse_lancedb_arrow_schema()
+            write_kwargs: dict[str, Any] = {}
         else:
-            expected_dim = None
+            if self.validate_vector_length and self.on_bad_vectors != "error":
+                expected_dim: int | None = self.vector_dim
+            else:
+                expected_dim = None
 
-        results, counts = _create_lancedb_results(records or [], expected_dim=expected_dim)
-        schema = _lancedb_arrow_schema(self.vector_dim)
+            results, counts = _create_lancedb_results(records or [], expected_dim=expected_dim)
+            schema = _lancedb_arrow_schema(self.vector_dim, retrieval_mode="hybrid" if self.hybrid else "dense")
 
-        write_kwargs: dict[str, Any] = {
-            "on_bad_vectors": self.on_bad_vectors,
-        }
-        if self.on_bad_vectors == "fill":
-            write_kwargs["fill_value"] = self.fill_value
+            write_kwargs = {
+                "on_bad_vectors": self.on_bad_vectors,
+            }
+            if self.on_bad_vectors == "fill":
+                write_kwargs["fill_value"] = self.fill_value
 
         create_kwargs: dict[str, Any] = {
             "schema": schema,
@@ -454,8 +531,9 @@ class LanceDB(VDB):
         metric="l2",
         num_partitions=16,
         num_sub_vectors=256,
-        hybrid: bool = None,
-        fts_language: str = None,
+        hybrid: bool | None = None,
+        sparse: bool | None = None,
+        fts_language: str | None = None,
         **kwargs,
     ):
         """Create vector and optionally FTS indexes on the LanceDB table.
@@ -465,7 +543,17 @@ class LanceDB(VDB):
         single-row tables skip the vector index; hybrid FTS may still be built.
         """
         hybrid = hybrid if hybrid is not None else self.hybrid
+        sparse = sparse if sparse is not None else self.sparse
         fts_language = fts_language or self.fts_language
+
+        if sparse:
+            fts_index_start = time.perf_counter()
+            table.create_fts_index("text", language=fts_language, replace=True)
+            for index_stub in table.list_indices():
+                if "text" in index_stub.name.lower() or "fts" in index_stub.name.lower():
+                    table.wait_for_index([index_stub.name], timeout=timedelta(seconds=600))
+            _record_timing("lancedb.fts_index_ready", time.perf_counter() - fts_index_start)
+            return
 
         num_rows = int(table.count_rows())
         requested_partitions = int(num_partitions)
@@ -532,6 +620,7 @@ class LanceDB(VDB):
                 num_partitions=self.num_partitions,
                 num_sub_vectors=self.num_sub_vectors,
                 hybrid=self.hybrid,
+                sparse=self.sparse,
                 fts_language=self.fts_language,
             )
         else:
@@ -626,6 +715,57 @@ class LanceDB(VDB):
 
         counts["put"] = len(rows)
         return counts
+
+    def sparse_retrieval(self, query_texts: Iterable[str], **kwargs: Any) -> list[list[dict[str, Any]]]:
+        """Search a LanceDB FTS-only table without query embeddings."""
+        table_path = kwargs.pop("table_path", self.uri)
+        table_name = kwargs.pop("table_name", self.table_name)
+        result_fields = kwargs.pop("result_fields", None)
+        top_k = int(kwargs.pop("top_k", 10))
+        text_column_value = kwargs.pop("text_column_name", kwargs.pop("fts_columns", "text"))
+        if isinstance(text_column_value, (list, tuple)):
+            text_column_name = str(text_column_value[0] if text_column_value else "text")
+        else:
+            text_column_name = str(text_column_value)
+
+        search_kwargs_raw = kwargs.pop("search_kwargs", None)
+        if search_kwargs_raw is None:
+            search_kwargs: dict[str, Any] = {}
+        elif not isinstance(search_kwargs_raw, dict):
+            raise TypeError(f"search_kwargs must be a dict or None; got {type(search_kwargs_raw).__name__}")
+        else:
+            search_kwargs = dict(search_kwargs_raw)
+
+        query_type = search_kwargs.get("query_type")
+        if query_type is not None:
+            query_type_value = getattr(query_type, "value", query_type)
+            if str(query_type_value).lower() != "fts":
+                raise ValueError(
+                    "LanceDB sparse retrieval requires search_kwargs['query_type']='fts'; " f"got {query_type!r}."
+                )
+        search_kwargs["query_type"] = "fts"
+        search_kwargs.setdefault("fts_columns", text_column_name)
+
+        where_clause = kwargs.pop("where", None)
+        _filter_fallback = kwargs.pop("_filter", None)
+        if where_clause is None:
+            where_clause = _filter_fallback
+        if where_clause is not None:
+            where_clause = str(where_clause).strip() or None
+
+        table = lancedb.connect(uri=table_path).open_table(table_name)
+
+        search_results = []
+        for query_text in query_texts:
+            query = table.search(str(query_text), **search_kwargs)
+            if where_clause is not None:
+                query = query.where(where_clause)
+            query = query.limit(top_k)
+            if result_fields is not None:
+                query = query.select(result_fields)
+            search_results.append(query.to_list())
+
+        return search_results
 
     def retrieval(self, vectors: Iterable[Sequence[float]], **kwargs: Any) -> list[list[dict[str, Any]]]:
         """Search LanceDB with precomputed query vectors.

--- a/nemo_retriever/src/nemo_retriever/common/vdb/lancedb_capabilities.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/lancedb_capabilities.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""LanceDB table capability inspection for query routing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import pyarrow as pa
+
+LanceRetrievalMode = Literal["dense", "hybrid", "sparse", "unknown"]
+
+_RETRIEVAL_MODE_METADATA_KEYS = (
+    "retrieval_mode",
+    "nemo_retriever.retrieval_mode",
+)
+_RETRIEVAL_MODES: dict[str, LanceRetrievalMode] = {
+    "dense": "dense",
+    "hybrid": "hybrid",
+    "sparse": "sparse",
+}
+
+
+@dataclass(frozen=True)
+class LanceTableCapabilities:
+    """Detected LanceDB table features used to select a retrieval path."""
+
+    has_vector: bool
+    has_fts: bool
+    retrieval_mode: LanceRetrievalMode
+    vector_column: str | None
+    text_column: str | None
+
+    def query_mode(self, *, hybrid: bool | None = None) -> LanceRetrievalMode:
+        """Return the effective query mode after applying an optional hybrid override.
+
+        Args:
+            hybrid: ``True`` requests hybrid retrieval when FTS is available,
+                ``False`` requests dense retrieval when a vector column exists,
+                and ``None`` leaves the detected table mode unchanged.
+
+        Returns:
+            The retrieval mode the query path should execute.
+        """
+        if self.retrieval_mode == "sparse":
+            return "sparse"
+        if hybrid is True:
+            return "hybrid" if self.has_fts else "dense"
+        if hybrid is False and self.has_vector:
+            return "dense"
+        return self.retrieval_mode
+
+
+def _table_schema(table: Any) -> pa.Schema:
+    schema = table.schema
+    return schema() if callable(schema) else schema
+
+
+def _metadata_retrieval_mode(schema: pa.Schema) -> LanceRetrievalMode | None:
+    metadata = schema.metadata or {}
+    for key in _RETRIEVAL_MODE_METADATA_KEYS:
+        value = metadata.get(key.encode("utf-8"))
+        if value is None:
+            continue
+        normalized = value.decode("utf-8", errors="replace").strip().lower()
+        if normalized in _RETRIEVAL_MODES:
+            return _RETRIEVAL_MODES[normalized]
+    return None
+
+
+def _is_vector_type(data_type: pa.DataType) -> bool:
+    is_list_type = (
+        pa.types.is_list(data_type)
+        or pa.types.is_large_list(data_type)
+        or getattr(pa.types, "is_fixed_size_list", lambda _type: False)(data_type)
+    )
+    if not is_list_type:
+        return False
+    value_type = data_type.value_type
+    return pa.types.is_floating(value_type) or pa.types.is_integer(value_type)
+
+
+def _detect_vector_column(schema: pa.Schema) -> str | None:
+    vector_fields = [field.name for field in schema if _is_vector_type(field.type)]
+    if "vector" in vector_fields:
+        return "vector"
+    return vector_fields[0] if vector_fields else None
+
+
+def _detect_text_column(schema: pa.Schema, fts_columns: list[str]) -> str | None:
+    schema_names = set(schema.names)
+    for column in fts_columns:
+        if column in schema_names:
+            return column
+    if "text" in schema_names:
+        return "text"
+    for field in schema:
+        if pa.types.is_string(field.type) or pa.types.is_large_string(field.type):
+            return field.name
+    return None
+
+
+def _index_columns(index: Any) -> list[str]:
+    columns = getattr(index, "columns", None)
+    if columns is None:
+        return []
+    if isinstance(columns, str):
+        return [columns]
+    try:
+        return [str(column) for column in columns]
+    except TypeError:
+        return []
+
+
+def _detect_fts_columns(table: Any) -> list[str]:
+    list_indices = getattr(table, "list_indices", None)
+    if not callable(list_indices):
+        return []
+
+    fts_columns: list[str] = []
+    for index in list_indices():
+        index_type = str(getattr(index, "index_type", "") or "").strip().lower()
+        index_repr = str(index).lower()
+        if index_type == "fts" or "index(fts" in index_repr or " fts" in index_repr:
+            fts_columns.extend(_index_columns(index))
+    return list(dict.fromkeys(column for column in fts_columns if column))
+
+
+def _mode_from_capabilities(has_vector: bool, has_fts: bool) -> LanceRetrievalMode:
+    if has_vector and has_fts:
+        return "hybrid"
+    if has_vector:
+        return "dense"
+    if has_fts:
+        return "sparse"
+    return "unknown"
+
+
+def inspect_lancedb_table(uri: str, table_name: str) -> LanceTableCapabilities:
+    """Inspect a LanceDB table by URI and table name.
+
+    Args:
+        uri: LanceDB database URI.
+        table_name: Name of the table to inspect.
+
+    Returns:
+        Detected table capabilities.
+
+    Raises:
+        Exception: Propagates LanceDB connection and table-open errors, such as
+            a missing database or table.
+    """
+    import lancedb  # type: ignore
+
+    table = lancedb.connect(uri).open_table(table_name)
+    return inspect_lancedb_table_object(table)
+
+
+def inspect_lancedb_table_object(table: Any) -> LanceTableCapabilities:
+    """Inspect an already-open LanceDB table object.
+
+    Args:
+        table: LanceDB table-like object exposing ``schema`` and optionally
+            ``list_indices()``.
+
+    Returns:
+        Detected table capabilities based on schema, FTS indexes, and optional
+        retrieval-mode schema metadata.
+    """
+    schema = _table_schema(table)
+    fts_columns = _detect_fts_columns(table)
+    vector_column = _detect_vector_column(schema)
+    text_column = _detect_text_column(schema, fts_columns)
+    has_vector = vector_column is not None
+    has_fts = bool(fts_columns)
+
+    retrieval_mode = _metadata_retrieval_mode(schema) or _mode_from_capabilities(has_vector, has_fts)
+
+    return LanceTableCapabilities(
+        has_vector=has_vector,
+        has_fts=has_fts,
+        retrieval_mode=retrieval_mode,
+        vector_column=vector_column,
+        text_column=text_column,
+    )

--- a/nemo_retriever/src/nemo_retriever/common/vdb/lancedb_capabilities.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/lancedb_capabilities.py
@@ -12,6 +12,7 @@ from typing import Any, Literal
 import pyarrow as pa
 
 LanceRetrievalMode = Literal["dense", "hybrid", "sparse", "unknown"]
+LanceQueryModeOverride = Literal["auto", "dense", "hybrid", "sparse"]
 
 _RETRIEVAL_MODE_METADATA_KEYS = (
     "retrieval_mode",
@@ -34,23 +35,20 @@ class LanceTableCapabilities:
     vector_column: str | None
     text_column: str | None
 
-    def query_mode(self, *, hybrid: bool | None = None) -> LanceRetrievalMode:
-        """Return the effective query mode after applying an optional hybrid override.
+    def query_mode(self, *, mode_override: LanceQueryModeOverride = "auto") -> LanceRetrievalMode:
+        """Return the effective query mode after applying an optional mode override.
 
         Args:
-            hybrid: ``True`` requests hybrid retrieval when FTS is available,
-                ``False`` requests dense retrieval when a vector column exists,
-                and ``None`` leaves the detected table mode unchanged.
+            mode_override: ``auto`` leaves the detected table mode unchanged.
+                ``dense``, ``hybrid``, and ``sparse`` request that explicit
+                retrieval mode and are validated by the caller against the table
+                capabilities.
 
         Returns:
             The retrieval mode the query path should execute.
         """
-        if self.retrieval_mode == "sparse":
-            return "sparse"
-        if hybrid is True:
-            return "hybrid" if self.has_fts else "dense"
-        if hybrid is False and self.has_vector:
-            return "dense"
+        if mode_override != "auto":
+            return mode_override
         return self.retrieval_mode
 
 

--- a/nemo_retriever/src/nemo_retriever/common/vdb/lancedb_capabilities.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/lancedb_capabilities.py
@@ -12,7 +12,6 @@ from typing import Any, Literal
 import pyarrow as pa
 
 LanceRetrievalMode = Literal["dense", "hybrid", "sparse", "unknown"]
-LanceQueryModeOverride = Literal["auto", "dense", "hybrid", "sparse"]
 
 _RETRIEVAL_MODE_METADATA_KEYS = (
     "retrieval_mode",
@@ -27,29 +26,11 @@ _RETRIEVAL_MODES: dict[str, LanceRetrievalMode] = {
 
 @dataclass(frozen=True)
 class LanceTableCapabilities:
-    """Detected LanceDB table features used to select a retrieval path."""
-
     has_vector: bool
     has_fts: bool
     retrieval_mode: LanceRetrievalMode
     vector_column: str | None
     text_column: str | None
-
-    def query_mode(self, *, mode_override: LanceQueryModeOverride = "auto") -> LanceRetrievalMode:
-        """Return the effective query mode after applying an optional mode override.
-
-        Args:
-            mode_override: ``auto`` leaves the detected table mode unchanged.
-                ``dense``, ``hybrid``, and ``sparse`` request that explicit
-                retrieval mode and are validated by the caller against the table
-                capabilities.
-
-        Returns:
-            The retrieval mode the query path should execute.
-        """
-        if mode_override != "auto":
-            return mode_override
-        return self.retrieval_mode
 
 
 def _table_schema(table: Any) -> pa.Schema:
@@ -138,19 +119,6 @@ def _mode_from_capabilities(has_vector: bool, has_fts: bool) -> LanceRetrievalMo
 
 
 def inspect_lancedb_table(uri: str, table_name: str) -> LanceTableCapabilities:
-    """Inspect a LanceDB table by URI and table name.
-
-    Args:
-        uri: LanceDB database URI.
-        table_name: Name of the table to inspect.
-
-    Returns:
-        Detected table capabilities.
-
-    Raises:
-        Exception: Propagates LanceDB connection and table-open errors, such as
-            a missing database or table.
-    """
     import lancedb  # type: ignore
 
     table = lancedb.connect(uri).open_table(table_name)
@@ -158,16 +126,6 @@ def inspect_lancedb_table(uri: str, table_name: str) -> LanceTableCapabilities:
 
 
 def inspect_lancedb_table_object(table: Any) -> LanceTableCapabilities:
-    """Inspect an already-open LanceDB table object.
-
-    Args:
-        table: LanceDB table-like object exposing ``schema`` and optionally
-            ``list_indices()``.
-
-    Returns:
-        Detected table capabilities based on schema, FTS indexes, and optional
-        retrieval-mode schema metadata.
-    """
     schema = _table_schema(table)
     fts_columns = _detect_fts_columns(table)
     vector_column = _detect_vector_column(schema)

--- a/nemo_retriever/src/nemo_retriever/common/vdb/records.py
+++ b/nemo_retriever/src/nemo_retriever/common/vdb/records.py
@@ -85,12 +85,14 @@ def _derive_fidelity(content_type: Any, metadata: dict[str, Any], content_metada
     return None
 
 
-def _client_record_from_graph_row(row: dict[str, Any]) -> dict[str, Any] | None:
+def _client_record_from_graph_row(row: dict[str, Any], *, require_embedding: bool = True) -> dict[str, Any] | None:
     metadata = _dict_or_empty(row.get("metadata"))
 
     embedding = _embedding_from_graph_row(row, metadata)
     text = row.get("text") or row.get("content") or metadata.get("content")
-    if embedding is None or not text:
+    if require_embedding and embedding is None:
+        return None
+    if not text:
         return None
 
     content_metadata = _dict_or_empty(metadata.get("content_metadata"))
@@ -132,7 +134,8 @@ def _client_record_from_graph_row(row: dict[str, Any]) -> dict[str, Any] | None:
         source_metadata.setdefault("source_name", source_name)
 
     record_metadata = dict(metadata)
-    record_metadata["embedding"] = embedding
+    if embedding is not None:
+        record_metadata["embedding"] = embedding
     record_metadata["content"] = str(text)
     record_metadata["content_metadata"] = content_metadata
     record_metadata["source_metadata"] = source_metadata
@@ -159,6 +162,24 @@ def to_client_vdb_records(rows: list[dict[str, Any]]) -> list[list[dict[str, Any
         if isinstance(row, dict) and (record := _client_record_from_graph_row(row)) is not None
     ]
     # Preserve legacy contract: no uploadable rows → [], not [[]].
+    return [inner] if inner else []
+
+
+def to_sparse_client_vdb_records(rows: Any) -> list[list[dict[str, Any]]]:
+    """Convert graph-pipeline rows into text/provenance records for sparse LanceDB ingest."""
+    if hasattr(rows, "to_pandas"):
+        rows = rows.to_pandas()
+    if hasattr(rows, "to_dict"):
+        rows = rows.to_dict("records")
+    if isinstance(rows, list) and all(isinstance(batch, list) for batch in rows):
+        nested = [[record for record in batch if isinstance(record, dict) and record.get("metadata")] for batch in rows]
+        nested = [batch for batch in nested if batch]
+        return nested
+    inner = [
+        record
+        for row in rows or []
+        if isinstance(row, dict) and (record := _client_record_from_graph_row(row, require_embedding=False)) is not None
+    ]
     return [inner] if inner else []
 
 

--- a/nemo_retriever/src/nemo_retriever/graph/retriever.py
+++ b/nemo_retriever/src/nemo_retriever/graph/retriever.py
@@ -17,7 +17,7 @@ from nemo_retriever.graph.retriever_utils import (
     rerank_long_dataframe_to_hits,
 )
 from nemo_retriever.common.vdb.lancedb_capabilities import (
-    LanceQueryModeOverride,
+    LanceRetrievalMode,
     LanceTableCapabilities,
     inspect_lancedb_table,
 )
@@ -273,7 +273,7 @@ class Retriever:
             )
         if "hybrid" in lancedb_kwargs:
             mode_override = "hybrid" if bool(lancedb_kwargs["hybrid"]) else "dense"
-        mode = caps.query_mode(mode_override=cast(LanceQueryModeOverride, mode_override))
+        mode = caps.retrieval_mode if mode_override == "auto" else cast(LanceRetrievalMode, mode_override)
 
         if mode == "unknown":
             raise ValueError(

--- a/nemo_retriever/src/nemo_retriever/graph/retriever.py
+++ b/nemo_retriever/src/nemo_retriever/graph/retriever.py
@@ -16,9 +16,10 @@ from nemo_retriever.graph.retriever_utils import (
     filter_retrieval_kwargs,
     rerank_long_dataframe_to_hits,
 )
+from nemo_retriever.common.vdb.lancedb_capabilities import LanceTableCapabilities, inspect_lancedb_table
+from nemo_retriever.common.vdb.records import RetrievalHit, normalize_retrieval_results
 from nemo_retriever.query.shaping import shape_query_hits
 from nemo_retriever.operators.vdb import RetrieveVdbOperator
-from nemo_retriever.common.vdb.records import RetrievalHit
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +81,9 @@ class Retriever:
 
     _cached_graph: Any = field(default=None, init=False, repr=False, compare=False)
     _cache_key: Any = field(default=None, init=False, repr=False, compare=False)
+    _lancedb_capabilities_cache: dict[tuple[str, str], LanceTableCapabilities] = field(
+        default_factory=dict, init=False, repr=False, compare=False
+    )
 
     def __post_init__(self) -> None:
         if self.run_mode not in ("local", "service"):
@@ -216,6 +220,88 @@ class Retriever:
             raise TypeError(f"Unexpected query graph output type: {type(out).__name__}")
         return out
 
+    def _inspect_lancedb_capabilities(self, uri: str, table_name: str) -> LanceTableCapabilities:
+        key = (uri, table_name)
+        caps = self._lancedb_capabilities_cache.get(key)
+        if caps is None:
+            caps = inspect_lancedb_table(uri, table_name)
+            self._lancedb_capabilities_cache[key] = caps
+        return caps
+
+    def _resolve_lancedb_query_mode(
+        self,
+        runtime_vdb_kwargs: Optional[dict[str, Any]],
+    ) -> tuple[str, LanceTableCapabilities, str, str, bool] | None:
+        if self.graph is not None:
+            return None
+
+        lancedb_kwargs = dict(self.vdb_kwargs or {})
+        if "vdb" in lancedb_kwargs:
+            return None
+        if "vdb_op" in lancedb_kwargs:
+            if str(lancedb_kwargs.get("vdb_op") or "").strip().lower() != "lancedb":
+                return None
+            lancedb_kwargs = dict(lancedb_kwargs.get("vdb_kwargs") or {})
+        lancedb_kwargs.update(dict(runtime_vdb_kwargs or {}))
+
+        uri = str(
+            lancedb_kwargs.get("table_path")
+            or lancedb_kwargs.get("uri")
+            or lancedb_kwargs.get("lancedb_uri")
+            or "lancedb"
+        )
+        table_name = str(lancedb_kwargs.get("table_name") or lancedb_kwargs.get("lancedb_table") or "nv-ingest")
+        caps = self._inspect_lancedb_capabilities(uri, table_name)
+
+        hybrid_override = None
+        if "hybrid" in lancedb_kwargs:
+            hybrid_override = bool(lancedb_kwargs["hybrid"])
+        mode = caps.query_mode(hybrid=hybrid_override)
+
+        if mode == "unknown":
+            raise ValueError(
+                f"LanceDB table {table_name!r} at {uri!r} is not queryable: "
+                "no vector column or FTS index was detected."
+            )
+        if mode == "dense" and not caps.has_vector:
+            raise ValueError(
+                f"LanceDB table {table_name!r} at {uri!r} cannot run dense retrieval: " "no vector column was detected."
+            )
+        if mode == "hybrid" and (not caps.has_vector or not caps.has_fts):
+            raise ValueError(
+                f"LanceDB table {table_name!r} at {uri!r} cannot run hybrid retrieval: "
+                "both a vector column and FTS index are required."
+            )
+        if mode == "sparse" and not caps.has_fts:
+            raise ValueError(
+                f"LanceDB table {table_name!r} at {uri!r} cannot run sparse retrieval: " "no FTS index was detected."
+            )
+
+        return mode, caps, uri, table_name, "hybrid" in lancedb_kwargs
+
+    def _execute_sparse_lancedb_queries(
+        self,
+        query_texts: list[str],
+        *,
+        retrieval_top_k: int,
+        vdb_call_kwargs: Optional[dict[str, Any]],
+        caps: LanceTableCapabilities,
+        uri: str,
+        table_name: str,
+    ) -> list[list[dict[str, Any]]]:
+        from nemo_retriever.common.vdb.lancedb import LanceDB
+
+        text_column = caps.text_column or "text"
+        retrieval_kwargs = {
+            **filter_retrieval_kwargs(dict(vdb_call_kwargs or {})),
+            "top_k": int(retrieval_top_k),
+            "table_path": uri,
+            "table_name": table_name,
+            "text_column_name": text_column,
+        }
+        vdb = LanceDB(uri=uri, table_name=table_name, overwrite=False, sparse=True)
+        return normalize_retrieval_results(vdb.sparse_retrieval(query_texts, **retrieval_kwargs))
+
     def query(
         self,
         query: str,
@@ -289,11 +375,40 @@ class Retriever:
         refine = self._refine_factor()
         retrieval_top_k = candidate_top_k * refine if self.rerank else candidate_top_k
 
+        vdb_call_kwargs = dict(vdb_kwargs or {})
+        lancedb_mode = self._resolve_lancedb_query_mode(vdb_call_kwargs)
+        if lancedb_mode is not None:
+            mode, caps, uri, table_name, has_hybrid_override = lancedb_mode
+            if mode == "sparse":
+                raw_hits = self._execute_sparse_lancedb_queries(
+                    query_texts,
+                    retrieval_top_k=retrieval_top_k,
+                    vdb_call_kwargs=vdb_call_kwargs,
+                    caps=caps,
+                    uri=uri,
+                    table_name=table_name,
+                )
+                return [
+                    shape_query_hits(
+                        hits,
+                        top_k=effective_top_k,
+                        page_dedup=page_dedup,
+                        content_types=content_types,
+                    )
+                    for hits in raw_hits
+                ]
+            if mode == "hybrid":
+                vdb_call_kwargs["hybrid"] = True
+            elif mode == "dense" and has_hybrid_override:
+                vdb_call_kwargs["hybrid"] = False
+            if caps.vector_column and caps.vector_column != "vector":
+                vdb_call_kwargs.setdefault("vector_column_name", caps.vector_column)
+
         raw_hits = self._execute_queries_graph(
             query_texts,
             effective_top_k=candidate_top_k,
             retrieval_top_k=retrieval_top_k,
-            vdb_call_kwargs=vdb_kwargs,
+            vdb_call_kwargs=vdb_call_kwargs,
             embed_extra=embed_kwargs,
         )
         return [

--- a/nemo_retriever/src/nemo_retriever/graph/retriever.py
+++ b/nemo_retriever/src/nemo_retriever/graph/retriever.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence, cast
 
 import pandas as pd
 
@@ -16,12 +16,18 @@ from nemo_retriever.graph.retriever_utils import (
     filter_retrieval_kwargs,
     rerank_long_dataframe_to_hits,
 )
-from nemo_retriever.common.vdb.lancedb_capabilities import LanceTableCapabilities, inspect_lancedb_table
+from nemo_retriever.common.vdb.lancedb_capabilities import (
+    LanceQueryModeOverride,
+    LanceTableCapabilities,
+    inspect_lancedb_table,
+)
 from nemo_retriever.common.vdb.records import RetrievalHit, normalize_retrieval_results
 from nemo_retriever.query.shaping import shape_query_hits
 from nemo_retriever.operators.vdb import RetrieveVdbOperator
 
 logger = logging.getLogger(__name__)
+
+_QUERY_ROUTING_VDB_KWARGS = frozenset({"retrieval_mode"})
 
 if TYPE_CHECKING:
     from nemo_retriever.models.llm.types import (
@@ -35,7 +41,14 @@ if TYPE_CHECKING:
 def _coerce_vdb_init(user: dict[str, Any]) -> dict[str, Any]:
     """Normalize ``vdb_kwargs`` into :class:`RetrieveVdbOperator` constructor kwargs."""
     u = dict(user or {})
+    for key in _QUERY_ROUTING_VDB_KWARGS:
+        u.pop(key, None)
     if "vdb" in u or "vdb_op" in u:
+        if isinstance(u.get("vdb_kwargs"), dict):
+            nested = dict(u["vdb_kwargs"])
+            for key in _QUERY_ROUTING_VDB_KWARGS:
+                nested.pop(key, None)
+            u["vdb_kwargs"] = nested
         return u
     return {"vdb_op": "lancedb", "vdb_kwargs": u}
 
@@ -253,10 +266,14 @@ class Retriever:
         table_name = str(lancedb_kwargs.get("table_name") or lancedb_kwargs.get("lancedb_table") or "nv-ingest")
         caps = self._inspect_lancedb_capabilities(uri, table_name)
 
-        hybrid_override = None
+        mode_override = str(lancedb_kwargs.get("retrieval_mode") or "auto").strip().lower()
+        if mode_override not in {"auto", "dense", "hybrid", "sparse"}:
+            raise ValueError(
+                f"Unsupported LanceDB retrieval mode {mode_override!r}; " "use 'auto', 'dense', 'hybrid', or 'sparse'."
+            )
         if "hybrid" in lancedb_kwargs:
-            hybrid_override = bool(lancedb_kwargs["hybrid"])
-        mode = caps.query_mode(hybrid=hybrid_override)
+            mode_override = "hybrid" if bool(lancedb_kwargs["hybrid"]) else "dense"
+        mode = caps.query_mode(mode_override=cast(LanceQueryModeOverride, mode_override))
 
         if mode == "unknown":
             raise ValueError(
@@ -277,7 +294,7 @@ class Retriever:
                 f"LanceDB table {table_name!r} at {uri!r} cannot run sparse retrieval: " "no FTS index was detected."
             )
 
-        return mode, caps, uri, table_name, "hybrid" in lancedb_kwargs
+        return mode, caps, uri, table_name, mode_override != "auto"
 
     def _execute_sparse_lancedb_queries(
         self,
@@ -377,8 +394,10 @@ class Retriever:
 
         vdb_call_kwargs = dict(vdb_kwargs or {})
         lancedb_mode = self._resolve_lancedb_query_mode(vdb_call_kwargs)
+        for key in _QUERY_ROUTING_VDB_KWARGS:
+            vdb_call_kwargs.pop(key, None)
         if lancedb_mode is not None:
-            mode, caps, uri, table_name, has_hybrid_override = lancedb_mode
+            mode, caps, uri, table_name, has_mode_override = lancedb_mode
             if mode == "sparse":
                 raw_hits = self._execute_sparse_lancedb_queries(
                     query_texts,
@@ -399,7 +418,7 @@ class Retriever:
                 ]
             if mode == "hybrid":
                 vdb_call_kwargs["hybrid"] = True
-            elif mode == "dense" and has_hybrid_override:
+            elif mode == "dense" and has_mode_override:
                 vdb_call_kwargs["hybrid"] = False
             if caps.vector_column and caps.vector_column != "vector":
                 vdb_call_kwargs.setdefault("vector_column_name", caps.vector_column)

--- a/nemo_retriever/src/nemo_retriever/ingest/execution.py
+++ b/nemo_retriever/src/nemo_retriever/ingest/execution.py
@@ -11,6 +11,8 @@ from typing import Any, Sequence
 from nemo_retriever.ingest.plan import ResolvedIngestPlan
 from nemo_retriever.ingestor.manifest import format_branch_summary
 from nemo_retriever.ingestor import Ingestor, create_ingestor
+from nemo_retriever.common.vdb.lancedb import LanceDB
+from nemo_retriever.common.vdb.records import to_sparse_client_vdb_records
 
 logger = logging.getLogger(__name__)
 
@@ -72,11 +74,12 @@ def build_ingest_pipeline(plan: ResolvedIngestPlan) -> Ingestor:
     if plan.caption_params is not None:
         ingestor = ingestor.caption(plan.caption_params)
 
-    ingestor = ingestor.embed(plan.embed_params) if plan.embed_params is not None else ingestor.embed()
+    if not plan.sparse:
+        ingestor = ingestor.embed(plan.embed_params) if plan.embed_params is not None else ingestor.embed()
     if plan.store_params is not None:
         ingestor = ingestor.store(plan.store_params)
 
-    if plan.vdb_params is not None:
+    if plan.vdb_params is not None and not plan.sparse:
         ingestor = ingestor.vdb_upload(plan.vdb_params)
     return ingestor
 
@@ -112,6 +115,8 @@ def execute_ingest_plan(
         initial_n_rows = _count_lancedb_rows(lancedb_uri, table_name)
 
     result = build_ingest_pipeline(plan).ingest()
+    if plan.sparse:
+        _write_sparse_lancedb_result(result, lancedb_uri=lancedb_uri, table_name=table_name, overwrite=overwrite)
 
     result_n_rows = _count_result_rows(result) if verify_rows else None
     n_rows = _count_lancedb_rows(lancedb_uri, table_name) if verify_rows else None
@@ -149,6 +154,12 @@ def _resolve_lancedb_target(plan: ResolvedIngestPlan) -> tuple[str, str, bool] |
     table_name = str(vdb_kwargs.get("table_name") or vdb_kwargs.get("lancedb_table") or plan.table_name)
     overwrite = bool(vdb_kwargs.get("overwrite", True))
     return lancedb_uri, table_name, overwrite
+
+
+def _write_sparse_lancedb_result(result: object, *, lancedb_uri: str, table_name: str, overwrite: bool) -> None:
+    records = to_sparse_client_vdb_records(result)
+    vdb = LanceDB(uri=lancedb_uri, table_name=table_name, overwrite=overwrite, sparse=True)
+    vdb.run(records)
 
 
 def _raise_for_empty_ingest(

--- a/nemo_retriever/src/nemo_retriever/ingest/plan.py
+++ b/nemo_retriever/src/nemo_retriever/ingest/plan.py
@@ -205,6 +205,8 @@ class IngestStorageOptions:
     overwrite: bool = True
     # Also build the LanceDB FTS/BM25 index so `query --hybrid` can fuse lexical + vector.
     hybrid: bool = False
+    # Skip dense embedding and write a text-only LanceDB FTS table.
+    sparse: bool = False
 
 
 @dataclass(frozen=True)
@@ -301,6 +303,7 @@ class ResolvedIngestPlan:
     vdb_params: VdbUploadParams | None
     lancedb_uri: str
     table_name: str
+    sparse: bool = False
 
     def extract_call_kwargs(self) -> dict[str, Any]:
         kwargs: dict[str, Any] = {}
@@ -583,6 +586,8 @@ def resolve_ingest_plan(request: IngestPlanRequest) -> ResolvedIngestPlan:
     chunk = request.chunk
     embed = request.embed
     storage = request.storage
+    if storage.sparse and storage.hybrid:
+        raise ValueError("Pass only one retrieval-mode ingest option: --sparse or --hybrid.")
 
     validated_run_mode = _validate_run_mode(runtime.run_mode)
     validated_profile = validate_ingest_profile(source.profile)
@@ -642,14 +647,16 @@ def resolve_ingest_plan(request: IngestPlanRequest) -> ResolvedIngestPlan:
         embed_gpus_per_actor=embed.batch.embed_gpus_per_actor,
     )
     extract_params = ExtractParams(**extract_kwargs)
-    embed_params = EmbedParams(**embed_kwargs) if embed_kwargs else None
+    embed_params = None if storage.sparse else EmbedParams(**embed_kwargs) if embed_kwargs else None
     vdb_upload_kwargs = {
         "uri": storage.lancedb_uri,
         "table_name": storage.table_name,
         "overwrite": bool(storage.overwrite),
     }
     # Keep vector-only ingest kwargs unchanged unless hybrid indexing is explicitly requested.
-    if storage.hybrid:
+    if storage.sparse:
+        vdb_upload_kwargs["sparse"] = True
+    elif storage.hybrid:
         vdb_upload_kwargs["hybrid"] = True
     vdb_params = VdbUploadParams(vdb_kwargs=vdb_upload_kwargs)
     caption_params = build_caption_params(
@@ -724,4 +731,5 @@ def resolve_ingest_plan(request: IngestPlanRequest) -> ResolvedIngestPlan:
         vdb_params=vdb_params,
         lancedb_uri=storage.lancedb_uri,
         table_name=storage.table_name,
+        sparse=bool(storage.sparse),
     )

--- a/nemo_retriever/src/nemo_retriever/ingest/plan.py
+++ b/nemo_retriever/src/nemo_retriever/ingest/plan.py
@@ -43,6 +43,7 @@ from nemo_retriever.common.input_files import (
 IngestRunModeValue = Literal["inprocess", "batch"]
 IngestInputTypeValue = Literal["auto", "pdf", "doc", "txt", "html", "image", "audio", "video"]
 IngestProfileValue = Literal["auto", "fast-text"]
+IngestIndexModeValue = Literal["dense", "hybrid", "sparse"]
 AudioSplitTypeValue = Literal["size", "time", "frame"]
 LocalIngestEmbedBackendValue = Literal["vllm", "hf"]
 OcrLangValue = OCRLang
@@ -50,6 +51,7 @@ OcrVersionValue = OCRVersion
 TableOutputFormatValue = Literal["pseudo_markdown", "markdown"]
 _SUPPORTED_RUN_MODES: tuple[IngestRunModeValue, ...] = ("inprocess", "batch")
 _SUPPORTED_PROFILES: tuple[IngestProfileValue, ...] = ("auto", "fast-text")
+_SUPPORTED_INDEX_MODES: tuple[IngestIndexModeValue, ...] = ("dense", "hybrid", "sparse")
 _SUPPORTED_AUDIO_SPLIT_TYPES: tuple[AudioSplitTypeValue, ...] = ("size", "time", "frame")
 _SUPPORTED_INPUT_TYPES: tuple[IngestInputTypeValue, ...] = (
     "auto",
@@ -203,10 +205,7 @@ class IngestStorageOptions:
     lancedb_uri: str = "lancedb"
     table_name: str = "nemo-retriever"
     overwrite: bool = True
-    # Also build the LanceDB FTS/BM25 index so `query --hybrid` can fuse lexical + vector.
-    hybrid: bool = False
-    # Skip dense embedding and write a text-only LanceDB FTS table.
-    sparse: bool = False
+    index_mode: IngestIndexModeValue = "dense"
 
 
 @dataclass(frozen=True)
@@ -239,6 +238,13 @@ def validate_ingest_profile(profile: str) -> IngestProfileValue:
     if profile not in _SUPPORTED_PROFILES:
         raise ValueError(f"profile must be one of {', '.join(_SUPPORTED_PROFILES)}, got {profile!r}.")
     return cast(IngestProfileValue, profile)
+
+
+def validate_ingest_index_mode(index_mode: str) -> IngestIndexModeValue:
+    normalized = index_mode.strip().lower()
+    if normalized not in _SUPPORTED_INDEX_MODES:
+        raise ValueError(f"index_mode must be one of {', '.join(_SUPPORTED_INDEX_MODES)}, got {index_mode!r}.")
+    return cast(IngestIndexModeValue, normalized)
 
 
 def _validate_audio_split_type(split_type: str) -> AudioSplitTypeValue:
@@ -586,12 +592,11 @@ def resolve_ingest_plan(request: IngestPlanRequest) -> ResolvedIngestPlan:
     chunk = request.chunk
     embed = request.embed
     storage = request.storage
-    if storage.sparse and storage.hybrid:
-        raise ValueError("Pass only one retrieval-mode ingest option: --sparse or --hybrid.")
 
     validated_run_mode = _validate_run_mode(runtime.run_mode)
     validated_profile = validate_ingest_profile(source.profile)
     validated_input_type = validate_ingest_input_type(source.input_type)
+    validated_index_mode = validate_ingest_index_mode(storage.index_mode)
     validated_audio_split_type = _validate_audio_split_type(media.audio_split_type)
     document_list = expand_ingest_documents(source.documents, input_type=validated_input_type)
     branches = plan_extraction_branches(build_input_manifest(document_list))
@@ -647,16 +652,16 @@ def resolve_ingest_plan(request: IngestPlanRequest) -> ResolvedIngestPlan:
         embed_gpus_per_actor=embed.batch.embed_gpus_per_actor,
     )
     extract_params = ExtractParams(**extract_kwargs)
-    embed_params = None if storage.sparse else EmbedParams(**embed_kwargs) if embed_kwargs else None
+    embed_params = None if validated_index_mode == "sparse" else EmbedParams(**embed_kwargs) if embed_kwargs else None
     vdb_upload_kwargs = {
         "uri": storage.lancedb_uri,
         "table_name": storage.table_name,
         "overwrite": bool(storage.overwrite),
     }
-    # Keep vector-only ingest kwargs unchanged unless hybrid indexing is explicitly requested.
-    if storage.sparse:
+    # Keep dense ingest kwargs unchanged unless the index mode needs additional LanceDB behavior.
+    if validated_index_mode == "sparse":
         vdb_upload_kwargs["sparse"] = True
-    elif storage.hybrid:
+    elif validated_index_mode == "hybrid":
         vdb_upload_kwargs["hybrid"] = True
     vdb_params = VdbUploadParams(vdb_kwargs=vdb_upload_kwargs)
     caption_params = build_caption_params(
@@ -731,5 +736,5 @@ def resolve_ingest_plan(request: IngestPlanRequest) -> ResolvedIngestPlan:
         vdb_params=vdb_params,
         lancedb_uri=storage.lancedb_uri,
         table_name=storage.table_name,
-        sparse=bool(storage.sparse),
+        sparse=validated_index_mode == "sparse",
     )

--- a/nemo_retriever/src/nemo_retriever/query/options.py
+++ b/nemo_retriever/src/nemo_retriever/query/options.py
@@ -5,7 +5,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Sequence
+from typing import Literal, Sequence
+
+
+QueryRetrievalMode = Literal["auto", "dense", "hybrid", "sparse"]
 
 
 @dataclass(frozen=True)
@@ -14,9 +17,9 @@ class QueryRetrievalOptions:
     candidate_k: int | None = None
     page_dedup: bool = False
     content_types: str | Sequence[str] | None = None
-    # Fused vector + full-text (BM25) retrieval override. ``None`` lets LanceDB
-    # table capability detection choose dense, hybrid, or sparse automatically.
-    hybrid: bool | None = None
+    # ``auto`` lets LanceDB table capability detection choose dense, hybrid, or
+    # sparse retrieval. Explicit modes are expert overrides.
+    retrieval_mode: QueryRetrievalMode = "auto"
 
 
 @dataclass(frozen=True)

--- a/nemo_retriever/src/nemo_retriever/query/options.py
+++ b/nemo_retriever/src/nemo_retriever/query/options.py
@@ -14,9 +14,9 @@ class QueryRetrievalOptions:
     candidate_k: int | None = None
     page_dedup: bool = False
     content_types: str | Sequence[str] | None = None
-    # Fused vector + full-text (BM25) retrieval. Opt-in (default off) preserves the
-    # legacy vector-only path; requires the LanceDB table to carry an FTS index.
-    hybrid: bool = False
+    # Fused vector + full-text (BM25) retrieval override. ``None`` lets LanceDB
+    # table capability detection choose dense, hybrid, or sparse automatically.
+    hybrid: bool | None = None
 
 
 @dataclass(frozen=True)

--- a/nemo_retriever/src/nemo_retriever/query/workflow.py
+++ b/nemo_retriever/src/nemo_retriever/query/workflow.py
@@ -55,8 +55,8 @@ def _build_retriever_kwargs(request: QueryRequest) -> dict[str, Any]:
         "uri": request.storage.lancedb_uri,
         "table_name": request.storage.table_name,
     }
-    if request.retrieval.hybrid is not None:
-        vdb_kwargs["hybrid"] = bool(request.retrieval.hybrid)
+    if request.retrieval.retrieval_mode != "auto":
+        vdb_kwargs["retrieval_mode"] = request.retrieval.retrieval_mode
     retriever_kwargs: dict[str, Any] = {
         "top_k": request.retrieval.top_k,
         "vdb_kwargs": vdb_kwargs,
@@ -110,9 +110,12 @@ def agentic_query_documents(request: QueryRequest) -> list[dict[str, Any]]:
     from nemo_retriever.query.agentic import AgenticRetrievalConfig, AgenticRetriever
 
     api_key = resolve_remote_api_key()
+    vdb_kwargs: dict[str, Any] = {"uri": request.storage.lancedb_uri, "table_name": request.storage.table_name}
+    if request.retrieval.retrieval_mode != "auto":
+        vdb_kwargs["retrieval_mode"] = request.retrieval.retrieval_mode
     cfg_kwargs: dict[str, Any] = {
         "vdb_op": "lancedb",
-        "vdb_kwargs": {"uri": request.storage.lancedb_uri, "table_name": request.storage.table_name},
+        "vdb_kwargs": vdb_kwargs,
         "top_k": int(request.retrieval.top_k),
         "embedding_endpoint": request.embed.embed_invoke_url,
         "embedding_api_key": api_key or "",

--- a/nemo_retriever/src/nemo_retriever/query/workflow.py
+++ b/nemo_retriever/src/nemo_retriever/query/workflow.py
@@ -4,15 +4,31 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 from nemo_retriever.common.params import build_embed_option_kwargs
-from nemo_retriever.query.options import QueryRequest, QueryRerankOptions
+from nemo_retriever.common.vdb.lancedb_capabilities import LanceRetrievalMode
 from nemo_retriever.graph.retriever import Retriever
+from nemo_retriever.query.options import QueryRequest, QueryRerankOptions
 from nemo_retriever.common.remote_auth import resolve_remote_api_key
 from nemo_retriever.common.vdb.records import RetrievalHit
 
 _LOCAL_VL_RERANK_MODEL = "nvidia/llama-nemotron-rerank-vl-1b-v2"
+
+
+@dataclass(frozen=True)
+class QueryDocumentsResult:
+    hits: list[RetrievalHit]
+    strategies: list[str]
+
+
+def _strategies_for_retrieval_mode(mode: LanceRetrievalMode | None) -> list[str]:
+    if mode == "hybrid":
+        return ["semantic", "lexical"]
+    if mode == "sparse":
+        return ["lexical"]
+    return ["semantic"]
 
 
 def _build_rerank_kwargs(options: QueryRerankOptions) -> dict[str, str]:
@@ -39,9 +55,8 @@ def _build_retriever_kwargs(request: QueryRequest) -> dict[str, Any]:
         "uri": request.storage.lancedb_uri,
         "table_name": request.storage.table_name,
     }
-    # Only inject hybrid when opted in, so the vector-only path stays byte-for-byte legacy.
-    if request.retrieval.hybrid:
-        vdb_kwargs["hybrid"] = True
+    if request.retrieval.hybrid is not None:
+        vdb_kwargs["hybrid"] = bool(request.retrieval.hybrid)
     retriever_kwargs: dict[str, Any] = {
         "top_k": request.retrieval.top_k,
         "vdb_kwargs": vdb_kwargs,
@@ -56,15 +71,27 @@ def _build_retriever_kwargs(request: QueryRequest) -> dict[str, Any]:
     return retriever_kwargs
 
 
-def query_documents(request: QueryRequest) -> list[RetrievalHit]:
-    """Run the SDK query path used by the root CLI."""
+def query_documents_with_metadata(request: QueryRequest) -> QueryDocumentsResult:
+    """Run the SDK query path and return hits plus resolved retrieval strategy metadata."""
     retriever = Retriever(**_build_retriever_kwargs(request))
-    return retriever.query(
+    mode: LanceRetrievalMode | None = None
+    resolve_mode = getattr(retriever, "_resolve_lancedb_query_mode", None)
+    if callable(resolve_mode):
+        lancedb_mode = resolve_mode(None)
+        if lancedb_mode is not None:
+            mode = lancedb_mode[0]
+    hits = retriever.query(
         request.query,
         candidate_k=request.retrieval.candidate_k,
         page_dedup=request.retrieval.page_dedup,
         content_types=request.retrieval.content_types,
     )
+    return QueryDocumentsResult(hits=hits, strategies=_strategies_for_retrieval_mode(mode))
+
+
+def query_documents(request: QueryRequest) -> list[RetrievalHit]:
+    """Run the SDK query path used by the root CLI."""
+    return query_documents_with_metadata(request).hits
 
 
 def agentic_query_documents(request: QueryRequest) -> list[dict[str, Any]]:

--- a/nemo_retriever/tests/test_lancedb_capabilities.py
+++ b/nemo_retriever/tests/test_lancedb_capabilities.py
@@ -147,6 +147,56 @@ def test_existing_dense_query_behavior_is_unchanged(monkeypatch, tmp_path) -> No
     assert calls == [{}]
 
 
+def test_explicit_dense_override_on_hybrid_table(monkeypatch, tmp_path) -> None:
+    uri = str(tmp_path / "db")
+    _create_vector_table(uri, "hybrid", fts=True)
+    calls: list[dict[str, Any]] = []
+
+    def fake_execute(self, query_texts, **kwargs):  # noqa: ANN001
+        calls.append(kwargs["vdb_call_kwargs"])
+        return [[{"text": "alpha safety manual", "metadata": {"type": "text"}, "source": "alpha.pdf"}]]
+
+    monkeypatch.setattr(Retriever, "_execute_queries_graph", fake_execute)
+
+    Retriever(vdb_kwargs={"uri": uri, "table_name": "hybrid", "retrieval_mode": "dense"}).query("alpha", top_k=1)
+
+    assert calls == [{"hybrid": False}]
+
+
+def test_explicit_hybrid_override_on_hybrid_table(monkeypatch, tmp_path) -> None:
+    uri = str(tmp_path / "db")
+    _create_vector_table(uri, "hybrid", fts=True)
+    calls: list[dict[str, Any]] = []
+
+    def fake_execute(self, query_texts, **kwargs):  # noqa: ANN001
+        calls.append(kwargs["vdb_call_kwargs"])
+        return [[{"text": "alpha safety manual", "metadata": {"type": "text"}, "source": "alpha.pdf"}]]
+
+    monkeypatch.setattr(Retriever, "_execute_queries_graph", fake_execute)
+
+    Retriever(vdb_kwargs={"uri": uri, "table_name": "hybrid", "retrieval_mode": "hybrid"}).query("alpha", top_k=1)
+
+    assert calls == [{"hybrid": True}]
+
+
+def test_explicit_sparse_override_on_hybrid_table_uses_sparse_retrieval(monkeypatch, tmp_path) -> None:
+    uri = str(tmp_path / "db")
+    _create_vector_table(uri, "hybrid", fts=True)
+
+    def fail_embed_graph(*_args: Any, **_kwargs: Any) -> list[list[dict[str, Any]]]:
+        raise AssertionError("sparse override should not build or execute the embedding graph")
+
+    monkeypatch.setattr(Retriever, "_execute_queries_graph", fail_embed_graph)
+
+    hits = Retriever(vdb_kwargs={"uri": uri, "table_name": "hybrid", "retrieval_mode": "sparse"}).query(
+        "alpha",
+        top_k=1,
+    )
+
+    assert hits
+    assert hits[0]["text"] == "alpha safety manual"
+
+
 def test_retriever_caches_lancedb_capability_inspection(monkeypatch) -> None:
     calls: list[tuple[str, str]] = []
     caps = LanceTableCapabilities(

--- a/nemo_retriever/tests/test_lancedb_capabilities.py
+++ b/nemo_retriever/tests/test_lancedb_capabilities.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+lancedb = pytest.importorskip("lancedb")
+pa = pytest.importorskip("pyarrow")
+
+from nemo_retriever.common.vdb.lancedb_capabilities import inspect_lancedb_table  # noqa: E402
+from nemo_retriever.common.vdb.lancedb_capabilities import LanceTableCapabilities  # noqa: E402
+from nemo_retriever.graph.retriever import Retriever  # noqa: E402
+import nemo_retriever.graph.retriever as retriever_module  # noqa: E402
+
+
+def _create_vector_table(uri: str, table_name: str, *, fts: bool = False) -> None:
+    schema = pa.schema(
+        [
+            pa.field("vector", pa.list_(pa.float32(), 2)),
+            pa.field("text", pa.string()),
+            pa.field("metadata", pa.string()),
+            pa.field("source", pa.string()),
+            pa.field("id", pa.string()),
+        ]
+    )
+    rows = [
+        {
+            "vector": [1.0, 0.0],
+            "text": "alpha safety manual",
+            "metadata": json.dumps({"page_number": 1, "type": "text"}),
+            "source": json.dumps({"source_id": "alpha.pdf"}),
+            "id": "alpha",
+        }
+    ]
+    table = lancedb.connect(uri).create_table(table_name, data=rows, schema=schema, mode="overwrite")
+    if fts:
+        table.create_fts_index("text", replace=True)
+
+
+def _create_sparse_table(uri: str, table_name: str) -> None:
+    schema = pa.schema(
+        [
+            pa.field("text", pa.string()),
+            pa.field("metadata", pa.string()),
+            pa.field("source", pa.string()),
+            pa.field("id", pa.string()),
+        ]
+    )
+    rows = [
+        {
+            "text": "alpha safety manual",
+            "metadata": json.dumps({"page_number": 1, "type": "text"}),
+            "source": json.dumps({"source_id": "alpha.pdf"}),
+            "id": "alpha",
+        }
+    ]
+    table = lancedb.connect(uri).create_table(table_name, data=rows, schema=schema, mode="overwrite")
+    table.create_fts_index("text", replace=True)
+
+
+def test_detector_returns_dense_for_vector_only_table(tmp_path) -> None:
+    uri = str(tmp_path / "db")
+    _create_vector_table(uri, "dense")
+
+    caps = inspect_lancedb_table(uri, "dense")
+
+    assert caps.has_vector is True
+    assert caps.has_fts is False
+    assert caps.vector_column == "vector"
+    assert caps.text_column == "text"
+    assert caps.retrieval_mode == "dense"
+
+
+def test_detector_returns_hybrid_for_vector_plus_fts_table(tmp_path) -> None:
+    uri = str(tmp_path / "db")
+    _create_vector_table(uri, "hybrid", fts=True)
+
+    caps = inspect_lancedb_table(uri, "hybrid")
+
+    assert caps.has_vector is True
+    assert caps.has_fts is True
+    assert caps.retrieval_mode == "hybrid"
+
+
+def test_detector_returns_sparse_for_fts_only_table(tmp_path) -> None:
+    uri = str(tmp_path / "db")
+    _create_sparse_table(uri, "sparse")
+
+    caps = inspect_lancedb_table(uri, "sparse")
+
+    assert caps.has_vector is False
+    assert caps.has_fts is True
+    assert caps.vector_column is None
+    assert caps.text_column == "text"
+    assert caps.retrieval_mode == "sparse"
+
+
+def test_sparse_query_does_not_call_embedding_graph(monkeypatch, tmp_path) -> None:
+    uri = str(tmp_path / "db")
+    _create_sparse_table(uri, "sparse")
+
+    def fail_embed_graph(*_args: Any, **_kwargs: Any) -> list[list[dict[str, Any]]]:
+        raise AssertionError("sparse query should not build or execute the embedding graph")
+
+    monkeypatch.setattr(Retriever, "_execute_queries_graph", fail_embed_graph)
+
+    hits = Retriever(vdb_kwargs={"uri": uri, "table_name": "sparse"}).query("alpha", top_k=1)
+
+    assert hits
+    assert hits[0]["text"] == "alpha safety manual"
+
+
+def test_hybrid_table_query_automatically_enables_hybrid(monkeypatch, tmp_path) -> None:
+    uri = str(tmp_path / "db")
+    _create_vector_table(uri, "hybrid", fts=True)
+    calls: list[dict[str, Any]] = []
+
+    def fake_execute(self, query_texts, **kwargs):  # noqa: ANN001
+        calls.append(kwargs["vdb_call_kwargs"])
+        return [[{"text": "alpha safety manual", "metadata": {"type": "text"}, "source": "alpha.pdf"}]]
+
+    monkeypatch.setattr(Retriever, "_execute_queries_graph", fake_execute)
+
+    Retriever(vdb_kwargs={"uri": uri, "table_name": "hybrid"}).query("alpha", top_k=1)
+
+    assert calls == [{"hybrid": True}]
+
+
+def test_existing_dense_query_behavior_is_unchanged(monkeypatch, tmp_path) -> None:
+    uri = str(tmp_path / "db")
+    _create_vector_table(uri, "dense")
+    calls: list[dict[str, Any]] = []
+
+    def fake_execute(self, query_texts, **kwargs):  # noqa: ANN001
+        calls.append(kwargs["vdb_call_kwargs"])
+        return [[{"text": "alpha safety manual", "metadata": {"type": "text"}, "source": "alpha.pdf"}]]
+
+    monkeypatch.setattr(Retriever, "_execute_queries_graph", fake_execute)
+
+    Retriever(vdb_kwargs={"uri": uri, "table_name": "dense"}).query("alpha", top_k=1)
+
+    assert calls == [{}]
+
+
+def test_retriever_caches_lancedb_capability_inspection(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+    caps = LanceTableCapabilities(
+        has_vector=True,
+        has_fts=False,
+        retrieval_mode="dense",
+        vector_column="vector",
+        text_column="text",
+    )
+
+    def fake_inspect(uri: str, table_name: str) -> LanceTableCapabilities:
+        calls.append((uri, table_name))
+        return caps
+
+    monkeypatch.setattr(retriever_module, "inspect_lancedb_table", fake_inspect)
+
+    retriever = Retriever(vdb_kwargs={"uri": "memory://db", "table_name": "docs"})
+
+    assert retriever._resolve_lancedb_query_mode({}) == ("dense", caps, "memory://db", "docs", False)
+    assert retriever._resolve_lancedb_query_mode({}) == ("dense", caps, "memory://db", "docs", False)
+    assert calls == [("memory://db", "docs")]

--- a/nemo_retriever/tests/test_lancedb_capabilities.py
+++ b/nemo_retriever/tests/test_lancedb_capabilities.py
@@ -12,10 +12,9 @@ import pytest
 lancedb = pytest.importorskip("lancedb")
 pa = pytest.importorskip("pyarrow")
 
-from nemo_retriever.common.vdb.lancedb_capabilities import inspect_lancedb_table  # noqa: E402
-from nemo_retriever.common.vdb.lancedb_capabilities import LanceTableCapabilities  # noqa: E402
-from nemo_retriever.graph.retriever import Retriever  # noqa: E402
 import nemo_retriever.graph.retriever as retriever_module  # noqa: E402
+from nemo_retriever.common.vdb.lancedb_capabilities import LanceTableCapabilities, inspect_lancedb_table  # noqa: E402
+from nemo_retriever.graph.retriever import Retriever  # noqa: E402
 
 
 def _create_vector_table(uri: str, table_name: str, *, fts: bool = False) -> None:
@@ -63,6 +62,25 @@ def _create_sparse_table(uri: str, table_name: str) -> None:
     table.create_fts_index("text", replace=True)
 
 
+def _fail_embed_graph(*_args: Any, **_kwargs: Any) -> list[list[dict[str, Any]]]:
+    raise AssertionError("sparse query should not build or execute the embedding graph")
+
+
+def _patch_graph_hits(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    def fake_execute(
+        _self: Retriever,
+        _query_texts: list[str],
+        **kwargs: Any,
+    ) -> list[list[dict[str, Any]]]:
+        calls.append(kwargs["vdb_call_kwargs"])
+        return [[{"text": "alpha safety manual", "metadata": {"type": "text"}, "source": "alpha.pdf"}]]
+
+    monkeypatch.setattr(Retriever, "_execute_queries_graph", fake_execute)
+    return calls
+
+
 def test_detector_returns_dense_for_vector_only_table(tmp_path) -> None:
     uri = str(tmp_path / "db")
     _create_vector_table(uri, "dense")
@@ -104,10 +122,7 @@ def test_sparse_query_does_not_call_embedding_graph(monkeypatch, tmp_path) -> No
     uri = str(tmp_path / "db")
     _create_sparse_table(uri, "sparse")
 
-    def fail_embed_graph(*_args: Any, **_kwargs: Any) -> list[list[dict[str, Any]]]:
-        raise AssertionError("sparse query should not build or execute the embedding graph")
-
-    monkeypatch.setattr(Retriever, "_execute_queries_graph", fail_embed_graph)
+    monkeypatch.setattr(Retriever, "_execute_queries_graph", _fail_embed_graph)
 
     hits = Retriever(vdb_kwargs={"uri": uri, "table_name": "sparse"}).query("alpha", top_k=1)
 
@@ -118,13 +133,7 @@ def test_sparse_query_does_not_call_embedding_graph(monkeypatch, tmp_path) -> No
 def test_hybrid_table_query_automatically_enables_hybrid(monkeypatch, tmp_path) -> None:
     uri = str(tmp_path / "db")
     _create_vector_table(uri, "hybrid", fts=True)
-    calls: list[dict[str, Any]] = []
-
-    def fake_execute(self, query_texts, **kwargs):  # noqa: ANN001
-        calls.append(kwargs["vdb_call_kwargs"])
-        return [[{"text": "alpha safety manual", "metadata": {"type": "text"}, "source": "alpha.pdf"}]]
-
-    monkeypatch.setattr(Retriever, "_execute_queries_graph", fake_execute)
+    calls = _patch_graph_hits(monkeypatch)
 
     Retriever(vdb_kwargs={"uri": uri, "table_name": "hybrid"}).query("alpha", top_k=1)
 
@@ -134,13 +143,7 @@ def test_hybrid_table_query_automatically_enables_hybrid(monkeypatch, tmp_path) 
 def test_existing_dense_query_behavior_is_unchanged(monkeypatch, tmp_path) -> None:
     uri = str(tmp_path / "db")
     _create_vector_table(uri, "dense")
-    calls: list[dict[str, Any]] = []
-
-    def fake_execute(self, query_texts, **kwargs):  # noqa: ANN001
-        calls.append(kwargs["vdb_call_kwargs"])
-        return [[{"text": "alpha safety manual", "metadata": {"type": "text"}, "source": "alpha.pdf"}]]
-
-    monkeypatch.setattr(Retriever, "_execute_queries_graph", fake_execute)
+    calls = _patch_graph_hits(monkeypatch)
 
     Retriever(vdb_kwargs={"uri": uri, "table_name": "dense"}).query("alpha", top_k=1)
 
@@ -150,13 +153,7 @@ def test_existing_dense_query_behavior_is_unchanged(monkeypatch, tmp_path) -> No
 def test_explicit_dense_override_on_hybrid_table(monkeypatch, tmp_path) -> None:
     uri = str(tmp_path / "db")
     _create_vector_table(uri, "hybrid", fts=True)
-    calls: list[dict[str, Any]] = []
-
-    def fake_execute(self, query_texts, **kwargs):  # noqa: ANN001
-        calls.append(kwargs["vdb_call_kwargs"])
-        return [[{"text": "alpha safety manual", "metadata": {"type": "text"}, "source": "alpha.pdf"}]]
-
-    monkeypatch.setattr(Retriever, "_execute_queries_graph", fake_execute)
+    calls = _patch_graph_hits(monkeypatch)
 
     Retriever(vdb_kwargs={"uri": uri, "table_name": "hybrid", "retrieval_mode": "dense"}).query("alpha", top_k=1)
 
@@ -166,13 +163,7 @@ def test_explicit_dense_override_on_hybrid_table(monkeypatch, tmp_path) -> None:
 def test_explicit_hybrid_override_on_hybrid_table(monkeypatch, tmp_path) -> None:
     uri = str(tmp_path / "db")
     _create_vector_table(uri, "hybrid", fts=True)
-    calls: list[dict[str, Any]] = []
-
-    def fake_execute(self, query_texts, **kwargs):  # noqa: ANN001
-        calls.append(kwargs["vdb_call_kwargs"])
-        return [[{"text": "alpha safety manual", "metadata": {"type": "text"}, "source": "alpha.pdf"}]]
-
-    monkeypatch.setattr(Retriever, "_execute_queries_graph", fake_execute)
+    calls = _patch_graph_hits(monkeypatch)
 
     Retriever(vdb_kwargs={"uri": uri, "table_name": "hybrid", "retrieval_mode": "hybrid"}).query("alpha", top_k=1)
 
@@ -183,10 +174,7 @@ def test_explicit_sparse_override_on_hybrid_table_uses_sparse_retrieval(monkeypa
     uri = str(tmp_path / "db")
     _create_vector_table(uri, "hybrid", fts=True)
 
-    def fail_embed_graph(*_args: Any, **_kwargs: Any) -> list[list[dict[str, Any]]]:
-        raise AssertionError("sparse override should not build or execute the embedding graph")
-
-    monkeypatch.setattr(Retriever, "_execute_queries_graph", fail_embed_graph)
+    monkeypatch.setattr(Retriever, "_execute_queries_graph", _fail_embed_graph)
 
     hits = Retriever(vdb_kwargs={"uri": uri, "table_name": "hybrid", "retrieval_mode": "sparse"}).query(
         "alpha",

--- a/nemo_retriever/tests/test_query_workflow_options.py
+++ b/nemo_retriever/tests/test_query_workflow_options.py
@@ -47,6 +47,32 @@ def test_query_request_builds_retriever_kwargs_without_rerank(monkeypatch) -> No
     ]
 
 
+def test_query_request_builds_retriever_kwargs_with_retrieval_mode(monkeypatch) -> None:
+    retriever_calls: list[dict[str, Any]] = []
+
+    class FakeRetriever:
+        def __init__(self, **kwargs: Any) -> None:
+            retriever_calls.append(kwargs)
+
+        def query(self, query: str, **_kwargs: Any) -> list[dict[str, Any]]:
+            return []
+
+    monkeypatch.setattr(query_workflow, "Retriever", FakeRetriever)
+    request = QueryRequest(
+        query="deployment?",
+        retrieval=QueryRetrievalOptions(top_k=3, retrieval_mode="sparse"),
+        storage=QueryStorageOptions(lancedb_uri="/tmp/lancedb", table_name="docs"),
+    )
+
+    assert query_workflow.query_documents(request) == []
+    assert retriever_calls == [
+        {
+            "top_k": 3,
+            "vdb_kwargs": {"uri": "/tmp/lancedb", "table_name": "docs", "retrieval_mode": "sparse"},
+        }
+    ]
+
+
 def test_query_request_builds_retriever_kwargs_with_embed_and_remote_rerank(monkeypatch) -> None:
     retriever_calls: list[dict[str, Any]] = []
     monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-test")

--- a/nemo_retriever/tests/test_query_workflow_options.py
+++ b/nemo_retriever/tests/test_query_workflow_options.py
@@ -129,6 +129,33 @@ def test_query_documents_uses_typed_request(monkeypatch) -> None:
     ]
 
 
+@pytest.mark.parametrize(
+    ("mode", "strategies"),
+    [
+        ("dense", ["semantic"]),
+        ("hybrid", ["semantic", "lexical"]),
+        ("sparse", ["lexical"]),
+    ],
+)
+def test_query_documents_with_metadata_reports_resolved_strategy(monkeypatch, mode, strategies) -> None:
+    class FakeRetriever:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        def _resolve_lancedb_query_mode(self, _vdb_kwargs: Any) -> tuple[str, object, str, str, bool]:
+            return mode, object(), "uri", "table", False
+
+        def query(self, query: str, **_kwargs: Any) -> list[dict[str, Any]]:
+            return [{"text": query, "source": "doc.pdf", "page_number": 1}]
+
+    monkeypatch.setattr(query_workflow, "Retriever", FakeRetriever)
+
+    result = query_workflow.query_documents_with_metadata(QueryRequest(query="deployment?"))
+
+    assert result.hits == [{"text": "deployment?", "source": "doc.pdf", "page_number": 1}]
+    assert result.strategies == strategies
+
+
 def test_service_query_uses_candidate_pool_and_preserves_local_shaping(monkeypatch) -> None:
     client_calls: list[dict[str, Any]] = []
 

--- a/nemo_retriever/tests/test_retriever_queries.py
+++ b/nemo_retriever/tests/test_retriever_queries.py
@@ -57,6 +57,7 @@ def _install_mock_graph(monkeypatch: pytest.MonkeyPatch, hits: list[list[dict[st
         return graph
 
     monkeypatch.setattr(Retriever, "_get_graph", fresh_get)
+    monkeypatch.setattr(Retriever, "_resolve_lancedb_query_mode", lambda self, runtime_vdb_kwargs: None)
     return resolved
 
 
@@ -133,9 +134,7 @@ class TestQueriesGraphExecution:
             def resolve_for_local_execution(self) -> FakeResolvedGraph:
                 return FakeResolvedGraph()
 
-        monkeypatch.setattr(Retriever, "_build_default_graph", lambda self, *, embed_extra=None: FakeGraph())
-
-        out = _make_retriever(top_k=1, rerank=True).query("q")
+        out = _make_retriever(top_k=1, rerank=True, graph=FakeGraph()).query("q")
 
         assert out == [{"text": "reranker winner", "source": "rerank.pdf", "page_number": 2, "_rerank_score": 0.9}]
         assert [call["top_k"] for call in execute_kwargs] == [4]

--- a/nemo_retriever/tests/test_root_cli_workflow.py
+++ b/nemo_retriever/tests/test_root_cli_workflow.py
@@ -1441,3 +1441,54 @@ def test_root_ingest_passes_hybrid_into_vdb_kwargs(monkeypatch, tmp_path) -> Non
         "overwrite": True,
         "hybrid": True,
     }
+
+
+def test_root_ingest_sparse_skips_embedding_and_writes_fts_table(monkeypatch, tmp_path) -> None:
+    lancedb = pytest.importorskip("lancedb")
+    fake_ingestor = _make_fake_ingestor()
+    doc = tmp_path / "a.pdf"
+    doc.write_bytes(b"%PDF-1.4\n")
+    fake_ingestor.ingest.return_value = [
+        {
+            "text": "alpha sparse manual",
+            "metadata": {
+                "content_metadata": {"id": "alpha", "page_number": 1, "type": "text"},
+                "source_metadata": {"source_id": str(doc)},
+            },
+        }
+    ]
+
+    monkeypatch.setattr(ingest_execution, "create_ingestor", lambda **_: fake_ingestor)
+
+    result = RUNNER.invoke(
+        cli_main.app,
+        [
+            "ingest",
+            str(doc),
+            "--lancedb-uri",
+            str(tmp_path / "db"),
+            "--table-name",
+            "sparse_docs",
+            "--sparse",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    fake_ingestor.embed.assert_not_called()
+    fake_ingestor.vdb_upload.assert_not_called()
+
+    table = lancedb.connect(str(tmp_path / "db")).open_table("sparse_docs")
+    assert "vector" not in table.schema.names
+    assert table.schema.metadata[b"retrieval_mode"] == b"sparse"
+    index_names = {index.name.lower() for index in table.list_indices()}
+    assert any("text" in name or "fts" in name for name in index_names)
+
+
+def test_root_ingest_rejects_sparse_and_hybrid_together(tmp_path) -> None:
+    doc = tmp_path / "a.pdf"
+    doc.write_bytes(b"%PDF-1.4\n")
+
+    result = RUNNER.invoke(cli_main.app, ["ingest", str(doc), "--sparse", "--hybrid"])
+
+    assert result.exit_code == 1
+    assert "Pass only one retrieval-mode ingest option" in result.output

--- a/nemo_retriever/tests/test_root_cli_workflow.py
+++ b/nemo_retriever/tests/test_root_cli_workflow.py
@@ -986,6 +986,9 @@ def test_root_ingest_local_help_uses_shared_graph_contract() -> None:
     assert "--api-key" in result.output
     assert "--dedup" in result.output
     assert "--caption" in result.output
+    assert "--index-mode" in result.output
+    assert "--hybrid" not in result.output
+    assert "--sparse" not in result.output
     assert re.search(r"--no-caption(?!-)", result.output) is None
 
 
@@ -1421,7 +1424,29 @@ def test_root_ingest_quiet_invokes_silencing_and_capture(monkeypatch, tmp_path) 
     assert "Ingested 1 file(s) → 3 row(s) in LanceDB lancedb/nemo-retriever." in result.output
 
 
-def test_root_ingest_passes_hybrid_into_vdb_kwargs(monkeypatch, tmp_path) -> None:
+def test_root_ingest_index_mode_hybrid_passes_hybrid_into_vdb_kwargs(monkeypatch, tmp_path) -> None:
+    fake_ingestor = _make_fake_ingestor()
+    doc = tmp_path / "a.pdf"
+    doc.write_bytes(b"%PDF-1.4\n")
+
+    monkeypatch.setattr(ingest_execution, "create_ingestor", lambda **_: fake_ingestor)
+    monkeypatch.setattr(ingest_execution, "_count_lancedb_rows", lambda *_, **__: 1)
+
+    result = RUNNER.invoke(
+        cli_main.app,
+        ["ingest", str(doc), "--lancedb-uri", "/tmp/lancedb", "--table-name", "docs", "--index-mode", "hybrid"],
+    )
+
+    assert result.exit_code == 0
+    assert fake_ingestor.vdb_upload.call_args.args[0].vdb_kwargs == {
+        "uri": "/tmp/lancedb",
+        "table_name": "docs",
+        "overwrite": True,
+        "hybrid": True,
+    }
+
+
+def test_root_ingest_deprecated_hybrid_alias_still_maps_to_hybrid(monkeypatch, tmp_path) -> None:
     fake_ingestor = _make_fake_ingestor()
     doc = tmp_path / "a.pdf"
     doc.write_bytes(b"%PDF-1.4\n")
@@ -1443,7 +1468,7 @@ def test_root_ingest_passes_hybrid_into_vdb_kwargs(monkeypatch, tmp_path) -> Non
     }
 
 
-def test_root_ingest_sparse_skips_embedding_and_writes_fts_table(monkeypatch, tmp_path) -> None:
+def test_root_ingest_index_mode_sparse_skips_embedding_and_writes_fts_table(monkeypatch, tmp_path) -> None:
     lancedb = pytest.importorskip("lancedb")
     fake_ingestor = _make_fake_ingestor()
     doc = tmp_path / "a.pdf"
@@ -1469,7 +1494,8 @@ def test_root_ingest_sparse_skips_embedding_and_writes_fts_table(monkeypatch, tm
             str(tmp_path / "db"),
             "--table-name",
             "sparse_docs",
-            "--sparse",
+            "--index-mode",
+            "sparse",
         ],
     )
 
@@ -1484,11 +1510,68 @@ def test_root_ingest_sparse_skips_embedding_and_writes_fts_table(monkeypatch, tm
     assert any("text" in name or "fts" in name for name in index_names)
 
 
-def test_root_ingest_rejects_sparse_and_hybrid_together(tmp_path) -> None:
+def test_root_ingest_deprecated_sparse_alias_still_maps_to_sparse(monkeypatch, tmp_path) -> None:
+    fake_ingestor = _make_fake_ingestor()
+    doc = tmp_path / "a.pdf"
+    doc.write_bytes(b"%PDF-1.4\n")
+    fake_ingestor.ingest.return_value = [{"text": "alpha sparse manual"}]
+    writes: list[dict[str, Any]] = []
+
+    def fake_write_sparse_result(result: object, *, lancedb_uri: str, table_name: str, overwrite: bool) -> None:
+        writes.append(
+            {
+                "result": result,
+                "lancedb_uri": lancedb_uri,
+                "table_name": table_name,
+                "overwrite": overwrite,
+            }
+        )
+
+    monkeypatch.setattr(ingest_execution, "create_ingestor", lambda **_: fake_ingestor)
+    monkeypatch.setattr(ingest_execution, "_write_sparse_lancedb_result", fake_write_sparse_result)
+    monkeypatch.setattr(ingest_execution, "_count_lancedb_rows", lambda *_, **__: 1)
+
+    result = RUNNER.invoke(
+        cli_main.app,
+        [
+            "ingest",
+            str(doc),
+            "--lancedb-uri",
+            "/tmp/lancedb",
+            "--table-name",
+            "sparse_docs",
+            "--sparse",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    fake_ingestor.embed.assert_not_called()
+    fake_ingestor.vdb_upload.assert_not_called()
+    assert writes == [
+        {
+            "result": [{"text": "alpha sparse manual"}],
+            "lancedb_uri": "/tmp/lancedb",
+            "table_name": "sparse_docs",
+            "overwrite": True,
+        }
+    ]
+
+
+def test_root_ingest_rejects_multiple_index_mode_options(tmp_path) -> None:
+    doc = tmp_path / "a.pdf"
+    doc.write_bytes(b"%PDF-1.4\n")
+
+    result = RUNNER.invoke(cli_main.app, ["ingest", str(doc), "--index-mode", "hybrid", "--sparse"])
+
+    assert result.exit_code == 1
+    assert "pass only one index mode option" in result.output
+
+
+def test_root_ingest_rejects_deprecated_sparse_and_hybrid_aliases_together(tmp_path) -> None:
     doc = tmp_path / "a.pdf"
     doc.write_bytes(b"%PDF-1.4\n")
 
     result = RUNNER.invoke(cli_main.app, ["ingest", str(doc), "--sparse", "--hybrid"])
 
     assert result.exit_code == 1
-    assert "Pass only one retrieval-mode ingest option" in result.output
+    assert "pass only one index mode option" in result.output

--- a/nemo_retriever/tests/test_root_query_cli.py
+++ b/nemo_retriever/tests/test_root_query_cli.py
@@ -326,7 +326,7 @@ def test_root_query_reports_os_errors(monkeypatch) -> None:
     def fail_query_documents(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:
         raise OSError("database unavailable")
 
-    monkeypatch.setattr(query_cli_app, "query_local_documents", fail_query_documents)
+    monkeypatch.setattr(query_cli_app, "query_local_documents_with_metadata", fail_query_documents)
 
     result = RUNNER.invoke(cli_main.app, ["query", "hello"])
 

--- a/nemo_retriever/tests/test_root_query_cli.py
+++ b/nemo_retriever/tests/test_root_query_cli.py
@@ -464,7 +464,7 @@ def test_root_query_agentic_plumbs_rerank_into_config(monkeypatch) -> None:
     assert "reranker" not in config_calls[-1]
 
 
-def test_root_query_passes_hybrid_into_vdb_kwargs(monkeypatch) -> None:
+def test_root_query_passes_retrieval_mode_into_vdb_kwargs(monkeypatch) -> None:
     retriever_calls: list[dict[str, Any]] = []
 
     class FakeRetriever:
@@ -478,13 +478,51 @@ def test_root_query_passes_hybrid_into_vdb_kwargs(monkeypatch) -> None:
 
     result = RUNNER.invoke(
         cli_main.app,
-        ["query", "q", "--top-k", "5", "--lancedb-uri", "/tmp/lancedb", "--table-name", "docs", "--hybrid"],
+        [
+            "query",
+            "q",
+            "--top-k",
+            "5",
+            "--lancedb-uri",
+            "/tmp/lancedb",
+            "--table-name",
+            "docs",
+            "--retrieval-mode",
+            "dense",
+        ],
     )
 
     assert result.exit_code == 0
     assert retriever_calls == [
-        {"top_k": 5, "vdb_kwargs": {"uri": "/tmp/lancedb", "table_name": "docs", "hybrid": True}}
+        {"top_k": 5, "vdb_kwargs": {"uri": "/tmp/lancedb", "table_name": "docs", "retrieval_mode": "dense"}}
     ]
+
+
+def test_root_query_keeps_hidden_hybrid_alias(monkeypatch) -> None:
+    retriever_calls: list[dict[str, Any]] = []
+
+    class FakeRetriever:
+        def __init__(self, **kwargs: Any) -> None:
+            retriever_calls.append(kwargs)
+
+        def query(self, query: str, **_kwargs: Any) -> list[dict[str, Any]]:
+            return []
+
+    monkeypatch.setattr(query_core, "Retriever", FakeRetriever)
+
+    result = RUNNER.invoke(cli_main.app, ["query", "q", "--hybrid"])
+
+    assert result.exit_code == 0
+    assert retriever_calls == [
+        {"top_k": 10, "vdb_kwargs": {"uri": "lancedb", "table_name": "nemo-retriever", "retrieval_mode": "hybrid"}}
+    ]
+
+
+def test_root_query_rejects_retrieval_mode_and_hybrid_alias_together() -> None:
+    result = RUNNER.invoke(cli_main.app, ["query", "q", "--retrieval-mode", "dense", "--hybrid"])
+
+    assert result.exit_code == 1
+    assert "pass only one of --retrieval-mode or deprecated --hybrid" in result.output
 
 
 def test_root_query_max_text_chars_truncates_and_omits(monkeypatch) -> None:
@@ -520,6 +558,14 @@ def test_root_query_help_lists_service_subcommand() -> None:
     assert "service" in result.output
     assert "--run-mode" not in result.output
     assert "--lancedb-uri" not in result.output
+
+
+def test_root_query_local_help_shows_retrieval_mode_not_hybrid() -> None:
+    result = RUNNER.invoke(cli_main.app, ["query", "q", "--help"])
+
+    assert result.exit_code == 0
+    assert "--retrieval-mode" in result.output
+    assert "--hybrid" not in result.output
 
 
 def test_root_query_service_help_hides_local_only_options() -> None:

--- a/skills/nemo-retriever/scripts/doctor.py
+++ b/skills/nemo-retriever/scripts/doctor.py
@@ -128,7 +128,6 @@ def main():
                 "evidence",
                 "--top-k",
                 "3",
-                "--no-hybrid",
                 "--table-name",
                 table,
                 "--lancedb-uri",


### PR DESCRIPTION
## Summary
- Add LanceDB table capability detection so local query auto-routes dense, hybrid, and sparse tables without mode flags.
- Add expert `--retrieval-mode auto|dense|hybrid|sparse` for explicit query overrides; default `auto` preserves artifact-driven routing.
- Add public ingest `--index-mode dense|hybrid|sparse` with dense as the default, plus hidden deprecated `--hybrid` and `--sparse` ingest aliases for compatibility.
- Keep deprecated query `--hybrid` as a hidden compatibility alias for `--retrieval-mode hybrid`.
- Add opt-in sparse LanceDB ingest/query support while preserving query output shape.
- Clean up the retrieval-mode diff by removing an unused capability wrapper and deduplicating repeated test fakes.

## Validation
- Focused changed-test set: `UV_PROJECT_ENVIRONMENT=/tmp/nemo-retriever-retrieval-mode-venv uv run --project nemo_retriever pytest nemo_retriever/tests/test_root_cli_workflow.py nemo_retriever/tests/test_root_query_cli.py nemo_retriever/tests/test_query_workflow_options.py nemo_retriever/tests/test_lancedb_capabilities.py nemo_retriever/tests/test_retriever_queries.py` -> 133 passed.
- Live CLI e2e with temp text docs, real `retriever ingest local`, real LanceDB tables, and a local OpenAI-compatible embedding endpoint covered: `--index-mode dense` with auto/dense query, `--index-mode hybrid` with auto/hybrid/dense/sparse query, and `--index-mode sparse` with auto/sparse query. Each returned `alpha safety manual` as the top hit and detected the expected table capabilities.
- Ruff passed on PR-changed Python files.
- Flake8 passed on PR-changed Python files.
- Pre-commit passed on PR-changed files: trailing whitespace, EOF, large files, Python AST, debug statements, black, flake8.
- `git diff --check` passed.
