### PR TITLE
Security: Hardcoded Tika Server URL without Authentication

### DIFF
--- a/nemo_retriever/src/nemo_retriever/common/api/internal/extract/pdf/engines/tika.py
+++ b/nemo_retriever/src/nemo_retriever/common/api/internal/extract/pdf/engines/tika.py
@@ -15,13 +15,14 @@
 # limitations under the License.
 
 import io
+import os
 from typing import Dict, Any, Optional, List
 
 import pandas as pd
 
 import requests
 
-TIKA_URL = "http://tika:9998/tika"
+TIKA_URL = os.environ.get("TIKA_URL", "http://tika:9998/tika")
 
 
 def tika_extractor(


### PR DESCRIPTION
## Summary

Security: Hardcoded Tika Server URL without Authentication

## Problem

**Severity**: `Medium` | **File**: `nemo_retriever/src/nemo_retriever/common/api/internal/extract/pdf/engines/tika.py:L48`

The `tika_extractor` function in `tika.py` sends PDF content to a hardcoded internal URL (`http://tika:9998/tika`) without any authentication mechanism. This could allow unauthorized access to the Tika server if the network is compromised, and the lack of TLS means data is transmitted in plaintext. Additionally, the `requests.put` call does not verify SSL certificates (though not applicable here due to HTTP), and there is no timeout validation or retry logic for network failures beyond the basic timeout.

## Solution

Make the Tika URL configurable via environment variable or configuration file, add authentication headers if required, and consider using HTTPS with proper certificate verification. Validate the URL scheme to prevent SSRF if user input is ever involved.

## Changes

- `nemo_retriever/src/nemo_retriever/common/api/internal/extract/pdf/engines/tika.py` (modified)