### PR TITLE
[codex] Clarify CLI model defaults

### DIFF
--- a/nemo_retriever/src/nemo_retriever/cli/ingest/app.py
+++ b/nemo_retriever/src/nemo_retriever/cli/ingest/app.py
@@ -10,6 +10,7 @@ from typer.core import TyperGroup
 
 from nemo_retriever.cli.ingest.graph_commands import _graph_ingest_command
 from nemo_retriever.cli.ingest.service import _service_command
+from nemo_retriever.cli.ingest.options import DEFAULT_CAPTION_MODEL, DEFAULT_EMBED_MODEL
 
 _DEFAULT_COMMAND = "local"
 _GROUP_OPTIONS = {"--help", "-h"}
@@ -31,6 +32,18 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
-app.command("local")(_graph_ingest_command)
-app.command("batch")(_graph_ingest_command)
+app.command(
+    "local",
+    help=(
+        f"Run local ingest into a LanceDB index. Default embedding model: {DEFAULT_EMBED_MODEL}. "
+        f"Default caption model when captioning: {DEFAULT_CAPTION_MODEL}."
+    ),
+)(_graph_ingest_command)
+app.command(
+    "batch",
+    help=(
+        f"Run Ray batch ingest into a LanceDB index. Default embedding model: {DEFAULT_EMBED_MODEL}. "
+        f"Default caption model when captioning: {DEFAULT_CAPTION_MODEL}."
+    ),
+)(_graph_ingest_command)
 app.command("service")(_service_command)

--- a/nemo_retriever/src/nemo_retriever/cli/ingest/options.py
+++ b/nemo_retriever/src/nemo_retriever/cli/ingest/options.py
@@ -8,6 +8,7 @@ from typing import Annotated
 
 import typer
 
+from nemo_retriever.common.params import CaptionParams
 from nemo_retriever.ingest.plan import (
     AudioSplitTypeValue,
     IngestIndexModeValue,
@@ -17,6 +18,10 @@ from nemo_retriever.ingest.plan import (
     OcrVersionValue,
     TableOutputFormatValue,
 )
+from nemo_retriever.models import VL_EMBED_MODEL
+
+DEFAULT_EMBED_MODEL = VL_EMBED_MODEL
+DEFAULT_CAPTION_MODEL = str(CaptionParams.model_fields["model_name"].default)
 
 DocumentsArgument = Annotated[
     list[str],
@@ -163,7 +168,13 @@ ApiKeyOption = Annotated[
 ]
 CaptionModelNameOption = Annotated[
     str | None,
-    typer.Option("--caption-model-name", help="Optional VLM caption model name override."),
+    typer.Option(
+        "--caption-model-name",
+        help=(
+            f"Optional VLM caption model name override. Defaults to {DEFAULT_CAPTION_MODEL} "
+            "when --caption is enabled."
+        ),
+    ),
 ]
 CaptionContextTextMaxCharsOption = Annotated[
     int | None,
@@ -272,7 +283,10 @@ TableOutputFormatOption = Annotated[
 EmbedInvokeUrlOption = Annotated[str | None, typer.Option("--embed-invoke-url", help="Embedding NIM endpoint URL.")]
 EmbedModelNameOption = Annotated[
     str | None,
-    typer.Option("--embed-model-name", help="Optional embedding model name override."),
+    typer.Option(
+        "--embed-model-name",
+        help=f"Optional embedding model name override. Defaults to {DEFAULT_EMBED_MODEL} when omitted.",
+    ),
 ]
 LocalIngestEmbedBackendOption = Annotated[
     LocalIngestEmbedBackendValue | None,

--- a/nemo_retriever/src/nemo_retriever/cli/ingest/options.py
+++ b/nemo_retriever/src/nemo_retriever/cli/ingest/options.py
@@ -21,7 +21,7 @@ from nemo_retriever.ingest.plan import (
 from nemo_retriever.models import VL_EMBED_MODEL
 
 DEFAULT_EMBED_MODEL = VL_EMBED_MODEL
-DEFAULT_CAPTION_MODEL = str(CaptionParams.model_fields["model_name"].default)
+DEFAULT_CAPTION_MODEL = CaptionParams().model_name
 
 DocumentsArgument = Annotated[
     list[str],

--- a/nemo_retriever/src/nemo_retriever/cli/pdf/stage.py
+++ b/nemo_retriever/src/nemo_retriever/cli/pdf/stage.py
@@ -554,7 +554,10 @@ def render_page_elements(
     nemotron_parse_model_name: Optional[str] = typer.Option(
         None,
         "--nemotron-parse-model-name",
-        help="Nemotron Parse model name (optional; defaults to schema default).",
+        help=(
+            "Nemotron Parse model name. Used only with --method nemotron_parse; "
+            "omitted value uses that method's schema default."
+        ),
     ),
     extract_text: bool = typer.Option(True, "--extract-text/--no-extract-text", help="Extract text primitives."),
     extract_images: bool = typer.Option(
@@ -705,13 +708,15 @@ def render_page_elements(
                 "Nemotron Parse endpoint required for method 'nemotron_parse'. "
                 "Set --nemotron-parse-grpc-endpoint or --nemotron-parse-http-endpoint."
             )
-        extractor_cfg["nemotron_parse_config"] = {
+        nemotron_parse_config = {
             "auth_token": auth_token,
             # Nemotron Parse may still rely on YOLOX for region proposals depending on config.
             "yolox_endpoints": [yolox_grpc_endpoint, yolox_http_endpoint],
             "nemotron_parse_endpoints": [nemotron_parse_grpc_endpoint, nemotron_parse_http_endpoint],
-            "nemotron_parse_model_name": nemotron_parse_model_name,
         }
+        if nemotron_parse_model_name is not None:
+            nemotron_parse_config["nemotron_parse_model_name"] = nemotron_parse_model_name
+        extractor_cfg["nemotron_parse_config"] = nemotron_parse_config
 
     extractor_schema = load_pdf_extractor_schema_from_dict(extractor_cfg)
     task_cfg = make_pdf_task_config(

--- a/nemo_retriever/src/nemo_retriever/cli/query/app.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query/app.py
@@ -155,7 +155,14 @@ def _retrieval_options(
     )
 
 
-@app.command("_local", hidden=True)
+@app.command(
+    "_local",
+    hidden=True,
+    help=(
+        f"Query a local LanceDB index. Default embedding model: {opts.DEFAULT_EMBED_MODEL}. "
+        f"Default local reranker model when reranking: {opts.DEFAULT_RERANK_MODEL}."
+    ),
+)
 def _local_command(
     ctx: typer.Context,
     query: opts.QueryArgument,

--- a/nemo_retriever/src/nemo_retriever/cli/query/options.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query/options.py
@@ -8,6 +8,11 @@ from typing import Annotated
 
 import typer
 
+from nemo_retriever.models import VL_EMBED_MODEL, VL_RERANK_MODEL
+
+DEFAULT_EMBED_MODEL = VL_EMBED_MODEL
+DEFAULT_RERANK_MODEL = VL_RERANK_MODEL
+
 
 QueryArgument = Annotated[str, typer.Argument(..., help="Query text.")]
 TopKOption = Annotated[
@@ -62,7 +67,10 @@ EmbedInvokeUrlOption = Annotated[
 ]
 EmbedModelNameOption = Annotated[
     str | None,
-    typer.Option("--embed-model-name", help="Optional embedding model name override."),
+    typer.Option(
+        "--embed-model-name",
+        help=f"Optional embedding model name override. Defaults to {DEFAULT_EMBED_MODEL} when omitted.",
+    ),
 ]
 RerankerInvokeUrlOption = Annotated[
     str | None,
@@ -82,7 +90,7 @@ RerankerModelNameOption = Annotated[
     str | None,
     typer.Option(
         "--reranker-model-name",
-        help="Optional reranker model name override (used by the local GPU reranker).",
+        help=("Optional reranker model name override. When reranking locally, " f"defaults to {DEFAULT_RERANK_MODEL}."),
     ),
 ]
 RerankerBackendOption = Annotated[

--- a/nemo_retriever/src/nemo_retriever/query/workflow.py
+++ b/nemo_retriever/src/nemo_retriever/query/workflow.py
@@ -8,13 +8,14 @@ from dataclasses import dataclass
 from typing import Any
 
 from nemo_retriever.common.params import build_embed_option_kwargs
-from nemo_retriever.common.vdb.lancedb_capabilities import LanceRetrievalMode
-from nemo_retriever.graph.retriever import Retriever
-from nemo_retriever.query.options import QueryRequest, QueryRerankOptions
 from nemo_retriever.common.remote_auth import resolve_remote_api_key
+from nemo_retriever.common.vdb.lancedb_capabilities import LanceRetrievalMode
 from nemo_retriever.common.vdb.records import RetrievalHit
+from nemo_retriever.graph.retriever import Retriever
+from nemo_retriever.models import VL_RERANK_MODEL
+from nemo_retriever.query.options import QueryRequest, QueryRerankOptions
 
-_LOCAL_VL_RERANK_MODEL = "nvidia/llama-nemotron-rerank-vl-1b-v2"
+_LOCAL_VL_RERANK_MODEL = VL_RERANK_MODEL
 
 
 @dataclass(frozen=True)

--- a/nemo_retriever/tests/test_pdf_stage_compact_json.py
+++ b/nemo_retriever/tests/test_pdf_stage_compact_json.py
@@ -8,7 +8,15 @@ that bloat sidecars for programmatic consumers."""
 
 from __future__ import annotations
 
+import pandas as pd
+from typer.testing import CliRunner
+
+import nemo_retriever.cli.pdf.stage as pdf_stage
 from nemo_retriever.cli.pdf.stage import _strip_null_empty
+from nemo_retriever.common.api.internal.schemas.extract.extract_pdf_schema import (
+    NemotronParseConfigSchema,
+    PDFExtractorSchema,
+)
 
 
 def test_strip_drops_nulls_and_empty_collections():
@@ -44,3 +52,45 @@ def test_strip_filters_lists_and_drops_emptied_lists():
 
 def test_strip_preserves_scalar_strings_and_numbers():
     assert _strip_null_empty({"text": "hello", "n": 42}) == {"text": "hello", "n": 42}
+
+
+def _invoke_pdf_stage_and_capture_config(monkeypatch, tmp_path, args: list[str]) -> PDFExtractorSchema:
+    pdf = tmp_path / "doc.pdf"
+    pdf.write_bytes(b"%PDF-1.4\n")
+    captured: list[PDFExtractorSchema] = []
+
+    monkeypatch.setattr(pdf_stage, "_safe_pdf_page_count", lambda _path: 1)
+    monkeypatch.setattr(pdf_stage, "pdf_files_to_ledger_df", lambda *_args, **_kwargs: pd.DataFrame())
+
+    def fake_extract(_df_ledger, *, extractor_config, **_kwargs):
+        captured.append(extractor_config)
+        return pd.DataFrame(), {}
+
+    monkeypatch.setattr(pdf_stage, "extract_pdf_primitives_from_ledger_df", fake_extract)
+
+    result = CliRunner().invoke(pdf_stage.app, [str(pdf), *args])
+    assert result.exit_code == 0, result.output
+    return captured[0]
+
+
+def test_pdf_stage_default_pdfium_does_not_configure_nemotron_parse(monkeypatch, tmp_path):
+    extractor_config = _invoke_pdf_stage_and_capture_config(monkeypatch, tmp_path, [])
+
+    assert extractor_config.nemotron_parse_config is None
+
+
+def test_pdf_stage_nemotron_parse_omits_model_to_use_schema_default(monkeypatch, tmp_path):
+    extractor_config = _invoke_pdf_stage_and_capture_config(
+        monkeypatch,
+        tmp_path,
+        [
+            "--method",
+            "nemotron_parse",
+            "--nemotron-parse-http-endpoint",
+            "http://parse:8000/v1/chat/completions",
+        ],
+    )
+
+    assert extractor_config.nemotron_parse_config.nemotron_parse_model_name == (
+        NemotronParseConfigSchema.model_fields["nemotron_parse_model_name"].default
+    )

--- a/nemo_retriever/tests/test_pdf_stage_compact_json.py
+++ b/nemo_retriever/tests/test_pdf_stage_compact_json.py
@@ -94,3 +94,20 @@ def test_pdf_stage_nemotron_parse_omits_model_to_use_schema_default(monkeypatch,
     assert extractor_config.nemotron_parse_config.nemotron_parse_model_name == (
         NemotronParseConfigSchema.model_fields["nemotron_parse_model_name"].default
     )
+
+
+def test_pdf_stage_nemotron_parse_uses_explicit_model_name(monkeypatch, tmp_path):
+    extractor_config = _invoke_pdf_stage_and_capture_config(
+        monkeypatch,
+        tmp_path,
+        [
+            "--method",
+            "nemotron_parse",
+            "--nemotron-parse-http-endpoint",
+            "http://parse:8000/v1/chat/completions",
+            "--nemotron-parse-model-name",
+            "my-custom-model",
+        ],
+    )
+
+    assert extractor_config.nemotron_parse_config.nemotron_parse_model_name == "my-custom-model"

--- a/nemo_retriever/tests/test_root_query_cli.py
+++ b/nemo_retriever/tests/test_root_query_cli.py
@@ -11,6 +11,7 @@ from typing import Any
 from typer.testing import CliRunner
 
 import nemo_retriever.query.workflow as query_core
+from nemo_retriever.models import VL_EMBED_MODEL, VL_RERANK_MODEL
 
 RUNNER = CliRunner()
 cli_main = importlib.import_module("nemo_retriever.cli.main")
@@ -566,6 +567,16 @@ def test_root_query_local_help_shows_retrieval_mode_not_hybrid() -> None:
     assert result.exit_code == 0
     assert "--retrieval-mode" in result.output
     assert "--hybrid" not in result.output
+
+
+def test_root_query_local_help_names_default_models() -> None:
+    result = RUNNER.invoke(cli_main.app, ["query", "q", "--help"])
+
+    assert result.exit_code == 0
+    assert "Default embedding model" in result.output
+    assert VL_EMBED_MODEL in result.output
+    assert "Default local reranker model" in result.output
+    assert VL_RERANK_MODEL in result.output
 
 
 def test_root_query_service_help_hides_local_only_options() -> None:


### PR DESCRIPTION
## Summary
- Show concrete default model names in root query and ingest CLI help.
- Keep the local query reranker default tied to the shared model constant.
- Scope Nemotron Parse model defaults to the `--method nemotron_parse` PDF path, not regular PDF extraction.

## Validation
- `uv run --with pytest --no-sync python -m pytest tests/test_pdf_stage_compact_json.py tests/test_root_query_cli.py tests/test_root_cli_workflow.py -q`
- commit hooks: black, flake8, and standard pre-commit checks