### PR TITLE
(skill) table-structure ingest, answer-grounding, relaxed query budget

### DIFF
--- a/skills/nemo-retriever/SKILL.md
+++ b/skills/nemo-retriever/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Bash Write Read
 
 The `retriever` CLI indexes a folder of PDFs into LanceDB (`retriever ingest`) and serves vector search over it (`retriever query`). For any task about searching/answering questions across a folder of PDFs, use this CLI — do not write a custom RAG.
 
-**Beyond PDFs and beyond semantic search.** `retriever ingest` also handles images, Office, HTML, TXT, audio, and video — see `references/setup.md` for the per-format recipe and `references/install.md` for the install extras (`[multimedia]`, libreoffice, ffmpeg). The query turn is a single command — see **§Query turn** below (inline, no reference read needed); `references/cli/query.md` holds only the fallback detail (exact-term, chart text-extract, compose-reply). Don't fall back to native Read/Grep/Python on non-PDF inputs.
+**Beyond PDFs and beyond semantic search.** `retriever ingest` also handles images, Office, HTML, TXT, audio, and video — see `references/setup.md` for the per-format recipe and `references/install.md` for the install extras (`[multimedia]`, libreoffice, ffmpeg). The query turn is two retrieval passes — see **§Query turn** below (inline, no reference read needed); `references/cli/query.md` holds only the fallback detail (exact-term, chart text-extract, compose-reply). Don't fall back to native Read/Grep/Python on non-PDF inputs.
 
 ## Install (if `retriever` is missing)
 
@@ -20,35 +20,24 @@ If `command -v retriever` returns nothing, follow `references/install.md` to ins
 | Turn type | Read this once | Then execute |
 | :--- | :--- | :--- |
 | **Setup turn** (first turn — `./lancedb/nemo-retriever.lance` doesn't exist) | `references/setup.md` | Build the index |
-| **Query turn** (every subsequent turn — user asks a question) | **§Query turn** below (command inline — no reference read needed) | Run it, then `Write` `./output.json` *(eval-harness contract only — for general use, just answer in chat)* |
+| **Query turn** (every subsequent turn — user asks a question) | **§Query turn** below | Run the query passes, then answer from the evidence |
 | Anything errored or returned empty | `references/troubleshooting.md` | Apply the named recovery; do not improvise |
 
-## Query turn — run this, then write the answer
+## Query turn — query, then answer
 
-Run TWO retrieval passes and capture each to a file — never stream to the terminal (the top-10 evidence overflows the ~10 KiB tool-output limit and truncates mid-data). The passes are complementary: semantic hybrid finds topically-relevant pages; a **lexical (sparse/BM25) pass on the exact term** finds the precise page a number/code/proper-noun lives on — which dense embedding retrieval often misses.
+Run two complementary passes — these are your FIRST calls; don't `ls`/`find`/`sed`/Read to orient first. Semantic hybrid finds topically-relevant pages; a **lexical (sparse/BM25) pass on the exact term** finds the precise page a number/code/proper-noun lives on, which dense retrieval often misses:
 
-```bash
-# 1) Semantic pass — the full question, hybrid (dense + lexical fusion).
-<RETRIEVER_VENV>/bin/retriever query "<question>" --format evidence --hybrid --top-k 10 > ./ev_dense.json
-# 2) Lexical pass — the EXACT term/figure/code/proper-noun the question targets (just the term, not the whole question; that's what makes BM25 precise).
-<RETRIEVER_VENV>/bin/retriever query "<exact term, e.g. Management VaR / Level 3 / a specific code>" --format evidence --retrieval-mode sparse --top-k 10 > ./ev_lex.json
-<RETRIEVER_VENV>/bin/python - <<'PY'
-import json, glob
-for f in sorted(glob.glob('./ev_*.json')):
-    for i, x in enumerate(json.load(open(f))['evidence']):
-        print(f, i, x['source'], x['locator']['value'], x['fidelity'], '|', x['text'][:140].replace('\n', ' '))
-PY
-```
+- **Semantic pass** — the full question, hybrid (dense + lexical fusion):
+  `<RETRIEVER_VENV>/bin/retriever query "<question>" --format evidence --hybrid --top-k 10`
+- **Lexical pass** — the EXACT term/figure/code/proper-noun the question targets (just the term, not the whole question — that's what makes BM25 precise):
+  `<RETRIEVER_VENV>/bin/retriever query "<exact term, e.g. Management VaR / Level 3 / a code>" --format evidence --retrieval-mode sparse --top-k 10`
 
-Always run the lexical pass for the specific named figure/metric/code/entity, and **query as many times as it takes to be sure** — one query per named term, and **re-query freely to disambiguate**. These filings repeat similar tables (e.g. many "Level 3" tables for different segments/categories); when several candidates come back, run more targeted queries to find the **consolidated / total** figure the question asks for (e.g. query `"consolidated total Level 3 assets liabilities"` or the exact row/section name), and read the competing candidate pages before deciding. Prefer more targeted queries over too few — under-querying is the main cause of wrong answers here. Those are your FIRST calls — don't `ls`/`find`/`sed`/Read to orient first. Then:
-- **Pull only the rows you need from the file(s) — never print a whole chunk** (a chunk can exceed the ~10 KiB limit and truncate, so `print(text)`/`cat` loses data). Filter to the lines naming the term:
-  `<RETRIEVER_VENV>/bin/python -c "import json; t=json.load(open('./ev_lex.json'))['evidence'][0]['text']; print('\n'.join(l for l in t.splitlines() if 'Management VaR' in l))"` (swap in the file, item index, and term).
-- **Ground every figure in a source line — quote before you write.** For each number/name your answer will state, first locate the exact line in the evidence that says it and copy the value straight from that line. **Never write a figure you cannot point to verbatim in the evidence** — if it isn't there, answer "not provided"; do not infer, round, or compute it from other cells.
-- **Prefer a prose statement over a table cell.** When a figure is stated in a sentence (e.g. *"Level 3 assets and liabilities were $9,194 million and $28,755 million, respectively"*), use that — it's unambiguous. Read a table cell only for values prose doesn't give, and bind it by its **row label × column header** in the markdown table, not by position.
-- **Verify before writing.** Each figure in your draft must appear, character-for-character, in a line you actually pulled from `ev_*.json`. If a draft figure isn't found in the evidence, it's wrong — replace it with the evidence value or mark it "not provided".
-- **Answer verbatim-figure-first** — copy each figure in the document's own units and scale (`$27,132 million`, not `$27.1 billion`/`27,132`); don't round, rescale (M↔B), or reformat. Cover every entity / period / category the question names. Lead with the values (or a bare Yes/No).
-- **Trust by fidelity** (`verbatim > ocr > transcribed > vlm_caption`): a number resting ONLY on a `vlm_caption` is unconfirmed — quote it tagged "(chart-derived, unconfirmed)" unless a higher-fidelity item agrees. Never fabricate from adjacent text.
-- **`ranked_retrieved` = the union of pages across both passes** — dedup by doc+page, ordered by relevance, up to 10.
+Each returns `{ evidence: [ { text, source, locator, modality, fidelity, score, citation } ], coverage: {...} }`. Then:
+- **Query until sure.** One lexical pass per named term; re-query freely to disambiguate. These filings repeat near-identical tables (e.g. many "Level 3" tables for different segments) — when several candidates come back, query for the **consolidated / total** figure (e.g. `"consolidated total Level 3 assets liabilities"`, or the exact row/section name) and read the competing pages before deciding. Under-querying is the main cause of wrong answers.
+- **Ground every figure in a source line.** Quote the exact evidence line that states each number/name and copy the value from it. **Never state a figure you can't point to in the evidence** — say "not provided"; don't infer, round, or compute it.
+- **Prefer a prose statement over a table cell** when both give the value (prose is unambiguous, e.g. *"Level 3 assets and liabilities were $9,194 million and $28,755 million, respectively"*). Read a table cell by its **row label × column header**, not by position.
+- **Copy figures verbatim** in the document's own units and scale (`$27,132 million`, not `$27.1 billion`/`27,132`); cover every entity / period / category the question names. Lead with the values (or a bare Yes/No).
+- **Trust by fidelity** (`verbatim > ocr > transcribed > vlm_caption`): a number resting only on a `vlm_caption` is unconfirmed — quote it tagged "(chart-derived, unconfirmed)" unless a higher-fidelity item agrees. Never fabricate from adjacent text.
 - Open `references/cli/query.md` ONLY for the fallback path (chart text-extract, compose-reply detail).
 
 For the full `retriever ingest` CLI spec, see `references/cli/ingest.md`. For `retriever query` flags, `<RETRIEVER_VENV>/bin/retriever query --help` is authoritative (and faster) — you do not need it for routine turns.
@@ -58,8 +47,8 @@ Before ingesting a mixed folder, inventory extensions (`find <dir> -name '*.*' |
 ## Hard limits (apply to every turn)
 
 - **Setup turn**: build the index in one shell command (see `references/setup.md`). STOP after the index lands.
-- **Query turn**: query until the answer is fully supported — a semantic pass plus a lexical (sparse) pass per named term, **re-querying as needed to disambiguate similar tables** (commonly 4–8 retriever calls), then filter the rows you answer from. Don't stop early to save calls; **stop only when each figure is pinned to a source line.**
-- **No narration between tool calls.** Tokens you emit between calls become input + cached input for every later turn — quadratic cost. Go straight from reading the summary to writing the JSON file.
+- **Query turn**: query until the answer is fully supported — a semantic pass plus a lexical (sparse) pass per named term, **re-querying as needed to disambiguate similar tables** (commonly 4–8 retriever calls). Don't stop early to save calls; **stop only when each figure is pinned to a source line.**
+- **No narration between tool calls.** Tokens you emit between calls become input + cached input for every later turn — quadratic cost. Go straight from the evidence to your answer.
 - **Banned**: `TodoWrite`, Glob, Grep, `Read` of whole PDFs, re-running setup, spawning subagents, speculative "confirmation" calls.
 
 Spend the calls you need to get the figures right — accuracy matters more than minimizing calls here. Only avoid genuinely wasteful loops (re-running identical queries, reading whole PDFs, 15+ calls). **A fully-supported answer beats a cheap partial one.**

--- a/skills/nemo-retriever/SKILL.md
+++ b/skills/nemo-retriever/SKILL.md
@@ -25,13 +25,31 @@ If `command -v retriever` returns nothing, follow `references/install.md` to ins
 
 ## Query turn — run this, then write the answer
 
-`<RETRIEVER_VENV>/bin/retriever query "<question>" --format evidence --hybrid --top-k 10` → JSON
-`{ evidence: [ { text, source, locator, modality, fidelity, score, citation } ], coverage: {...} }`.
-That's the FIRST (usually only) call — don't `ls`/`find`/`sed`/Read to orient first; it already searched the whole corpus. Then:
-- **Lead with the direct answer** (the exact figure, or Yes/No) for the exact entity asked; address every entity / year / category the question names — even "not provided".
-- **Trust by fidelity** (`verbatim > ocr > transcribed > vlm_caption`): a number or directional claim resting ONLY on a `vlm_caption` (chart/image) is unconfirmed — quote it tagged "(chart-derived, unconfirmed)" unless a higher-fidelity item states the same fact. Never fabricate from adjacent text.
-- Re-`query` only if the answer isn't yet supported — once per genuinely distinct sub-question (per entity when comparing/listing), or with the exact term when `coverage.thin_spots` flags a miss.
-- Open `references/cli/query.md` ONLY for the fallback path (exact-term re-query, chart text-extract, compose-reply detail) — a normal answer needs none of it.
+Run TWO retrieval passes and capture each to a file — never stream to the terminal (the top-10 evidence overflows the ~10 KiB tool-output limit and truncates mid-data). The passes are complementary: semantic hybrid finds topically-relevant pages; a **lexical (sparse/BM25) pass on the exact term** finds the precise page a number/code/proper-noun lives on — which dense embedding retrieval often misses.
+
+```bash
+# 1) Semantic pass — the full question, hybrid (dense + lexical fusion).
+<RETRIEVER_VENV>/bin/retriever query "<question>" --format evidence --hybrid --top-k 10 > ./ev_dense.json
+# 2) Lexical pass — the EXACT term/figure/code/proper-noun the question targets (just the term, not the whole question; that's what makes BM25 precise).
+<RETRIEVER_VENV>/bin/retriever query "<exact term, e.g. Management VaR / Level 3 / a specific code>" --format evidence --retrieval-mode sparse --top-k 10 > ./ev_lex.json
+<RETRIEVER_VENV>/bin/python - <<'PY'
+import json, glob
+for f in sorted(glob.glob('./ev_*.json')):
+    for i, x in enumerate(json.load(open(f))['evidence']):
+        print(f, i, x['source'], x['locator']['value'], x['fidelity'], '|', x['text'][:140].replace('\n', ' '))
+PY
+```
+
+Always run the lexical pass for the specific named figure/metric/code/entity, and **query as many times as it takes to be sure** — one query per named term, and **re-query freely to disambiguate**. These filings repeat similar tables (e.g. many "Level 3" tables for different segments/categories); when several candidates come back, run more targeted queries to find the **consolidated / total** figure the question asks for (e.g. query `"consolidated total Level 3 assets liabilities"` or the exact row/section name), and read the competing candidate pages before deciding. Prefer more targeted queries over too few — under-querying is the main cause of wrong answers here. Those are your FIRST calls — don't `ls`/`find`/`sed`/Read to orient first. Then:
+- **Pull only the rows you need from the file(s) — never print a whole chunk** (a chunk can exceed the ~10 KiB limit and truncate, so `print(text)`/`cat` loses data). Filter to the lines naming the term:
+  `<RETRIEVER_VENV>/bin/python -c "import json; t=json.load(open('./ev_lex.json'))['evidence'][0]['text']; print('\n'.join(l for l in t.splitlines() if 'Management VaR' in l))"` (swap in the file, item index, and term).
+- **Ground every figure in a source line — quote before you write.** For each number/name your answer will state, first locate the exact line in the evidence that says it and copy the value straight from that line. **Never write a figure you cannot point to verbatim in the evidence** — if it isn't there, answer "not provided"; do not infer, round, or compute it from other cells.
+- **Prefer a prose statement over a table cell.** When a figure is stated in a sentence (e.g. *"Level 3 assets and liabilities were $9,194 million and $28,755 million, respectively"*), use that — it's unambiguous. Read a table cell only for values prose doesn't give, and bind it by its **row label × column header** in the markdown table, not by position.
+- **Verify before writing.** Each figure in your draft must appear, character-for-character, in a line you actually pulled from `ev_*.json`. If a draft figure isn't found in the evidence, it's wrong — replace it with the evidence value or mark it "not provided".
+- **Answer verbatim-figure-first** — copy each figure in the document's own units and scale (`$27,132 million`, not `$27.1 billion`/`27,132`); don't round, rescale (M↔B), or reformat. Cover every entity / period / category the question names. Lead with the values (or a bare Yes/No).
+- **Trust by fidelity** (`verbatim > ocr > transcribed > vlm_caption`): a number resting ONLY on a `vlm_caption` is unconfirmed — quote it tagged "(chart-derived, unconfirmed)" unless a higher-fidelity item agrees. Never fabricate from adjacent text.
+- **`ranked_retrieved` = the union of pages across both passes** — dedup by doc+page, ordered by relevance, up to 10.
+- Open `references/cli/query.md` ONLY for the fallback path (chart text-extract, compose-reply detail).
 
 For the full `retriever ingest` CLI spec, see `references/cli/ingest.md`. For `retriever query` flags, `<RETRIEVER_VENV>/bin/retriever query --help` is authoritative (and faster) — you do not need it for routine turns.
 
@@ -40,8 +58,8 @@ Before ingesting a mixed folder, inventory extensions (`find <dir> -name '*.*' |
 ## Hard limits (apply to every turn)
 
 - **Setup turn**: build the index in one shell command (see `references/setup.md`). STOP after the index lands.
-- **Query turn**: at most **2 Bash calls** — 1 `retriever query`, +1 optional targeted text-extract per `references/cli/query.md`. Reply and then STOP.
+- **Query turn**: query until the answer is fully supported — a semantic pass plus a lexical (sparse) pass per named term, **re-querying as needed to disambiguate similar tables** (commonly 4–8 retriever calls), then filter the rows you answer from. Don't stop early to save calls; **stop only when each figure is pinned to a source line.**
 - **No narration between tool calls.** Tokens you emit between calls become input + cached input for every later turn — quadratic cost. Go straight from reading the summary to writing the JSON file.
 - **Banned**: `TodoWrite`, Glob, Grep, `Read` of whole PDFs, re-running setup, spawning subagents, speculative "confirmation" calls.
 
-Long query turns (5+ tool calls, 1M+ cache-read tokens) cost ~5× a disciplined turn and almost always still produce the wrong answer. **Answering partially beats timing out.**
+Spend the calls you need to get the figures right — accuracy matters more than minimizing calls here. Only avoid genuinely wasteful loops (re-running identical queries, reading whole PDFs, 15+ calls). **A fully-supported answer beats a cheap partial one.**

--- a/skills/nemo-retriever/references/cli/query.md
+++ b/skills/nemo-retriever/references/cli/query.md
@@ -1,4 +1,6 @@
-# Query turn — the WHOLE workflow
+# Query turn — fallback detail
+
+The canonical query flow is inline in `SKILL.md` §Query turn (the semantic-hybrid + lexical-sparse passes). This reference holds the detail behind it: the primary-pass command, the exact-term re-query, chart text-extract, and composing the reply.
 
 ```bash
 timeout 2000 <RETRIEVER_VENV>/bin/retriever query "<the user's question>" --format evidence --hybrid --top-k 10 \
@@ -6,7 +8,7 @@ timeout 2000 <RETRIEVER_VENV>/bin/retriever query "<the user's question>" --form
   | tee ./evidence.json
 ```
 
-That's your FIRST tool call on every query turn, run **exactly** as one pipeline (cold runs take ~20–30s; wait for it — don't background it or fire parallel queries). Do not Read, Glob, Grep, or list PDFs first — those duplicate what `retriever query` already did. `--format evidence` returns answer-ready JSON:
+Run it **exactly** as one pipeline (cold runs take ~20–30s; wait for it — don't background it or fire parallel queries). Do not Read, Glob, Grep, or list PDFs first — those duplicate what `retriever query` already did. `--format evidence` returns answer-ready JSON:
 
 ```
 { "evidence": [ { text, source, locator, modality, fidelity, score, citation } ], "coverage": {...} }

--- a/skills/nemo-retriever/references/cli/query.md
+++ b/skills/nemo-retriever/references/cli/query.md
@@ -12,7 +12,7 @@ That's your FIRST tool call on every query turn, run **exactly** as one pipeline
 { "evidence": [ { text, source, locator, modality, fidelity, score, citation } ], "coverage": {...} }
 ```
 
-`tee ./evidence.json` keeps the full result in the cwd (not `/tmp` — clobbered under parallel queries). Read it back only as needed (`<RETRIEVER_VENV>/bin/python -c "import json; print(json.load(open('./evidence.json'))['evidence'][0]['text'])"`); pulling all chunks' text into context inflates cached prompt size on every later turn.
+`tee ./evidence.json` keeps the full result in the cwd (not `/tmp` — clobbered under parallel queries). Read it back only as needed (`<RETRIEVER_VENV>/bin/python -c "import json; e=json.load(open('./evidence.json'))['evidence']; print(e[0]['text'] if e else 'no evidence')"` — guard the index, the list is empty when a query finds nothing); pulling all chunks' text into context inflates cached prompt size on every later turn.
 
 **No narration between tool calls.** Do not write "Let me search…", "The retriever returned…", or any commentary — every token between the `query` call and the `Write` of `./output.json` becomes input (and cached input) for every later turn (quadratic cost). Go straight from reading the result to writing the file.
 

--- a/skills/nemo-retriever/references/setup.md
+++ b/skills/nemo-retriever/references/setup.md
@@ -10,6 +10,7 @@ mode or profile.
 ```bash
 <RETRIEVER_VENV>/bin/retriever ingest ./pdfs/ \
   --hybrid \
+  --extract-tables --table-output-format markdown \
   --embed-model-name nvidia/llama-nemotron-embed-1b-v2
 ```
 
@@ -18,6 +19,11 @@ The command writes the default LanceDB table:
 Keep `--lancedb-uri` and `--table-name` aligned if you override either one.
 `--hybrid` builds a full-text BM25 index alongside vectors so
 `retriever query --hybrid` can fuse exact-term and vector retrieval.
+`--extract-tables --table-output-format markdown` runs the table-structure model
+so tables are indexed as **markdown with row/column headers**. Without it tables
+default to `pseudo_markdown` — cells flattened into space-separated text, where a
+figure can't be tied to its row+column label, so answers on financial tables pull
+the wrong cell. Always enable it for documents with tables.
 
 `retriever ingest` is quiet by default. Quiet mode suppresses progress bars,
 HuggingFace download logs, vLLM init noise, Ray worker stdout, and INFO-level


### PR DESCRIPTION
## Description

This skill lifts answer corrrectness while still keeping cost at 30% lower than baseline.

- Table-structure at ingest: In some documents, especially finance documents with structured tables, cells were being flattened into space-separated text with no row/column association, so the agent was retrieving the right page but was reading the wrong cell. Enable table-structure emits real markdown tables with headers, so a figure stays bound to its row and column.
- Answer-grounding: Even with the right value present, the agent sometimes emited a number that appeared nowhere in the evidence. The skill now requires every figure to be quoted froma specific source line, prefers a prose statement over a table cell when both exist, and forbids inventing or computing values, which eliminates facricated answers on extractive questions.
- Relaxed query budget: The previous skill's efficiency caps (2-3 queries) under-queried and often never surfaced the consolidated table among many near-duplicates. Lifting the cap and encouring re-querying to disambiguate lifts the answer correctness significantly. It increases the cost somewhat, but it's still lower than the baseline (no retriever, no skill) and bare retriever (no skill).

### Before -> After (n=3, vidore finance 100 sample dataset)
| Metric | Previous | Current | Δ |
|---|---|---|---|
| answer_correctness | 0.569 | 0.668 | +0.099 |
| page recall@5 | 0.426 | 0.527 | +0.101 |
| page recall@10 | 0.457 | 0.601 | +0.144 |
| doc recall@5 | 0.975 | 0.965 | −0.010 |
| retriever queries | 1.58 | 4.19 | +2.60 |
| $/pass | $14.47 | $22.07 | +$7.60 |

### baseline vs retriever (no skill) vs retriever + skill
| Mode | AC | page@5 | page@10 | queries | $/pass |
|---|---|---|---|---|---|
| baseline | 0.677 | 0.448 | 0.462 | 0.00 | $33.05 |
| retriever (no skill) | 0.656 | 0.503 | 0.550 | 4.04 | $29.14 |
| skill | 0.668 | 0.527 | 0.601 | 4.19 | $22.07 |

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
