### PR TITLE
fix(docs): repair Starter kits redirect loop breaking docs.nvidia.com links after PR 2195

### DIFF
--- a/docs/docs/extraction/agentic-retrieval-concept.md
+++ b/docs/docs/extraction/agentic-retrieval-concept.md
@@ -7,4 +7,4 @@ NeMo Retriever Library focuses on document ingestion, embeddings, vector stores,
 **Related**
 
 - [Semantic retrieval](vdbs.md#semantic-retrieval)
-- Framework examples: [Starter kits](notebooks/index.md)
+- Framework examples: [Starter kits](starter-kits.md)

--- a/docs/docs/extraction/concepts.md
+++ b/docs/docs/extraction/concepts.md
@@ -36,6 +36,6 @@ Token-based splitting uses the Llama 3.2 1B tokenizer (default `meta-llama/Llama
 
 - **Library mode** — Run without the full container stack where appropriate; see [Deployment options](deployment-options.md).
 - **Kubernetes / Helm (self-hosted)** — See [Deploy (Helm chart)](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) and [deployment options](deployment-options.md) for running the full microservices pipeline on your infrastructure.
-- **Notebooks** — [Jupyter examples](notebooks/index.md) for experimentation and RAG demos.
+- **Notebooks** — [Jupyter examples](starter-kits.md) for experimentation and RAG demos.
 
 For a concise comparison, refer to [Deployment options](deployment-options.md).

--- a/docs/docs/extraction/deployment-options.md
+++ b/docs/docs/extraction/deployment-options.md
@@ -28,7 +28,7 @@ For audio and video extraction in Kubernetes, set `service.installFfmpeg=true` s
 
 ### I want examples and notebooks
 
-1. [Jupyter Notebooks](notebooks/index.md)
+1. [Jupyter Notebooks](starter-kits.md)
 
 ### I need API details and keys
 

--- a/docs/docs/extraction/getting-started-about.md
+++ b/docs/docs/extraction/getting-started-about.md
@@ -9,6 +9,6 @@ Typical order:
 3. Deploy using one of:
     - [Deployment options](deployment-options.md) for how to run NeMo Retriever Library
     - **Supported:** [Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) for Kubernetes, plus [NeMo Retriever Library install docs](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the published charts
-4. Explore [Jupyter Notebooks](notebooks/index.md) for end-to-end examples.
+4. Explore [Jupyter Notebooks](starter-kits.md) for end-to-end examples.
 
 If you are new to the product, read [What is NeMo Retriever Library?](overview.md) and [Concepts](concepts.md) under **Introduction** first.

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -49,5 +49,5 @@ NeMo Retriever Library supports the following file types:
 - [Deployment options](deployment-options.md) — library, Helm, hosted vs self-hosted NIMs in one place
 - [Deploy on Kubernetes with Helm](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md)
 - [NeMo Retriever Library — prerequisites / deployment](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) (supported Helm charts)
-- [Notebooks](notebooks/index.md)
-- [NVIDIA AI Blueprints catalog](https://build.nvidia.com/explore/discover) — solution cards, enterprise RAG blueprints, and end-to-end patterns (including [Enterprise RAG — multimodal PDF data extraction](https://build.nvidia.com/nvidia/multimodal-pdf-data-extraction-for-enterprise-rag)); for integration pathways, refer to [Starter kits](notebooks/index.md).
+- [Notebooks](starter-kits.md)
+- [NVIDIA AI Blueprints catalog](https://build.nvidia.com/explore/discover) — solution cards, enterprise RAG blueprints, and end-to-end patterns (including [Enterprise RAG — multimodal PDF data extraction](https://build.nvidia.com/nvidia/multimodal-pdf-data-extraction-for-enterprise-rag)); for integration pathways, refer to [Starter kits](starter-kits.md).

--- a/docs/docs/extraction/starter-kits.md
+++ b/docs/docs/extraction/starter-kits.md
@@ -1,6 +1,6 @@
 # Notebooks for NeMo Retriever Library
 
-To get started using [NeMo Retriever Library](../overview.md), you can try one of the ready-made notebooks that are available.
+To get started using [NeMo Retriever Library](overview.md), you can try one of the ready-made notebooks that are available.
 
 ## Dataset Downloads for Benchmarking
 
@@ -10,9 +10,9 @@ If you plan to run benchmarking or evaluation tests, you must download the [Benc
 
 To get started with the basics, try one of the following guides or notebooks:
 
-- [Quickstart: retriever CLI](../../reference/retriever-cli-quickstart.md)
-- [Workflow: Ingest documents](../workflow-document-ingestion.md)
-- [Adding Custom Metadata for Filtered Search/Retrieval](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/nemo_retriever_retriever_query_metadata_filter.ipynb) — also summarized on [Vector databases — Metadata and filtering](../vdbs.md#metadata-and-filtering)
+- [Quickstart: retriever CLI](../reference/retriever-cli-quickstart.md)
+- [Workflow: Ingest documents](workflow-document-ingestion.md)
+- [Adding Custom Metadata for Filtered Search/Retrieval](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/nemo_retriever_retriever_query_metadata_filter.ipynb) — also summarized on [Vector databases — Metadata and filtering](vdbs.md#metadata-and-filtering)
 
 
 For more advanced scenarios, try one of the following notebooks:

--- a/docs/docs/extraction/starter-kits.md
+++ b/docs/docs/extraction/starter-kits.md
@@ -1,4 +1,4 @@
-# Notebooks for NeMo Retriever Library
+# Starter Kits for NeMo Retriever Library
 
 To get started using [NeMo Retriever Library](overview.md), you can try one of the ready-made notebooks that are available.
 

--- a/docs/docs/extraction/workflow-e2e-blueprints.md
+++ b/docs/docs/extraction/workflow-e2e-blueprints.md
@@ -5,4 +5,4 @@ Use these external resources for end-to-end RAG implementations with NeMo Retrie
 - [Enterprise RAG - multimodal PDF data extraction](https://build.nvidia.com/nvidia/multimodal-pdf-data-extraction-for-enterprise-rag)
 - [NVIDIA AI Blueprints catalog](https://build.nvidia.com/explore/discover)
 
-For framework-specific integration patterns, refer to [Starter kits](notebooks/index.md).
+For framework-specific integration patterns, refer to [Starter kits](starter-kits.md).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -102,7 +102,7 @@ nav:
       - Extending/Customizing NeMo Retriever Library with custom code: https://github.com/NVIDIA/NeMo-Retriever/tree/main/nemo_retriever/src/nemo_retriever/graph#nemo-retriever-graph
       - "NimClient and custom NIM endpoints": extraction/nimclient.md
   - "9. Integrations & ecosystem":
-      - "Starter kits": extraction/notebooks/index.md
+      - "Starter kits": extraction/starter-kits.md
   - "10. Evaluation & benchmarks":
       - "Evaluate on your own documents": extraction/evaluate-on-your-data.md
   - "11. Reference":
@@ -157,10 +157,11 @@ plugins:
         extraction/hosted-nims-when-to-use.md: extraction/deployment-options.md
         extraction/releasenotes-nv-ingest.md: extraction/releasenotes.md
         extraction/ngc-api-key.md: extraction/api-keys.md
-        extraction/notebooks.md: extraction/notebooks/index.md
+        extraction/notebooks/index.md: extraction/starter-kits.md
+        extraction/notebooks.md: extraction/starter-kits.md
         extraction/data-store.md: extraction/vdbs.md
         extraction/custom-metadata.md: extraction/vdbs.md#metadata-and-filtering
-        extraction/integrations-langchain-llamaindex-haystack.md: extraction/notebooks/index.md
+        extraction/integrations-langchain-llamaindex-haystack.md: extraction/starter-kits.md
         extraction/nemoretriever-parse.md: extraction/multimodal-extraction.md#text-and-layout-extraction
         extraction/supported-file-types.md: extraction/multimodal-extraction.md#supported-file-types-and-formats
         extraction/text-layout-extraction.md: extraction/multimodal-extraction.md#text-and-layout-extraction
@@ -209,7 +210,7 @@ markdown_extensions:
 
 # MkDocs 1.6+: exclude suite landing and legacy duplicate pages (still in repo for parity).
 # extraction/chunking.md — removed from nav; content is under concepts.md (redirect_maps keeps old URLs).
-# Use /index.md (docs root only); bare index.md would exclude every index.md (e.g. extraction/notebooks/index.md).
+# Use /index.md (docs root only); bare index.md would exclude every index.md (e.g. under subfolders).
 exclude_docs: |
   /index.md
   extraction/chunking.md


### PR DESCRIPTION
## Summary

Fixes broken **Starter kits / Notebooks** links on [docs.nvidia.com](https://docs.nvidia.com/nemo/retriever/26.5.0/extraction/overview/) after PR #2195 consolidated integration docs.

PR #2195 correctly removed standalone pages and added `mkdocs-redirects` entries, but two redirect targets pointed at `extraction/notebooks/index.md`. The redirects plugin treats `index.md` and the built `index.html` as the same output path, so redirect stubs **overwrote** the real Starter kits page with a self-redirect (`url=./`). Browsers then loop forever on `/extraction/notebooks/`.

This PR moves the canonical page to `extraction/starter-kits.md` and points legacy URLs at that page instead of `notebooks/index.md`.

## Problem (live site today)

Verified on https://docs.nvidia.com/nemo/retriever/26.5.0/extraction/overview/ after the automated docs.nvidia.com publish:

| Link | Symptom | HTTP status |
|------|---------|-------------|
| **Related Topics → Notebooks** | Infinite redirect (`Redirecting...`, `url=./`) | 200 (misleading) |
| **Related Topics → Integrations** (older deploy) | Redirects to notebooks, then loops | 200 |
| **Sidebar → Custom metadata** | Stale pre-#2195 page still on S3 | 200 (wrong content) |

HTTP 200 alone is not sufficient — the notebooks path is unusable in a browser.

Root cause: `mkdocs-redirects` issue class documented in [mkdocs/mkdocs-redirects#24](https://github.com/mkdocs/mkdocs-redirects/issues/24) and [#36](https://github.com/mkdocs/mkdocs-redirects/issues/36) — **do not redirect to a nested `index.md` that is also the canonical build output**.

PR #2195 redirect map (broken):

```yaml
extraction/notebooks.md: extraction/notebooks/index.md
extraction/integrations-langchain-llamaindex-haystack.md: extraction/notebooks/index.md
```

## Fix

1. **Move** `extraction/notebooks/index.md` → `extraction/starter-kits.md` (matches nav label "Starter kits" from #2195).
2. **Update** nav and internal links to use `starter-kits.md`.
3. **Retarget** redirects to `extraction/starter-kits.md` (safe — not an index collision):

```yaml
extraction/notebooks/index.md: extraction/starter-kits.md
extraction/notebooks.md: extraction/starter-kits.md
extraction/integrations-langchain-llamaindex-haystack.md: extraction/starter-kits.md
```

Local `mkdocs build` result after fix:

- `/extraction/starter-kits/` — full content page
- `/extraction/notebooks/` — redirect → `../starter-kits/`
- `/extraction/integrations-langchain-llamaindex-haystack/` — redirect → `../starter-kits/`
- `/extraction/custom-metadata/` — redirect → `../vdbs/#metadata-and-filtering` (unchanged; republish will replace stale S3 copy)

## After merge

Run **NRL documentation — docs.nvidia.com publish** (live) so `aws s3 sync --delete` replaces stale `custom-metadata/` HTML and refreshes overview/nav from current `main`.

## Test plan

- [x] `mkdocs build -f docs/mkdocs.yml --strict` locally — no redirect-target warnings
- [x] Built `/extraction/starter-kits/index.html` contains page content (not redirect stub)
- [x] Built `/extraction/notebooks/index.html` redirects to `../starter-kits/`
- [x] Built `/extraction/integrations-langchain-llamaindex-haystack/index.html` redirects to `../starter-kits/`
- [ ] After merge + docs.nvidia.com publish: verify overview Related Topics links work in browser
- [ ] Confirm stale `custom-metadata/` page replaced by redirect to `vdbs/#metadata-and-filtering`

## Related

- PR #2195 — doc path consolidation (introduced redirect targets)
- PR #2223 — automated docs.nvidia.com publish (surfaced the issue on production)
