### PR TITLE
docs(publish): trim versions.json to active production trains (26.5.0, 26.3.0)

### DIFF
--- a/docs/publish/versions.json
+++ b/docs/publish/versions.json
@@ -2,9 +2,7 @@
   {
     "version": "26.5.0",
     "title": "26.5.0",
-    "aliases": [
-      "latest"
-    ]
+    "aliases": ["latest"]
   },
   {
     "version": "26.3.0",

--- a/docs/publish/versions.json
+++ b/docs/publish/versions.json
@@ -10,40 +10,5 @@
     "version": "26.3.0",
     "title": "26.3.0",
     "aliases": []
-  },
-  {
-    "version": "26.1.2",
-    "title": "26.1.2",
-    "aliases": []
-  },
-  {
-    "version": "26.1.1",
-    "title": "26.1.1",
-    "aliases": []
-  },
-  {
-    "version": "25.9.0",
-    "title": "25.9.0",
-    "aliases": []
-  },
-  {
-    "version": "25.6.3",
-    "title": "25.6.3",
-    "aliases": []
-  },
-  {
-    "version": "25.6.2",
-    "title": "25.6.2",
-    "aliases": []
-  },
-  {
-    "version": "25.4.2",
-    "title": "25.4.2",
-    "aliases": []
-  },
-  {
-    "version": "25.3.0",
-    "title": "25.3.0",
-    "aliases": []
   }
 ]


### PR DESCRIPTION
## Summary
- Trims `docs/publish/versions.json` so the docs.nvidia.com version picker lists only **active production** trains: **26.5.0** (`latest`) and **26.3.0**.
- Removes **25.3.0**, **25.4.2**, **25.6.2**, **25.6.3**, **25.9.0**, **26.1.1**, and **26.1.2** — these are archived under `techdocs-assets-archive-prod/nemo/retriever/` and should not appear in the live picker.

## Why this is needed
The automated **NRL documentation — docs.nvidia.com publish** workflow copies `docs/publish/versions.json` into each build artifact and uploads it to S3 (`developer/docs/nemo/retriever/versions.json`). It does **not** merge with or read from the archive bucket. Stale entries in the repo file keep showing archived versions in the picker until this file is updated and republished.

## After merge
1. Merge triggers publish (path `docs/publish/versions.json` is under `docs/**`), **or** run **NRL documentation — docs.nvidia.com publish** manually on `main`.
2. Verify live `versions.json` at https://docs.nvidia.com/nemo/retriever/latest/ shows only 26.5.0 and 26.3.0.
3. Optional platform cleanup: remove retired version folders from `brightspot-assets-prod` if they still exist (archive bucket is already separate).

## Test plan
- [ ] Confirm JSON is valid and lists 26.5.0 with `"latest"` alias only
- [ ] After merge + publish, confirm version picker on docs.nvidia.com
- [ ] Confirm archived trains remain accessible only via archive policy (not picker)
