### PR TITLE
[codex] fix readme typical use snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ For small-scale workloads, such as workloads of fewer than 100 PDFs, you can use
 After [following the quickstart installation steps](nemo_retriever), you can start ingesting content like with the following snippet:
 ```python
 from nemo_retriever import create_ingestor
-from nemo_retriever.io import to_markdown, to_markdown_by_page
+from nemo_retriever.common.io import to_markdown, to_markdown_by_page
 from pathlib import Path
 
-documents = [str(Path("../data/multimodal_test.pdf"))]
+documents = [str(Path("data/multimodal_test.pdf"))]
 ingestor = create_ingestor(run_mode="batch")
 
 # ingestion tasks are chainable and defined lazily
@@ -93,7 +93,7 @@ dict_keys([1, 2, 3])
 To query for relevant snippets of the ingested content, and use them with an LLM to generate answers, use the following code.
 
 ```python
-from nemo_retriever.retriever import Retriever
+from nemo_retriever.graph.retriever import Retriever
 from openai import OpenAI
 import os
 

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -103,7 +103,7 @@ The examples below use default local GPU inference (no `invoke_url` specified) a
 ### Ingest a test pdf
 ```python
 from nemo_retriever import create_ingestor
-from nemo_retriever.io import to_markdown, to_markdown_by_page
+from nemo_retriever.common.io import to_markdown, to_markdown_by_page
 from pathlib import Path
 
 documents = [str(Path("../data/multimodal_test.pdf"))]
@@ -225,7 +225,7 @@ Since the ingestion job automatically populated a lancedb table with all these c
 ### Run a recall query
 
 ```python
-from nemo_retriever.retriever import Retriever
+from nemo_retriever.graph.retriever import Retriever
 
 retriever = Retriever(
   # values used by the graph_pipeline example above
@@ -330,7 +330,7 @@ embedding model in `embed_kwargs` must match the one used during ingestion so
 query vectors land in the same embedding space as the stored chunks.
 
 ```python
-from nemo_retriever.retriever import Retriever
+from nemo_retriever.graph.retriever import Retriever
 from nemo_retriever.llm import LiteLLMClient
 
 retriever = Retriever(
@@ -435,7 +435,7 @@ ingestor = (
 ### Render results as markdown
 
 If you want a readable markdown view of extracted results, pass a single document's extraction
-records to `nemo_retriever.io.to_markdown`. The helper returns one markdown string (or `None`
+records to `nemo_retriever.common.io.to_markdown`. The helper returns one markdown string (or `None`
 if there is no content), with per-page sections joined under a single document heading.
 
 For multi-document runs, pass one document at a time—for example, `to_markdown(results[0])`.

--- a/nemo_retriever/tests/test_readme_typical_use.py
+++ b/nemo_retriever/tests/test_readme_typical_use.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _front_page_typical_use_python_blocks() -> list[tuple[int, str]]:
+    readme = _repo_root() / "README.md"
+    if not readme.is_file():
+        pytest.skip("front-page README.md is unavailable in this test layout")
+
+    text = readme.read_text(encoding="utf-8")
+    match = re.search(
+        r"## Typical Use\n(?P<section>.*?)\n## Documentation Resources",
+        text,
+        re.DOTALL,
+    )
+    assert match is not None, "README.md is missing the Typical Use section"
+
+    blocks: list[tuple[int, str]] = []
+    for index, code in enumerate(re.findall(r"```python\n(.*?)```", match.group("section"), re.DOTALL)):
+        # The middle README block is doctest-style inspection output, not an
+        # executable setup/query snippet.
+        if ">>>" not in code:
+            blocks.append((index, code))
+    return blocks
+
+
+class _FakeIngestor:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, Any]] = []
+
+    def files(self, documents: list[str]) -> "_FakeIngestor":
+        self.calls.append(("files", documents))
+        return self
+
+    def extract(self, **kwargs: Any) -> "_FakeIngestor":
+        self.calls.append(("extract", kwargs))
+        return self
+
+    def embed(self) -> "_FakeIngestor":
+        self.calls.append(("embed", None))
+        return self
+
+    def vdb_upload(self) -> "_FakeIngestor":
+        self.calls.append(("vdb_upload", None))
+        return self
+
+    def ingest(self) -> pd.DataFrame:
+        self.calls.append(("ingest", None))
+        return pd.DataFrame(
+            [
+                {
+                    "page_number": 1,
+                    "text": "Cat Jumping onto a laptop In a home office",
+                    "path": "data/multimodal_test.pdf",
+                },
+                {
+                    "page_number": 1,
+                    "text": "| Animal | Activity | Place |\n| Cat | Jumping onto a laptop | In a home office |",
+                    "path": "data/multimodal_test.pdf",
+                },
+            ]
+        )
+
+
+def test_front_page_typical_use_snippets_execute_through_query(monkeypatch, capsys) -> None:
+    """Run the executable front-page README snippets through query/answer.
+
+    The harness keeps CI lightweight by faking the expensive ingestion,
+    retrieval, and hosted LLM calls while executing the public imports and
+    snippet wiring exactly as documented.
+    """
+    import nemo_retriever
+
+    retriever_module = importlib.import_module("nemo_retriever.graph.retriever")
+    blocks = _front_page_typical_use_python_blocks()
+    assert len(blocks) == 2
+    assert "create_ingestor" in blocks[0][1]
+    assert "OpenAI" in blocks[1][1]
+
+    ingestors: list[_FakeIngestor] = []
+    retriever_init_calls: list[dict[str, Any]] = []
+    retriever_queries: list[str] = []
+    llm_requests: list[dict[str, Any]] = []
+
+    def fake_create_ingestor(**_kwargs: Any) -> _FakeIngestor:
+        ingestor = _FakeIngestor()
+        ingestors.append(ingestor)
+        return ingestor
+
+    class FakeRetriever:
+        def __init__(self, **kwargs: Any) -> None:
+            retriever_init_calls.append(kwargs)
+
+        def query(self, query: str) -> list[dict[str, Any]]:
+            retriever_queries.append(query)
+            return [
+                {
+                    "text": "Cat Jumping onto a laptop In a home office",
+                    "source": "data/multimodal_test.pdf",
+                    "page_number": 1,
+                }
+            ]
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+            self.chat = types.SimpleNamespace(completions=types.SimpleNamespace(create=self._create_completion))
+
+        def _create_completion(self, **kwargs: Any) -> Any:
+            llm_requests.append(kwargs)
+            return types.SimpleNamespace(
+                choices=[
+                    types.SimpleNamespace(
+                        message=types.SimpleNamespace(
+                            content=("Cat is responsible for the typos because it is jumping " "onto the laptop.")
+                        )
+                    )
+                ]
+            )
+
+    fake_openai_module = types.ModuleType("openai")
+    fake_openai_module.OpenAI = FakeOpenAI
+    monkeypatch.setitem(sys.modules, "openai", fake_openai_module)
+    monkeypatch.setattr(nemo_retriever, "create_ingestor", fake_create_ingestor)
+    monkeypatch.setattr(retriever_module, "Retriever", FakeRetriever)
+
+    namespace: dict[str, Any] = {"__name__": "__readme_typical_use__"}
+    for block_index, code in blocks:
+        exec(compile(code, f"README.md#python-{block_index}", "exec"), namespace)
+
+    assert [call[0] for call in ingestors[0].calls] == [
+        "files",
+        "extract",
+        "embed",
+        "vdb_upload",
+        "ingest",
+    ]
+    assert ingestors[0].calls[0] == ("files", ["data/multimodal_test.pdf"])
+    assert retriever_init_calls == [{}]
+    assert retriever_queries == ["Given their activities, which animal is responsible for the typos in my documents?"]
+    assert "Cat Jumping onto a laptop" in llm_requests[0]["messages"][0]["content"]
+    assert namespace["answer"].startswith("Cat is responsible")
+    assert "Cat is responsible" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Update the front-page README snippets for the current package layout:
  - `nemo_retriever.common.io` for markdown helpers
  - `nemo_retriever.graph.retriever` for `Retriever`
- Fix the front-page sample PDF path when the snippet is run from the repo root.
- Add a focused unit harness that reads `README.md`, executes the public Typical Use snippets through `Query Ingested Content`, and fakes only the expensive ingestion/retrieval/LLM calls.

## Why
The front-page README could fail before any ingestion/query work ran because it still imported moved modules. The harness is meant to catch broken snippet imports and wiring in normal CI without requiring GPU models, LanceDB population, remote NIMs, or an LLM call.

## Validation
- `uv run --project nemo_retriever --extra dev python -m pytest nemo_retriever/tests/test_readme_typical_use.py nemo_retriever/tests/test_src_documentation_snippets.py::test_public_retriever_examples_do_not_use_unsupported_constructor_kwargs -q`
- Verified the regression path by temporarily reverting the front-page import to `from nemo_retriever.io import ...`; the new test failed on `README.md#python-0` with the expected import error.
