### PR TITLE
docs(extraction): chart modality requires pdfium path, not nemotron_parse (NVBugs 6365988)

### DIFF
--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -21,16 +21,17 @@ For more information, refer to [Vector databases](vdbs.md).
 For images that `nemoretriever-page-elements-v3` does not classify as tables, charts, or infographics,
 you can use our VLM caption task to create a dense caption of the detected image. 
 That caption is then embedded along with the rest of your content. 
-For chart-labeled PDF regions and other caption scope limits, see [Are PDF chart or figure regions captioned when Omni is enabled?](#are-pdf-chart-or-figure-regions-captioned-when-omni-is-enabled). For more information, refer to [Extract Captions from Images](nemo-retriever-api-reference.md).
+For chart-labeled PDF regions and other caption scope limits, refer to [Are PDF chart or figure regions captioned when Omni is enabled?](#are-pdf-chart-or-figure-regions-captioned-when-omni-is-enabled). For more information, refer to [Extract Captions from Images](nemo-retriever-api-reference.md).
 
 ## Are PDF chart or figure regions captioned when Omni is enabled?
 
-No. Chart-labeled PDF regions are not routed through Omni captioning. See [Image captioning](prerequisites-support-matrix.md#image-captioning-2605) for scope, validation, and what the caption stage covers.
+No. Chart-labeled PDF regions are not routed through Omni captioning. Refer to [Image captioning](prerequisites-support-matrix.md#image-captioning-2605) for scope, validation, and what the caption stage covers.
 
 ## When should I consider advanced visual parsing?
 
-For scanned documents, or documents with complex layouts, 
-you can use [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse) as an alternate PDF extraction method by setting `extract_method="nemotron_parse"`. 
+For scanned documents, or documents with complex layouts,
+you can use [nemotron-parse](https://build.nvidia.com/nvidia/nemotron-parse) as an alternate PDF extraction method by setting `extract_method="nemotron_parse"`.
+Nemotron Parse does not produce chart modality rows. For chart detection and chart-filtered retrieval, use the default **pdfium** layout path instead (refer to [Charts and infographics](multimodal-extraction.md#charts-and-infographics)).
 For more information, refer to [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse).
 
 ## Why are the environment variables different between library mode and self-hosted mode?

--- a/docs/docs/extraction/multimodal-extraction.md
+++ b/docs/docs/extraction/multimodal-extraction.md
@@ -27,7 +27,7 @@ NeMo Retriever Library accepts multiple document and media types. A current list
 For PDFs, NeMo Retriever Library typically uses **pdfium**-based extraction with configurable depth and paths. Scanned or mixed pages may use hybrid, OCR-oriented, or Nemotron Parse methods. For `extract_method` options such as `pdfium`, `pdfium_hybrid`, `ocr`, and `nemotron_parse`, refer to the [Python API reference](nemo-retriever-api-reference.md).
 
 !!! note
-    `extract_method="nemotron_parse"` requires the Nemotron Parse NIM client dependencies. Install them with the `nemotron-parse` extra, for example `pip install "nemo-retriever[nemotron-parse]"`, before running PDF extraction through Nemotron Parse.
+    `extract_method="nemotron_parse"` requires the Nemotron Parse NIM client dependencies. Install them with the `nemotron-parse` extra, for example `pip install "nemo-retriever[nemotron-parse]"`, before running PDF extraction through Nemotron Parse. This path does not produce chart modality rows; for chart detection, refer to [Charts and infographics](#charts-and-infographics).
 
 **Related**
 
@@ -49,7 +49,18 @@ NeMo Retriever Library detects tables as structured page elements, processes the
 
 Charts and infographic regions are classified with other page layout elements (tables, text blocks, titles) and processed through layout detection and OCR. `extract_charts` and `extract_infographics` are enabled by default. Outputs use the same metadata schema as other extracted objects.
 
-Chart-labeled PDF regions are **not** routed through the Omni caption stage; they remain on the layout-and-OCR path. For scope and validation guidance, see [Image captioning](prerequisites-support-matrix.md#image-captioning-2605).
+!!! important "Chart modality requires the default layout path"
+    [Nemotron Parse v1.2](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2) semantic classes do not include `Chart` or `Infographic`. The model labels regions as `Text`, `Table`, `Picture`, `Caption`, `List-item`, `Section-header`, and similar types instead.
+
+    When you set `extract_method="nemotron_parse"`:
+
+    - The pipeline does not produce `chart` modality rows, even when `extract_charts=True`.
+    - Chart-filtered retrieval (for example, queries scoped to figure or chart content) returns no hits.
+    - Chart-heavy figure pages are typically emitted as `Picture` or other non-chart modalities.
+
+    For chart detection and chart-specific retrieval, use the default **pdfium** layout path (page-elements detection and OCR), not `extract_method="nemotron_parse"`.
+
+Chart-labeled PDF regions are **not** routed through the Omni caption stage; they remain on the layout-and-OCR path. For scope and validation guidance, refer to [Image captioning](prerequisites-support-matrix.md#image-captioning-2605).
 
 For natural-language infographic descriptions, optionally enable [image captioning](#image-captioning) and set `caption_infographics=True` when you need VLM captions on infographic regions.
 

--- a/docs/docs/extraction/multimodal-extraction.md
+++ b/docs/docs/extraction/multimodal-extraction.md
@@ -54,11 +54,11 @@ Charts and infographic regions are classified with other page layout elements (t
 
     When you set `extract_method="nemotron_parse"`:
 
-    - The pipeline does not produce `chart` modality rows, even when `extract_charts=True`.
-    - Chart-filtered retrieval (for example, queries scoped to figure or chart content) returns no hits.
-    - Chart-heavy figure pages are typically emitted as `Picture` or other non-chart modalities.
+    - The pipeline does not produce `chart` or `infographic` modality rows, even when `extract_charts=True` or `extract_infographics=True`.
+    - Chart- and infographic-filtered retrieval (for example, queries scoped to figure or chart content) returns no hits.
+    - Chart-heavy and infographic-heavy pages are typically emitted as `Picture` or other non-chart modalities.
 
-    For chart detection and chart-specific retrieval, use the default **pdfium** layout path (page-elements detection and OCR), not `extract_method="nemotron_parse"`.
+    For chart and infographic detection and modality-specific retrieval, use the default **pdfium** layout path (page-elements detection and OCR), not `extract_method="nemotron_parse"`.
 
 Chart-labeled PDF regions are **not** routed through the Omni caption stage; they remain on the layout-and-OCR path. For scope and validation guidance, refer to [Image captioning](prerequisites-support-matrix.md#image-captioning-2605).
 


### PR DESCRIPTION
## Summary

- Document that Nemotron Parse v1.2 does not emit `Chart` or `Infographic` semantic classes, so `extract_method=nemotron_parse` cannot produce chart modality rows for chart-filtered retrieval.
- Add an admonition on **Charts and infographics** steering users to the default **pdfium** layout path (page-elements detection and OCR).
- Cross-link from the Nemotron Parse note and FAQ **When should I consider advanced visual parsing?** section.

## Test plan

- [x] Verified Nemotron Parse v1.2 accepted classes in `nemo_retriever/src/nemo_retriever/models/nim/primitives/model_interface/nemotron_parse.py` (no `Chart`/`Infographic`; `Picture` only for image regions).
- [x] `verify_docs.py` — no broken links in affected files.
- [x] `check-nrl-doc-leakage.ps1` — new content uses **refer to** link CTAs; no deploy leakage in diff.
- [ ] Publish preview / docs.nvidia.com after merge.

NVBugs: 6365988