### PR TITLE
Support evidence/coverage output format on /v1/query

### DIFF
--- a/nemo_retriever/src/nemo_retriever/cli/evidence.py
+++ b/nemo_retriever/src/nemo_retriever/cli/evidence.py
@@ -1,105 +1,19 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-26, NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Answer-ready ``{evidence, coverage}`` shaping for ``retriever query --format evidence``.
+"""Backwards-compatible re-export.
 
-The skill reasons over this shape: each evidence item is fidelity-tagged and
-citation-ready, and ``coverage`` summarizes what was searched and flags thin spots.
-``--format evidence`` is opt-in; ``query``'s default output stays the flat hit list.
+Evidence shaping moved to :mod:`nemo_retriever.query.evidence` so the service
+``/v1/query`` endpoint can reuse it without the service depending on ``cli``.
+Import from there directly in new code.
 """
 
 from __future__ import annotations
 
-import os
-from typing import Any
+from nemo_retriever.query.evidence import (
+    _evidence_item,
+    _normalize_modality,
+    build_evidence_result,
+)
 
-from nemo_retriever.common.vdb.records import _derive_fidelity
-
-_KNOWN_MODALITIES = {"text", "table", "chart", "image", "audio", "video_frame"}
-
-
-def _normalize_modality(value: Any) -> str:
-    m = str(value or "text").lower()
-    if m in _KNOWN_MODALITIES:
-        return m
-    if m.startswith("table"):
-        return "table"
-    if m.startswith("chart"):
-        return "chart"
-    if m.startswith(("image", "infographic")):
-        return "image"
-    if m.startswith("video"):
-        return "video_frame"
-    if m.startswith("audio"):
-        return "audio"
-    return "text"
-
-
-def _evidence_item(hit: dict[str, Any]) -> dict[str, Any]:
-    meta = hit.get("metadata") if isinstance(hit.get("metadata"), dict) else {}
-    src_raw = hit.get("pdf_basename") or hit.get("source") or ""
-    source = os.path.basename(str(src_raw))
-    if source.lower().endswith(".pdf"):
-        source = source[:-4]
-    raw_modality = hit.get("content_type") or meta.get("type") or "text"
-    modality = _normalize_modality(raw_modality)
-
-    page = hit.get("page_number")
-    if page is not None:
-        locator = {"kind": "page", "value": page}
-        citation = f"{source} p.{page}"
-    elif meta.get("segment_start_seconds") is not None:
-        locator = {"kind": "segment", "value": meta["segment_start_seconds"]}
-        citation = f"{source} @{meta['segment_start_seconds']}"
-    elif meta.get("frame_timestamp_seconds") is not None:
-        locator = {"kind": "timestamp", "value": meta["frame_timestamp_seconds"]}
-        citation = f"{source} @{meta['frame_timestamp_seconds']}"
-    elif meta.get("bbox_xyxy_norm") is not None:
-        locator = {"kind": "bbox", "value": meta["bbox_xyxy_norm"]}
-        citation = source
-    else:
-        locator = {"kind": "page", "value": None}
-        citation = source
-
-    fidelity = meta.get("fidelity") or _derive_fidelity(raw_modality, meta, meta) or "verbatim"
-
-    if "_score" in hit and hit["_score"] is not None:
-        score: float = hit["_score"]
-    elif "_distance" in hit and hit["_distance"] is not None:
-        score = hit["_distance"]
-    else:
-        score = 0.0
-
-    return {
-        "text": hit.get("text", ""),
-        "source": source,
-        "locator": locator,
-        "modality": modality,
-        "fidelity": fidelity,
-        "score": score,
-        "citation": citation,
-    }
-
-
-def build_evidence_result(hits: list, strategies_used: list[str]) -> dict[str, Any]:
-    """Assemble the answer-ready ``{evidence, coverage}`` contract shape from raw hits.
-
-    ``evidence`` items are fidelity-tagged and citation-ready; ``coverage`` summarizes
-    what was searched (``strategies_used``, ``n_docs_seen``) and flags thin spots
-    (single source, low-fidelity-only, out-of-corpus). This is the shape the skill
-    reasons over — emitted by ``retriever query --format evidence``.
-    """
-    evidence = [_evidence_item(h) for h in (hits or [])]
-    sources = {e["source"] for e in evidence if e.get("source")}
-    thin: list[str] = []
-    if not evidence:
-        thin.append("no matches — likely out of corpus")
-    else:
-        if len(sources) == 1:
-            thin.append("single source")
-        if all(e["fidelity"] == "vlm_caption" for e in evidence):
-            thin.append("only low-fidelity (chart/image) evidence")
-    return {
-        "evidence": evidence,
-        "coverage": {"strategies_used": strategies_used, "n_docs_seen": len(sources), "thin_spots": thin},
-    }
+__all__ = ["build_evidence_result", "_evidence_item", "_normalize_modality"]

--- a/nemo_retriever/src/nemo_retriever/cli/evidence.py
+++ b/nemo_retriever/src/nemo_retriever/cli/evidence.py
@@ -10,10 +10,6 @@ Import from there directly in new code.
 
 from __future__ import annotations
 
-from nemo_retriever.query.evidence import (
-    _evidence_item,
-    _normalize_modality,
-    build_evidence_result,
-)
+from nemo_retriever.query.evidence import build_evidence_result
 
-__all__ = ["build_evidence_result", "_evidence_item", "_normalize_modality"]
+__all__ = ["build_evidence_result"]

--- a/nemo_retriever/src/nemo_retriever/cli/query/app.py
+++ b/nemo_retriever/src/nemo_retriever/cli/query/app.py
@@ -12,7 +12,7 @@ import click
 import typer
 from typer.core import TyperGroup
 
-from nemo_retriever.cli.evidence import build_evidence_result
+from nemo_retriever.query.evidence import build_evidence_result
 from nemo_retriever.cli.query import options as opts
 from nemo_retriever.cli.query_workflow import agentic_query_documents as query_agentic_documents
 from nemo_retriever.cli.query_workflow import query_documents_with_metadata as query_local_documents_with_metadata

--- a/nemo_retriever/src/nemo_retriever/query/evidence.py
+++ b/nemo_retriever/src/nemo_retriever/query/evidence.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-26, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Answer-ready ``{evidence, coverage}`` shaping shared by the CLI and the service.
+
+The skill reasons over this shape: each evidence item is fidelity-tagged and
+citation-ready, and ``coverage`` summarizes what was searched and flags thin spots.
+Both ``retriever query --format evidence`` (CLI) and ``POST /v1/query`` with
+``format=evidence`` (service) project raw retrieval hits through this module, so
+the two surfaces stay in lockstep.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from nemo_retriever.common.vdb.records import _derive_fidelity
+
+_KNOWN_MODALITIES = {"text", "table", "chart", "image", "audio", "video_frame"}
+
+
+def _normalize_modality(value: Any) -> str:
+    m = str(value or "text").lower()
+    if m in _KNOWN_MODALITIES:
+        return m
+    if m.startswith("table"):
+        return "table"
+    if m.startswith("chart"):
+        return "chart"
+    if m.startswith(("image", "infographic")):
+        return "image"
+    if m.startswith("video"):
+        return "video_frame"
+    if m.startswith("audio"):
+        return "audio"
+    return "text"
+
+
+def _evidence_item(hit: dict[str, Any]) -> dict[str, Any]:
+    meta = hit.get("metadata") if isinstance(hit.get("metadata"), dict) else {}
+    src_raw = hit.get("pdf_basename") or hit.get("source") or ""
+    source = os.path.basename(str(src_raw))
+    if source.lower().endswith(".pdf"):
+        source = source[:-4]
+    raw_modality = hit.get("content_type") or meta.get("type") or "text"
+    modality = _normalize_modality(raw_modality)
+
+    page = hit.get("page_number")
+    if page is not None:
+        locator = {"kind": "page", "value": page}
+        citation = f"{source} p.{page}"
+    elif meta.get("segment_start_seconds") is not None:
+        locator = {"kind": "segment", "value": meta["segment_start_seconds"]}
+        citation = f"{source} @{meta['segment_start_seconds']}"
+    elif meta.get("frame_timestamp_seconds") is not None:
+        locator = {"kind": "timestamp", "value": meta["frame_timestamp_seconds"]}
+        citation = f"{source} @{meta['frame_timestamp_seconds']}"
+    elif meta.get("bbox_xyxy_norm") is not None:
+        locator = {"kind": "bbox", "value": meta["bbox_xyxy_norm"]}
+        citation = source
+    else:
+        locator = {"kind": "page", "value": None}
+        citation = source
+
+    fidelity = meta.get("fidelity") or _derive_fidelity(raw_modality, meta, meta) or "verbatim"
+
+    if "_score" in hit and hit["_score"] is not None:
+        score: float = hit["_score"]
+    elif "_distance" in hit and hit["_distance"] is not None:
+        score = hit["_distance"]
+    else:
+        score = 0.0
+
+    return {
+        "text": hit.get("text", ""),
+        "source": source,
+        "locator": locator,
+        "modality": modality,
+        "fidelity": fidelity,
+        "score": score,
+        "citation": citation,
+    }
+
+
+def build_evidence_result(hits: list, strategies_used: list[str]) -> dict[str, Any]:
+    """Assemble the answer-ready ``{evidence, coverage}`` contract shape from raw hits.
+
+    ``evidence`` items are fidelity-tagged and citation-ready; ``coverage`` summarizes
+    what was searched (``strategies_used``, ``n_docs_seen``) and flags thin spots
+    (single source, low-fidelity-only, out-of-corpus). This is the shape the skill
+    reasons over — emitted by ``retriever query --format evidence`` and by the
+    service ``/v1/query`` endpoint with ``format=evidence``.
+    """
+    evidence = [_evidence_item(h) for h in (hits or [])]
+    sources = {e["source"] for e in evidence if e.get("source")}
+    thin: list[str] = []
+    if not evidence:
+        thin.append("no matches — likely out of corpus")
+    else:
+        if len(sources) == 1:
+            thin.append("single source")
+        if all(e["fidelity"] == "vlm_caption" for e in evidence):
+            thin.append("only low-fidelity (chart/image) evidence")
+    return {
+        "evidence": evidence,
+        "coverage": {"strategies_used": strategies_used, "n_docs_seen": len(sources), "thin_spots": thin},
+    }

--- a/nemo_retriever/src/nemo_retriever/query/evidence.py
+++ b/nemo_retriever/src/nemo_retriever/query/evidence.py
@@ -56,8 +56,8 @@ def _evidence_item(hit: dict[str, Any]) -> dict[str, Any]:
     elif meta.get("frame_timestamp_seconds") is not None:
         locator = {"kind": "timestamp", "value": meta["frame_timestamp_seconds"]}
         citation = f"{source} @{meta['frame_timestamp_seconds']}"
-    elif meta.get("bbox_xyxy_norm") is not None:
-        locator = {"kind": "bbox", "value": meta["bbox_xyxy_norm"]}
+    elif (bbox := meta.get("bbox_xyxy_norm") or hit.get("bbox_xyxy_norm")) is not None:
+        locator = {"kind": "bbox", "value": bbox}
         citation = source
     else:
         locator = {"kind": "page", "value": None}

--- a/nemo_retriever/src/nemo_retriever/query/evidence.py
+++ b/nemo_retriever/src/nemo_retriever/query/evidence.py
@@ -56,7 +56,7 @@ def _evidence_item(hit: dict[str, Any]) -> dict[str, Any]:
     elif meta.get("frame_timestamp_seconds") is not None:
         locator = {"kind": "timestamp", "value": meta["frame_timestamp_seconds"]}
         citation = f"{source} @{meta['frame_timestamp_seconds']}"
-    elif (bbox := meta.get("bbox_xyxy_norm") or hit.get("bbox_xyxy_norm")) is not None:
+    elif bbox := meta.get("bbox_xyxy_norm") or hit.get("bbox_xyxy_norm"):
         locator = {"kind": "bbox", "value": bbox}
         citation = source
     else:

--- a/nemo_retriever/src/nemo_retriever/service/cli.py
+++ b/nemo_retriever/src/nemo_retriever/service/cli.py
@@ -140,8 +140,6 @@ def start(
 def ingest(
     files: list[Path] = typer.Argument(..., help="One or more document files to ingest."),
     server_url: str = typer.Option("http://localhost:7670", "--server-url", "-s", help="Retriever service base URL."),
-    use_sse: bool = typer.Option(True, "--sse/--no-sse", help="Use SSE streaming (default) or poll."),
-    poll_interval: float = typer.Option(2.0, "--poll-interval", help="Seconds between status polls (no-SSE mode)."),
     concurrency: int = typer.Option(8, "--concurrency", help="Max concurrent uploads."),
     api_token: Optional[str] = typer.Option(
         None,
@@ -159,11 +157,9 @@ def ingest(
             max_concurrency=concurrency,
             api_token=api_token,
         )
-        await client.ingest_documents(
-            files=files,
-            use_sse=use_sse,
-            poll_interval=poll_interval,
-        )
+        # The client always streams via SSE with an automatic bulk-poll fallback,
+        # so there are no SSE/poll knobs to forward here.
+        await client.ingest_documents(files=files)
 
     asyncio.run(_run())
 

--- a/nemo_retriever/src/nemo_retriever/service/mcp_server.py
+++ b/nemo_retriever/src/nemo_retriever/service/mcp_server.py
@@ -200,7 +200,7 @@ class ServiceMCPClient:
         query: str,
         *,
         top_k: int = 5,
-        format: str = "hits",
+        format: QueryFormat = "hits",
         payload: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         body = dict(payload or {})

--- a/nemo_retriever/src/nemo_retriever/service/mcp_server.py
+++ b/nemo_retriever/src/nemo_retriever/service/mcp_server.py
@@ -26,6 +26,7 @@ from fastmcp import FastMCP
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from nemo_retriever.service.config import ServiceConfig
+from nemo_retriever.service.query_schema import QueryFormat
 
 logger = logging.getLogger(__name__)
 
@@ -194,10 +195,18 @@ class ServiceMCPClient:
         self._raise_for_status(resp)
         return dict(self._json_or_text(resp))
 
-    async def query(self, query: str, *, top_k: int = 5, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    async def query(
+        self,
+        query: str,
+        *,
+        top_k: int = 5,
+        format: str = "hits",
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         body = dict(payload or {})
         body.setdefault("query", query)
         body.setdefault("top_k", top_k)
+        body.setdefault("format", format)
         async with self._client() as client:
             resp = await client.post("/v1/query", json=body)
         self._raise_for_status(resp)
@@ -479,10 +488,19 @@ def build_mcp(settings: ServiceMCPSettings | None = None) -> FastMCP:
 
     @mcp.tool(
         name="query",
-        description="Search ingested documents through the service VectorDB endpoint.",
+        description=(
+            "Search ingested documents through the service VectorDB endpoint. "
+            "format='hits' (default) returns raw retrieval hits; format='evidence' "
+            "returns the fidelity-tagged, citation-ready {evidence, coverage} shape."
+        ),
     )
-    async def query(query: str, top_k: int = 5, payload: dict[str, Any] | None = None) -> dict[str, Any]:
-        return await service.query(query, top_k=top_k, payload=payload)
+    async def query(
+        query: str,
+        top_k: int = 5,
+        format: QueryFormat = "hits",
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return await service.query(query, top_k=top_k, format=format, payload=payload)
 
     @mcp.tool(name="answer", description="Search ingested documents and generate an answer.")
     async def answer(

--- a/nemo_retriever/src/nemo_retriever/service/query_schema.py
+++ b/nemo_retriever/src/nemo_retriever/service/query_schema.py
@@ -36,11 +36,38 @@ class QueryResponse(BaseModel):
         return [result.hits for result in self.results]
 
 
+class Locator(BaseModel):
+    """Where an evidence item lives in its source (page / segment / timestamp / bbox)."""
+
+    kind: str
+    value: Any = None
+
+
+class EvidenceItem(BaseModel):
+    """One fidelity-tagged, citation-ready evidence span."""
+
+    text: str
+    source: str
+    locator: Locator
+    modality: str
+    fidelity: str
+    score: float
+    citation: str
+
+
+class Coverage(BaseModel):
+    """Summary of what was searched, plus flagged thin spots."""
+
+    strategies_used: list[str]
+    n_docs_seen: int
+    thin_spots: list[str]
+
+
 class EvidenceResult(BaseModel):
     """One query's answer-ready evidence, mirroring ``retriever query --format evidence``."""
 
-    evidence: list[dict[str, Any]]
-    coverage: dict[str, Any]
+    evidence: list[EvidenceItem]
+    coverage: Coverage
 
 
 class EvidenceQueryResponse(BaseModel):

--- a/nemo_retriever/src/nemo_retriever/service/query_schema.py
+++ b/nemo_retriever/src/nemo_retriever/service/query_schema.py
@@ -4,14 +4,23 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
+
+QueryFormat = Literal["hits", "evidence"]
 
 
 class QueryRequest(BaseModel):
     query: str | list[str]
     top_k: int = Field(default=10, ge=1, le=1000)
+    format: QueryFormat = Field(
+        default="hits",
+        description=(
+            "Output shape: 'hits' (default) returns raw retrieval hits; 'evidence' "
+            "returns the fidelity-tagged, citation-ready {evidence, coverage} shape."
+        ),
+    )
 
 
 class QueryResult(BaseModel):
@@ -25,3 +34,14 @@ class QueryResponse(BaseModel):
         if expected_results is not None and len(self.results) != expected_results:
             raise ValueError(f"expected {expected_results} result set(s), got {len(self.results)}")
         return [result.hits for result in self.results]
+
+
+class EvidenceResult(BaseModel):
+    """One query's answer-ready evidence, mirroring ``retriever query --format evidence``."""
+
+    evidence: list[dict[str, Any]]
+    coverage: dict[str, Any]
+
+
+class EvidenceQueryResponse(BaseModel):
+    results: list[EvidenceResult]

--- a/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
+++ b/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
@@ -41,7 +41,17 @@ import uvicorn
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
-from nemo_retriever.service.query_schema import QueryRequest, QueryResponse, QueryResult
+from nemo_retriever.query.evidence import build_evidence_result
+from nemo_retriever.service.query_schema import (
+    EvidenceQueryResponse,
+    EvidenceResult,
+    QueryRequest,
+    QueryResponse,
+    QueryResult,
+)
+
+# /v1/query is dense vector search only; report that honestly in coverage.
+_QUERY_STRATEGIES = ["dense"]
 
 logger = logging.getLogger(__name__)
 
@@ -327,8 +337,8 @@ def create_vectordb_app(
         written = await asyncio.to_thread(_state.write_rows, req.rows)
         return WriteResponse(written=written, total_rows=_state.total_rows())
 
-    @app.post("/v1/query", response_model=QueryResponse, tags=["query"])
-    async def query(req: QueryRequest) -> QueryResponse:
+    @app.post("/v1/query", response_model=None, tags=["query"])
+    async def query(req: QueryRequest) -> QueryResponse | EvidenceQueryResponse:
         if _state is None:
             raise HTTPException(503, "VectorDB not initialised")
 
@@ -347,14 +357,20 @@ def create_vectordb_app(
 
         queries = req.query if isinstance(req.query, list) else [req.query]
         if not queries:
+            if req.format == "evidence":
+                return EvidenceQueryResponse(results=[])
             return QueryResponse(results=[])
 
         async with _query_semaphore:
             vectors = await asyncio.to_thread(_state.embed_queries, queries)
             hits_per_query = await asyncio.to_thread(_state.search, vectors, req.top_k)
 
-        results = [QueryResult(hits=hits) for hits in hits_per_query]
-        return QueryResponse(results=results)
+        if req.format == "evidence":
+            return EvidenceQueryResponse(
+                results=[EvidenceResult(**build_evidence_result(hits, _QUERY_STRATEGIES)) for hits in hits_per_query]
+            )
+
+        return QueryResponse(results=[QueryResult(hits=hits) for hits in hits_per_query])
 
     return app
 

--- a/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
+++ b/nemo_retriever/src/nemo_retriever/service/vectordb_app.py
@@ -34,7 +34,7 @@ import asyncio
 import logging
 import threading
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Union
 
 import lancedb
 import uvicorn
@@ -337,7 +337,7 @@ def create_vectordb_app(
         written = await asyncio.to_thread(_state.write_rows, req.rows)
         return WriteResponse(written=written, total_rows=_state.total_rows())
 
-    @app.post("/v1/query", response_model=None, tags=["query"])
+    @app.post("/v1/query", response_model=Union[QueryResponse, EvidenceQueryResponse], tags=["query"])
     async def query(req: QueryRequest) -> QueryResponse | EvidenceQueryResponse:
         if _state is None:
             raise HTTPException(503, "VectorDB not initialised")

--- a/nemo_retriever/tests/test_service_mcp.py
+++ b/nemo_retriever/tests/test_service_mcp.py
@@ -74,6 +74,7 @@ def test_query_tool_client_posts_payload_and_auth_header() -> None:
             "filters": {"source": "a.pdf"},
             "query": "What is indexed?",
             "top_k": 2,
+            "format": "hits",
         },
     }
     assert result["results"][0]["hits"][0]["text"] == "match"

--- a/nemo_retriever/tests/test_service_vectordb_app.py
+++ b/nemo_retriever/tests/test_service_vectordb_app.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 from fastapi.testclient import TestClient
 
@@ -82,3 +82,53 @@ def test_vector_db_state_local_embed_queries() -> None:
 
     assert vectors == [[1.0, 2.0]]
     mock_embedder.embed_queries.assert_called_once_with(["hello"])
+
+
+_CANNED_HITS = [
+    {
+        "text": "Revenue grew 12% year over year.",
+        "pdf_basename": "10k_2023.pdf",
+        "page_number": 12,
+        "content_type": "text",
+        "_score": 0.91,
+        "metadata": {},
+    }
+]
+
+
+def _query_app(tmp_path):
+    return create_vectordb_app(
+        lancedb_uri=str(tmp_path),
+        table_name="t",
+        embed_endpoint="http://embed.example/v1/embeddings",
+        embed_model="nvidia/llama-nemotron-embed-vl-1b-v2",
+    )
+
+
+def test_query_evidence_format_returns_evidence_coverage(tmp_path) -> None:
+    app = _query_app(tmp_path)
+    with patch.object(VectorDBState, "table_exists", new_callable=PropertyMock, return_value=True), patch.object(
+        VectorDBState, "embed_queries", return_value=[[0.1, 0.2]]
+    ), patch.object(VectorDBState, "search", return_value=[_CANNED_HITS]):
+        with TestClient(app) as client:
+            resp = client.post("/v1/query", json={"query": "revenue", "top_k": 5, "format": "evidence"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert list(body) == ["results"]
+    assert len(body["results"]) == 1
+    item = body["results"][0]
+    assert set(item) == {"evidence", "coverage"}
+
+    ev = item["evidence"][0]
+    assert ev["source"] == "10k_2023"
+    assert ev["citation"] == "10k_2023 p.12"
+    assert ev["locator"] == {"kind": "page", "value": 12}
+    assert ev["modality"] == "text"
+    assert ev["fidelity"] == "verbatim"
+    assert ev["score"] == 0.91
+
+    coverage = item["coverage"]
+    assert coverage["strategies_used"] == ["dense"]
+    assert coverage["n_docs_seen"] == 1
+    assert coverage["thin_spots"] == ["single source"]

--- a/nemo_retriever/tests/test_service_vectordb_evidence_integration.py
+++ b/nemo_retriever/tests/test_service_vectordb_evidence_integration.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end-ish check of ``/v1/query?format=evidence`` over a real LanceDB table.
+
+Unlike ``test_service_vectordb_app.py`` (which mocks ``VectorDBState.search``), this
+drives the full server path: real ``/internal/vectordb/write`` → real LanceDB vector
+search → real ``normalize_retrieval_results`` → real ``build_evidence_result``. Only
+the embedding *model* is stubbed (it needs a NIM/GPU otherwise); everything that the
+evidence projection depends on — schema columns, the JSON-string ``metadata``
+round-trip, score/locator/fidelity derivation — runs for real.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from nemo_retriever.service.vectordb_app import VectorDBState, create_vectordb_app
+
+_DIM = 4
+# One stored chunk, in the real LanceDB schema (metadata is a JSON *string* column).
+_ROW = {
+    "vector": [1.0, 0.0, 0.0, 0.0],
+    "pdf_page": "10k_2023_12",
+    "filename": "10k_2023.pdf",
+    "pdf_basename": "10k_2023.pdf",
+    "page_number": 12,
+    "source": "10k_2023.pdf",
+    "source_id": "10k_2023.pdf",
+    "path": "/data/10k_2023.pdf",
+    "text": "Revenue grew 12% year over year.",
+    "metadata": json.dumps({"page_number": 12, "type": "text"}),
+    "stored_image_uri": "",
+    "content_type": "text",
+    "bbox_xyxy_norm": "",
+}
+
+
+def test_query_evidence_format_end_to_end_over_real_lancedb(tmp_path) -> None:
+    app = create_vectordb_app(
+        lancedb_uri=str(tmp_path),
+        table_name="nemo_retriever",
+        embed_endpoint="http://embed.example/v1/embeddings",  # -> embed_mode="remote"
+        embed_model="nvidia/llama-nemotron-embed-vl-1b-v2",
+    )
+
+    # Stub ONLY the embedding model; real LanceDB does the rest.
+    with patch.object(VectorDBState, "embed_queries", return_value=[[1.0, 0.0, 0.0, 0.0]]):
+        with TestClient(app) as client:
+            write = client.post("/internal/vectordb/write", json={"rows": [_ROW]})
+            assert write.status_code == 200, write.text
+            assert write.json()["total_rows"] == 1
+
+            resp = client.post(
+                "/v1/query",
+                json={"query": "revenue", "top_k": 5, "format": "evidence"},
+            )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert list(body) == ["results"]
+    assert len(body["results"]) == 1
+
+    item = body["results"][0]
+    assert set(item) == {"evidence", "coverage"}
+
+    ev = item["evidence"][0]
+    assert ev["text"] == "Revenue grew 12% year over year."
+    assert ev["source"] == "10k_2023"
+    assert ev["citation"] == "10k_2023 p.12"
+    assert ev["locator"] == {"kind": "page", "value": 12}
+    assert ev["modality"] == "text"
+    assert ev["fidelity"] == "verbatim"
+    # Score is the real LanceDB distance/relevance — present and numeric, value not asserted.
+    assert isinstance(ev["score"], (int, float))
+
+    coverage = item["coverage"]
+    assert coverage["strategies_used"] == ["dense"]
+    assert coverage["n_docs_seen"] == 1
+    assert coverage["thin_spots"] == ["single source"]


### PR DESCRIPTION
## Description
The skill's answer discipline is built entirely on the CLI's `--format evidence` which produces an answer-ready shape. The service mode however only returned raw hits, so an agent talking over MCP couldn't get the same evidence the CLI gives. This PR closes the gap by making the same evidence format reachable through the service.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
