### PR TITLE
feat(harness): add portable runfile sessions and replayable Slack reports

### DIFF
--- a/nemo_retriever/developer_docs/harness_retriever_ingest_query_prd.md
+++ b/nemo_retriever/developer_docs/harness_retriever_ingest_query_prd.md
@@ -1,6 +1,15 @@
 # Retriever Harness PRD: End-to-End Ingest/Query Benchmarks
 
-Last updated: 2026-06-24
+Last updated: 2026-07-01
+
+## Implementation Status
+
+The current implementation includes the core runner described here plus two
+orchestration-neutral extensions: `run-files` applies a machine-local dataset
+path map to one or more checked-in runfiles, and `post-slack` renders or posts
+completed artifacts. It does not include recurring scheduling, deployment,
+locking, retry policy, or secret distribution. The harness README is the
+normative user and agent guide; this PRD records the design rationale.
 
 ## Summary
 
@@ -12,7 +21,7 @@ engineers. The harness should run the new library direction end to end:
    `retriever query`.
 3. Run full BEIR-style evaluation.
 4. Emit stable `summary_metrics` and machine-readable artifacts for humans,
-   agents, and future nightly reporting.
+   agents, and downstream reporting.
 
 This is a total revamp, not a compatibility wrapper around the current harness.
 Assume `retriever pipeline run` is deleted in the next release. The current
@@ -84,19 +93,19 @@ Reference links are at the end of this document.
 - Do not adopt Hydra, MLflow Projects, W&B Sweeps, or another orchestration
   framework in phase one.
 - Do not make this a public supported product API.
-- Do not build Slack posting in phase one. Design artifacts so a Slack sink can
-  be added later.
+- Do not couple benchmark execution to Slack or another reporting transport.
+- Do not add recurring scheduling or deployment infrastructure to the harness.
 - Do not make CLI text formatting part of the run contract.
-- Do not make pytest the validation strategy for the harness. This harness is
-  itself a functional evaluation tool; success should be judged by harness
-  command exit codes and artifact contracts.
+- Do not make pytest the sole validation strategy for the harness. Unit tests
+  protect artifact and reporting contracts; real harness exit codes and
+  artifacts validate end-to-end behavior.
 
 ## Users
 
 - Retriever engineers validating ingest/query behavior.
 - Performance owners running throughput and quality ablations.
 - Agents asked to run a named benchmark or ablation.
-- Future nightly automation that needs stable result files.
+- External automation that needs stable result files.
 
 ## Design Principles
 
@@ -262,6 +271,11 @@ Rules:
   default source of truth for recurring benchmark definitions.
 - During `--dry-run`, gates for unavailable execution metrics are skipped and
   reported in `results.json`; static dataset gates are still evaluated.
+
+Machine-specific document and query paths belong in a separate, untracked
+dataset path map. `run-files --dataset-paths <file>` applies that map after
+runfile overrides and before CLI `--set` overrides. Passing one runfile creates
+a one-dataset session; passing multiple runfiles creates a suite session.
 
 ### Ablations
 
@@ -564,6 +578,9 @@ retriever harness run <benchmark> --set query.top_k=20
 retriever harness run <benchmark> --set ingest.profile=fast-text
 retriever harness run --runfile /tmp/ablation.yaml
 retriever harness run-set <runset>
+retriever harness run-files --dataset-paths /local/dataset_paths.yaml <runfile>...
+retriever harness post-slack --preview <session-or-results>...
+retriever harness post-slack <session-or-results>...
 retriever harness diff <run-a-dir> <run-b-dir> --json
 ```
 
@@ -575,6 +592,8 @@ Notes:
 - `--dry-run` should be available on `run` and `run-set`.
 - `--json` on read-only commands writes machine-readable output to stdout.
   Human formatting remains non-contractual.
+- `post-slack` consumes existing artifacts and never runs ingest or query.
+- No CLI command installs or owns recurring scheduling.
 
 Defer or remove:
 
@@ -593,9 +612,10 @@ reporting UI.
 
 ## Functional Validation
 
-The harness should be validated like an evaluation runner, not like a conventional
-pytest-heavy library component. Developers should prove behavior by running the
-harness commands and inspecting stable artifacts.
+The harness should be validated both as a library contract and as an evaluation
+runner. Focused tests protect resolution, artifact, and reporting behavior;
+developers should also prove execution behavior by running harness commands and
+inspecting stable artifacts.
 
 Minimum local validation commands:
 
@@ -640,9 +660,8 @@ Known dataset facts, benchmark result ranges, and suggested gates should live in
 `nemo_retriever/harness/EXPECTED_RESULTS.md`, not in benchmark Python code.
 
 The harness may include tiny no-GPU fixtures or fake benchmark specs to make
-developer validation cheap, but the primary confidence signal is functional
-execution through the CLI and artifact contract. Existing pytest-style harness
-tests can be retired as this replacement matures.
+developer validation cheap, but execution changes still require functional
+validation through the CLI and artifact contract.
 
 ## Implementation Plan
 
@@ -677,7 +696,8 @@ tests can be retired as this replacement matures.
 - Build `diff --json` around `summary_metrics` and BEIR deltas.
 - Rebuild richer `compare` only if the team needs it after stable artifacts
   exist.
-- Add nightly runner and Slack sink later.
+- Keep Slack as an optional post-hoc artifact sink.
+- Keep recurring execution and deployment in separately reviewed infrastructure.
 
 ## Open Decisions
 
@@ -713,6 +733,10 @@ tests can be retired as this replacement matures.
   set, writes BEIR outputs, and emits stable `summary_metrics`.
 - `retriever harness run-set <name>` expands a code-owned ablation and writes
   `expanded_runs.json`.
+- `retriever harness run-files` runs one or more checked-in requests with an
+  optional machine-local dataset path map.
+- `retriever harness post-slack --preview` reads artifacts without requiring a
+  webhook or contacting Slack.
 - Every run writes `status.json`, `events.jsonl`, and `results.json`.
 - Failed runs write typed failure data without requiring stdout inspection.
 - Unknown `--set` keys fail before execution.
@@ -723,7 +747,8 @@ tests can be retired as this replacement matures.
   `nemo_retriever.examples.graph_pipeline`.
 - CLI text formatting is explicitly non-contractual; machine consumers use
   artifact files or `--json` read-only commands.
-- Phase-one validation is functional and artifact-driven, not pytest-gated.
+- Validation combines focused contract tests with functional, artifact-driven
+  benchmark execution.
 
 ## References
 

--- a/nemo_retriever/developer_docs/harness_retriever_ingest_query_prd.md
+++ b/nemo_retriever/developer_docs/harness_retriever_ingest_query_prd.md
@@ -276,6 +276,8 @@ Machine-specific document and query paths belong in a separate, untracked
 dataset path map. `run-files --dataset-paths <file>` applies that map after
 runfile overrides and before CLI `--set` overrides. Passing one runfile creates
 a one-dataset session; passing multiple runfiles creates a suite session.
+`run-files` owns dry-run behavior for the session so a session cannot mix
+planned and executed children.
 
 ### Ablations
 

--- a/nemo_retriever/developer_docs/harness_retriever_ingest_query_prd.md
+++ b/nemo_retriever/developer_docs/harness_retriever_ingest_query_prd.md
@@ -26,7 +26,7 @@ in the repository as reviewed Python objects.
 
 The second most important design choice: stdout is not an API. The harness can
 print concise human summaries, but agents and orchestrators must rely on stable
-files such as `status.json`, `summary_metrics.json`, `beir_metrics.json`, and
+files such as `status.json`, `results.json`, `beir_metrics.json`, and
 `query_results.jsonl`.
 
 ## Research Notes
@@ -326,7 +326,7 @@ Write `status.json` early and update it at phase transitions:
   "started_at": "2026-06-23T12:00:00Z",
   "updated_at": "2026-06-23T12:34:56Z",
   "artifact_dir": "/artifacts/jp20_beir_20260623_120000",
-  "summary_metrics_path": null,
+  "results_path": null,
   "failure": null
 }
 ```
@@ -396,8 +396,8 @@ Use coarse but stable exit codes:
 - `30`: artifact write failure
 - `70`: unexpected internal error
 
-Agents should prefer `status.json` for detail and exit codes for coarse process
-control.
+Agents should poll `status.json` while a run is active, read `results.json` when
+it is terminal, and use exit codes for coarse process control.
 
 ### Metric Gates
 
@@ -523,12 +523,13 @@ The exact values above are illustrative. The key names should be stable.
 Per run:
 
 - `results.json`: authoritative run result.
-- `summary_metrics.json`: the same compact object from `results.json`, written
-  separately for simple consumers.
 - `status.json`: current and final phase/status state.
 - `events.jsonl`: append-only phase changes and run milestones.
+- `runfile.json`: original runfile payload when one was used.
 - `resolved_benchmark.json`: fully resolved benchmark spec.
 - `ingest_plan.json`: redacted dry-run ingest plan.
+- `query_plan.json`: resolved query execution plan.
+- `run.log`: captured lower-level output and full exception tracebacks.
 - `beir_metrics.json`: full BEIR metrics.
 - `beir_run.trec`: BEIR/TREC runfile.
 - `query_results.jsonl`: per-query hits and latency.
@@ -542,10 +543,11 @@ Session/runset:
 - `expanded_runs.json`: resolved run order for runsets.
 
 Do not make `compare` phase-one critical. Comparing runs can be rebuilt later
-from `summary_metrics.json` and `session_summary.json`.
+from `results.json` and `session_summary.json`.
 
-`results.json` should include pointers to every artifact path so external
-systems can ingest one file and discover the rest.
+`results.json` should include relative pointers to every artifact path so
+external systems can ingest one file, discover the rest, and move the complete
+run directory without rewriting its manifest.
 
 ## CLI
 
@@ -610,7 +612,7 @@ Functional validation should assert:
 - parseable `--json` output for read-only commands
 - `status.json` exists and has the expected final status
 - `events.jsonl` exists and includes phase transitions
-- `resolved_benchmark.json`, `summary_metrics.json`, and `results.json` exist
+- `resolved_benchmark.json` and `results.json` exist
 - `run.log` exists for non-dry execution runs and contains suppressed
   lower-level stdout/stderr
 - invalid overrides exit with code `2`
@@ -711,8 +713,7 @@ tests can be retired as this replacement matures.
   set, writes BEIR outputs, and emits stable `summary_metrics`.
 - `retriever harness run-set <name>` expands a code-owned ablation and writes
   `expanded_runs.json`.
-- Every run writes `status.json`, `events.jsonl`, `summary_metrics.json`, and
-  `results.json`.
+- Every run writes `status.json`, `events.jsonl`, and `results.json`.
 - Failed runs write typed failure data without requiring stdout inspection.
 - Unknown `--set` keys fail before execution.
 - The harness has no user-facing `--engine` flag.

--- a/nemo_retriever/harness/EXPECTED_RESULTS.md
+++ b/nemo_retriever/harness/EXPECTED_RESULTS.md
@@ -3,18 +3,29 @@
 
 # Harness Expected Results
 
-Known dataset facts, canonical benchmark result ranges, and suggested
-`--require` gates for `retriever harness`.
+Known dataset facts, canonical benchmark result ranges, and suggested integrity
+gates for `retriever harness`.
 
-This file is documentation, not executable policy. Use these values to choose
-explicit `--require` gates for local validation, agent-run ablations, and
-nightly jobs. Update it when datasets, benchmark definitions, hardware, or
-retrieval behavior intentionally change.
+This file is documentation, not executable policy. Use dataset facts for
+explicit `--require` gates. Use quality and performance ranges to judge whether
+a result is in the expected ballpark. Update the references when datasets,
+benchmark definitions, hardware, or retrieval behavior intentionally change.
 
 Only canonical benchmark expectations belong here. Exploratory runs, fast-text
 fallbacks, chunking experiments, and failed attempts should stay in run
 artifacts or handoff notes until the team chooses them as canonical benchmark
 definitions.
+
+File counts, page counts, and query counts are portable dataset-integrity gates.
+Recall and nDCG are reference ranges that help developers and agents identify
+results outside the expected ballpark. Do not treat the quality ranges as
+universal pass/fail policy across different hardware and runtime profiles.
+
+Performance observations such as ingest seconds, pages/sec, and query latency
+are reference points for a specific environment. Treat them as hardware- and
+configuration-sensitive unless the GPU SKU/count, CUDA driver, model backend,
+vLLM/kernel settings, Ray worker layout, storage path, and dataset mount are
+controlled.
 
 ## JP20
 
@@ -37,9 +48,7 @@ Suggested full BEIR command:
 retriever harness run jp20_beir \
   --require 'files==20' \
   --require 'pages==1940' \
-  --require 'query_count==115' \
-  --require 'recall_5>=0.85' \
-  --require 'ndcg_10>=0.75'
+  --require 'query_count==115'
 ```
 
 Recent observed `jp20_beir` metrics on local hardware:
@@ -52,7 +61,8 @@ Recent observed `jp20_beir` metrics on local hardware:
 - `recall_10`: about `0.930` to `0.948`
 - `ndcg_10`: about `0.793` to `0.802`
 
-Avoid hard-gating on latency unless the run environment is controlled.
+Avoid hard-gating on latency or throughput unless the run environment is
+controlled and recorded in the artifacts.
 
 ## BO20
 
@@ -84,9 +94,7 @@ retriever harness run \
   --runfile nemo_retriever/harness/runfiles/bo767_beir.json \
   --require 'files==767' \
   --require 'pages==54730' \
-  --require 'query_count==991' \
-  --require 'recall_5>=0.84' \
-  --require 'ndcg_10>=0.74'
+  --require 'query_count==991'
 ```
 
 Recent observed `bo767_beir` metrics on H100 batch execution:

--- a/nemo_retriever/harness/EXPECTED_RESULTS.md
+++ b/nemo_retriever/harness/EXPECTED_RESULTS.md
@@ -27,6 +27,10 @@ configuration-sensitive unless the GPU SKU/count, CUDA driver, model backend,
 vLLM/kernel settings, Ray worker layout, storage path, and dataset mount are
 controlled.
 
+The dataset paths below are registry reference paths, not a portable filesystem
+contract. Use `harness/dataset_paths.example.yaml` and `run-files
+--dataset-paths` to point checked-in runfiles at the current machine.
+
 ## JP20
 
 Dataset:
@@ -45,10 +49,14 @@ Benchmarks:
 Suggested full BEIR command:
 
 ```bash
-retriever harness run jp20_beir \
+retriever harness run-files \
+  --session-name jp20_beir \
+  --output-dir /local/path/to/retriever-artifacts/jp20-beir \
+  --dataset-paths /local/path/to/dataset_paths.yaml \
   --require 'files==20' \
   --require 'pages==1940' \
-  --require 'query_count==115'
+  --require 'query_count==115' \
+  nemo_retriever/harness/runfiles/jp20_beir.json
 ```
 
 Recent observed `jp20_beir` metrics on local hardware:
@@ -90,11 +98,14 @@ Benchmark:
 Suggested full BEIR command:
 
 ```bash
-retriever harness run \
-  --runfile nemo_retriever/harness/runfiles/bo767_beir.json \
+retriever harness run-files \
+  --session-name bo767_beir \
+  --output-dir /local/path/to/retriever-artifacts/bo767-beir \
+  --dataset-paths /local/path/to/dataset_paths.yaml \
   --require 'files==767' \
   --require 'pages==54730' \
-  --require 'query_count==991'
+  --require 'query_count==991' \
+  nemo_retriever/harness/runfiles/bo767_beir.json
 ```
 
 Recent observed `bo767_beir` metrics on H100 batch execution:

--- a/nemo_retriever/harness/HANDOFF.md
+++ b/nemo_retriever/harness/HANDOFF.md
@@ -108,20 +108,22 @@ is restored or replaced.
 
 ## Artifact contract
 
-Per run, read these files instead of scraping CLI text:
+Poll `status.json` while a run is active and read `results.json` when it is
+terminal. Follow its relative artifact pointers only when more evidence is
+needed:
 
 - `status.json`
 - `events.jsonl`
 - `resolved_benchmark.json`
 - `ingest_plan.json`
 - `query_plan.json`
-- `summary_metrics.json`
 - `environment.json`
 - `results.json`
 - `run.log` when ingest/query execution runs
 - `beir_metrics.json` when BEIR evaluation executes
 - `beir_run.trec` when BEIR evaluation executes
 - `query_results.jsonl` when queries execute
+- `lancedb/` when ingest executes
 
 Dry-runs resolve the benchmark, ingest plan, query plan, and summary metrics,
 but intentionally do not execute ingest or BEIR queries. Dry-run artifact

--- a/nemo_retriever/harness/HANDOFF.md
+++ b/nemo_retriever/harness/HANDOFF.md
@@ -26,6 +26,18 @@ the harness.
 The harness must not route these commands through `retriever pipeline run` or
 `nemo_retriever.examples.graph_pipeline`.
 
+## Implementation Map
+
+- `runfile.py` parses one portable run request; `dataset_paths.py` resolves the
+  machine-local dataset map.
+- `execution.py` preflights and executes one benchmark.
+- `runsets.py` converts runsets or runfiles into prepared runs, then executes
+  both through one session loop.
+- `json_io.py` atomically publishes JSON artifacts; `artifact_writer.py` owns
+  per-run status, events, logs, and artifact cleanup.
+- `slack.py` reads completed artifacts and renders or posts a report. It does
+  not participate in benchmark execution.
+
 ## Configuration Ownership
 
 The Python registry owns benchmark and dataset semantics. Checked-in runfiles

--- a/nemo_retriever/harness/HANDOFF.md
+++ b/nemo_retriever/harness/HANDOFF.md
@@ -16,7 +16,8 @@ the harness.
   overrides.
 - `run-set` executes a code-owned benchmark group using registry paths.
 - `run-files` executes one or more checked-in runfiles and can apply a
-  machine-local dataset path map. It is the portable suite entry point.
+  machine-local dataset path map. It is the portable suite entry point and owns
+  dry-run behavior for the complete session.
 - `post-slack` only reads completed artifacts. It does not execute benchmarks
   or mutate their results.
 - Scheduling, deployment, retries, locking, and secret distribution are outside

--- a/nemo_retriever/harness/HANDOFF.md
+++ b/nemo_retriever/harness/HANDOFF.md
@@ -1,170 +1,81 @@
 <!-- SPDX-FileCopyrightText: Copyright (c) 2024-26, NVIDIA CORPORATION & AFFILIATES. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-# Retriever harness handoff
+# Retriever Harness Maintainer Notes
 
-Operator notes for the revamped internal `retriever harness`.
+The user and agent contract is documented in [`README.md`](README.md). Keep this
+file limited to implementation boundaries that maintainers need when changing
+the harness.
 
-## Scope
+## Product Boundary
 
-- Developer-only benchmark harness for Retriever engineers.
-- Artifact-first: stdout is for humans; agents and orchestrators should read
-  JSON artifacts.
-- Uses shared Retriever ingest/query workflow code.
-- Does not route phase-one commands through `retriever pipeline run` or
-  `nemo_retriever.examples.graph_pipeline`.
+- `retriever ingest` and `retriever query` are the direct product workflows.
+- `retriever harness` is a developer benchmark/evaluation runner built on the
+  same planning and workflow APIs.
+- `run` executes one registered benchmark using registry paths or explicit
+  overrides.
+- `run-set` executes a code-owned benchmark group using registry paths.
+- `run-files` executes one or more checked-in runfiles and can apply a
+  machine-local dataset path map. It is the portable suite entry point.
+- `post-slack` only reads completed artifacts. It does not execute benchmarks
+  or mutate their results.
+- Scheduling, deployment, retries, locking, and secret distribution are outside
+  this harness surface.
 
-## Core commands
+The harness must not route these commands through `retriever pipeline run` or
+`nemo_retriever.examples.graph_pipeline`.
 
-Run from the repository root through the `nemo_retriever` project:
+## Configuration Ownership
 
-```bash
-uv run --project nemo_retriever retriever harness list --json
-uv run --project nemo_retriever retriever harness show jp20_beir --json
-uv run --project nemo_retriever retriever harness run jp20_beir \
-  --dry-run \
-  --output-dir /tmp/retriever-harness-dry-run \
-  --json
+The Python registry owns benchmark and dataset semantics. Checked-in runfiles
+own concrete modes, metric gates, and narrow overrides. A local
+`dataset_paths.yaml` owns machine-specific document and query locations and
+must remain outside source control.
 
-uv run --project nemo_retriever retriever harness run jp20_beir \
-  --output-dir /tmp/retriever-harness-jp20-beir \
-  --require 'files==20' \
-  --require 'pages==1940' \
-  --require 'query_count==115' \
-  --require 'recall_5>=0.85' \
-  --require 'ndcg_10>=0.75' \
-  --json
-```
+Resolution precedence is:
 
-The primary command surface is intentionally small:
+1. Registry defaults.
+2. Runfile overrides.
+3. Machine-local dataset paths.
+4. CLI `--set` overrides.
 
-- `list`
-- `show`
-- `run`
-- `run-set`
-- `diff`
+Large checked-in benchmark runfiles use batch ingest. Do not silently change
+their mode or hardware-sensitive worker tuning without fresh validation.
 
-Legacy graph-pipeline harness execution, sweep, nightly, runner, reporting, and
-portal commands are not part of the phase-one CLI surface. Portal and Helm
-support files are preserved for follow-on owner work.
+## Artifact Contract
 
-For review, start with `README.md`, then inspect the core implementation in
-`benchmark_registry.py`, `resolution.py`, `execution.py`, `beir_runner.py`,
-`metrics.py`, `artifact_writer.py`, and `json_io.py`. `json_io.py` is the shared
-artifact JSON read/write seam used to avoid duplicate JSON helper behavior. The
-intentional deletion set is the old subprocess-oriented
-runner/sweep/nightly/reporting/stdout-parser machinery, not the portal or Helm
-ownership surfaces.
+Poll `status.json` while a run is active. Read `results.json` after one run is
+terminal and `session_summary.json` after a multi-run session is terminal.
+Those files contain summary metrics and relative pointers to detailed evidence.
 
-Useful negative-path checks:
+Detailed run evidence can include:
 
-```bash
-uv run --project nemo_retriever retriever harness run jp20_beir \
-  --dry-run \
-  --output-dir /tmp/retriever-harness-invalid \
-  --set query.nope=1 \
-  --json
-
-uv run --project nemo_retriever retriever harness run jp20_beir \
-  --dry-run \
-  --output-dir /tmp/retriever-harness-missing \
-  --set dataset.path=/tmp/retriever-harness-does-not-exist \
-  --json
-
-uv run --project nemo_retriever retriever harness run jp20_beir \
-  --dry-run \
-  --output-dir /tmp/retriever-harness-gate-fail \
-  --require 'files>20' \
-  --json
-```
-
-Expected exit codes:
-
-- `0`: success
-- `2`: invalid benchmark/config/override
-- `3`: dataset or input missing
-- `10`: ingest failure
-- `11`: query failure
-- `12`: evaluation failure
-- `20`: metric gate failure
-- `30`: artifact write failure
-- `70`: unexpected internal error
-
-## Built-in benchmarks
-
-The current code-owned registry includes:
-
-- `jp20_smoke`: cheap JP20 fast-text ingest check; no BEIR queries.
-- `jp20_beir`: full JP20 ingest plus 115 BEIR queries and recall/NDCG metrics.
-- `bo20_smoke`
-- `bo767_beir`
-- `financebench_beir`
-- `bo10k_beir_fast_text`
-
-`earnings_consulting` corpus exists locally, but the old
-`data/earnings_consulting_multimodal.csv` query/qrels file is not present in
-this checkout. Do not treat `earnings_beir` as phase-one-ready until that file
-is restored or replaced.
-
-## Artifact contract
-
-Poll `status.json` while a run is active and read `results.json` when it is
-terminal. Follow its relative artifact pointers only when more evidence is
-needed:
-
-- `status.json`
 - `events.jsonl`
+- `runfile.json`
 - `resolved_benchmark.json`
 - `ingest_plan.json`
 - `query_plan.json`
 - `environment.json`
-- `results.json`
-- `run.log` when ingest/query execution runs
-- `beir_metrics.json` when BEIR evaluation executes
-- `beir_run.trec` when BEIR evaluation executes
-- `query_results.jsonl` when queries execute
-- `lancedb/` when ingest executes
+- `run.log`
+- `beir_metrics.json`
+- `beir_run.trec`
+- `query_results.jsonl`
+- `lancedb/`
 
-Dry-runs resolve the benchmark, ingest plan, query plan, and summary metrics,
-but intentionally do not execute ingest or BEIR queries. Dry-run artifact
-payloads list only files that were actually written; they do not create or
-advertise empty BEIR result files.
+New runs do not write `summary_metrics.json`. Compatibility readers may still
+accept that file in older artifact directories. Failure summaries stay concise;
+full tracebacks belong in `run.log`.
 
-Non-dry harness runs use the same quiet capture behavior as `retriever ingest
---quiet`: noisy lower-level model/progress output is suppressed on success and
-flushed on failure. Suppressed output is persisted to `run.log` for both
-successful and failed non-dry runs.
+## Validation
 
-## Expectations And Gates
+At minimum, changes should cover:
 
-Use explicit `--require` gates. The harness intentionally does not encode
-recommended thresholds in Python; known results live in
-`nemo_retriever/harness/EXPECTED_RESULTS.md` so humans and agents can inspect
-and update them as benchmarks mature.
+- CLI help and dry-run behavior for `run`, `run-set`, and `run-files`.
+- One-run and multi-run terminal artifact shapes.
+- Missing inputs, invalid overrides, and metric-gate failures.
+- Dataset path precedence and secret redaction.
+- Slack preview without a webhook and transport errors without secret leakage.
+- A real benchmark smoke run when execution behavior changes.
 
-Current JP20 examples:
-
-- `jp20_smoke`: `files==20`, `pages==1940`
-- `jp20_beir`: `files==20`, `pages==1940`, `query_count==115`,
-  `recall_5>=0.85`, `ndcg_10>=0.75`
-
-Dry-runs can only evaluate gates for metrics available without execution, such
-as `files` and `pages`.
-
-## Current validated smoke
-
-Validated in the dedicated Retriever harness worktree:
-
-- `retriever harness list --json` exits `0`.
-- `retriever harness show jp20_beir --json` exits `0`.
-- `retriever harness run jp20_beir --dry-run --output-dir /tmp/retriever-harness-dry-run --json` exits `0`.
-- Invalid override `--set query.nope=1` exits `2`.
-- Missing dataset override exits `3`.
-- Passing gate `--require 'files>=20'` exits `0`.
-- Failing gate `--require 'files>20'` exits `20` with
-  `failure_reason=metric_gate_failed`.
-- Invalid gate syntax exits `2` with `failure_reason=invalid_metric_gate`.
-- `run-set jp20_core --dry-run --require 'files>=20'` exits `0`.
-- `run-set jp20_core --dry-run --require 'files>20'` exits `20`.
-- `retriever harness run jp20_beir --require 'recall_5>=0.85' --require 'ndcg_10>=0.75' --json`
-  exits `0` on the current local dataset/hardware.
+Use `EXPECTED_RESULTS.md` for dataset facts and observed metric ranges. Do not
+turn hardware-sensitive reference numbers into implicit global pass/fail policy.

--- a/nemo_retriever/harness/README.md
+++ b/nemo_retriever/harness/README.md
@@ -108,8 +108,8 @@ Intentional removals:
 
 Intentional preserves:
 
-- `portal/`, `history.py`, `scheduler.py`, `slack.py`: retained for the
-  upcoming portal repurpose work
+- `portal/`, `history.py`, and `scheduler.py`: retained for upcoming portal
+  repurpose work; `slack.py` now owns artifact replay and Slack payloads
 - `helm_manager.py`, `helm-profiles/`, and harness Helm examples: retained for
   Helm owner follow-up work
 

--- a/nemo_retriever/harness/README.md
+++ b/nemo_retriever/harness/README.md
@@ -148,11 +148,6 @@ uv run --project nemo_retriever retriever harness run-files \
   nemo_retriever/harness/runfiles/financebench_beir.json
 ```
 
-If model startup specifically reports that the DeepGEMM backend is unavailable,
-`VLLM_USE_DEEP_GEMM=0` can select fallback kernels. Do not set it preemptively;
-it can affect throughput. The harness records the setting in
-`environment.json` when present.
-
 `run-files` owns the session layout. Runfiles passed to this command cannot set
 their own `output_dir` or `run_id`. The session uses the following paths and
 identifiers:

--- a/nemo_retriever/harness/README.md
+++ b/nemo_retriever/harness/README.md
@@ -70,6 +70,8 @@ parallelism and memory pressure.
 - `show`: inspect one benchmark definition.
 - `run`: run one benchmark.
 - `run-set`: expand and run a code-owned runset.
+- `run-files`: execute one or more checked-in runfiles as one session.
+- `post-slack`: post an existing session or run artifact set to Slack.
 - `diff`: compare two run artifact directories by `summary_metrics.json`.
 
 Legacy graph-pipeline harness execution, sweep, nightly, runner, reporting, and
@@ -128,6 +130,146 @@ The harness accepts JSON, YAML, or YML runfiles. Runfiles use
 `schema_version: 1`; unknown top-level runfile keys fail during resolution with
 exit code `2`. The checked-in JP20 example is
 [`runfiles/jp20_beir.json`](runfiles/jp20_beir.json).
+
+### Configure Machine-Local Dataset Paths
+
+Dataset locations vary between developer systems. Keep benchmark definitions
+and checked-in runfiles independent of one machine's mount layout. Copy
+[`dataset_paths.example.yaml`](dataset_paths.example.yaml) to an untracked
+location, then set the document and query paths available on the machine that
+runs the harness.
+
+Pass the local file with `--dataset-paths`. Relative paths in the file resolve
+relative to the file itself. The harness writes the resolved absolute paths to
+`expanded_runs.json` and each run's `resolved_benchmark.json`.
+
+Settings resolve in this order, from lowest to highest precedence:
+
+1. Benchmark registry defaults.
+2. Checked-in runfile overrides.
+3. Machine-local dataset paths.
+4. Command-line `--set` overrides.
+
+### Run Several Runfiles as One Session
+
+The following command runs the canonical library benchmarks and writes all
+artifacts beneath one session directory:
+
+```bash
+export VLLM_USE_DEEP_GEMM=0
+export RETRIEVER_SESSION_DIR=/local/path/to/retriever-artifacts/library-nightly-$(date -u +%Y%m%d_%H%M%S_UTC)
+
+uv run --project nemo_retriever retriever harness run-files \
+  --session-name library_nightly \
+  --output-dir "$RETRIEVER_SESSION_DIR" \
+  --dataset-paths /local/path/to/dataset_paths.yaml \
+  --json \
+  nemo_retriever/harness/runfiles/jp20_beir.json \
+  nemo_retriever/harness/runfiles/bo767_beir.json \
+  nemo_retriever/harness/runfiles/earnings_beir.json \
+  nemo_retriever/harness/runfiles/financebench_beir.json
+```
+
+On vLLM environments affected by the current DeepGEMM availability check,
+`VLLM_USE_DEEP_GEMM=0` keeps the local embedding backend enabled while using
+fallback kernels. Remove the variable after the vLLM and DeepGEMM dependency
+stack is repaired. Because this setting can affect throughput, the harness
+records it in `environment.json`.
+
+`run-files` owns the session layout. Runfiles passed to this command cannot set
+their own `output_dir` or `run_id`. The session uses the following paths and
+identifiers:
+
+```text
+<session-output-dir>/
+  expanded_runs.json
+  session_summary.json
+  001_<runfile-name>/
+  002_<runfile-name>/
+
+run ID: <session-name>_<index>_<runfile-name>
+```
+
+Session names and runfile names can contain letters, numbers, periods,
+underscores, and hyphens. Other characters fail validation before execution.
+
+## Post Results to Slack
+
+Harness execution and Slack reporting are separate operations. `run-files`
+writes local artifacts and never contacts Slack. `post-slack` reads an existing
+session or run artifact, builds a summary, and sends that summary without
+rerunning ingestion or queries.
+
+This separation lets you inspect a completed session before reporting it and
+reuse the same artifacts when report formatting changes.
+
+### Prerequisites
+
+Before you post a report, verify the following:
+
+- The run completed far enough to write `session_summary.json` or
+  `results.json`.
+- The environment includes the `requests` package.
+- `SLACK_WEBHOOK_URL` contains an incoming webhook for the destination channel.
+
+Set the webhook in the process environment:
+
+```bash
+export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..."
+```
+
+Do not put the webhook URL in a runfile, dataset paths file, shell argument, or
+artifact. For scheduled runs, load it from a permissions-restricted environment
+file outside the repository.
+
+### Post a Completed Session
+
+Pass the session directory to `post-slack`:
+
+```bash
+uv run --project nemo_retriever retriever harness post-slack \
+  --title "nemo-retriever library nightly" \
+  "$RETRIEVER_SESSION_DIR"
+```
+
+You can also pass one or more run artifact directories or `results.json` files.
+Each invocation sends a new Slack message; it does not modify the completed
+harness artifacts.
+
+By default, the report includes file and page counts, ingest time, ingest
+pages/sec, query count, recall, nDCG, environment details, and local artifact
+paths when those values are available. Use repeated `--metric-key` options to
+select a different metric set. Use `--no-artifact-paths` to omit local paths.
+
+### Preserve Run and Report Status
+
+A failed benchmark session normally still writes a summary that can be posted.
+When you schedule the harness, save the run exit code, attempt Slack reporting,
+then return the run failure after reporting:
+
+```bash
+uv run --project nemo_retriever retriever harness run-files \
+  --session-name library_nightly \
+  --output-dir "$RETRIEVER_SESSION_DIR" \
+  --dataset-paths /local/path/to/dataset_paths.yaml \
+  nemo_retriever/harness/runfiles/jp20_beir.json \
+  nemo_retriever/harness/runfiles/bo767_beir.json \
+  nemo_retriever/harness/runfiles/earnings_beir.json \
+  nemo_retriever/harness/runfiles/financebench_beir.json
+run_status=$?
+
+uv run --project nemo_retriever retriever harness post-slack "$RETRIEVER_SESSION_DIR"
+slack_status=$?
+
+if [ "$run_status" -ne 0 ]; then
+  exit "$run_status"
+fi
+exit "$slack_status"
+```
+
+Use a host-local scheduler such as cron and a nonblocking `flock` lock to avoid
+overlapping daily runs. Keep the session directory on runner-owned storage; the
+harness does not upload full artifacts to Slack or external artifact storage.
 
 ## Controls And Overrides
 

--- a/nemo_retriever/harness/README.md
+++ b/nemo_retriever/harness/README.md
@@ -3,7 +3,12 @@
 
 # Retriever Harness
 
-Developer benchmark harness for Retriever ingest/query evaluation.
+Developer benchmark harness for repeatable Retriever ingest/query evaluation.
+
+Use `retriever ingest` and `retriever query` when you want to operate Retriever
+directly on your own inputs. Use `retriever harness` when you want to run a
+registered benchmark with reproducible settings, metric gates, and a stable
+artifact contract. The harness does not install or operate a scheduler.
 
 The harness is artifact-first. Poll `status.json` while one run is active, read
 `results.json` when that run is terminal, and read `session_summary.json` for a
@@ -19,26 +24,29 @@ uv run --project nemo_retriever retriever harness list --runsets
 uv run --project nemo_retriever retriever harness show jp20_beir --json
 ```
 
-Resolve a benchmark without executing ingest or queries:
+The registry contains canonical benchmark definitions, but dataset mounts vary
+by machine. Before executing a checked-in runfile, copy
+[`dataset_paths.example.yaml`](dataset_paths.example.yaml) outside the repository
+and replace the example document and query paths with paths available locally.
+
+Dry-run one checked-in dataset with that path map:
 
 ```bash
-uv run --project nemo_retriever retriever harness run jp20_beir \
+uv run --project nemo_retriever retriever harness run-files \
+  --session-name jp20_check \
+  --output-dir /tmp/retriever-harness-jp20-check \
+  --dataset-paths /local/path/to/dataset_paths.yaml \
   --dry-run \
-  --output-dir /tmp/retriever-harness-dry-run \
-  --json
+  --json \
+  nemo_retriever/harness/runfiles/jp20_beir.json
 ```
 
-Run the cheap JP20 ingest smoke check:
+After inspecting `session_summary.json` and the child run's resolved plans,
+remove `--dry-run` to execute it. The same `run-files` command accepts multiple
+runfiles for a collection.
 
-```bash
-uv run --project nemo_retriever retriever harness run jp20_smoke \
-  --output-dir /tmp/retriever-harness-jp20-smoke \
-  --require 'files==20' \
-  --require 'pages==1940' \
-  --json
-```
-
-Run the full JP20 BEIR benchmark:
+If the registry's default paths already exist on the machine, `run` is the
+short form for one registered benchmark:
 
 ```bash
 uv run --project nemo_retriever retriever harness run jp20_beir \
@@ -46,17 +54,6 @@ uv run --project nemo_retriever retriever harness run jp20_beir \
   --require 'files==20' \
   --require 'pages==1940' \
   --require 'query_count==115' \
-  --require 'recall_5>=0.85' \
-  --require 'ndcg_10>=0.75' \
-  --json
-```
-
-Run the same JP20 BEIR request from a checked-in runfile:
-
-```bash
-uv run --project nemo_retriever retriever harness run \
-  --runfile nemo_retriever/harness/runfiles/jp20_beir.json \
-  --output-dir /tmp/retriever-harness-jp20-beir \
   --json
 ```
 
@@ -69,50 +66,17 @@ parallelism and memory pressure.
 
 - `list`: list code-owned benchmarks and optional runsets.
 - `show`: inspect one benchmark definition.
-- `run`: run one benchmark.
-- `run-set`: expand and run a code-owned runset.
-- `run-files`: execute one or more checked-in runfiles as one session.
-- `post-slack`: post an existing session or run artifact set to Slack.
+- `run`: run one registered benchmark using registry paths or explicit `--set`
+  overrides.
+- `run-set`: expand a code-owned benchmark group using registry paths.
+- `run-files`: execute one or more runfiles with an optional machine-local
+  dataset path map. This is the portable entry point for the checked-in suite.
+- `post-slack`: preview or post existing artifacts; it never executes a run.
 - `diff`: compare two run artifact directories by `results.json` summary metrics.
 
-Legacy graph-pipeline harness execution, sweep, nightly, runner, reporting, and
-portal commands are not part of the phase-one CLI surface. Portal and Helm
-support files are intentionally preserved for follow-on owner work.
-
-## Reviewer Guide
-
-Review the PR in this order:
-
-1. Start with this README for the user-facing harness contract.
-2. Read `benchmark_registry.py` for code-owned datasets, benchmarks, and
-   runsets.
-3. Read `resolution.py` for how registry specs, runfiles, CLI `--set`
-   overrides, and mode selection become ingest/query requests.
-4. Read `execution.py` for the artifact-first run lifecycle and exit-code
-   behavior.
-5. Read `beir_runner.py` and `metrics.py` for query evaluation and summary
-   metric construction.
-6. Read `artifact_writer.py` for artifact names, status updates, and `run.log`
-   capture.
-7. Read `json_io.py` for shared artifact JSON read/write helpers used by the
-   harness, diff, runset, Slack, and artifact-writing paths.
-
-Intentional removals:
-
-- old `run.py` and `runner.py`: subprocess-oriented graph-pipeline harness
-  execution and portal runner agent
-- old `parsers.py`: regex parsing of stdout/progress logs
-- old `nightly.py`, `reporting.py`, and nightly/sweep YAML: previous session
-  reporting and scheduled-run machinery
-- old harness pytests: this harness is validated by functional benchmark
-  execution and artifact/exit-code checks
-
-Intentional preserves:
-
-- `portal/`, `history.py`, and `scheduler.py`: retained for upcoming portal
-  repurpose work; `slack.py` now owns artifact replay and Slack payloads
-- `helm_manager.py`, `helm-profiles/`, and harness Helm examples: retained for
-  Helm owner follow-up work
+Legacy graph-pipeline, sweep, recurring-job, runner, reporting-UI, and portal
+commands are not part of this CLI surface. Scheduling and deployment belong to
+separate infrastructure, not the benchmark harness.
 
 ## Runfiles
 
@@ -140,6 +104,10 @@ and checked-in runfiles independent of one machine's mount layout. Copy
 location, then set the document and query paths available on the machine that
 runs the harness.
 
+The harness does not distribute or download private benchmark corpora or qrels.
+The operator must have access to the datasets referenced by the selected
+runfiles.
+
 Pass the local file with `--dataset-paths`. Relative paths in the file resolve
 relative to the file itself. The harness writes the resolved absolute paths to
 `expanded_runs.json` and each run's `resolved_benchmark.json`.
@@ -151,17 +119,26 @@ Settings resolve in this order, from lowest to highest precedence:
 3. Machine-local dataset paths.
 4. Command-line `--set` overrides.
 
-### Run Several Runfiles as One Session
+### Run One Or More Runfiles As A Session
 
-The following command runs the canonical library benchmarks and writes all
-artifacts beneath one session directory:
+For a single dataset, pass one runfile:
 
 ```bash
-export VLLM_USE_DEEP_GEMM=0
-export RETRIEVER_SESSION_DIR=/local/path/to/retriever-artifacts/library-nightly-$(date -u +%Y%m%d_%H%M%S_UTC)
+uv run --project nemo_retriever retriever harness run-files \
+  --session-name jp20_beir \
+  --output-dir /local/path/to/retriever-artifacts/jp20-beir \
+  --dataset-paths /local/path/to/dataset_paths.yaml \
+  nemo_retriever/harness/runfiles/jp20_beir.json
+```
+
+For the four-dataset library suite, pass all four runfiles. This is still an
+ordinary user-invoked harness session; the repository does not schedule it:
+
+```bash
+export RETRIEVER_SESSION_DIR=/local/path/to/retriever-artifacts/library-beir-$(date -u +%Y%m%d_%H%M%S_UTC)
 
 uv run --project nemo_retriever retriever harness run-files \
-  --session-name library_nightly \
+  --session-name library_beir \
   --output-dir "$RETRIEVER_SESSION_DIR" \
   --dataset-paths /local/path/to/dataset_paths.yaml \
   --json \
@@ -171,11 +148,10 @@ uv run --project nemo_retriever retriever harness run-files \
   nemo_retriever/harness/runfiles/financebench_beir.json
 ```
 
-On vLLM environments affected by the current DeepGEMM availability check,
-`VLLM_USE_DEEP_GEMM=0` keeps the local embedding backend enabled while using
-fallback kernels. Remove the variable after the vLLM and DeepGEMM dependency
-stack is repaired. Because this setting can affect throughput, the harness
-records it in `environment.json`.
+If model startup specifically reports that the DeepGEMM backend is unavailable,
+`VLLM_USE_DEEP_GEMM=0` can select fallback kernels. Do not set it preemptively;
+it can affect throughput. The harness records the setting in
+`environment.json` when present.
 
 `run-files` owns the session layout. Runfiles passed to this command cannot set
 their own `output_dir` or `run_id`. The session uses the following paths and
@@ -220,8 +196,8 @@ export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/..."
 ```
 
 Do not put the webhook URL in a runfile, dataset paths file, shell argument, or
-artifact. For scheduled runs, load it from a permissions-restricted environment
-file outside the repository.
+artifact. Load it from the process environment or a permissions-restricted
+secret file outside the repository.
 
 ### Post a Completed Session
 
@@ -229,7 +205,7 @@ Pass the session directory to `post-slack`:
 
 ```bash
 uv run --project nemo_retriever retriever harness post-slack \
-  --title "nemo-retriever library nightly" \
+  --title "nemo-retriever library benchmarks" \
   "$RETRIEVER_SESSION_DIR"
 ```
 
@@ -250,7 +226,7 @@ Use `--preview` to render the exact Slack payload without reading
 ```bash
 uv run --project nemo_retriever retriever harness post-slack \
   --preview \
-  --title "nemo-retriever library nightly" \
+  --title "nemo-retriever library benchmarks" \
   "$RETRIEVER_SESSION_DIR"
 ```
 
@@ -259,35 +235,9 @@ title, metric selection, or artifact-path setting. When the payload is ready,
 run the command again without `--preview` to post it. Preview and posting use
 the same artifact loader and payload formatter.
 
-### Preserve Run and Report Status
-
-A failed benchmark session normally still writes a summary that can be posted.
-When you schedule the harness, save the run exit code, attempt Slack reporting,
-then return the run failure after reporting:
-
-```bash
-uv run --project nemo_retriever retriever harness run-files \
-  --session-name library_nightly \
-  --output-dir "$RETRIEVER_SESSION_DIR" \
-  --dataset-paths /local/path/to/dataset_paths.yaml \
-  nemo_retriever/harness/runfiles/jp20_beir.json \
-  nemo_retriever/harness/runfiles/bo767_beir.json \
-  nemo_retriever/harness/runfiles/earnings_beir.json \
-  nemo_retriever/harness/runfiles/financebench_beir.json
-run_status=$?
-
-uv run --project nemo_retriever retriever harness post-slack "$RETRIEVER_SESSION_DIR"
-slack_status=$?
-
-if [ "$run_status" -ne 0 ]; then
-  exit "$run_status"
-fi
-exit "$slack_status"
-```
-
-Use a host-local scheduler such as cron and a nonblocking `flock` lock to avoid
-overlapping daily runs. Keep the session directory on runner-owned storage; the
-harness does not upload full artifacts to Slack or external artifact storage.
+`post-slack` has its own exit status and never changes the completed session's
+status or artifacts. Any policy that combines run status, report status,
+retries, locking, or recurrence belongs to the caller.
 
 ## Controls And Overrides
 
@@ -348,9 +298,11 @@ by the CLI:
 - query: `resolve_query_plan(...)` and shared query workflow objects
 - BEIR: harness-owned query iteration over the resolved query plan
 
-This keeps benchmark execution in-process at the Python boundary while still
-reusing the CLI-owned request/plan/workflow seams. Stdout remains diagnostic
-only; artifacts and exit codes are the contract.
+The harness controller calls those APIs in its Python process; this does not
+force the ingest workload into local/in-process mode. A runfile with `mode:
+batch` still resolves to Ray-backed batch ingest, while `mode: local` resolves
+to local in-process ingest. Stdout remains diagnostic only; artifacts and exit
+codes are the contract.
 
 ## Artifacts
 
@@ -361,6 +313,39 @@ Use one entrypoint for each lifecycle level instead of scanning the directory:
   pointers to detailed run evidence.
 - `session_summary.json`: authoritative terminal result for `run-set` and
   `run-files` sessions, with relative pointers to each child run.
+
+The terminal files are deliberately compact. A successful run has this shape:
+
+```json
+{
+  "benchmark": "jp20_beir",
+  "dataset": "jp20",
+  "success": true,
+  "exit_code": 0,
+  "summary_metrics": {"files": 20, "pages": 1940, "recall_5": 0.887},
+  "failure": null,
+  "artifacts": {"log": "run.log", "lancedb": "lancedb"}
+}
+```
+
+A multi-run session summarizes its children without embedding their detailed
+results:
+
+```json
+{
+  "session_type": "runfiles",
+  "session_name": "library_beir",
+  "success": true,
+  "exit_code": 0,
+  "runs": [
+    {
+      "benchmark": "jp20_beir",
+      "success": true,
+      "results_path": "001_jp20_beir/results.json"
+    }
+  ]
+}
+```
 
 Follow the pointers in `results.json` only when deeper evidence is needed:
 
@@ -381,6 +366,15 @@ remains readable. Failure messages in `status.json` and `results.json` are kept
 concise; use the listed debug artifacts, normally `run.log`, for full traces.
 When an output directory is reused, the harness removes only its known generated
 artifacts before starting; unrelated files in that directory are preserved.
+
+`environment.json` records an allowlisted set of reproducibility diagnostics,
+including source revision, Python and package versions, accelerator information,
+and selected Hugging Face, Ray, CUDA, and vLLM settings. Credentials and webhook
+values are not recorded.
+
+New runs keep summary metrics inside `results.json`; they do not emit a separate
+`summary_metrics.json`. `diff` and `post-slack` retain read compatibility with
+older harness artifacts.
 
 Dry-runs write only planning artifacts. They do not create empty `run.log`,
 `beir_metrics.json`, `beir_run.trec`, `query_results.jsonl`, or `lancedb/`.
@@ -410,17 +404,24 @@ not in benchmark Python code.
 
 For automated harness work:
 
-1. Start with `retriever harness list --runsets --json`.
-2. Use `retriever harness show <benchmark> --json` to inspect a benchmark.
-3. Use `--output-dir` so artifact paths are deterministic.
-4. Use `--dry-run` before expensive runs when changing paths, overrides, or
-   gates.
-5. Use explicit `--require` gates from `EXPECTED_RESULTS.md`.
-6. Decide success from the process exit code and `results.json`.
-7. Read `results.json.summary_metrics` for benchmark metrics.
-8. Read `run.log` only when lower-level ingest/query logs are needed.
+1. Use this harness only for registered benchmark/evaluation work. Use
+   `retriever ingest` and `retriever query` for direct product workflows.
+2. Start with `retriever harness list --runsets --json`, then inspect the target
+   with `retriever harness show <benchmark> --json`.
+3. Copy `dataset_paths.example.yaml` outside the repository and set the paths
+   available on the current machine.
+4. Use `run-files --dataset-paths ...` with one runfile for one dataset or
+   multiple runfiles for a suite.
+5. Always set `--output-dir`, and use `--dry-run` before expensive execution
+   when changing paths, overrides, or gates.
+6. Use explicit `--require` gates from `EXPECTED_RESULTS.md`.
+7. Decide success from the process exit code and `results.json` for one run or
+   `session_summary.json` for a session.
+8. Read `summary_metrics` from the applicable terminal JSON file. Follow its
+   pointers to `run.log` or other detailed evidence only when needed.
 9. Do not parse progress bars, human CLI formatting, or raw stdout as the API.
-10. Do not use `retriever pipeline run` for phase-one harness validation.
+10. Treat `post-slack` as optional post-processing. Previewing or posting never
+    executes a benchmark.
 
 ## Exit Codes
 
@@ -438,5 +439,4 @@ For automated harness work:
 
 - [`EXPECTED_RESULTS.md`](EXPECTED_RESULTS.md): dataset facts, observed metrics,
   and suggested explicit gates.
-- [`HANDOFF.md`](HANDOFF.md): current implementation notes and validation
-  history for this revamp.
+- [`HANDOFF.md`](HANDOFF.md): concise maintainer-oriented implementation notes.

--- a/nemo_retriever/harness/README.md
+++ b/nemo_retriever/harness/README.md
@@ -148,8 +148,9 @@ uv run --project nemo_retriever retriever harness run-files \
   nemo_retriever/harness/runfiles/financebench_beir.json
 ```
 
-`run-files` owns the session layout. Runfiles passed to this command cannot set
-their own `output_dir` or `run_id`. The session uses the following paths and
+`run-files` owns the session layout and execution mode. Runfiles passed to this
+command cannot set their own `output_dir`, `run_id`, or `dry_run`; use the
+session-level `--dry-run` flag instead. The session uses the following paths and
 identifiers:
 
 ```text
@@ -371,8 +372,12 @@ New runs keep summary metrics inside `results.json`; they do not emit a separate
 `summary_metrics.json`. `diff` and `post-slack` retain read compatibility with
 older harness artifacts.
 
-Dry-runs write only planning artifacts. They do not create empty `run.log`,
-`beir_metrics.json`, `beir_run.trec`, `query_results.jsonl`, or `lancedb/`.
+Dry-runs write the terminal status/result manifests and planning artifacts. They
+do not create empty `run.log`, `beir_metrics.json`, `beir_run.trec`,
+`query_results.jsonl`, or `lancedb/`.
+Treat `--dry-run` as configuration preflight, not execution evidence. When model
+startup or runtime behavior changes, follow it with a real run of the smallest
+appropriate registered benchmark.
 
 ## Gates
 
@@ -407,8 +412,9 @@ For automated harness work:
    available on the current machine.
 4. Use `run-files --dataset-paths ...` with one runfile for one dataset or
    multiple runfiles for a suite.
-5. Always set `--output-dir`, and use `--dry-run` before expensive execution
-   when changing paths, overrides, or gates.
+5. Always set `--output-dir`. Use `--dry-run` to preflight paths, overrides, and
+   gates before expensive execution, then use a small real benchmark when
+   runtime behavior needs validation.
 6. Use explicit `--require` gates from `EXPECTED_RESULTS.md`.
 7. Decide success from the process exit code and `results.json` for one run or
    `session_summary.json` for a session.

--- a/nemo_retriever/harness/README.md
+++ b/nemo_retriever/harness/README.md
@@ -5,9 +5,10 @@
 
 Developer benchmark harness for Retriever ingest/query evaluation.
 
-The harness is artifact-first. Humans may read CLI output, but agents and
-orchestrators should read `results.json`, `status.json`, and
-`summary_metrics.json`.
+The harness is artifact-first. Poll `status.json` while one run is active, read
+`results.json` when that run is terminal, and read `session_summary.json` for a
+multi-run session. Those terminal files point to detailed evidence; agents do
+not need to scan every file in the artifact directory.
 
 ## Quick Start
 
@@ -72,7 +73,7 @@ parallelism and memory pressure.
 - `run-set`: expand and run a code-owned runset.
 - `run-files`: execute one or more checked-in runfiles as one session.
 - `post-slack`: post an existing session or run artifact set to Slack.
-- `diff`: compare two run artifact directories by `summary_metrics.json`.
+- `diff`: compare two run artifact directories by `results.json` summary metrics.
 
 Legacy graph-pipeline harness execution, sweep, nightly, runner, reporting, and
 portal commands are not part of the phase-one CLI surface. Portal and Helm
@@ -89,8 +90,8 @@ Review the PR in this order:
    overrides, and mode selection become ingest/query requests.
 4. Read `execution.py` for the artifact-first run lifecycle and exit-code
    behavior.
-5. Read `beir_runner.py` and `metrics.py` for query evaluation and
-   `summary_metrics.json` construction.
+5. Read `beir_runner.py` and `metrics.py` for query evaluation and summary
+   metric construction.
 6. Read `artifact_writer.py` for artifact names, status updates, and `run.log`
    capture.
 7. Read `json_io.py` for shared artifact JSON read/write helpers used by the
@@ -237,9 +238,9 @@ Each invocation sends a new Slack message; it does not modify the completed
 harness artifacts.
 
 By default, the report includes file and page counts, ingest time, ingest
-pages/sec, query count, recall, nDCG, environment details, and local artifact
-paths when those values are available. Use repeated `--metric-key` options to
-select a different metric set. Use `--no-artifact-paths` to omit local paths.
+pages/sec, query count, recall, nDCG, and environment details when those values
+are available. Use repeated `--metric-key` options to select a different metric
+set. Use `--artifact-paths` when recipients can access the runner's local paths.
 
 ### Preview Report Formatting
 
@@ -353,28 +354,41 @@ only; artifacts and exit codes are the contract.
 
 ## Artifacts
 
-Read these files instead of scraping stdout:
+Use one entrypoint for each lifecycle level instead of scanning the directory:
 
-- `results.json`: authoritative run result and artifact manifest.
-- `status.json`: current/final run status, phase, and failure payload.
-- `summary_metrics.json`: compact metrics for gates, dashboards, and agents.
+- `status.json`: current phase and concise failure state while a run is active.
+- `results.json`: authoritative terminal result, summary metrics, and relative
+  pointers to detailed run evidence.
+- `session_summary.json`: authoritative terminal result for `run-set` and
+  `run-files` sessions, with relative pointers to each child run.
+
+Follow the pointers in `results.json` only when deeper evidence is needed:
+
 - `events.jsonl`: phase transitions and harness events.
-- `resolved_benchmark.json`: exact resolved benchmark spec.
-- `ingest_plan.json`: redacted ingest dry-run plan.
-- `query_plan.json`: resolved query plan.
+- `runfile.json`: original runfile payload, when a runfile was used.
+- `resolved_benchmark.json`: exact effective benchmark spec.
+- `ingest_plan.json`: redacted executable ingest plan.
+- `query_plan.json`: executable query plan.
 - `environment.json`: commit and runtime context.
-- `run.log`: captured lower-level stdout/stderr for non-dry execution.
-- `beir_metrics.json`: BEIR metrics when BEIR evaluation executes.
-- `beir_run.trec`: TREC runfile when BEIR evaluation executes.
-- `query_results.jsonl`: per-query results when queries execute.
+- `run.log`: captured lower-level stdout/stderr and full exception tracebacks.
+- `beir_metrics.json`: full BEIR metric family when evaluation executes.
+- `beir_run.trec`: standard TREC runfile when evaluation executes.
+- `query_results.jsonl`: per-query latency and ranked hits.
+- `lancedb/`: the ingested table and index used by the run.
+
+Artifact manifest paths are relative to the run directory so a copied session
+remains readable. Failure messages in `status.json` and `results.json` are kept
+concise; use the listed debug artifacts, normally `run.log`, for full traces.
+When an output directory is reused, the harness removes only its known generated
+artifacts before starting; unrelated files in that directory are preserved.
 
 Dry-runs write only planning artifacts. They do not create empty `run.log`,
-`beir_metrics.json`, `beir_run.trec`, or `query_results.jsonl` files.
+`beir_metrics.json`, `beir_run.trec`, `query_results.jsonl`, or `lancedb/`.
 
 ## Gates
 
 Use explicit `--require` gates. Gate expressions compare keys from
-`summary_metrics.json`:
+`results.json.summary_metrics`:
 
 ```bash
 --require 'files==20'
@@ -403,7 +417,7 @@ For automated harness work:
    gates.
 5. Use explicit `--require` gates from `EXPECTED_RESULTS.md`.
 6. Decide success from the process exit code and `results.json`.
-7. Read `summary_metrics.json` for benchmark metrics.
+7. Read `results.json.summary_metrics` for benchmark metrics.
 8. Read `run.log` only when lower-level ingest/query logs are needed.
 9. Do not parse progress bars, human CLI formatting, or raw stdout as the API.
 10. Do not use `retriever pipeline run` for phase-one harness validation.

--- a/nemo_retriever/harness/README.md
+++ b/nemo_retriever/harness/README.md
@@ -241,6 +241,23 @@ pages/sec, query count, recall, nDCG, environment details, and local artifact
 paths when those values are available. Use repeated `--metric-key` options to
 select a different metric set. Use `--no-artifact-paths` to omit local paths.
 
+### Preview Report Formatting
+
+Use `--preview` to render the exact Slack payload without reading
+`SLACK_WEBHOOK_URL` or making an HTTP request:
+
+```bash
+uv run --project nemo_retriever retriever harness post-slack \
+  --preview \
+  --title "nemo-retriever library nightly" \
+  "$RETRIEVER_SESSION_DIR"
+```
+
+Preview the same completed session as often as needed while adjusting the
+title, metric selection, or artifact-path setting. When the payload is ready,
+run the command again without `--preview` to post it. Preview and posting use
+the same artifact loader and payload formatter.
+
 ### Preserve Run and Report Status
 
 A failed benchmark session normally still writes a summary that can be posted.

--- a/nemo_retriever/harness/dataset_paths.example.yaml
+++ b/nemo_retriever/harness/dataset_paths.example.yaml
@@ -12,3 +12,5 @@ datasets:
   financebench:
     path: /path/to/datasets/nv-ingest/foundation_rag/financebench
     query_file: /path/to/NeMo-Retriever/data/financebench_train.json
+  vidore_v3_finance_en:
+    path: /path/to/datasets/nv-ingest/vidore_v3/vidore_v3_finance_en

--- a/nemo_retriever/harness/dataset_paths.example.yaml
+++ b/nemo_retriever/harness/dataset_paths.example.yaml
@@ -1,0 +1,14 @@
+schema_version: 1
+datasets:
+  jp20:
+    path: /path/to/datasets/nv-ingest/jp20
+    query_file: /path/to/datasets/nv-ingest/jp20_query_gt.csv
+  bo767:
+    path: /path/to/datasets/nv-ingest/bo767
+    query_file: /path/to/NeMo-Retriever/data/bo767_query_gt.csv
+  earnings_consulting:
+    path: /path/to/datasets/nv-ingest/earnings_consulting_flattened
+    query_file: /path/to/datasets/nv-ingest/earnings_consulting_multimodal.csv
+  financebench:
+    path: /path/to/datasets/nv-ingest/foundation_rag/financebench
+    query_file: /path/to/NeMo-Retriever/data/financebench_train.json

--- a/nemo_retriever/harness/runfiles/jp20_beir.json
+++ b/nemo_retriever/harness/runfiles/jp20_beir.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "name": "jp20_beir_expected",
+  "name": "jp20_beir",
   "benchmark": "jp20_beir",
   "mode": "local",
   "require": [

--- a/nemo_retriever/harness/runfiles/jp20_beir.json
+++ b/nemo_retriever/harness/runfiles/jp20_beir.json
@@ -6,9 +6,7 @@
   "require": [
     "files==20",
     "pages==1940",
-    "query_count==115",
-    "recall_5>=0.85",
-    "ndcg_10>=0.75"
+    "query_count==115"
   ],
   "set": {}
 }

--- a/nemo_retriever/src/nemo_retriever/graph/pipeline_graph.py
+++ b/nemo_retriever/src/nemo_retriever/graph/pipeline_graph.py
@@ -169,9 +169,18 @@ class Graph:
         Returns a list of leaf outputs (one per leaf node reached).
         """
         resolved = self.resolve_for_local_execution()
+        return resolved.execute_resolved(data, **kwargs)
+
+    def execute_resolved(self, data: Any, **kwargs: Any) -> List[Any]:
+        """Execute this graph without resolving or cloning it again.
+
+        This is an execution-lifecycle primitive for callers that intentionally
+        retain this graph and its stateful operator delegates, including locally
+        loaded models, across repeated executions.
+        """
         results: List[Any] = []
-        for root in resolved.roots:
-            resolved._execute_node(root, data, results, **kwargs)
+        for root in self.roots:
+            self._execute_node(root, data, results, **kwargs)
         return results
 
     def resolve(self, resources: Any) -> "Graph":

--- a/nemo_retriever/src/nemo_retriever/graph/pipeline_graph.py
+++ b/nemo_retriever/src/nemo_retriever/graph/pipeline_graph.py
@@ -169,14 +169,14 @@ class Graph:
         Returns a list of leaf outputs (one per leaf node reached).
         """
         resolved = self.resolve_for_local_execution()
-        return resolved.execute_resolved(data, **kwargs)
+        return resolved.execute_in_place(data, **kwargs)
 
-    def execute_resolved(self, data: Any, **kwargs: Any) -> List[Any]:
-        """Execute this graph without resolving or cloning it again.
+    def execute_in_place(self, data: Any, **kwargs: Any) -> List[Any]:
+        """Execute this graph as constructed, without resolving or cloning it.
 
-        This is an execution-lifecycle primitive for callers that intentionally
-        retain this graph and its stateful operator delegates, including locally
-        loaded models, across repeated executions.
+        Archetype operators resolve their delegates lazily, so retaining this
+        graph also retains stateful delegates such as locally loaded models
+        across repeated executions.
         """
         results: List[Any] = []
         for root in self.roots:

--- a/nemo_retriever/src/nemo_retriever/graph/retriever.py
+++ b/nemo_retriever/src/nemo_retriever/graph/retriever.py
@@ -94,6 +94,8 @@ class Retriever:
 
     _cached_graph: Any = field(default=None, init=False, repr=False, compare=False)
     _cache_key: Any = field(default=None, init=False, repr=False, compare=False)
+    _cached_resolved_graph: Any = field(default=None, init=False, repr=False, compare=False)
+    _resolved_graph_source: Any = field(default=None, init=False, repr=False, compare=False)
     _lancedb_capabilities_cache: dict[tuple[str, str], LanceTableCapabilities] = field(
         default_factory=dict, init=False, repr=False, compare=False
     )
@@ -185,6 +187,20 @@ class Retriever:
         self._cache_key = key
         return g
 
+    def _get_resolved_graph(self, graph: Any) -> Any:
+        """Resolve *graph* once and retain its stateful local operator delegates."""
+        # A caller-owned custom graph may be mutated in place between queries.
+        # Preserve the historical resolve-per-call behavior for that surface;
+        # Retriever-owned default graphs are immutable and safe to cache.
+        if self.graph is not None:
+            return graph.resolve_for_local_execution()
+        if self._cached_resolved_graph is not None and self._resolved_graph_source is graph:
+            return self._cached_resolved_graph
+        resolved = graph.resolve_for_local_execution()
+        self._cached_resolved_graph = resolved
+        self._resolved_graph_source = graph
+        return resolved
+
     def _execute_queries_graph(
         self,
         query_texts: list[str],
@@ -210,8 +226,14 @@ class Retriever:
             "top_k": int(retrieval_top_k),
             "query_texts": query_texts,
         }
-        resolved = graph.resolve_for_local_execution()
-        leaves = resolved.execute(df, **exec_kwargs)
+        resolved = self._get_resolved_graph(graph)
+        execute_resolved = getattr(resolved, "execute_resolved", None)
+        if callable(execute_resolved):
+            leaves = execute_resolved(df, **exec_kwargs)
+        else:
+            # Compatibility for graph-like custom objects predating
+            # ``Graph.execute_resolved``.
+            leaves = resolved.execute(df, **exec_kwargs)
         if len(leaves) != 1:
             raise RuntimeError(
                 f"Retriever query graph must yield exactly one leaf output; got {len(leaves)}. "

--- a/nemo_retriever/src/nemo_retriever/graph/retriever.py
+++ b/nemo_retriever/src/nemo_retriever/graph/retriever.py
@@ -94,8 +94,6 @@ class Retriever:
 
     _cached_graph: Any = field(default=None, init=False, repr=False, compare=False)
     _cache_key: Any = field(default=None, init=False, repr=False, compare=False)
-    _cached_resolved_graph: Any = field(default=None, init=False, repr=False, compare=False)
-    _resolved_graph_source: Any = field(default=None, init=False, repr=False, compare=False)
     _lancedb_capabilities_cache: dict[tuple[str, str], LanceTableCapabilities] = field(
         default_factory=dict, init=False, repr=False, compare=False
     )
@@ -187,20 +185,6 @@ class Retriever:
         self._cache_key = key
         return g
 
-    def _get_resolved_graph(self, graph: Any) -> Any:
-        """Resolve *graph* once and retain its stateful local operator delegates."""
-        # A caller-owned custom graph may be mutated in place between queries.
-        # Preserve the historical resolve-per-call behavior for that surface;
-        # Retriever-owned default graphs are immutable and safe to cache.
-        if self.graph is not None:
-            return graph.resolve_for_local_execution()
-        if self._cached_resolved_graph is not None and self._resolved_graph_source is graph:
-            return self._cached_resolved_graph
-        resolved = graph.resolve_for_local_execution()
-        self._cached_resolved_graph = resolved
-        self._resolved_graph_source = graph
-        return resolved
-
     def _execute_queries_graph(
         self,
         query_texts: list[str],
@@ -218,21 +202,21 @@ class Retriever:
         # with the embedded rows produced from ``df``. If this query graph grows
         # distributed/shuffled stages, carry row-local query text or IDs instead.
         graph = self._get_graph(embed_extra=embed_extra)
-        if not callable(getattr(graph, "resolve_for_local_execution", None)):
-            raise TypeError("graph must provide resolve_for_local_execution() (e.g. pipeline_graph.Graph)")
 
         exec_kwargs: dict[str, Any] = {
             **filter_retrieval_kwargs(dict(vdb_call_kwargs or {})),
             "top_k": int(retrieval_top_k),
             "query_texts": query_texts,
         }
-        resolved = self._get_resolved_graph(graph)
-        execute_resolved = getattr(resolved, "execute_resolved", None)
-        if callable(execute_resolved):
-            leaves = execute_resolved(df, **exec_kwargs)
+        if self.graph is None:
+            leaves = graph.execute_in_place(df, **exec_kwargs)
         else:
-            # Compatibility for graph-like custom objects predating
-            # ``Graph.execute_resolved``.
+            # Preserve resolve-per-query behavior for caller-owned graphs, which
+            # may be mutated between calls.
+            resolve = getattr(graph, "resolve_for_local_execution", None)
+            if not callable(resolve):
+                raise TypeError("graph must provide resolve_for_local_execution() (e.g. pipeline_graph.Graph)")
+            resolved = resolve()
             leaves = resolved.execute(df, **exec_kwargs)
         if len(leaves) != 1:
             raise RuntimeError(

--- a/nemo_retriever/src/nemo_retriever/harness/artifact_writer.py
+++ b/nemo_retriever/src/nemo_retriever/harness/artifact_writer.py
@@ -17,7 +17,7 @@ import traceback
 from typing import Any, Mapping
 
 from nemo_retriever.harness.contracts import FailurePayload, PHASE_VALUES, STATUS_VALUES
-from nemo_retriever.harness.json_io import jsonable, write_json
+from nemo_retriever.harness.json_io import artifact_write_error, jsonable, write_json
 
 _ARTIFACT_NAMES = {
     "status": "status.json",
@@ -41,9 +41,12 @@ def utc_now() -> str:
 
 
 def append_jsonl(path: Path, payload: Mapping[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(jsonable(payload), sort_keys=False) + "\n")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(jsonable(payload), sort_keys=False) + "\n")
+    except Exception as exc:
+        raise artifact_write_error(exc) from exc
 
 
 def append_text(path: Path, text: str) -> None:

--- a/nemo_retriever/src/nemo_retriever/harness/artifact_writer.py
+++ b/nemo_retriever/src/nemo_retriever/harness/artifact_writer.py
@@ -88,12 +88,19 @@ def capture_output_to_log(path: Path, *, label: str):
             os.close(saved_stdout)
 
 
+_SENSITIVE_KEY_PARTS = ("api_key", "password", "secret", "credential", "token")
+
+
+def _is_sensitive_key(value: Any) -> bool:
+    normalized = str(value).lower()
+    return any(token in normalized for token in _SENSITIVE_KEY_PARTS)
+
+
 def redact(value: Any) -> Any:
     if isinstance(value, dict):
         out: dict[str, Any] = {}
         for key, nested in value.items():
-            normalized = str(key).lower()
-            if any(token in normalized for token in ("api_key", "password", "secret", "credential", "token")):
+            if _is_sensitive_key(key):
                 out[key] = "<redacted>" if nested else nested
             else:
                 out[key] = redact(nested)
@@ -102,6 +109,10 @@ def redact(value: Any) -> Any:
         return [redact(item) for item in value]
     if isinstance(value, tuple):
         return [redact(item) for item in value]
+    if isinstance(value, str) and "=" in value:
+        key, _separator, _raw = value.partition("=")
+        if _is_sensitive_key(key):
+            return f"{key}=<redacted>"
     return value
 
 

--- a/nemo_retriever/src/nemo_retriever/harness/artifact_writer.py
+++ b/nemo_retriever/src/nemo_retriever/harness/artifact_writer.py
@@ -10,12 +10,30 @@ import io
 import json
 import os
 from pathlib import Path
+import shutil
 import sys
 import tempfile
+import traceback
 from typing import Any, Mapping
 
 from nemo_retriever.harness.contracts import FailurePayload, PHASE_VALUES, STATUS_VALUES
 from nemo_retriever.harness.json_io import jsonable, write_json
+
+_ARTIFACT_NAMES = {
+    "status": "status.json",
+    "events": "events.jsonl",
+    "environment": "environment.json",
+    "runfile": "runfile.json",
+    "resolved_benchmark": "resolved_benchmark.json",
+    "ingest_plan": "ingest_plan.json",
+    "query_plan": "query_plan.json",
+    "log": "run.log",
+    "query_results": "query_results.jsonl",
+    "beir_metrics": "beir_metrics.json",
+    "beir_run": "beir_run.trec",
+    "lancedb": "lancedb",
+}
+_LEGACY_ARTIFACT_NAMES = ("summary_metrics.json",)
 
 
 def utc_now() -> str:
@@ -43,12 +61,19 @@ def capture_output_to_log(path: Path, *, label: str):
         stdout_fd, stderr_fd = sys.stdout.fileno(), sys.stderr.fileno()
     except (AttributeError, OSError, ValueError, io.UnsupportedOperation):
         append_text(path, "stdio capture unavailable in this runtime\n")
-        yield
-        append_text(path, f"## {utc_now()} {label} complete\n")
+        try:
+            yield
+        except BaseException:
+            append_text(path, traceback.format_exc())
+            append_text(path, f"## {utc_now()} {label} failed\n")
+            raise
+        else:
+            append_text(path, f"## {utc_now()} {label} complete\n")
         return
 
     saved_stdout = saved_stderr = buf = None
     failed = False
+    failure_traceback: str | None = None
     try:
         saved_stdout = os.dup(stdout_fd)
         saved_stderr = os.dup(stderr_fd)
@@ -65,6 +90,7 @@ def capture_output_to_log(path: Path, *, label: str):
                 os.dup2(saved_stderr, stderr_fd)
         except BaseException:
             failed = True
+            failure_traceback = traceback.format_exc()
             raise
         finally:
             if buf is not None:
@@ -74,6 +100,10 @@ def capture_output_to_log(path: Path, *, label: str):
                     if captured:
                         handle.write(captured)
                         if not captured.endswith(b"\n"):
+                            handle.write(b"\n")
+                    if failure_traceback:
+                        handle.write(failure_traceback.encode("utf-8", errors="replace"))
+                        if not failure_traceback.endswith("\n"):
                             handle.write(b"\n")
                     handle.write(f"## {utc_now()} {label} {'failed' if failed else 'complete'}\n".encode("utf-8"))
                 if failed and captured:
@@ -123,9 +153,13 @@ class ArtifactWriter:
         self.benchmark = benchmark
         self.started_at = utc_now()
         self.artifact_dir.mkdir(parents=True, exist_ok=True)
+        for name in (*_ARTIFACT_NAMES.values(), *_LEGACY_ARTIFACT_NAMES, "results.json"):
+            path = self.artifact_dir / name
+            if path.is_dir() and not path.is_symlink():
+                shutil.rmtree(path)
+            elif path.exists() or path.is_symlink():
+                path.unlink()
         self.events_path = self.artifact_dir / "events.jsonl"
-        if self.events_path.exists():
-            self.events_path.unlink()
 
     def path(self, name: str) -> Path:
         return self.artifact_dir / name
@@ -150,7 +184,7 @@ class ArtifactWriter:
         status: str,
         phase: str,
         failure: FailurePayload | None = None,
-        summary_metrics_path: Path | None = None,
+        results_path: Path | None = None,
     ) -> dict[str, Any]:
         if status not in STATUS_VALUES:
             raise ValueError(f"Invalid status: {status}")
@@ -164,7 +198,7 @@ class ArtifactWriter:
             "started_at": self.started_at,
             "updated_at": utc_now(),
             "artifact_dir": str(self.artifact_dir),
-            "summary_metrics_path": str(summary_metrics_path) if summary_metrics_path is not None else None,
+            "results_path": str(results_path.relative_to(self.artifact_dir)) if results_path is not None else None,
             "failure": failure.to_dict() if failure is not None else None,
         }
         write_json(self.path("status.json"), payload)
@@ -173,19 +207,4 @@ class ArtifactWriter:
 
 
 def artifact_paths(writer: ArtifactWriter) -> dict[str, str]:
-    names = (
-        "status.json",
-        "events.jsonl",
-        "resolved_benchmark.json",
-        "ingest_plan.json",
-        "query_plan.json",
-        "summary_metrics.json",
-        "environment.json",
-        "runfile.json",
-        "results.json",
-        "run.log",
-        "beir_metrics.json",
-        "beir_run.trec",
-        "query_results.jsonl",
-    )
-    return {name: str(writer.path(name)) for name in names if writer.path(name).exists() or name == "results.json"}
+    return {key: name for key, name in _ARTIFACT_NAMES.items() if writer.path(name).exists()}

--- a/nemo_retriever/src/nemo_retriever/harness/artifact_writer.py
+++ b/nemo_retriever/src/nemo_retriever/harness/artifact_writer.py
@@ -88,7 +88,7 @@ def capture_output_to_log(path: Path, *, label: str):
             os.close(saved_stdout)
 
 
-_SENSITIVE_KEY_PARTS = ("api_key", "password", "secret", "credential", "token")
+_SENSITIVE_KEY_PARTS = ("api_key", "password", "secret", "credential", "token", "webhook")
 
 
 def _is_sensitive_key(value: Any) -> bool:

--- a/nemo_retriever/src/nemo_retriever/harness/artifact_writer.py
+++ b/nemo_retriever/src/nemo_retriever/harness/artifact_writer.py
@@ -140,9 +140,16 @@ def redact(value: Any) -> Any:
     if isinstance(value, tuple):
         return [redact(item) for item in value]
     if isinstance(value, str) and "=" in value:
-        key, _separator, _raw = value.partition("=")
+        key, _separator, raw = value.partition("=")
         if _is_sensitive_key(key):
             return f"{key}=<redacted>"
+        try:
+            structured_value = json.loads(raw)
+        except json.JSONDecodeError:
+            return value
+        redacted_value = redact(structured_value)
+        if redacted_value != structured_value:
+            return f"{key}={json.dumps(redacted_value, sort_keys=True)}"
     return value
 
 

--- a/nemo_retriever/src/nemo_retriever/harness/benchmark_registry.py
+++ b/nemo_retriever/src/nemo_retriever/harness/benchmark_registry.py
@@ -238,12 +238,6 @@ RUNSETS: dict[str, RunSet] = {
         tags=("jp20", "core"),
         description="Small jp20 smoke plus BEIR validation set.",
     ),
-    "library_nightly": RunSet(
-        name="library_nightly",
-        runs=("jp20_beir", "bo767_beir", "earnings_beir", "financebench_beir"),
-        tags=("nightly", "beir", "library"),
-        description="Canonical library nightly BEIR suite for JP20, BO767, Earnings, and FinanceBench.",
-    ),
 }
 
 

--- a/nemo_retriever/src/nemo_retriever/harness/benchmark_registry.py
+++ b/nemo_retriever/src/nemo_retriever/harness/benchmark_registry.py
@@ -237,7 +237,13 @@ RUNSETS: dict[str, RunSet] = {
         runs=("jp20_smoke", "jp20_beir"),
         tags=("jp20", "core"),
         description="Small jp20 smoke plus BEIR validation set.",
-    )
+    ),
+    "library_nightly": RunSet(
+        name="library_nightly",
+        runs=("jp20_beir", "bo767_beir", "earnings_beir", "financebench_beir"),
+        tags=("nightly", "beir", "library"),
+        description="Canonical library nightly BEIR suite for JP20, BO767, Earnings, and FinanceBench.",
+    ),
 }
 
 

--- a/nemo_retriever/src/nemo_retriever/harness/cli.py
+++ b/nemo_retriever/src/nemo_retriever/harness/cli.py
@@ -109,7 +109,10 @@ def run_command(
         list[str] | None,
         typer.Option("--require", help="Require a summary metric gate, e.g. recall_5>=0.80. Repeatable."),
     ] = None,
-    dry_run: Annotated[bool, typer.Option("--dry-run", help="Resolve plans and artifacts without execution.")] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Resolve configuration and write plans without executing ingest or query."),
+    ] = False,
     json_output: Annotated[bool, typer.Option("--json", help="Emit results JSON to stdout.")] = False,
 ) -> None:
     """Run one registered benchmark and write stable artifacts."""
@@ -187,7 +190,10 @@ def run_set_command(
         list[str] | None,
         typer.Option("--require", help="Require a summary metric gate for every run. Repeatable."),
     ] = None,
-    dry_run: Annotated[bool, typer.Option("--dry-run", help="Resolve plans and artifacts without execution.")] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Resolve configuration and write plans without executing ingest or query."),
+    ] = False,
     json_output: Annotated[bool, typer.Option("--json", help="Emit session summary JSON to stdout.")] = False,
 ) -> None:
     """Run a code-owned benchmark group using registry dataset paths."""
@@ -236,7 +242,10 @@ def run_files_command(
         list[str] | None,
         typer.Option("--require", help="Require a summary metric gate for every run. Repeatable."),
     ] = None,
-    dry_run: Annotated[bool, typer.Option("--dry-run", help="Resolve plans and artifacts without execution.")] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Resolve configuration and write plans without executing ingest or query."),
+    ] = False,
     json_output: Annotated[bool, typer.Option("--json", help="Emit session summary JSON to stdout.")] = False,
 ) -> None:
     """Run one or more runfiles, optionally with machine-local dataset paths."""

--- a/nemo_retriever/src/nemo_retriever/harness/cli.py
+++ b/nemo_retriever/src/nemo_retriever/harness/cli.py
@@ -25,7 +25,13 @@ from nemo_retriever.harness.diff import diff_artifact_dirs
 from nemo_retriever.harness.resolution import make_run_id
 from nemo_retriever.harness.runfile import load_runfile
 from nemo_retriever.harness.runsets import run_runfiles, run_runset
-from nemo_retriever.harness.slack import DEFAULT_SLACK_METRIC_KEYS, load_replay_report, post_report_to_slack
+from nemo_retriever.harness.slack import (
+    DEFAULT_SLACK_METRIC_KEYS,
+    build_slack_payload,
+    load_replay_report,
+    post_slack_payload,
+    resolve_slack_webhook_url,
+)
 
 app = typer.Typer(help="Artifact-first Retriever benchmark harness.")
 
@@ -270,24 +276,28 @@ def post_slack_command(
         bool,
         typer.Option("--artifact-paths/--no-artifact-paths", help="Include local artifact paths in the Slack post."),
     ] = True,
+    preview: Annotated[
+        bool,
+        typer.Option("--preview", help="Render the Slack payload as JSON without reading a webhook or posting."),
+    ] = False,
     json_output: Annotated[bool, typer.Option("--json", help="Emit posted Slack payload JSON to stdout.")] = False,
 ) -> None:
-    """Post an existing harness session or run artifact set to Slack."""
+    """Render or post a Slack report from existing harness artifacts."""
     try:
         report = load_replay_report(paths)
-        payload = post_report_to_slack(
-            report,
-            {
-                "title": title,
-                "metric_keys": metric_keys or DEFAULT_SLACK_METRIC_KEYS,
-                "post_artifact_paths": post_artifact_paths,
-            },
-        )
+        slack_config = {
+            "title": title,
+            "metric_keys": metric_keys or DEFAULT_SLACK_METRIC_KEYS,
+            "post_artifact_paths": post_artifact_paths,
+        }
+        payload = build_slack_payload(report, slack_config)
+        if not preview:
+            post_slack_payload(payload, resolve_slack_webhook_url())
     except Exception as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(code=1) from exc
 
-    if json_output:
+    if preview or json_output:
         _echo_json(payload)
     else:
         typer.echo(f"Posted Slack report for {report.session_name}")

--- a/nemo_retriever/src/nemo_retriever/harness/cli.py
+++ b/nemo_retriever/src/nemo_retriever/harness/cli.py
@@ -24,7 +24,8 @@ from nemo_retriever.harness.revamp_runner import (
 from nemo_retriever.harness.diff import diff_artifact_dirs
 from nemo_retriever.harness.resolution import make_run_id
 from nemo_retriever.harness.runfile import load_runfile
-from nemo_retriever.harness.runsets import run_runset
+from nemo_retriever.harness.runsets import run_runfiles, run_runset
+from nemo_retriever.harness.slack import DEFAULT_SLACK_METRIC_KEYS, load_replay_report, post_report_to_slack
 
 app = typer.Typer(help="Artifact-first Retriever benchmark harness.")
 
@@ -201,6 +202,95 @@ def run_set_command(
         typer.echo(f"Runset failed with exit code {outcome.exit_code}", err=True)
         typer.echo(f"Session artifacts: {outcome.artifact_dir}", err=True)
     raise typer.Exit(code=outcome.exit_code)
+
+
+@app.command("run-files")
+def run_files_command(
+    runfiles: Annotated[list[Path], typer.Argument(help="Runfile paths to execute as one session.")],
+    output_dir: Annotated[str | None, typer.Option("--output-dir", help="Directory for session artifacts.")] = None,
+    session_name: Annotated[str, typer.Option("--session-name", help="Stable session label.")] = "runfiles",
+    dataset_paths: Annotated[
+        Path | None,
+        typer.Option(
+            "--dataset-paths",
+            help="Machine-local YAML file that maps registered datasets to document and query paths.",
+        ),
+    ] = None,
+    mode: Annotated[str | None, typer.Option("--mode", help="Override ingest mode for every runfile.")] = None,
+    set_values: Annotated[
+        list[str] | None,
+        typer.Option("--set", help="Apply a small KEY=VALUE override to every run. Repeatable."),
+    ] = None,
+    requirements: Annotated[
+        list[str] | None,
+        typer.Option("--require", help="Require a summary metric gate for every run. Repeatable."),
+    ] = None,
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="Resolve plans and artifacts without execution.")] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Emit session summary JSON to stdout.")] = False,
+) -> None:
+    """Execute one or more checked-in runfiles as a single artifact session."""
+    try:
+        outcome = run_runfiles(
+            runfiles,
+            output_dir=output_dir,
+            session_name=session_name,
+            dataset_paths_file=dataset_paths,
+            mode=mode,
+            overrides=set_values or (),
+            requirements=requirements or (),
+            dry_run=dry_run,
+        )
+    except HarnessRunError as exc:
+        typer.echo(exc.failure.message, err=True)
+        raise typer.Exit(code=exc.exit_code) from exc
+
+    if json_output:
+        _echo_json(outcome.results)
+    elif outcome.exit_code == 0:
+        typer.echo(f"Session artifacts: {outcome.artifact_dir}")
+        typer.echo(f"Session summary: {outcome.artifact_dir / 'session_summary.json'}")
+    else:
+        typer.echo(f"Runfile session failed with exit code {outcome.exit_code}", err=True)
+        typer.echo(f"Session artifacts: {outcome.artifact_dir}", err=True)
+    raise typer.Exit(code=outcome.exit_code)
+
+
+@app.command("post-slack")
+def post_slack_command(
+    paths: Annotated[
+        list[Path],
+        typer.Argument(help="One session directory, or one or more run artifact directories/results.json files."),
+    ],
+    title: Annotated[str, typer.Option("--title", help="Slack message title.")] = "nemo_retriever Nightly Harness",
+    metric_keys: Annotated[
+        list[str] | None,
+        typer.Option("--metric-key", help="Summary metric key to include. Repeatable."),
+    ] = None,
+    post_artifact_paths: Annotated[
+        bool,
+        typer.Option("--artifact-paths/--no-artifact-paths", help="Include local artifact paths in the Slack post."),
+    ] = True,
+    json_output: Annotated[bool, typer.Option("--json", help="Emit posted Slack payload JSON to stdout.")] = False,
+) -> None:
+    """Post an existing harness session or run artifact set to Slack."""
+    try:
+        report = load_replay_report(paths)
+        payload = post_report_to_slack(
+            report,
+            {
+                "title": title,
+                "metric_keys": metric_keys or DEFAULT_SLACK_METRIC_KEYS,
+                "post_artifact_paths": post_artifact_paths,
+            },
+        )
+    except Exception as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+
+    if json_output:
+        _echo_json(payload)
+    else:
+        typer.echo(f"Posted Slack report for {report.session_name}")
 
 
 @app.command("diff")

--- a/nemo_retriever/src/nemo_retriever/harness/cli.py
+++ b/nemo_retriever/src/nemo_retriever/harness/cli.py
@@ -33,7 +33,12 @@ from nemo_retriever.harness.slack import (
     resolve_slack_webhook_url,
 )
 
-app = typer.Typer(help="Artifact-first Retriever benchmark harness.")
+app = typer.Typer(
+    help=(
+        "Developer benchmark and evaluation harness. Use 'retriever ingest' and "
+        "'retriever query' for direct product workflows."
+    )
+)
 
 
 def _echo_json(payload: object) -> None:
@@ -107,7 +112,7 @@ def run_command(
     dry_run: Annotated[bool, typer.Option("--dry-run", help="Resolve plans and artifacts without execution.")] = False,
     json_output: Annotated[bool, typer.Option("--json", help="Emit results JSON to stdout.")] = False,
 ) -> None:
-    """Run one benchmark and write stable artifacts."""
+    """Run one registered benchmark and write stable artifacts."""
     try:
         runfile_payload = None
         runfile_path = None
@@ -185,7 +190,7 @@ def run_set_command(
     dry_run: Annotated[bool, typer.Option("--dry-run", help="Resolve plans and artifacts without execution.")] = False,
     json_output: Annotated[bool, typer.Option("--json", help="Emit session summary JSON to stdout.")] = False,
 ) -> None:
-    """Expand and run a code-owned benchmark runset."""
+    """Run a code-owned benchmark group using registry dataset paths."""
     try:
         outcome = run_runset(
             runset,
@@ -234,7 +239,7 @@ def run_files_command(
     dry_run: Annotated[bool, typer.Option("--dry-run", help="Resolve plans and artifacts without execution.")] = False,
     json_output: Annotated[bool, typer.Option("--json", help="Emit session summary JSON to stdout.")] = False,
 ) -> None:
-    """Execute one or more checked-in runfiles as a single artifact session."""
+    """Run one or more runfiles, optionally with machine-local dataset paths."""
     try:
         outcome = run_runfiles(
             runfiles,
@@ -282,7 +287,7 @@ def post_slack_command(
     ] = False,
     json_output: Annotated[bool, typer.Option("--json", help="Emit posted Slack payload JSON to stdout.")] = False,
 ) -> None:
-    """Render or post a Slack report from existing harness artifacts."""
+    """Render or post existing harness artifacts without running benchmarks."""
     try:
         report = load_replay_report(paths)
         slack_config = {

--- a/nemo_retriever/src/nemo_retriever/harness/cli.py
+++ b/nemo_retriever/src/nemo_retriever/harness/cli.py
@@ -267,7 +267,7 @@ def post_slack_command(
         list[Path],
         typer.Argument(help="One session directory, or one or more run artifact directories/results.json files."),
     ],
-    title: Annotated[str, typer.Option("--title", help="Slack message title.")] = "nemo_retriever Nightly Harness",
+    title: Annotated[str, typer.Option("--title", help="Slack message title.")] = "nemo_retriever Harness Report",
     metric_keys: Annotated[
         list[str] | None,
         typer.Option("--metric-key", help="Summary metric key to include. Repeatable."),
@@ -275,7 +275,7 @@ def post_slack_command(
     post_artifact_paths: Annotated[
         bool,
         typer.Option("--artifact-paths/--no-artifact-paths", help="Include local artifact paths in the Slack post."),
-    ] = True,
+    ] = False,
     preview: Annotated[
         bool,
         typer.Option("--preview", help="Render the Slack payload as JSON without reading a webhook or posting."),
@@ -305,8 +305,8 @@ def post_slack_command(
 
 @app.command("diff")
 def diff_command(
-    left: Annotated[Path, typer.Argument(help="Left run artifact directory or summary_metrics.json file.")],
-    right: Annotated[Path, typer.Argument(help="Right run artifact directory or summary_metrics.json file.")],
+    left: Annotated[Path, typer.Argument(help="Left run artifact directory or results.json file.")],
+    right: Annotated[Path, typer.Argument(help="Right run artifact directory or results.json file.")],
     json_output: Annotated[bool, typer.Option("--json", help="Emit machine-readable JSON.")] = False,
 ) -> None:
     """Diff two run artifact directories by summary metrics."""

--- a/nemo_retriever/src/nemo_retriever/harness/contracts.py
+++ b/nemo_retriever/src/nemo_retriever/harness/contracts.py
@@ -47,6 +47,7 @@ class RunOutcome:
     exit_code: int
     artifact_dir: Path
     results: dict[str, Any]
+    results_path: Path | None
 
 
 class HarnessRunError(Exception):

--- a/nemo_retriever/src/nemo_retriever/harness/dataset_paths.py
+++ b/nemo_retriever/src/nemo_retriever/harness/dataset_paths.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-26, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+from nemo_retriever.harness.benchmark_registry import get_dataset
+from nemo_retriever.harness.contracts import EXIT_INVALID, FailurePayload, HarnessRunError
+
+
+@dataclass(frozen=True)
+class DatasetPaths:
+    path: Path
+    query_file: Path | None = None
+
+    def overrides(self) -> tuple[str, ...]:
+        values = [f"dataset.path={json.dumps(str(self.path))}"]
+        if self.query_file is not None:
+            query_file = json.dumps(str(self.query_file))
+            values.extend(
+                (
+                    f"dataset.query_file={query_file}",
+                    f"evaluation.dataset_name={query_file}",
+                )
+            )
+        return tuple(values)
+
+    def to_dict(self) -> dict[str, str]:
+        payload = {"path": str(self.path)}
+        if self.query_file is not None:
+            payload["query_file"] = str(self.query_file)
+        return payload
+
+
+def _invalid(message: str) -> HarnessRunError:
+    return HarnessRunError(
+        EXIT_INVALID,
+        FailurePayload(
+            failed_phase="resolve",
+            failure_reason="invalid_dataset_paths",
+            retryable=False,
+            message=message,
+        ),
+    )
+
+
+def _resolve_local_path(config_path: Path, value: Any, *, field: str) -> Path:
+    if not isinstance(value, str) or not value.strip():
+        raise _invalid(f"Dataset path field {field!r} must be a non-empty string.")
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = config_path.parent / path
+    return path.resolve()
+
+
+def load_dataset_paths(path: Path | None) -> dict[str, DatasetPaths]:
+    if path is None:
+        return {}
+
+    config_path = path.expanduser().resolve()
+    try:
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise _invalid(f"Could not read dataset paths file {config_path}: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise _invalid(f"Could not parse dataset paths file {config_path}: {exc}") from exc
+
+    if not isinstance(raw, Mapping):
+        raise _invalid("Dataset paths file must contain an object at the top level.")
+    unknown_top_level = sorted(set(raw) - {"schema_version", "datasets"})
+    if unknown_top_level:
+        raise _invalid(f"Dataset paths file contains unknown key {unknown_top_level[0]!r}.")
+    if raw.get("schema_version") != 1:
+        raise _invalid("Dataset paths file 'schema_version' must be 1.")
+
+    datasets = raw.get("datasets")
+    if not isinstance(datasets, Mapping) or not datasets:
+        raise _invalid("Dataset paths file 'datasets' must be a non-empty object.")
+
+    resolved: dict[str, DatasetPaths] = {}
+    for raw_name, raw_paths in datasets.items():
+        if not isinstance(raw_name, str) or not raw_name:
+            raise _invalid("Dataset path names must be non-empty strings.")
+        try:
+            get_dataset(raw_name)
+        except KeyError as exc:
+            raise _invalid(f"Dataset paths file references unknown dataset {raw_name!r}.") from exc
+        if not isinstance(raw_paths, Mapping):
+            raise _invalid(f"Dataset paths entry {raw_name!r} must be an object.")
+        unknown_fields = sorted(set(raw_paths) - {"path", "query_file"})
+        if unknown_fields:
+            raise _invalid(f"Dataset paths entry {raw_name!r} contains unknown key {unknown_fields[0]!r}.")
+        if "path" not in raw_paths:
+            raise _invalid(f"Dataset paths entry {raw_name!r} must set 'path'.")
+
+        query_file = raw_paths.get("query_file")
+        resolved[raw_name] = DatasetPaths(
+            path=_resolve_local_path(config_path, raw_paths["path"], field=f"{raw_name}.path"),
+            query_file=(
+                _resolve_local_path(config_path, query_file, field=f"{raw_name}.query_file")
+                if query_file is not None
+                else None
+            ),
+        )
+    return resolved

--- a/nemo_retriever/src/nemo_retriever/harness/diff.py
+++ b/nemo_retriever/src/nemo_retriever/harness/diff.py
@@ -8,13 +8,33 @@ from pathlib import Path
 from typing import Any
 
 from nemo_retriever.harness.contracts import EXIT_INVALID, FailurePayload, HarnessRunError
-from nemo_retriever.harness.json_io import artifact_file, read_json_object
+from nemo_retriever.harness.json_io import read_json_object
 
 
 def _read_summary(path_or_dir: Path) -> tuple[Path, dict[str, Any]]:
     try:
-        summary_path = artifact_file(path_or_dir, "summary_metrics.json")
-        return summary_path, read_json_object(summary_path)
+        path = path_or_dir.expanduser().resolve()
+        if path.is_dir():
+            results_path = path / "results.json"
+            legacy_summary_path = path / "summary_metrics.json"
+        elif path.name == "results.json":
+            results_path = path
+            legacy_summary_path = path.parent / "summary_metrics.json"
+        elif path.name == "summary_metrics.json":
+            results_path = path.parent / "results.json"
+            legacy_summary_path = path
+        else:
+            raise ValueError(f"Expected a run directory, results.json, or summary_metrics.json: {path}")
+
+        if results_path.exists():
+            payload = read_json_object(results_path)
+            summary = payload.get("summary_metrics")
+            if not isinstance(summary, dict):
+                raise ValueError(f"'summary_metrics' must be an object in {results_path}")
+            return results_path, summary
+        if legacy_summary_path.exists():
+            return legacy_summary_path, read_json_object(legacy_summary_path)
+        raise FileNotFoundError(f"No results.json or summary_metrics.json found under {path}")
     except (FileNotFoundError, ValueError) as exc:
         raise HarnessRunError(
             EXIT_INVALID,

--- a/nemo_retriever/src/nemo_retriever/harness/environment.py
+++ b/nemo_retriever/src/nemo_retriever/harness/environment.py
@@ -13,7 +13,18 @@ from typing import Any
 
 from nemo_retriever.harness.artifacts import last_commit
 
-_RECORDED_RUNTIME_ENV_KEYS = ("VLLM_USE_DEEP_GEMM",)
+_RECORDED_RUNTIME_ENV_KEYS = (
+    "CUDA_HOME",
+    "HF_HOME",
+    "HF_HUB_CACHE",
+    "HF_HUB_OFFLINE",
+    "NEMO_RETRIEVER_HF_CACHE_DIR",
+    "TRANSFORMERS_CACHE",
+    "TRANSFORMERS_OFFLINE",
+    "VLLM_DEEP_GEMM_WARMUP",
+    "VLLM_MOE_USE_DEEP_GEMM",
+    "VLLM_USE_DEEP_GEMM",
+)
 
 
 def _safe_package_version() -> str:

--- a/nemo_retriever/src/nemo_retriever/harness/environment.py
+++ b/nemo_retriever/src/nemo_retriever/harness/environment.py
@@ -5,12 +5,15 @@
 from __future__ import annotations
 
 from importlib import metadata
+import os
 import platform
 import socket
 import subprocess
 from typing import Any
 
 from nemo_retriever.harness.artifacts import last_commit
+
+_RECORDED_RUNTIME_ENV_KEYS = ("VLLM_USE_DEEP_GEMM",)
 
 
 def _safe_package_version() -> str:
@@ -49,6 +52,7 @@ def collect_environment() -> dict[str, Any]:
     except metadata.PackageNotFoundError:
         ray_version = "unknown"
     gpu_count, cuda_driver = _gpu_metadata()
+    runtime_environment = {key: os.environ[key] for key in _RECORDED_RUNTIME_ENV_KEYS if key in os.environ}
     return {
         "git_sha": last_commit(),
         "package_version": _safe_package_version(),
@@ -58,4 +62,5 @@ def collect_environment() -> dict[str, Any]:
         "gpu_count": gpu_count,
         "cuda_driver": cuda_driver,
         "ray_version": ray_version,
+        "runtime_environment": runtime_environment,
     }

--- a/nemo_retriever/src/nemo_retriever/harness/execution.py
+++ b/nemo_retriever/src/nemo_retriever/harness/execution.py
@@ -4,7 +4,8 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
+from copy import deepcopy
+from dataclasses import dataclass
 import re
 import time
 import traceback
@@ -34,7 +35,7 @@ from nemo_retriever.harness.contracts import (
     RunOutcome,
 )
 from nemo_retriever.harness.environment import collect_environment
-from nemo_retriever.harness.json_io import write_json
+from nemo_retriever.harness.json_io import artifact_write_error, write_json
 from nemo_retriever.harness.metrics import build_summary_metrics
 from nemo_retriever.harness.metric_gates import enforce_metric_gates, parse_metric_gates
 from nemo_retriever.harness.resolution import (
@@ -52,6 +53,19 @@ from nemo_retriever.query.workflow import resolve_query_plan
 _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 _EXCEPTION_LINE_RE = re.compile(r"(?:Error|Exception):")
 _MAX_FAILURE_MESSAGE_CHARS = 500
+
+
+@dataclass(frozen=True)
+class PreparedBenchmark:
+    """Validated benchmark inputs that can be executed without another preflight."""
+
+    benchmark: str
+    mode: str
+    overrides: tuple[str, ...]
+    requirements: tuple[str, ...]
+    dry_run: bool
+    resolved: dict[str, Any]
+    dataset_path: Path
 
 
 def _concise_message(message: str) -> str:
@@ -76,14 +90,6 @@ def _artifact_write_failure(exc: BaseException) -> FailurePayload:
         message=_concise_exception_message(exc),
         debug_artifacts=("status.json", "events.jsonl", "run.log"),
     )
-
-
-@contextmanager
-def _classify_artifact_write():
-    try:
-        yield
-    except Exception as exc:
-        raise HarnessRunError(EXIT_ARTIFACT_WRITE_FAILURE, _artifact_write_failure(exc)) from exc
 
 
 def _concise_failure(failure: FailurePayload) -> FailurePayload:
@@ -188,9 +194,13 @@ def _failure_outcome(
             resolved=resolved,
             summary_metrics=summary_metrics,
         )
+        results_path: Path | None = writer.path("results.json")
     except Exception as write_exc:
         exit_code = EXIT_ARTIFACT_WRITE_FAILURE
-        failure = _artifact_write_failure(write_exc)
+        if isinstance(write_exc, HarnessRunError) and write_exc.exit_code == EXIT_ARTIFACT_WRITE_FAILURE:
+            failure = write_exc.failure
+        else:
+            failure = _artifact_write_failure(write_exc)
         result = _run_result_payload(
             writer,
             status="failed",
@@ -201,7 +211,13 @@ def _failure_outcome(
             summary_metrics=summary_metrics or {},
             failure=failure,
         )
-    return RunOutcome(exit_code=exit_code, artifact_dir=writer.artifact_dir, results=result)
+        results_path = None
+    return RunOutcome(
+        exit_code=exit_code,
+        artifact_dir=writer.artifact_dir,
+        results=result,
+        results_path=results_path,
+    )
 
 
 def _mark_dry_run_metrics_unavailable(summary_metrics: dict[str, Any]) -> None:
@@ -218,12 +234,20 @@ def preflight_benchmark(
     overrides: Sequence[str],
     requirements: Sequence[str],
     dry_run: bool,
-) -> tuple[dict[str, Any], Path]:
+) -> PreparedBenchmark:
     """Resolve and validate one run without creating or replacing artifacts."""
     parse_metric_gates(requirements)
     resolved = resolve_benchmark(benchmark, mode=mode, overrides=overrides)
     dataset_path, _query_path = validate_dataset_inputs(resolved, dry_run=dry_run)
-    return resolved, dataset_path
+    return PreparedBenchmark(
+        benchmark=benchmark,
+        mode=mode,
+        overrides=tuple(overrides),
+        requirements=tuple(requirements),
+        dry_run=bool(dry_run),
+        resolved=resolved,
+        dataset_path=dataset_path,
+    )
 
 
 def run_benchmark(
@@ -238,13 +262,35 @@ def run_benchmark(
     runfile_payload: dict[str, Any] | None = None,
     runfile_path: str | None = None,
 ) -> RunOutcome:
-    resolved, dataset_path = preflight_benchmark(
+    prepared = preflight_benchmark(
         benchmark,
         mode=mode,
         overrides=overrides,
         requirements=requirements,
         dry_run=dry_run,
     )
+    return run_prepared_benchmark(
+        prepared,
+        output_dir=output_dir,
+        run_id=run_id,
+        runfile_payload=runfile_payload,
+        runfile_path=runfile_path,
+    )
+
+
+def run_prepared_benchmark(
+    prepared: PreparedBenchmark,
+    *,
+    output_dir: str | None = None,
+    run_id: str | None = None,
+    runfile_payload: dict[str, Any] | None = None,
+    runfile_path: str | None = None,
+) -> RunOutcome:
+    benchmark = prepared.benchmark
+    resolved = deepcopy(prepared.resolved)
+    dataset_path = prepared.dataset_path
+    requirements = prepared.requirements
+    dry_run = prepared.dry_run
     effective_run_id = run_id or make_run_id(benchmark)
     artifact_dir = resolve_artifact_dir(benchmark, effective_run_id, output_dir)
     try:
@@ -254,33 +300,30 @@ def run_benchmark(
             benchmark=benchmark,
         )
     except OSError as exc:
-        raise HarnessRunError(EXIT_ARTIFACT_WRITE_FAILURE, _artifact_write_failure(exc)) from exc
+        raise artifact_write_error(exc) from exc
     silence_noisy_libraries()
     summary_metrics: dict[str, Any] | None = None
     try:
         environment = collect_environment()
-        with _classify_artifact_write():
-            writer.status(status="planned", phase="resolve")
-            if runfile_payload is not None:
-                write_json(
-                    writer.path("runfile.json"),
-                    redact(
-                        {
-                            "source_path": runfile_path,
-                            "payload": runfile_payload,
-                        }
-                    ),
-                )
-            # Keep the pre-plan config when request validation fails. build_ingest_request
-            # then adds artifact-local storage paths, so the final config is written again.
-            write_json(writer.path("resolved_benchmark.json"), redact(resolved))
-            write_json(writer.path("environment.json"), environment)
+        writer.status(status="planned", phase="resolve")
+        if runfile_payload is not None:
+            write_json(
+                writer.path("runfile.json"),
+                redact(
+                    {
+                        "source_path": runfile_path,
+                        "payload": runfile_payload,
+                    }
+                ),
+            )
+        # Keep the pre-plan config when request validation fails. build_ingest_request
+        # then adds artifact-local storage paths, so the final config is written again.
+        write_json(writer.path("resolved_benchmark.json"), redact(resolved))
+        write_json(writer.path("environment.json"), environment)
 
-        with _classify_artifact_write():
-            writer.status(status="running", phase="ingest_plan")
+        writer.status(status="running", phase="ingest_plan")
         ingest_request = build_ingest_request(resolved, dataset_path, writer.artifact_dir)
-        with _classify_artifact_write():
-            write_json(writer.path("resolved_benchmark.json"), redact(resolved))
+        write_json(writer.path("resolved_benchmark.json"), redact(resolved))
         try:
             ingest_plan = resolve_ingest_plan(ingest_request)
             ingest_plan_payload = run_ingest_workflow(ingest_plan, dry_run=True)
@@ -306,16 +349,13 @@ def run_benchmark(
                     debug_artifacts=("resolved_benchmark.json",),
                 ),
             ) from exc
-        with _classify_artifact_write():
-            write_json(writer.path("ingest_plan.json"), redact(ingest_plan_payload))
+        write_json(writer.path("ingest_plan.json"), redact(ingest_plan_payload))
 
-        with _classify_artifact_write():
-            writer.status(status="running", phase="query_plan")
+        writer.status(status="running", phase="query_plan")
         query_request = build_query_request(resolved, "")
         query_plan = resolve_query_plan(query_request)
         query_plan_data = query_plan_payload(query_plan)
-        with _classify_artifact_write():
-            write_json(writer.path("query_plan.json"), query_plan_data)
+        write_json(writer.path("query_plan.json"), query_plan_data)
 
         ingest_summary: dict[str, Any] | None = None
         ingest_secs: float | None = None
@@ -324,12 +364,10 @@ def run_benchmark(
         query_count = 0
 
         if dry_run:
-            with _classify_artifact_write():
-                writer.event("write_artifacts", "dry_run", "Dry-run completed without executing ingest or query")
+            writer.event("write_artifacts", "dry_run", "Dry-run completed without executing ingest or query")
         else:
-            with _classify_artifact_write():
-                writer.status(status="running", phase="ingest")
-                writer.event("ingest", "ingest_start", f"Ingesting {len(ingest_plan.documents)} document(s)")
+            writer.status(status="running", phase="ingest")
+            writer.event("ingest", "ingest_start", f"Ingesting {len(ingest_plan.documents)} document(s)")
             ingest_start = time.perf_counter()
             try:
                 with capture_output_to_log(writer.path("run.log"), label="ingest"):
@@ -366,8 +404,7 @@ def run_benchmark(
         if dry_run:
             _mark_dry_run_metrics_unavailable(summary_metrics)
 
-        with _classify_artifact_write():
-            writer.status(status="running", phase="write_artifacts")
+        writer.status(status="running", phase="write_artifacts")
         skipped_metric_gates = enforce_metric_gates(summary_metrics, requirements, skip_missing=dry_run)
         result = _run_result_payload(
             writer,
@@ -381,14 +418,18 @@ def run_benchmark(
             metric_gates=list(requirements),
             skipped_metric_gates=list(skipped_metric_gates),
         )
-        with _classify_artifact_write():
-            write_json(writer.path("results.json"), result)
-            writer.status(
-                status="complete",
-                phase="write_artifacts",
-                results_path=writer.path("results.json"),
-            )
-        return RunOutcome(exit_code=EXIT_SUCCESS, artifact_dir=writer.artifact_dir, results=result)
+        write_json(writer.path("results.json"), result)
+        writer.status(
+            status="complete",
+            phase="write_artifacts",
+            results_path=writer.path("results.json"),
+        )
+        return RunOutcome(
+            exit_code=EXIT_SUCCESS,
+            artifact_dir=writer.artifact_dir,
+            results=result,
+            results_path=writer.path("results.json"),
+        )
     except HarnessRunError as exc:
         return _failure_outcome(
             writer,

--- a/nemo_retriever/src/nemo_retriever/harness/execution.py
+++ b/nemo_retriever/src/nemo_retriever/harness/execution.py
@@ -4,12 +4,15 @@
 
 from __future__ import annotations
 
+import re
 import time
+import traceback
 from typing import Any, Sequence
 
 from nemo_retriever.cli.ingest_workflow import run_ingest_workflow
 from nemo_retriever.cli.shared import silence_noisy_libraries
 from nemo_retriever.harness.artifact_writer import (
+    append_text,
     artifact_paths,
     ArtifactWriter,
     capture_output_to_log,
@@ -43,6 +46,48 @@ from nemo_retriever.harness.resolution import (
 from nemo_retriever.ingest.plan import resolve_ingest_plan
 from nemo_retriever.query.workflow import resolve_query_plan
 
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+_EXCEPTION_LINE_RE = re.compile(r"(?:Error|Exception):")
+_MAX_FAILURE_MESSAGE_CHARS = 500
+
+
+def _concise_message(message: str) -> str:
+    plain = _ANSI_ESCAPE_RE.sub("", str(message))
+    lines = [line.strip() for line in plain.splitlines() if line.strip()]
+    exception_lines = [line for line in lines if _EXCEPTION_LINE_RE.search(line)]
+    selected = exception_lines[-1] if exception_lines else lines[0] if lines else "Unknown harness failure"
+    if len(selected) <= _MAX_FAILURE_MESSAGE_CHARS:
+        return selected
+    return selected[: _MAX_FAILURE_MESSAGE_CHARS - 3].rstrip() + "..."
+
+
+def _concise_exception_message(exc: BaseException) -> str:
+    return f"{type(exc).__name__}: {_concise_message(str(exc))}"
+
+
+def _concise_failure(failure: FailurePayload) -> FailurePayload:
+    return FailurePayload(
+        failed_phase=failure.failed_phase,
+        failure_reason=failure.failure_reason,
+        retryable=failure.retryable,
+        message=_concise_message(failure.message),
+        debug_artifacts=failure.debug_artifacts,
+    )
+
+
+def _result_identity(resolved: dict[str, Any] | None) -> dict[str, str]:
+    if not isinstance(resolved, dict):
+        return {}
+    identity: dict[str, str] = {}
+    dataset = resolved.get("dataset")
+    if isinstance(dataset, dict) and dataset.get("name"):
+        identity["dataset"] = str(dataset["name"])
+    ingest = resolved.get("ingest")
+    if isinstance(ingest, dict) and ingest.get("run_mode"):
+        run_mode = str(ingest["run_mode"])
+        identity["mode"] = "local" if run_mode == "inprocess" else run_mode
+    return identity
+
 
 def _run_result_payload(
     writer: ArtifactWriter,
@@ -59,11 +104,11 @@ def _run_result_payload(
     result = {
         "run_id": writer.run_id,
         "benchmark": writer.benchmark,
+        **_result_identity(resolved),
         "status": status,
         "success": success,
         "exit_code": exit_code,
         "dry_run": bool(dry_run),
-        "resolved_benchmark": resolved,
         "summary_metrics": summary_metrics,
         "failure": failure.to_dict() if failure is not None else None,
         "artifacts": artifact_paths(writer),
@@ -83,16 +128,7 @@ def _write_failure_result(
 ) -> dict[str, Any]:
     if summary_metrics is None:
         summary_metrics = {}
-    try:
-        write_json(writer.path("summary_metrics.json"), summary_metrics)
-    except Exception:
-        pass
-    status_payload = writer.status(
-        status="failed",
-        phase=failure.failed_phase if failure.failed_phase in PHASE_VALUES else "write_artifacts",
-        failure=failure,
-        summary_metrics_path=writer.path("summary_metrics.json"),
-    )
+    failure = _concise_failure(failure)
     result = _run_result_payload(
         writer,
         status="failed",
@@ -102,9 +138,14 @@ def _write_failure_result(
         resolved=resolved,
         summary_metrics=summary_metrics,
         failure=failure,
-        status_payload=status_payload,
     )
     write_json(writer.path("results.json"), result)
+    writer.status(
+        status="failed",
+        phase=failure.failed_phase if failure.failed_phase in PHASE_VALUES else "write_artifacts",
+        failure=failure,
+        results_path=writer.path("results.json"),
+    )
     return result
 
 
@@ -150,11 +191,13 @@ def run_benchmark(
             )
         parse_metric_gates(requirements)
         resolved = resolve_benchmark(benchmark, mode=mode, overrides=overrides)
-        dataset_path, _query_path = validate_dataset_inputs(resolved, dry_run=dry_run)
+        write_json(writer.path("resolved_benchmark.json"), redact(resolved))
         write_json(writer.path("environment.json"), collect_environment())
+        dataset_path, _query_path = validate_dataset_inputs(resolved, dry_run=dry_run)
 
         writer.status(status="running", phase="ingest_plan")
         ingest_request = build_ingest_request(resolved, dataset_path, writer.artifact_dir)
+        write_json(writer.path("resolved_benchmark.json"), redact(resolved))
         try:
             ingest_plan = resolve_ingest_plan(ingest_request)
             ingest_plan_payload = run_ingest_workflow(ingest_plan, dry_run=True)
@@ -186,7 +229,6 @@ def run_benchmark(
         query_request = build_query_request(resolved, "")
         query_plan = resolve_query_plan(query_request)
         write_json(writer.path("query_plan.json"), query_plan_payload(query_plan))
-        write_json(writer.path("resolved_benchmark.json"), redact(resolved))
 
         ingest_summary: dict[str, Any] | None = None
         ingest_secs: float | None = None
@@ -210,7 +252,7 @@ def run_benchmark(
                         failed_phase="ingest",
                         failure_reason="ingest_failed",
                         retryable=False,
-                        message=str(exc),
+                        message=_concise_exception_message(exc),
                         debug_artifacts=("ingest_plan.json", "run.log"),
                     ),
                 ) from exc
@@ -234,7 +276,6 @@ def run_benchmark(
             _mark_dry_run_metrics_unavailable(summary_metrics)
 
         writer.status(status="running", phase="write_artifacts")
-        write_json(writer.path("summary_metrics.json"), summary_metrics)
         skipped_metric_gates = enforce_metric_gates(summary_metrics, requirements, skip_missing=dry_run)
         result = _run_result_payload(
             writer,
@@ -245,17 +286,14 @@ def run_benchmark(
             resolved=resolved,
             summary_metrics=summary_metrics,
             failure=None,
-            ingest_summary=ingest_summary,
-            beir_metrics=beir_metrics,
             metric_gates=list(requirements),
             skipped_metric_gates=list(skipped_metric_gates),
-            runfile={"source_path": runfile_path, "payload": runfile_payload} if runfile_payload is not None else None,
         )
         write_json(writer.path("results.json"), result)
         writer.status(
             status="complete",
             phase="write_artifacts",
-            summary_metrics_path=writer.path("summary_metrics.json"),
+            results_path=writer.path("results.json"),
         )
         return RunOutcome(exit_code=EXIT_SUCCESS, artifact_dir=writer.artifact_dir, results=result)
     except HarnessRunError as exc:
@@ -269,12 +307,13 @@ def run_benchmark(
         )
         return RunOutcome(exit_code=exc.exit_code, artifact_dir=writer.artifact_dir, results=result)
     except Exception as exc:
+        append_text(writer.path("run.log"), f"\n## {traceback.format_exc()}")
         failure = FailurePayload(
             failed_phase="write_artifacts",
             failure_reason="unexpected_internal_error",
             retryable=False,
-            message=str(exc),
-            debug_artifacts=("status.json", "events.jsonl"),
+            message=_concise_exception_message(exc),
+            debug_artifacts=("status.json", "events.jsonl", "run.log"),
         )
         result = _write_failure_result(
             writer,

--- a/nemo_retriever/src/nemo_retriever/harness/execution.py
+++ b/nemo_retriever/src/nemo_retriever/harness/execution.py
@@ -69,7 +69,7 @@ def _run_result_payload(
         "artifacts": artifact_paths(writer),
     }
     result.update(extra)
-    return result
+    return redact(result)
 
 
 def _write_failure_result(
@@ -141,10 +141,12 @@ def run_benchmark(
         if runfile_payload is not None:
             write_json(
                 writer.path("runfile.json"),
-                {
-                    "source_path": runfile_path,
-                    "payload": runfile_payload,
-                },
+                redact(
+                    {
+                        "source_path": runfile_path,
+                        "payload": runfile_payload,
+                    }
+                ),
             )
         parse_metric_gates(requirements)
         resolved = resolve_benchmark(benchmark, mode=mode, overrides=overrides)
@@ -184,7 +186,7 @@ def run_benchmark(
         query_request = build_query_request(resolved, "")
         query_plan = resolve_query_plan(query_request)
         write_json(writer.path("query_plan.json"), query_plan_payload(query_plan))
-        write_json(writer.path("resolved_benchmark.json"), resolved)
+        write_json(writer.path("resolved_benchmark.json"), redact(resolved))
 
         ingest_summary: dict[str, Any] | None = None
         ingest_secs: float | None = None

--- a/nemo_retriever/src/nemo_retriever/harness/execution.py
+++ b/nemo_retriever/src/nemo_retriever/harness/execution.py
@@ -211,6 +211,8 @@ def run_benchmark(
                     }
                 ),
             )
+        # Keep the pre-plan config when request validation fails. build_ingest_request
+        # then adds artifact-local storage paths, so the final config is written again.
         write_json(writer.path("resolved_benchmark.json"), redact(resolved))
         write_json(writer.path("environment.json"), collect_environment())
 

--- a/nemo_retriever/src/nemo_retriever/harness/execution.py
+++ b/nemo_retriever/src/nemo_retriever/harness/execution.py
@@ -21,6 +21,7 @@ from nemo_retriever.harness.artifact_writer import (
 )
 from nemo_retriever.harness.beir_runner import run_beir_queries
 from nemo_retriever.harness.contracts import (
+    EXIT_ARTIFACT_WRITE_FAILURE,
     EXIT_INGEST_FAILURE,
     EXIT_INTERNAL_ERROR,
     EXIT_INVALID,
@@ -199,7 +200,9 @@ def run_benchmark(
     )
     silence_noisy_libraries()
     summary_metrics: dict[str, Any] | None = None
+    current_phase = "resolve"
     try:
+        current_phase = "write_artifacts"
         writer.status(status="planned", phase="resolve")
         if runfile_payload is not None:
             write_json(
@@ -216,9 +219,12 @@ def run_benchmark(
         write_json(writer.path("resolved_benchmark.json"), redact(resolved))
         write_json(writer.path("environment.json"), collect_environment())
 
+        current_phase = "ingest_plan"
         writer.status(status="running", phase="ingest_plan")
         ingest_request = build_ingest_request(resolved, dataset_path, writer.artifact_dir)
+        current_phase = "write_artifacts"
         write_json(writer.path("resolved_benchmark.json"), redact(resolved))
+        current_phase = "ingest_plan"
         try:
             ingest_plan = resolve_ingest_plan(ingest_request)
             ingest_plan_payload = run_ingest_workflow(ingest_plan, dry_run=True)
@@ -244,11 +250,14 @@ def run_benchmark(
                     debug_artifacts=("resolved_benchmark.json",),
                 ),
             ) from exc
+        current_phase = "write_artifacts"
         write_json(writer.path("ingest_plan.json"), redact(ingest_plan_payload))
 
+        current_phase = "query_plan"
         writer.status(status="running", phase="query_plan")
         query_request = build_query_request(resolved, "")
         query_plan = resolve_query_plan(query_request)
+        current_phase = "write_artifacts"
         write_json(writer.path("query_plan.json"), query_plan_payload(query_plan))
 
         ingest_summary: dict[str, Any] | None = None
@@ -258,8 +267,10 @@ def run_benchmark(
         query_count = 0
 
         if dry_run:
+            current_phase = "write_artifacts"
             writer.event("write_artifacts", "dry_run", "Dry-run completed without executing ingest or query")
         else:
+            current_phase = "ingest"
             writer.status(status="running", phase="ingest")
             writer.event("ingest", "ingest_start", f"Ingesting {len(ingest_plan.documents)} document(s)")
             ingest_start = time.perf_counter()
@@ -280,6 +291,7 @@ def run_benchmark(
             ingest_secs = round(time.perf_counter() - ingest_start, 3)
 
             if (resolved.get("evaluation") or {}).get("mode") == "beir":
+                current_phase = "evaluate"
                 with capture_output_to_log(writer.path("run.log"), label="query_evaluate"):
                     query_latencies_ms, beir_metrics, query_count = run_beir_queries(
                         writer, resolved, query_plan, query_request
@@ -298,6 +310,7 @@ def run_benchmark(
         if dry_run:
             _mark_dry_run_metrics_unavailable(summary_metrics)
 
+        current_phase = "write_artifacts"
         writer.status(status="running", phase="write_artifacts")
         skipped_metric_gates = enforce_metric_gates(summary_metrics, requirements, skip_missing=dry_run)
         result = _run_result_payload(
@@ -320,30 +333,67 @@ def run_benchmark(
         )
         return RunOutcome(exit_code=EXIT_SUCCESS, artifact_dir=writer.artifact_dir, results=result)
     except HarnessRunError as exc:
-        result = _write_failure_result(
-            writer,
-            failure=exc.failure,
-            exit_code=exc.exit_code,
-            dry_run=dry_run,
-            resolved=resolved,
-            summary_metrics=summary_metrics,
-        )
-        return RunOutcome(exit_code=exc.exit_code, artifact_dir=writer.artifact_dir, results=result)
+        try:
+            result = _write_failure_result(
+                writer,
+                failure=exc.failure,
+                exit_code=exc.exit_code,
+                dry_run=dry_run,
+                resolved=resolved,
+                summary_metrics=summary_metrics,
+            )
+            return RunOutcome(exit_code=exc.exit_code, artifact_dir=writer.artifact_dir, results=result)
+        except Exception as write_exc:
+            failure = FailurePayload(
+                failed_phase="write_artifacts",
+                failure_reason="artifact_write_failed",
+                retryable=False,
+                message=_concise_exception_message(write_exc),
+                debug_artifacts=("status.json", "events.jsonl", "run.log"),
+            )
+            result = _run_result_payload(
+                writer,
+                status="failed",
+                success=False,
+                exit_code=EXIT_ARTIFACT_WRITE_FAILURE,
+                dry_run=dry_run,
+                resolved=resolved,
+                summary_metrics=summary_metrics or {},
+                failure=failure,
+            )
+            return RunOutcome(exit_code=EXIT_ARTIFACT_WRITE_FAILURE, artifact_dir=writer.artifact_dir, results=result)
     except Exception as exc:
-        append_text(writer.path("run.log"), f"\n## {traceback.format_exc()}")
+        try:
+            append_text(writer.path("run.log"), f"\n## {traceback.format_exc()}")
+        except Exception:
+            pass
+        artifact_write_failure = current_phase == "write_artifacts"
         failure = FailurePayload(
             failed_phase="write_artifacts",
-            failure_reason="unexpected_internal_error",
+            failure_reason="artifact_write_failed" if artifact_write_failure else "unexpected_internal_error",
             retryable=False,
             message=_concise_exception_message(exc),
             debug_artifacts=("status.json", "events.jsonl", "run.log"),
         )
-        result = _write_failure_result(
-            writer,
-            failure=failure,
-            exit_code=EXIT_INTERNAL_ERROR,
-            dry_run=dry_run,
-            resolved=resolved,
-            summary_metrics=summary_metrics,
-        )
-        return RunOutcome(exit_code=EXIT_INTERNAL_ERROR, artifact_dir=writer.artifact_dir, results=result)
+        exit_code = EXIT_ARTIFACT_WRITE_FAILURE if artifact_write_failure else EXIT_INTERNAL_ERROR
+        try:
+            result = _write_failure_result(
+                writer,
+                failure=failure,
+                exit_code=exit_code,
+                dry_run=dry_run,
+                resolved=resolved,
+                summary_metrics=summary_metrics,
+            )
+        except Exception:
+            result = _run_result_payload(
+                writer,
+                status="failed",
+                success=False,
+                exit_code=exit_code,
+                dry_run=dry_run,
+                resolved=resolved,
+                summary_metrics=summary_metrics or {},
+                failure=failure,
+            )
+        return RunOutcome(exit_code=exit_code, artifact_dir=writer.artifact_dir, results=result)

--- a/nemo_retriever/src/nemo_retriever/harness/execution.py
+++ b/nemo_retriever/src/nemo_retriever/harness/execution.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 import re
 import time
 import traceback
@@ -65,6 +66,24 @@ def _concise_message(message: str) -> str:
 
 def _concise_exception_message(exc: BaseException) -> str:
     return f"{type(exc).__name__}: {_concise_message(str(exc))}"
+
+
+def _artifact_write_failure(exc: BaseException) -> FailurePayload:
+    return FailurePayload(
+        failed_phase="write_artifacts",
+        failure_reason="artifact_write_failed",
+        retryable=False,
+        message=_concise_exception_message(exc),
+        debug_artifacts=("status.json", "events.jsonl", "run.log"),
+    )
+
+
+@contextmanager
+def _classify_artifact_write():
+    try:
+        yield
+    except Exception as exc:
+        raise HarnessRunError(EXIT_ARTIFACT_WRITE_FAILURE, _artifact_write_failure(exc)) from exc
 
 
 def _concise_failure(failure: FailurePayload) -> FailurePayload:
@@ -151,6 +170,40 @@ def _write_failure_result(
     return result
 
 
+def _failure_outcome(
+    writer: ArtifactWriter,
+    *,
+    failure: FailurePayload,
+    exit_code: int,
+    dry_run: bool,
+    resolved: dict[str, Any] | None,
+    summary_metrics: dict[str, Any] | None,
+) -> RunOutcome:
+    try:
+        result = _write_failure_result(
+            writer,
+            failure=failure,
+            exit_code=exit_code,
+            dry_run=dry_run,
+            resolved=resolved,
+            summary_metrics=summary_metrics,
+        )
+    except Exception as write_exc:
+        exit_code = EXIT_ARTIFACT_WRITE_FAILURE
+        failure = _artifact_write_failure(write_exc)
+        result = _run_result_payload(
+            writer,
+            status="failed",
+            success=False,
+            exit_code=exit_code,
+            dry_run=dry_run,
+            resolved=resolved,
+            summary_metrics=summary_metrics or {},
+            failure=failure,
+        )
+    return RunOutcome(exit_code=exit_code, artifact_dir=writer.artifact_dir, results=result)
+
+
 def _mark_dry_run_metrics_unavailable(summary_metrics: dict[str, Any]) -> None:
     static_keys = {"files", "pages"}
     for key in list(summary_metrics):
@@ -193,38 +246,41 @@ def run_benchmark(
         dry_run=dry_run,
     )
     effective_run_id = run_id or make_run_id(benchmark)
-    writer = ArtifactWriter(
-        artifact_dir=resolve_artifact_dir(benchmark, effective_run_id, output_dir),
-        run_id=effective_run_id,
-        benchmark=benchmark,
-    )
+    artifact_dir = resolve_artifact_dir(benchmark, effective_run_id, output_dir)
+    try:
+        writer = ArtifactWriter(
+            artifact_dir=artifact_dir,
+            run_id=effective_run_id,
+            benchmark=benchmark,
+        )
+    except OSError as exc:
+        raise HarnessRunError(EXIT_ARTIFACT_WRITE_FAILURE, _artifact_write_failure(exc)) from exc
     silence_noisy_libraries()
     summary_metrics: dict[str, Any] | None = None
-    current_phase = "resolve"
     try:
-        current_phase = "write_artifacts"
-        writer.status(status="planned", phase="resolve")
-        if runfile_payload is not None:
-            write_json(
-                writer.path("runfile.json"),
-                redact(
-                    {
-                        "source_path": runfile_path,
-                        "payload": runfile_payload,
-                    }
-                ),
-            )
-        # Keep the pre-plan config when request validation fails. build_ingest_request
-        # then adds artifact-local storage paths, so the final config is written again.
-        write_json(writer.path("resolved_benchmark.json"), redact(resolved))
-        write_json(writer.path("environment.json"), collect_environment())
+        environment = collect_environment()
+        with _classify_artifact_write():
+            writer.status(status="planned", phase="resolve")
+            if runfile_payload is not None:
+                write_json(
+                    writer.path("runfile.json"),
+                    redact(
+                        {
+                            "source_path": runfile_path,
+                            "payload": runfile_payload,
+                        }
+                    ),
+                )
+            # Keep the pre-plan config when request validation fails. build_ingest_request
+            # then adds artifact-local storage paths, so the final config is written again.
+            write_json(writer.path("resolved_benchmark.json"), redact(resolved))
+            write_json(writer.path("environment.json"), environment)
 
-        current_phase = "ingest_plan"
-        writer.status(status="running", phase="ingest_plan")
+        with _classify_artifact_write():
+            writer.status(status="running", phase="ingest_plan")
         ingest_request = build_ingest_request(resolved, dataset_path, writer.artifact_dir)
-        current_phase = "write_artifacts"
-        write_json(writer.path("resolved_benchmark.json"), redact(resolved))
-        current_phase = "ingest_plan"
+        with _classify_artifact_write():
+            write_json(writer.path("resolved_benchmark.json"), redact(resolved))
         try:
             ingest_plan = resolve_ingest_plan(ingest_request)
             ingest_plan_payload = run_ingest_workflow(ingest_plan, dry_run=True)
@@ -250,15 +306,16 @@ def run_benchmark(
                     debug_artifacts=("resolved_benchmark.json",),
                 ),
             ) from exc
-        current_phase = "write_artifacts"
-        write_json(writer.path("ingest_plan.json"), redact(ingest_plan_payload))
+        with _classify_artifact_write():
+            write_json(writer.path("ingest_plan.json"), redact(ingest_plan_payload))
 
-        current_phase = "query_plan"
-        writer.status(status="running", phase="query_plan")
+        with _classify_artifact_write():
+            writer.status(status="running", phase="query_plan")
         query_request = build_query_request(resolved, "")
         query_plan = resolve_query_plan(query_request)
-        current_phase = "write_artifacts"
-        write_json(writer.path("query_plan.json"), query_plan_payload(query_plan))
+        query_plan_data = query_plan_payload(query_plan)
+        with _classify_artifact_write():
+            write_json(writer.path("query_plan.json"), query_plan_data)
 
         ingest_summary: dict[str, Any] | None = None
         ingest_secs: float | None = None
@@ -267,12 +324,12 @@ def run_benchmark(
         query_count = 0
 
         if dry_run:
-            current_phase = "write_artifacts"
-            writer.event("write_artifacts", "dry_run", "Dry-run completed without executing ingest or query")
+            with _classify_artifact_write():
+                writer.event("write_artifacts", "dry_run", "Dry-run completed without executing ingest or query")
         else:
-            current_phase = "ingest"
-            writer.status(status="running", phase="ingest")
-            writer.event("ingest", "ingest_start", f"Ingesting {len(ingest_plan.documents)} document(s)")
+            with _classify_artifact_write():
+                writer.status(status="running", phase="ingest")
+                writer.event("ingest", "ingest_start", f"Ingesting {len(ingest_plan.documents)} document(s)")
             ingest_start = time.perf_counter()
             try:
                 with capture_output_to_log(writer.path("run.log"), label="ingest"):
@@ -291,7 +348,6 @@ def run_benchmark(
             ingest_secs = round(time.perf_counter() - ingest_start, 3)
 
             if (resolved.get("evaluation") or {}).get("mode") == "beir":
-                current_phase = "evaluate"
                 with capture_output_to_log(writer.path("run.log"), label="query_evaluate"):
                     query_latencies_ms, beir_metrics, query_count = run_beir_queries(
                         writer, resolved, query_plan, query_request
@@ -310,8 +366,8 @@ def run_benchmark(
         if dry_run:
             _mark_dry_run_metrics_unavailable(summary_metrics)
 
-        current_phase = "write_artifacts"
-        writer.status(status="running", phase="write_artifacts")
+        with _classify_artifact_write():
+            writer.status(status="running", phase="write_artifacts")
         skipped_metric_gates = enforce_metric_gates(summary_metrics, requirements, skip_missing=dry_run)
         result = _run_result_payload(
             writer,
@@ -325,75 +381,40 @@ def run_benchmark(
             metric_gates=list(requirements),
             skipped_metric_gates=list(skipped_metric_gates),
         )
-        write_json(writer.path("results.json"), result)
-        writer.status(
-            status="complete",
-            phase="write_artifacts",
-            results_path=writer.path("results.json"),
-        )
+        with _classify_artifact_write():
+            write_json(writer.path("results.json"), result)
+            writer.status(
+                status="complete",
+                phase="write_artifacts",
+                results_path=writer.path("results.json"),
+            )
         return RunOutcome(exit_code=EXIT_SUCCESS, artifact_dir=writer.artifact_dir, results=result)
     except HarnessRunError as exc:
-        try:
-            result = _write_failure_result(
-                writer,
-                failure=exc.failure,
-                exit_code=exc.exit_code,
-                dry_run=dry_run,
-                resolved=resolved,
-                summary_metrics=summary_metrics,
-            )
-            return RunOutcome(exit_code=exc.exit_code, artifact_dir=writer.artifact_dir, results=result)
-        except Exception as write_exc:
-            failure = FailurePayload(
-                failed_phase="write_artifacts",
-                failure_reason="artifact_write_failed",
-                retryable=False,
-                message=_concise_exception_message(write_exc),
-                debug_artifacts=("status.json", "events.jsonl", "run.log"),
-            )
-            result = _run_result_payload(
-                writer,
-                status="failed",
-                success=False,
-                exit_code=EXIT_ARTIFACT_WRITE_FAILURE,
-                dry_run=dry_run,
-                resolved=resolved,
-                summary_metrics=summary_metrics or {},
-                failure=failure,
-            )
-            return RunOutcome(exit_code=EXIT_ARTIFACT_WRITE_FAILURE, artifact_dir=writer.artifact_dir, results=result)
+        return _failure_outcome(
+            writer,
+            failure=exc.failure,
+            exit_code=exc.exit_code,
+            dry_run=dry_run,
+            resolved=resolved,
+            summary_metrics=summary_metrics,
+        )
     except Exception as exc:
         try:
             append_text(writer.path("run.log"), f"\n## {traceback.format_exc()}")
         except Exception:
             pass
-        artifact_write_failure = current_phase == "write_artifacts"
         failure = FailurePayload(
             failed_phase="write_artifacts",
-            failure_reason="artifact_write_failed" if artifact_write_failure else "unexpected_internal_error",
+            failure_reason="unexpected_internal_error",
             retryable=False,
             message=_concise_exception_message(exc),
             debug_artifacts=("status.json", "events.jsonl", "run.log"),
         )
-        exit_code = EXIT_ARTIFACT_WRITE_FAILURE if artifact_write_failure else EXIT_INTERNAL_ERROR
-        try:
-            result = _write_failure_result(
-                writer,
-                failure=failure,
-                exit_code=exit_code,
-                dry_run=dry_run,
-                resolved=resolved,
-                summary_metrics=summary_metrics,
-            )
-        except Exception:
-            result = _run_result_payload(
-                writer,
-                status="failed",
-                success=False,
-                exit_code=exit_code,
-                dry_run=dry_run,
-                resolved=resolved,
-                summary_metrics=summary_metrics or {},
-                failure=failure,
-            )
-        return RunOutcome(exit_code=exit_code, artifact_dir=writer.artifact_dir, results=result)
+        return _failure_outcome(
+            writer,
+            failure=failure,
+            exit_code=EXIT_INTERNAL_ERROR,
+            dry_run=dry_run,
+            resolved=resolved,
+            summary_metrics=summary_metrics,
+        )

--- a/nemo_retriever/src/nemo_retriever/harness/execution.py
+++ b/nemo_retriever/src/nemo_retriever/harness/execution.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import re
 import time
 import traceback
+from pathlib import Path
 from typing import Any, Sequence
 
 from nemo_retriever.cli.ingest_workflow import run_ingest_workflow
@@ -156,6 +157,21 @@ def _mark_dry_run_metrics_unavailable(summary_metrics: dict[str, Any]) -> None:
             summary_metrics[key] = None
 
 
+def preflight_benchmark(
+    benchmark: str,
+    *,
+    mode: str,
+    overrides: Sequence[str],
+    requirements: Sequence[str],
+    dry_run: bool,
+) -> tuple[dict[str, Any], Path]:
+    """Resolve and validate one run without creating or replacing artifacts."""
+    parse_metric_gates(requirements)
+    resolved = resolve_benchmark(benchmark, mode=mode, overrides=overrides)
+    dataset_path, _query_path = validate_dataset_inputs(resolved, dry_run=dry_run)
+    return resolved, dataset_path
+
+
 def run_benchmark(
     benchmark: str,
     *,
@@ -168,6 +184,13 @@ def run_benchmark(
     runfile_payload: dict[str, Any] | None = None,
     runfile_path: str | None = None,
 ) -> RunOutcome:
+    resolved, dataset_path = preflight_benchmark(
+        benchmark,
+        mode=mode,
+        overrides=overrides,
+        requirements=requirements,
+        dry_run=dry_run,
+    )
     effective_run_id = run_id or make_run_id(benchmark)
     writer = ArtifactWriter(
         artifact_dir=resolve_artifact_dir(benchmark, effective_run_id, output_dir),
@@ -175,7 +198,6 @@ def run_benchmark(
         benchmark=benchmark,
     )
     silence_noisy_libraries()
-    resolved: dict[str, Any] | None = None
     summary_metrics: dict[str, Any] | None = None
     try:
         writer.status(status="planned", phase="resolve")
@@ -189,11 +211,8 @@ def run_benchmark(
                     }
                 ),
             )
-        parse_metric_gates(requirements)
-        resolved = resolve_benchmark(benchmark, mode=mode, overrides=overrides)
         write_json(writer.path("resolved_benchmark.json"), redact(resolved))
         write_json(writer.path("environment.json"), collect_environment())
-        dataset_path, _query_path = validate_dataset_inputs(resolved, dry_run=dry_run)
 
         writer.status(status="running", phase="ingest_plan")
         ingest_request = build_ingest_request(resolved, dataset_path, writer.artifact_dir)

--- a/nemo_retriever/src/nemo_retriever/harness/json_io.py
+++ b/nemo_retriever/src/nemo_retriever/harness/json_io.py
@@ -5,8 +5,28 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+import tempfile
 from typing import Any, Mapping
+
+from nemo_retriever.harness.contracts import (
+    EXIT_ARTIFACT_WRITE_FAILURE,
+    FailurePayload,
+    HarnessRunError,
+)
+
+
+def artifact_write_error(exc: BaseException) -> HarnessRunError:
+    return HarnessRunError(
+        EXIT_ARTIFACT_WRITE_FAILURE,
+        FailurePayload(
+            failed_phase="write_artifacts",
+            failure_reason="artifact_write_failed",
+            retryable=False,
+            message=f"{type(exc).__name__}: {exc}",
+        ),
+    )
 
 
 def jsonable(value: Any) -> Any:
@@ -14,8 +34,29 @@ def jsonable(value: Any) -> Any:
 
 
 def write_json(path: Path, payload: Mapping[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(jsonable(payload), indent=2, sort_keys=False) + "\n", encoding="utf-8")
+    temporary_path: Path | None = None
+    try:
+        rendered = json.dumps(jsonable(payload), indent=2, sort_keys=False) + "\n"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary_path = Path(handle.name)
+            handle.write(rendered)
+        assert temporary_path is not None
+        os.replace(temporary_path, path)
+    except Exception as exc:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise artifact_write_error(exc) from exc
 
 
 def read_json_object(path: Path) -> dict[str, Any]:

--- a/nemo_retriever/src/nemo_retriever/harness/metric_gates.py
+++ b/nemo_retriever/src/nemo_retriever/harness/metric_gates.py
@@ -88,7 +88,7 @@ def enforce_metric_gates(
                 failure_reason="metric_gate_failed",
                 retryable=False,
                 message="; ".join(failures),
-                debug_artifacts=("summary_metrics.json", "results.json"),
+                debug_artifacts=(),
             ),
         )
     return tuple(skipped)

--- a/nemo_retriever/src/nemo_retriever/harness/runfile.py
+++ b/nemo_retriever/src/nemo_retriever/harness/runfile.py
@@ -11,6 +11,7 @@ from typing import Any, Mapping, Sequence
 
 import yaml
 
+from nemo_retriever.harness.benchmark_registry import get_benchmark
 from nemo_retriever.harness.contracts import EXIT_INVALID, FailurePayload, HarnessRunError
 
 _ALLOWED_RUNFILE_KEYS = {
@@ -141,6 +142,10 @@ def load_runfile(path: Path) -> RunFileRequest:
         raise _invalid("Runfile must set 'benchmark' to a registered benchmark name.")
     if "benchmark" in payload and "base" in payload and payload["benchmark"] != payload["base"]:
         raise _invalid("Runfile cannot set conflicting 'benchmark' and 'base' values.")
+    try:
+        get_benchmark(benchmark)
+    except KeyError as exc:
+        raise _invalid(f"Runfile references unknown benchmark {benchmark!r}.") from exc
 
     dry_run = payload.get("dry_run")
     if dry_run is not None and not isinstance(dry_run, bool):

--- a/nemo_retriever/src/nemo_retriever/harness/runsets.py
+++ b/nemo_retriever/src/nemo_retriever/harness/runsets.py
@@ -4,21 +4,43 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from difflib import get_close_matches
 from pathlib import Path
+import re
 from typing import Any, Sequence
 
-from nemo_retriever.harness.artifacts import get_artifacts_root
-from nemo_retriever.harness.benchmark_registry import get_runset, runset_names
+from nemo_retriever.harness.artifact_writer import redact
+from nemo_retriever.harness.artifacts import get_artifacts_root, last_commit, now_timestr
+from nemo_retriever.harness.benchmark_registry import get_benchmark, get_runset, runset_names
 from nemo_retriever.harness.contracts import EXIT_INVALID, EXIT_SUCCESS, FailurePayload, HarnessRunError, RunOutcome
+from nemo_retriever.harness.dataset_paths import load_dataset_paths
 from nemo_retriever.harness.execution import run_benchmark
 from nemo_retriever.harness.json_io import write_json
+from nemo_retriever.harness.runfile import load_runfile
+
+_SESSION_LABEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+def _invalid_runfile(message: str) -> HarnessRunError:
+    return HarnessRunError(
+        EXIT_INVALID,
+        FailurePayload(
+            failed_phase="resolve",
+            failure_reason="invalid_runfile",
+            retryable=False,
+            message=message,
+        ),
+    )
+
+
+def _validate_session_label(value: str, *, field: str) -> str:
+    if not _SESSION_LABEL_RE.fullmatch(value):
+        raise _invalid_runfile(f"{field} must contain only letters, numbers, '.', '_', and '-': {value!r}")
+    return value
 
 
 def _session_id(runset: str) -> str:
-    stamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_UTC")
-    return f"{runset}_{stamp}"
+    return f"{runset}_{now_timestr()}"
 
 
 def _session_dir(runset: str, output_dir: str | None) -> Path:
@@ -44,14 +66,58 @@ def _runset_or_error(name: str):
         ) from exc
 
 
-def _run_outcome_summary(benchmark: str, outcome: RunOutcome) -> dict[str, Any]:
-    return {
+def _run_outcome_summary(
+    benchmark: str,
+    outcome: RunOutcome,
+    *,
+    run_name: str | None = None,
+    runfile_path: str | None = None,
+    mode: str | None = None,
+) -> dict[str, Any]:
+    resolved = outcome.results.get("resolved_benchmark")
+    dataset = resolved.get("dataset") if isinstance(resolved, dict) else None
+    failure = outcome.results.get("failure")
+    payload = {
+        "run_name": run_name or benchmark,
         "benchmark": benchmark,
         "artifact_dir": str(outcome.artifact_dir),
         "exit_code": outcome.exit_code,
         "success": outcome.exit_code == EXIT_SUCCESS,
         "summary_metrics": outcome.results.get("summary_metrics", {}),
         "results_path": str(outcome.artifact_dir / "results.json"),
+    }
+    if isinstance(dataset, dict) and dataset.get("name"):
+        payload["dataset"] = str(dataset["name"])
+    if runfile_path is not None:
+        payload["runfile_path"] = runfile_path
+    if mode is not None:
+        payload["mode"] = mode
+    if isinstance(failure, dict):
+        payload["failure_reason"] = failure.get("message") or failure.get("failure_reason")
+    return payload
+
+
+def _session_summary(
+    *,
+    session_type: str,
+    exit_code: int,
+    dry_run: bool,
+    run_results: list[dict[str, Any]],
+    run_commit: str,
+    **extra: Any,
+) -> dict[str, Any]:
+    success = exit_code == EXIT_SUCCESS
+    return {
+        "session_type": session_type,
+        "timestamp": now_timestr(),
+        "run_commit": run_commit,
+        "latest_commit": run_commit,
+        "success": success,
+        "all_passed": success,
+        "exit_code": exit_code,
+        "dry_run": bool(dry_run),
+        "runs": run_results,
+        **extra,
     }
 
 
@@ -65,6 +131,7 @@ def run_runset(
     dry_run: bool = False,
 ) -> RunOutcome:
     spec = _runset_or_error(runset)
+    run_commit = last_commit()
     session_dir = _session_dir(runset, output_dir)
     session_dir.mkdir(parents=True, exist_ok=True)
     expanded_runs = [
@@ -80,10 +147,12 @@ def run_runset(
     ]
     write_json(
         session_dir / "expanded_runs.json",
-        {
-            "runset": spec.to_dict(),
-            "runs": expanded_runs,
-        },
+        redact(
+            {
+                "runset": spec.to_dict(),
+                "runs": expanded_runs,
+            }
+        ),
     )
 
     run_results: list[dict[str, Any]] = []
@@ -102,12 +171,114 @@ def run_runset(
         if exit_code == EXIT_SUCCESS and outcome.exit_code != EXIT_SUCCESS:
             exit_code = outcome.exit_code
 
-    session_summary = {
-        "runset": spec.name,
-        "success": exit_code == EXIT_SUCCESS,
-        "exit_code": exit_code,
-        "dry_run": bool(dry_run),
-        "runs": run_results,
-    }
+    session_summary = _session_summary(
+        session_type="runset",
+        exit_code=exit_code,
+        dry_run=dry_run,
+        run_results=run_results,
+        run_commit=run_commit,
+        runset=spec.name,
+    )
+    write_json(session_dir / "session_summary.json", session_summary)
+    return RunOutcome(exit_code=exit_code, artifact_dir=session_dir, results=session_summary)
+
+
+def run_runfiles(
+    runfiles: Sequence[Path],
+    *,
+    output_dir: str | None = None,
+    session_name: str = "runfiles",
+    dataset_paths_file: Path | None = None,
+    mode: str | None = None,
+    overrides: Sequence[str] = (),
+    requirements: Sequence[str] = (),
+    dry_run: bool = False,
+) -> RunOutcome:
+    if not runfiles:
+        raise _invalid_runfile("At least one runfile path is required.")
+
+    session_name = _validate_session_label(session_name, field="--session-name")
+    run_commit = last_commit()
+    local_dataset_paths = load_dataset_paths(dataset_paths_file)
+    requests = [load_runfile(path) for path in runfiles]
+    session_dir = _session_dir(session_name, output_dir)
+    expanded_runs: list[dict[str, Any]] = []
+    for index, request in enumerate(requests, start=1):
+        run_name = _validate_session_label(request.name or request.benchmark, field="Runfile name")
+        if request.output_dir is not None or request.run_id is not None:
+            raise _invalid_runfile(
+                f"Runfile {request.source_path} cannot set 'output_dir' or 'run_id' when used with run-files; "
+                "the session owns artifact paths and run IDs."
+            )
+        try:
+            dataset_name = get_benchmark(request.benchmark).dataset
+        except KeyError:
+            dataset_name = None
+        dataset_paths = local_dataset_paths.get(dataset_name) if dataset_name is not None else None
+        dataset_overrides = dataset_paths.overrides() if dataset_paths is not None else ()
+        expanded_runs.append(
+            {
+                "index": index,
+                "name": run_name,
+                "benchmark": request.benchmark,
+                "dataset": dataset_name,
+                "runfile_path": str(request.source_path),
+                "artifact_dir": str((session_dir / f"{index:03d}_{run_name}").resolve()),
+                "mode": mode or request.mode or "local",
+                "dataset_paths": dataset_paths.to_dict() if dataset_paths is not None else None,
+                "overrides": [*request.overrides, *dataset_overrides, *overrides],
+                "requirements": [*request.requirements, *requirements],
+                "dry_run": bool(dry_run or request.dry_run),
+            }
+        )
+
+    session_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        session_dir / "expanded_runs.json",
+        redact(
+            {
+                "session_name": session_name,
+                "run_commit": run_commit,
+                "dataset_paths_file": str(dataset_paths_file.expanduser().resolve()) if dataset_paths_file else None,
+                "runfiles": expanded_runs,
+            }
+        ),
+    )
+
+    run_results: list[dict[str, Any]] = []
+    exit_code = EXIT_SUCCESS
+    for expanded, request in zip(expanded_runs, requests, strict=True):
+        outcome = run_benchmark(
+            request.benchmark,
+            output_dir=str(expanded["artifact_dir"]),
+            run_id=f"{session_name}_{expanded['index']:03d}_{expanded['name']}",
+            mode=str(expanded["mode"]),
+            overrides=tuple(expanded["overrides"]),
+            requirements=tuple(expanded["requirements"]),
+            dry_run=bool(expanded["dry_run"]),
+            runfile_payload=dict(request.payload),
+            runfile_path=str(request.source_path),
+        )
+        run_results.append(
+            _run_outcome_summary(
+                request.benchmark,
+                outcome,
+                run_name=str(expanded["name"]),
+                runfile_path=str(request.source_path),
+                mode=str(expanded["mode"]),
+            )
+        )
+        if exit_code == EXIT_SUCCESS and outcome.exit_code != EXIT_SUCCESS:
+            exit_code = outcome.exit_code
+
+    session_summary = _session_summary(
+        session_type="runfiles",
+        exit_code=exit_code,
+        dry_run=any(bool(expanded["dry_run"]) for expanded in expanded_runs),
+        run_results=run_results,
+        run_commit=run_commit,
+        session_name=session_name,
+        dataset_paths_file=str(dataset_paths_file.expanduser().resolve()) if dataset_paths_file else None,
+    )
     write_json(session_dir / "session_summary.json", session_summary)
     return RunOutcome(exit_code=exit_code, artifact_dir=session_dir, results=session_summary)

--- a/nemo_retriever/src/nemo_retriever/harness/runsets.py
+++ b/nemo_retriever/src/nemo_retriever/harness/runsets.py
@@ -14,7 +14,7 @@ from nemo_retriever.harness.artifacts import get_artifacts_root, last_commit, no
 from nemo_retriever.harness.benchmark_registry import get_benchmark, get_runset, runset_names
 from nemo_retriever.harness.contracts import EXIT_INVALID, EXIT_SUCCESS, FailurePayload, HarnessRunError, RunOutcome
 from nemo_retriever.harness.dataset_paths import load_dataset_paths
-from nemo_retriever.harness.execution import run_benchmark
+from nemo_retriever.harness.execution import preflight_benchmark, run_benchmark
 from nemo_retriever.harness.json_io import write_json
 from nemo_retriever.harness.runfile import load_runfile
 
@@ -143,6 +143,14 @@ def run_runset(
     dry_run: bool = False,
 ) -> RunOutcome:
     spec = _runset_or_error(runset)
+    for benchmark in spec.runs:
+        preflight_benchmark(
+            benchmark,
+            mode=mode,
+            overrides=overrides,
+            requirements=requirements,
+            dry_run=dry_run,
+        )
     run_commit = last_commit()
     session_dir = _session_dir(runset, output_dir)
     session_dir.mkdir(parents=True, exist_ok=True)
@@ -217,17 +225,24 @@ def run_runfiles(
     expanded_runs: list[dict[str, Any]] = []
     for index, request in enumerate(requests, start=1):
         run_name = _validate_session_label(request.name or request.benchmark, field="Runfile name")
-        if request.output_dir is not None or request.run_id is not None:
+        if request.output_dir is not None or request.run_id is not None or request.dry_run is not None:
             raise _invalid_runfile(
-                f"Runfile {request.source_path} cannot set 'output_dir' or 'run_id' when used with run-files; "
-                "the session owns artifact paths and run IDs."
+                f"Runfile {request.source_path} cannot set 'output_dir', 'run_id', or 'dry_run' when used with "
+                "run-files; the session owns artifact paths, run IDs, and dry-run behavior."
             )
-        try:
-            dataset_name = get_benchmark(request.benchmark).dataset
-        except KeyError:
-            dataset_name = None
-        dataset_paths = local_dataset_paths.get(dataset_name) if dataset_name is not None else None
+        dataset_name = get_benchmark(request.benchmark).dataset
+        dataset_paths = local_dataset_paths.get(dataset_name)
         dataset_overrides = dataset_paths.overrides() if dataset_paths is not None else ()
+        effective_mode = mode or request.mode or "local"
+        effective_overrides = (*request.overrides, *dataset_overrides, *overrides)
+        effective_requirements = (*request.requirements, *requirements)
+        preflight_benchmark(
+            request.benchmark,
+            mode=effective_mode,
+            overrides=effective_overrides,
+            requirements=effective_requirements,
+            dry_run=dry_run,
+        )
         expanded_runs.append(
             {
                 "index": index,
@@ -236,11 +251,11 @@ def run_runfiles(
                 "dataset": dataset_name,
                 "runfile_path": str(request.source_path),
                 "artifact_dir": f"{index:03d}_{run_name}",
-                "mode": mode or request.mode or "local",
+                "mode": effective_mode,
                 "dataset_paths": dataset_paths.to_dict() if dataset_paths is not None else None,
-                "overrides": [*request.overrides, *dataset_overrides, *overrides],
-                "requirements": [*request.requirements, *requirements],
-                "dry_run": bool(dry_run or request.dry_run),
+                "overrides": list(effective_overrides),
+                "requirements": list(effective_requirements),
+                "dry_run": bool(dry_run),
             }
         )
 
@@ -287,7 +302,7 @@ def run_runfiles(
     session_summary = _session_summary(
         session_type="runfiles",
         exit_code=exit_code,
-        dry_run=any(bool(expanded["dry_run"]) for expanded in expanded_runs),
+        dry_run=dry_run,
         run_results=run_results,
         run_commit=run_commit,
         session_name=session_name,

--- a/nemo_retriever/src/nemo_retriever/harness/runsets.py
+++ b/nemo_retriever/src/nemo_retriever/harness/runsets.py
@@ -12,7 +12,14 @@ from typing import Any, Sequence
 from nemo_retriever.harness.artifact_writer import redact
 from nemo_retriever.harness.artifacts import get_artifacts_root, last_commit, now_timestr
 from nemo_retriever.harness.benchmark_registry import get_benchmark, get_runset, runset_names
-from nemo_retriever.harness.contracts import EXIT_INVALID, EXIT_SUCCESS, FailurePayload, HarnessRunError, RunOutcome
+from nemo_retriever.harness.contracts import (
+    EXIT_INTERNAL_ERROR,
+    EXIT_INVALID,
+    EXIT_SUCCESS,
+    FailurePayload,
+    HarnessRunError,
+    RunOutcome,
+)
 from nemo_retriever.harness.dataset_paths import load_dataset_paths
 from nemo_retriever.harness.execution import preflight_benchmark, run_benchmark
 from nemo_retriever.harness.json_io import write_json
@@ -47,6 +54,12 @@ def _session_dir(runset: str, output_dir: str | None) -> Path:
     if output_dir:
         return Path(output_dir).expanduser().resolve()
     return (get_artifacts_root() / _session_id(runset)).resolve()
+
+
+def _remove_stale_session_summary(session_dir: Path) -> None:
+    summary_path = session_dir / "session_summary.json"
+    if summary_path.exists() or summary_path.is_symlink():
+        summary_path.unlink()
 
 
 def _runset_or_error(name: str):
@@ -109,6 +122,40 @@ def _run_outcome_summary(
     return payload
 
 
+def _failed_child_outcome(
+    *,
+    benchmark: str,
+    artifact_dir: Path,
+    dry_run: bool,
+    exc: BaseException,
+) -> RunOutcome:
+    if isinstance(exc, HarnessRunError):
+        exit_code = exc.exit_code
+        failure = exc.failure
+    else:
+        exit_code = EXIT_INTERNAL_ERROR
+        failure = FailurePayload(
+            failed_phase="resolve",
+            failure_reason="unexpected_internal_error",
+            retryable=False,
+            message=f"{type(exc).__name__}: {exc}",
+        )
+    result = redact(
+        {
+            "benchmark": benchmark,
+            "status": "failed",
+            "success": False,
+            "exit_code": exit_code,
+            "dry_run": bool(dry_run),
+            "summary_metrics": {},
+            "failure": failure.to_dict(),
+        }
+    )
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    write_json(artifact_dir / "results.json", result)
+    return RunOutcome(exit_code=exit_code, artifact_dir=artifact_dir, results=result)
+
+
 def _session_summary(
     *,
     session_type: str,
@@ -154,6 +201,7 @@ def run_runset(
     run_commit = last_commit()
     session_dir = _session_dir(runset, output_dir)
     session_dir.mkdir(parents=True, exist_ok=True)
+    _remove_stale_session_summary(session_dir)
     expanded_runs = [
         {
             "index": index,
@@ -178,15 +226,24 @@ def run_runset(
     run_results: list[dict[str, Any]] = []
     exit_code = EXIT_SUCCESS
     for expanded in expanded_runs:
-        outcome = run_benchmark(
-            str(expanded["benchmark"]),
-            output_dir=str(session_dir / str(expanded["artifact_dir"])),
-            run_id=f"{runset}_{expanded['index']:03d}_{expanded['benchmark']}",
-            mode=mode,
-            overrides=overrides,
-            requirements=requirements,
-            dry_run=dry_run,
-        )
+        artifact_dir = session_dir / str(expanded["artifact_dir"])
+        try:
+            outcome = run_benchmark(
+                str(expanded["benchmark"]),
+                output_dir=str(artifact_dir),
+                run_id=f"{runset}_{expanded['index']:03d}_{expanded['benchmark']}",
+                mode=mode,
+                overrides=overrides,
+                requirements=requirements,
+                dry_run=dry_run,
+            )
+        except Exception as exc:
+            outcome = _failed_child_outcome(
+                benchmark=str(expanded["benchmark"]),
+                artifact_dir=artifact_dir,
+                dry_run=dry_run,
+                exc=exc,
+            )
         run_results.append(_run_outcome_summary(str(expanded["benchmark"]), outcome, session_dir=session_dir))
         if exit_code == EXIT_SUCCESS and outcome.exit_code != EXIT_SUCCESS:
             exit_code = outcome.exit_code
@@ -260,6 +317,7 @@ def run_runfiles(
         )
 
     session_dir.mkdir(parents=True, exist_ok=True)
+    _remove_stale_session_summary(session_dir)
     write_json(
         session_dir / "expanded_runs.json",
         redact(
@@ -275,17 +333,26 @@ def run_runfiles(
     run_results: list[dict[str, Any]] = []
     exit_code = EXIT_SUCCESS
     for expanded, request in zip(expanded_runs, requests, strict=True):
-        outcome = run_benchmark(
-            request.benchmark,
-            output_dir=str(session_dir / str(expanded["artifact_dir"])),
-            run_id=f"{session_name}_{expanded['index']:03d}_{expanded['name']}",
-            mode=str(expanded["mode"]),
-            overrides=tuple(expanded["overrides"]),
-            requirements=tuple(expanded["requirements"]),
-            dry_run=bool(expanded["dry_run"]),
-            runfile_payload=dict(request.payload),
-            runfile_path=str(request.source_path),
-        )
+        artifact_dir = session_dir / str(expanded["artifact_dir"])
+        try:
+            outcome = run_benchmark(
+                request.benchmark,
+                output_dir=str(artifact_dir),
+                run_id=f"{session_name}_{expanded['index']:03d}_{expanded['name']}",
+                mode=str(expanded["mode"]),
+                overrides=tuple(expanded["overrides"]),
+                requirements=tuple(expanded["requirements"]),
+                dry_run=bool(expanded["dry_run"]),
+                runfile_payload=dict(request.payload),
+                runfile_path=str(request.source_path),
+            )
+        except Exception as exc:
+            outcome = _failed_child_outcome(
+                benchmark=request.benchmark,
+                artifact_dir=artifact_dir,
+                dry_run=bool(expanded["dry_run"]),
+                exc=exc,
+            )
         run_results.append(
             _run_outcome_summary(
                 request.benchmark,

--- a/nemo_retriever/src/nemo_retriever/harness/runsets.py
+++ b/nemo_retriever/src/nemo_retriever/harness/runsets.py
@@ -13,6 +13,7 @@ from nemo_retriever.harness.artifact_writer import redact
 from nemo_retriever.harness.artifacts import get_artifacts_root, last_commit, now_timestr
 from nemo_retriever.harness.benchmark_registry import get_benchmark, get_runset, runset_names
 from nemo_retriever.harness.contracts import (
+    EXIT_ARTIFACT_WRITE_FAILURE,
     EXIT_INTERNAL_ERROR,
     EXIT_INVALID,
     EXIT_SUCCESS,
@@ -140,19 +141,33 @@ def _failed_child_outcome(
             retryable=False,
             message=f"{type(exc).__name__}: {exc}",
         )
-    result = redact(
-        {
-            "benchmark": benchmark,
-            "status": "failed",
-            "success": False,
-            "exit_code": exit_code,
-            "dry_run": bool(dry_run),
-            "summary_metrics": {},
-            "failure": failure.to_dict(),
-        }
-    )
-    artifact_dir.mkdir(parents=True, exist_ok=True)
-    write_json(artifact_dir / "results.json", result)
+
+    def failure_result() -> dict[str, Any]:
+        return redact(
+            {
+                "benchmark": benchmark,
+                "status": "failed",
+                "success": False,
+                "exit_code": exit_code,
+                "dry_run": bool(dry_run),
+                "summary_metrics": {},
+                "failure": failure.to_dict(),
+            }
+        )
+
+    result = failure_result()
+    try:
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        write_json(artifact_dir / "results.json", result)
+    except Exception as write_exc:
+        exit_code = EXIT_ARTIFACT_WRITE_FAILURE
+        failure = FailurePayload(
+            failed_phase="write_artifacts",
+            failure_reason="artifact_write_failed",
+            retryable=False,
+            message=f"{type(write_exc).__name__}: {write_exc}",
+        )
+        result = failure_result()
     return RunOutcome(exit_code=exit_code, artifact_dir=artifact_dir, results=result)
 
 

--- a/nemo_retriever/src/nemo_retriever/harness/runsets.py
+++ b/nemo_retriever/src/nemo_retriever/harness/runsets.py
@@ -4,10 +4,11 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from difflib import get_close_matches
 from pathlib import Path
 import re
-from typing import Any, Sequence
+from typing import Any, Mapping, Sequence
 
 from nemo_retriever.harness.artifact_writer import redact
 from nemo_retriever.harness.artifacts import get_artifacts_root, last_commit, now_timestr
@@ -22,11 +23,23 @@ from nemo_retriever.harness.contracts import (
     RunOutcome,
 )
 from nemo_retriever.harness.dataset_paths import load_dataset_paths
-from nemo_retriever.harness.execution import preflight_benchmark, run_benchmark
-from nemo_retriever.harness.json_io import write_json
+from nemo_retriever.harness.execution import PreparedBenchmark, preflight_benchmark, run_prepared_benchmark
+from nemo_retriever.harness.json_io import artifact_write_error, write_json
 from nemo_retriever.harness.runfile import load_runfile
 
 _SESSION_LABEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+@dataclass(frozen=True)
+class PreparedRun:
+    """One preflighted child in a runset or runfile session."""
+
+    name: str
+    artifact_name: str
+    prepared: PreparedBenchmark
+    runfile_payload: dict[str, Any] | None = None
+    runfile_path: str | None = None
+    summary_mode: str | None = None
 
 
 def _invalid_runfile(message: str) -> HarnessRunError:
@@ -59,8 +72,11 @@ def _session_dir(runset: str, output_dir: str | None) -> Path:
 
 def _remove_stale_session_summary(session_dir: Path) -> None:
     summary_path = session_dir / "session_summary.json"
-    if summary_path.exists() or summary_path.is_symlink():
-        summary_path.unlink()
+    try:
+        if summary_path.exists() or summary_path.is_symlink():
+            summary_path.unlink()
+    except OSError as exc:
+        raise artifact_write_error(exc) from exc
 
 
 def _runset_or_error(name: str):
@@ -91,12 +107,15 @@ def _run_outcome_summary(
 ) -> dict[str, Any]:
     failure = outcome.results.get("failure")
     artifact_dir = outcome.artifact_dir.resolve()
-    try:
-        artifact_dir_value = artifact_dir.relative_to(session_dir.resolve()).as_posix()
-        results_path_value = f"{artifact_dir_value}/results.json"
-    except ValueError:
-        artifact_dir_value = str(artifact_dir)
-        results_path_value = str(artifact_dir / "results.json")
+
+    def session_path(path: Path) -> str:
+        resolved_path = path.resolve()
+        try:
+            return resolved_path.relative_to(session_dir.resolve()).as_posix()
+        except ValueError:
+            return str(resolved_path)
+
+    artifact_dir_value = session_path(artifact_dir)
     payload = {
         "run_name": run_name or benchmark,
         "benchmark": benchmark,
@@ -104,8 +123,9 @@ def _run_outcome_summary(
         "exit_code": outcome.exit_code,
         "success": outcome.exit_code == EXIT_SUCCESS,
         "summary_metrics": outcome.results.get("summary_metrics", {}),
-        "results_path": results_path_value,
     }
+    if outcome.results_path is not None:
+        payload["results_path"] = session_path(outcome.results_path)
     dataset = outcome.results.get("dataset")
     if not dataset:
         try:
@@ -123,12 +143,32 @@ def _run_outcome_summary(
     return payload
 
 
+def _failed_result_payload(
+    *,
+    benchmark: str,
+    dry_run: bool,
+    exit_code: int,
+    failure: FailurePayload,
+) -> dict[str, Any]:
+    return redact(
+        {
+            "benchmark": benchmark,
+            "status": "failed",
+            "success": False,
+            "exit_code": exit_code,
+            "dry_run": bool(dry_run),
+            "summary_metrics": {},
+            "failure": failure.to_dict(),
+        }
+    )
+
+
 def _failed_child_outcome(
     *,
     benchmark: str,
     artifact_dir: Path,
     dry_run: bool,
-    exc: BaseException,
+    exc: Exception,
 ) -> RunOutcome:
     if isinstance(exc, HarnessRunError):
         exit_code = exc.exit_code
@@ -142,33 +182,40 @@ def _failed_child_outcome(
             message=f"{type(exc).__name__}: {exc}",
         )
 
-    def failure_result() -> dict[str, Any]:
-        return redact(
-            {
-                "benchmark": benchmark,
-                "status": "failed",
-                "success": False,
-                "exit_code": exit_code,
-                "dry_run": bool(dry_run),
-                "summary_metrics": {},
-                "failure": failure.to_dict(),
-            }
-        )
-
-    result = failure_result()
+    result = _failed_result_payload(
+        benchmark=benchmark,
+        dry_run=dry_run,
+        exit_code=exit_code,
+        failure=failure,
+    )
     try:
         artifact_dir.mkdir(parents=True, exist_ok=True)
-        write_json(artifact_dir / "results.json", result)
+        results_path: Path | None = artifact_dir / "results.json"
+        write_json(results_path, result)
     except Exception as write_exc:
         exit_code = EXIT_ARTIFACT_WRITE_FAILURE
-        failure = FailurePayload(
-            failed_phase="write_artifacts",
-            failure_reason="artifact_write_failed",
-            retryable=False,
-            message=f"{type(write_exc).__name__}: {write_exc}",
+        if isinstance(write_exc, HarnessRunError) and write_exc.exit_code == EXIT_ARTIFACT_WRITE_FAILURE:
+            failure = write_exc.failure
+        else:
+            failure = FailurePayload(
+                failed_phase="write_artifacts",
+                failure_reason="artifact_write_failed",
+                retryable=False,
+                message=f"{type(write_exc).__name__}: {write_exc}",
+            )
+        result = _failed_result_payload(
+            benchmark=benchmark,
+            dry_run=dry_run,
+            exit_code=exit_code,
+            failure=failure,
         )
-        result = failure_result()
-    return RunOutcome(exit_code=exit_code, artifact_dir=artifact_dir, results=result)
+        results_path = None
+    return RunOutcome(
+        exit_code=exit_code,
+        artifact_dir=artifact_dir,
+        results=result,
+        results_path=results_path,
+    )
 
 
 def _session_summary(
@@ -195,6 +242,74 @@ def _session_summary(
     }
 
 
+def _run_session(
+    *,
+    session_type: str,
+    session_name: str,
+    session_dir: Path,
+    runs: Sequence[PreparedRun],
+    expanded_payload: Mapping[str, Any],
+    run_commit: str,
+    dry_run: bool,
+    summary_extra: Mapping[str, Any],
+) -> RunOutcome:
+    try:
+        session_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise artifact_write_error(exc) from exc
+    _remove_stale_session_summary(session_dir)
+    write_json(session_dir / "expanded_runs.json", redact(dict(expanded_payload)))
+
+    run_results: list[dict[str, Any]] = []
+    exit_code = EXIT_SUCCESS
+    for run in runs:
+        artifact_dir = session_dir / run.artifact_name
+        try:
+            outcome = run_prepared_benchmark(
+                run.prepared,
+                output_dir=str(artifact_dir),
+                run_id=f"{session_name}_{run.artifact_name}",
+                runfile_payload=run.runfile_payload,
+                runfile_path=run.runfile_path,
+            )
+        except Exception as exc:
+            outcome = _failed_child_outcome(
+                benchmark=run.prepared.benchmark,
+                artifact_dir=artifact_dir,
+                dry_run=run.prepared.dry_run,
+                exc=exc,
+            )
+        run_results.append(
+            _run_outcome_summary(
+                run.prepared.benchmark,
+                outcome,
+                session_dir=session_dir,
+                run_name=run.name,
+                runfile_path=run.runfile_path,
+                mode=run.summary_mode,
+            )
+        )
+        if exit_code == EXIT_SUCCESS and outcome.exit_code != EXIT_SUCCESS:
+            exit_code = outcome.exit_code
+
+    session_summary = _session_summary(
+        session_type=session_type,
+        exit_code=exit_code,
+        dry_run=dry_run,
+        run_results=run_results,
+        run_commit=run_commit,
+        **dict(summary_extra),
+    )
+    summary_path = session_dir / "session_summary.json"
+    write_json(summary_path, session_summary)
+    return RunOutcome(
+        exit_code=exit_code,
+        artifact_dir=session_dir,
+        results=session_summary,
+        results_path=summary_path,
+    )
+
+
 def run_runset(
     runset: str,
     *,
@@ -205,74 +320,45 @@ def run_runset(
     dry_run: bool = False,
 ) -> RunOutcome:
     spec = _runset_or_error(runset)
-    for benchmark in spec.runs:
-        preflight_benchmark(
+    runs: list[PreparedRun] = []
+    expanded_runs: list[dict[str, Any]] = []
+    for index, benchmark in enumerate(spec.runs, start=1):
+        prepared = preflight_benchmark(
             benchmark,
             mode=mode,
             overrides=overrides,
             requirements=requirements,
             dry_run=dry_run,
         )
-    run_commit = last_commit()
-    session_dir = _session_dir(runset, output_dir)
-    session_dir.mkdir(parents=True, exist_ok=True)
-    _remove_stale_session_summary(session_dir)
-    expanded_runs = [
-        {
-            "index": index,
-            "benchmark": benchmark,
-            "artifact_dir": f"{index:03d}_{benchmark}",
-            "mode": mode,
-            "overrides": list(overrides),
-            "dry_run": bool(dry_run),
-        }
-        for index, benchmark in enumerate(spec.runs, start=1)
-    ]
-    write_json(
-        session_dir / "expanded_runs.json",
-        redact(
+        artifact_name = f"{index:03d}_{benchmark}"
+        runs.append(
+            PreparedRun(
+                name=benchmark,
+                artifact_name=artifact_name,
+                prepared=prepared,
+            )
+        )
+        expanded_runs.append(
             {
-                "runset": spec.to_dict(),
-                "runs": expanded_runs,
+                "index": index,
+                "benchmark": benchmark,
+                "artifact_dir": artifact_name,
+                "mode": mode,
+                "overrides": list(overrides),
+                "dry_run": bool(dry_run),
             }
-        ),
-    )
+        )
 
-    run_results: list[dict[str, Any]] = []
-    exit_code = EXIT_SUCCESS
-    for expanded in expanded_runs:
-        artifact_dir = session_dir / str(expanded["artifact_dir"])
-        try:
-            outcome = run_benchmark(
-                str(expanded["benchmark"]),
-                output_dir=str(artifact_dir),
-                run_id=f"{runset}_{expanded['index']:03d}_{expanded['benchmark']}",
-                mode=mode,
-                overrides=overrides,
-                requirements=requirements,
-                dry_run=dry_run,
-            )
-        except Exception as exc:
-            outcome = _failed_child_outcome(
-                benchmark=str(expanded["benchmark"]),
-                artifact_dir=artifact_dir,
-                dry_run=dry_run,
-                exc=exc,
-            )
-        run_results.append(_run_outcome_summary(str(expanded["benchmark"]), outcome, session_dir=session_dir))
-        if exit_code == EXIT_SUCCESS and outcome.exit_code != EXIT_SUCCESS:
-            exit_code = outcome.exit_code
-
-    session_summary = _session_summary(
+    return _run_session(
         session_type="runset",
-        exit_code=exit_code,
+        session_name=runset,
+        session_dir=_session_dir(runset, output_dir),
+        runs=runs,
+        expanded_payload={"runset": spec.to_dict(), "runs": expanded_runs},
+        run_commit=last_commit(),
         dry_run=dry_run,
-        run_results=run_results,
-        run_commit=run_commit,
-        runset=spec.name,
+        summary_extra={"runset": spec.name},
     )
-    write_json(session_dir / "session_summary.json", session_summary)
-    return RunOutcome(exit_code=exit_code, artifact_dir=session_dir, results=session_summary)
 
 
 def run_runfiles(
@@ -293,7 +379,7 @@ def run_runfiles(
     run_commit = last_commit()
     local_dataset_paths = load_dataset_paths(dataset_paths_file)
     requests = [load_runfile(path) for path in runfiles]
-    session_dir = _session_dir(session_name, output_dir)
+    runs: list[PreparedRun] = []
     expanded_runs: list[dict[str, Any]] = []
     for index, request in enumerate(requests, start=1):
         run_name = _validate_session_label(request.name or request.benchmark, field="Runfile name")
@@ -308,12 +394,23 @@ def run_runfiles(
         effective_mode = mode or request.mode or "local"
         effective_overrides = (*request.overrides, *dataset_overrides, *overrides)
         effective_requirements = (*request.requirements, *requirements)
-        preflight_benchmark(
+        prepared = preflight_benchmark(
             request.benchmark,
             mode=effective_mode,
             overrides=effective_overrides,
             requirements=effective_requirements,
             dry_run=dry_run,
+        )
+        artifact_name = f"{index:03d}_{run_name}"
+        runs.append(
+            PreparedRun(
+                name=run_name,
+                artifact_name=artifact_name,
+                prepared=prepared,
+                runfile_payload=dict(request.payload),
+                runfile_path=str(request.source_path),
+                summary_mode=effective_mode,
+            )
         )
         expanded_runs.append(
             {
@@ -322,7 +419,7 @@ def run_runfiles(
                 "benchmark": request.benchmark,
                 "dataset": dataset_name,
                 "runfile_path": str(request.source_path),
-                "artifact_dir": f"{index:03d}_{run_name}",
+                "artifact_dir": artifact_name,
                 "mode": effective_mode,
                 "dataset_paths": dataset_paths.to_dict() if dataset_paths is not None else None,
                 "overrides": list(effective_overrides),
@@ -331,64 +428,22 @@ def run_runfiles(
             }
         )
 
-    session_dir.mkdir(parents=True, exist_ok=True)
-    _remove_stale_session_summary(session_dir)
-    write_json(
-        session_dir / "expanded_runs.json",
-        redact(
-            {
-                "session_name": session_name,
-                "run_commit": run_commit,
-                "dataset_paths_file": str(dataset_paths_file.expanduser().resolve()) if dataset_paths_file else None,
-                "runfiles": expanded_runs,
-            }
-        ),
-    )
-
-    run_results: list[dict[str, Any]] = []
-    exit_code = EXIT_SUCCESS
-    for expanded, request in zip(expanded_runs, requests, strict=True):
-        artifact_dir = session_dir / str(expanded["artifact_dir"])
-        try:
-            outcome = run_benchmark(
-                request.benchmark,
-                output_dir=str(artifact_dir),
-                run_id=f"{session_name}_{expanded['index']:03d}_{expanded['name']}",
-                mode=str(expanded["mode"]),
-                overrides=tuple(expanded["overrides"]),
-                requirements=tuple(expanded["requirements"]),
-                dry_run=bool(expanded["dry_run"]),
-                runfile_payload=dict(request.payload),
-                runfile_path=str(request.source_path),
-            )
-        except Exception as exc:
-            outcome = _failed_child_outcome(
-                benchmark=request.benchmark,
-                artifact_dir=artifact_dir,
-                dry_run=bool(expanded["dry_run"]),
-                exc=exc,
-            )
-        run_results.append(
-            _run_outcome_summary(
-                request.benchmark,
-                outcome,
-                session_dir=session_dir,
-                run_name=str(expanded["name"]),
-                runfile_path=str(request.source_path),
-                mode=str(expanded["mode"]),
-            )
-        )
-        if exit_code == EXIT_SUCCESS and outcome.exit_code != EXIT_SUCCESS:
-            exit_code = outcome.exit_code
-
-    session_summary = _session_summary(
+    dataset_paths_value = str(dataset_paths_file.expanduser().resolve()) if dataset_paths_file else None
+    return _run_session(
         session_type="runfiles",
-        exit_code=exit_code,
-        dry_run=dry_run,
-        run_results=run_results,
-        run_commit=run_commit,
         session_name=session_name,
-        dataset_paths_file=str(dataset_paths_file.expanduser().resolve()) if dataset_paths_file else None,
+        session_dir=_session_dir(session_name, output_dir),
+        runs=runs,
+        expanded_payload={
+            "session_name": session_name,
+            "run_commit": run_commit,
+            "dataset_paths_file": dataset_paths_value,
+            "runfiles": expanded_runs,
+        },
+        run_commit=run_commit,
+        dry_run=dry_run,
+        summary_extra={
+            "session_name": session_name,
+            "dataset_paths_file": dataset_paths_value,
+        },
     )
-    write_json(session_dir / "session_summary.json", session_summary)
-    return RunOutcome(exit_code=exit_code, artifact_dir=session_dir, results=session_summary)

--- a/nemo_retriever/src/nemo_retriever/harness/runsets.py
+++ b/nemo_retriever/src/nemo_retriever/harness/runsets.py
@@ -70,24 +70,36 @@ def _run_outcome_summary(
     benchmark: str,
     outcome: RunOutcome,
     *,
+    session_dir: Path,
     run_name: str | None = None,
     runfile_path: str | None = None,
     mode: str | None = None,
 ) -> dict[str, Any]:
-    resolved = outcome.results.get("resolved_benchmark")
-    dataset = resolved.get("dataset") if isinstance(resolved, dict) else None
     failure = outcome.results.get("failure")
+    artifact_dir = outcome.artifact_dir.resolve()
+    try:
+        artifact_dir_value = artifact_dir.relative_to(session_dir.resolve()).as_posix()
+        results_path_value = f"{artifact_dir_value}/results.json"
+    except ValueError:
+        artifact_dir_value = str(artifact_dir)
+        results_path_value = str(artifact_dir / "results.json")
     payload = {
         "run_name": run_name or benchmark,
         "benchmark": benchmark,
-        "artifact_dir": str(outcome.artifact_dir),
+        "artifact_dir": artifact_dir_value,
         "exit_code": outcome.exit_code,
         "success": outcome.exit_code == EXIT_SUCCESS,
         "summary_metrics": outcome.results.get("summary_metrics", {}),
-        "results_path": str(outcome.artifact_dir / "results.json"),
+        "results_path": results_path_value,
     }
-    if isinstance(dataset, dict) and dataset.get("name"):
-        payload["dataset"] = str(dataset["name"])
+    dataset = outcome.results.get("dataset")
+    if not dataset:
+        try:
+            dataset = get_benchmark(benchmark).dataset
+        except KeyError:
+            dataset = None
+    if dataset:
+        payload["dataset"] = str(dataset)
     if runfile_path is not None:
         payload["runfile_path"] = runfile_path
     if mode is not None:
@@ -138,7 +150,7 @@ def run_runset(
         {
             "index": index,
             "benchmark": benchmark,
-            "artifact_dir": str((session_dir / f"{index:03d}_{benchmark}").resolve()),
+            "artifact_dir": f"{index:03d}_{benchmark}",
             "mode": mode,
             "overrides": list(overrides),
             "dry_run": bool(dry_run),
@@ -160,14 +172,14 @@ def run_runset(
     for expanded in expanded_runs:
         outcome = run_benchmark(
             str(expanded["benchmark"]),
-            output_dir=str(expanded["artifact_dir"]),
+            output_dir=str(session_dir / str(expanded["artifact_dir"])),
             run_id=f"{runset}_{expanded['index']:03d}_{expanded['benchmark']}",
             mode=mode,
             overrides=overrides,
             requirements=requirements,
             dry_run=dry_run,
         )
-        run_results.append(_run_outcome_summary(str(expanded["benchmark"]), outcome))
+        run_results.append(_run_outcome_summary(str(expanded["benchmark"]), outcome, session_dir=session_dir))
         if exit_code == EXIT_SUCCESS and outcome.exit_code != EXIT_SUCCESS:
             exit_code = outcome.exit_code
 
@@ -223,7 +235,7 @@ def run_runfiles(
                 "benchmark": request.benchmark,
                 "dataset": dataset_name,
                 "runfile_path": str(request.source_path),
-                "artifact_dir": str((session_dir / f"{index:03d}_{run_name}").resolve()),
+                "artifact_dir": f"{index:03d}_{run_name}",
                 "mode": mode or request.mode or "local",
                 "dataset_paths": dataset_paths.to_dict() if dataset_paths is not None else None,
                 "overrides": [*request.overrides, *dataset_overrides, *overrides],
@@ -250,7 +262,7 @@ def run_runfiles(
     for expanded, request in zip(expanded_runs, requests, strict=True):
         outcome = run_benchmark(
             request.benchmark,
-            output_dir=str(expanded["artifact_dir"]),
+            output_dir=str(session_dir / str(expanded["artifact_dir"])),
             run_id=f"{session_name}_{expanded['index']:03d}_{expanded['name']}",
             mode=str(expanded["mode"]),
             overrides=tuple(expanded["overrides"]),
@@ -263,6 +275,7 @@ def run_runfiles(
             _run_outcome_summary(
                 request.benchmark,
                 outcome,
+                session_dir=session_dir,
                 run_name=str(expanded["name"]),
                 runfile_path=str(request.source_path),
                 mode=str(expanded["mode"]),

--- a/nemo_retriever/src/nemo_retriever/harness/slack.py
+++ b/nemo_retriever/src/nemo_retriever/harness/slack.py
@@ -8,7 +8,7 @@ from typing import Any
 from nemo_retriever.harness.artifacts import now_timestr
 from nemo_retriever.harness.json_io import read_json_object
 
-DEFAULT_USERNAME = "nemo_retriever Nightly"
+DEFAULT_USERNAME = "nemo_retriever Harness"
 DEFAULT_ICON_EMOJI = ":satellite:"
 _BLANK_ROW = [
     {"type": "rich_text", "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": " "}]}]},
@@ -39,7 +39,7 @@ DEFAULT_SLACK_METRIC_KEYS = (
 
 
 @dataclass
-class NightlyRunReport:
+class HarnessRunReport:
     run_name: str
     dataset: str
     preset: str | None
@@ -53,7 +53,7 @@ class NightlyRunReport:
 
 
 @dataclass
-class NightlySessionReport:
+class HarnessSessionReport:
     session_name: str
     session_dir: Path
     session_type: str
@@ -61,7 +61,7 @@ class NightlySessionReport:
     latest_commit: str | None
     all_passed: bool
     dry_run: bool
-    results: list[NightlyRunReport]
+    results: list[HarnessRunReport]
 
 
 def _normalize_metrics(raw_metrics: Any) -> dict[str, Any]:
@@ -135,9 +135,13 @@ def _run_metadata(results_payload: dict[str, Any], environment_payload: dict[str
     return metadata
 
 
-def _normalize_run_report(summary_entry: dict[str, Any]) -> NightlyRunReport:
+def _normalize_run_report(summary_entry: dict[str, Any], *, session_dir: Path) -> HarnessRunReport:
     artifact_dir_str = summary_entry.get("artifact_dir")
-    artifact_dir = Path(artifact_dir_str).expanduser().resolve() if artifact_dir_str else None
+    artifact_dir = Path(artifact_dir_str).expanduser() if artifact_dir_str else None
+    if artifact_dir is not None:
+        if not artifact_dir.is_absolute():
+            artifact_dir = session_dir / artifact_dir
+        artifact_dir = artifact_dir.resolve()
     results_payload = _load_results_payload(artifact_dir)
     environment_payload = _load_environment_payload(artifact_dir)
     test_config = results_payload.get("test_config", {})
@@ -162,7 +166,7 @@ def _normalize_run_report(summary_entry: dict[str, Any]) -> NightlyRunReport:
         or environment_payload.get("git_commit")
     )
 
-    return NightlyRunReport(
+    return HarnessRunReport(
         run_name=str(
             summary_entry.get("run_name")
             or summary_entry.get("benchmark")
@@ -171,6 +175,7 @@ def _normalize_run_report(summary_entry: dict[str, Any]) -> NightlyRunReport:
         ),
         dataset=str(
             summary_entry.get("dataset")
+            or results_payload.get("dataset")
             or _resolved_dataset_name(results_payload)
             or test_config.get("dataset_label")
             or "unknown_dataset"
@@ -194,7 +199,7 @@ def _normalize_run_report(summary_entry: dict[str, Any]) -> NightlyRunReport:
     )
 
 
-def load_session_report(session_summary_path: Path) -> NightlySessionReport:
+def load_session_report(session_summary_path: Path) -> HarnessSessionReport:
     resolved_summary_path = Path(session_summary_path).expanduser().resolve()
     if resolved_summary_path.is_dir():
         resolved_summary_path = resolved_summary_path / "session_summary.json"
@@ -203,7 +208,11 @@ def load_session_report(session_summary_path: Path) -> NightlySessionReport:
     raw_results = payload.get("runs", payload.get("results", []))
     if not isinstance(raw_results, list):
         raise ValueError(f"'results' or 'runs' must be a list in {resolved_summary_path}")
-    results = [_normalize_run_report(dict(item)) for item in raw_results if isinstance(item, dict)]
+    results = [
+        _normalize_run_report(dict(item), session_dir=resolved_summary_path.parent)
+        for item in raw_results
+        if isinstance(item, dict)
+    ]
     latest_commit = (
         payload.get("run_commit")
         or payload.get("latest_commit")
@@ -211,7 +220,7 @@ def load_session_report(session_summary_path: Path) -> NightlySessionReport:
     )
     all_passed = payload.get("all_passed", payload.get("success", False))
 
-    return NightlySessionReport(
+    return HarnessSessionReport(
         session_name=str(payload.get("session_name") or payload.get("runset") or resolved_summary_path.parent.name),
         session_dir=resolved_summary_path.parent,
         session_type=str(payload.get("session_type") or "nightly"),
@@ -223,7 +232,7 @@ def load_session_report(session_summary_path: Path) -> NightlySessionReport:
     )
 
 
-def load_replay_report(replay_paths: list[Path]) -> NightlySessionReport:
+def load_replay_report(replay_paths: list[Path]) -> HarnessSessionReport:
     if not replay_paths:
         raise ValueError("At least one replay path is required")
 
@@ -234,7 +243,7 @@ def load_replay_report(replay_paths: list[Path]) -> NightlySessionReport:
             raise ValueError("Replay accepts either one session directory or one or more run directories")
         return load_session_report(session_dirs[0] / "session_summary.json")
 
-    run_reports: list[NightlyRunReport] = []
+    run_reports: list[HarnessRunReport] = []
     latest_commit: str | None = None
     dry_run = True
 
@@ -255,9 +264,14 @@ def load_replay_report(replay_paths: list[Path]) -> NightlySessionReport:
         latest_commit = latest_commit or (str(payload_commit) if payload_commit else None)
         dry_run = dry_run and bool(payload.get("dry_run", False))
         run_reports.append(
-            NightlyRunReport(
+            HarnessRunReport(
                 run_name=str(payload.get("benchmark") or artifact_dir.name),
-                dataset=str(_resolved_dataset_name(payload) or test_config.get("dataset_label") or artifact_dir.name),
+                dataset=str(
+                    payload.get("dataset")
+                    or _resolved_dataset_name(payload)
+                    or test_config.get("dataset_label")
+                    or artifact_dir.name
+                ),
                 preset=str(test_config.get("preset")) if test_config.get("preset") else None,
                 success=bool(payload.get("success")),
                 return_code=int(return_code) if return_code is not None else None,
@@ -270,10 +284,10 @@ def load_replay_report(replay_paths: list[Path]) -> NightlySessionReport:
         )
 
     session_dir = resolved_paths[0].parent if resolved_paths else Path.cwd()
-    return NightlySessionReport(
+    return HarnessSessionReport(
         session_name=f"replay_{now_timestr()}",
         session_dir=session_dir,
-        session_type="nightly_replay",
+        session_type="artifact_replay",
         timestamp=now_timestr(),
         latest_commit=latest_commit,
         all_passed=all(run.success for run in run_reports),
@@ -351,9 +365,9 @@ def _two_column_row_bold(left: str, right: str) -> list[dict[str, Any]]:
     ]
 
 
-def build_slack_payload(report: NightlySessionReport, slack_config: dict[str, Any]) -> dict[str, Any]:
+def build_slack_payload(report: HarnessSessionReport, slack_config: dict[str, Any]) -> dict[str, Any]:
     metric_keys = [str(key) for key in slack_config.get("metric_keys", [])]
-    post_artifact_paths = bool(slack_config.get("post_artifact_paths", True))
+    post_artifact_paths = bool(slack_config.get("post_artifact_paths", False))
     passed_count = sum(1 for run in report.results if run.success)
     total_count = len(report.results)
     if report.dry_run:
@@ -408,7 +422,7 @@ def build_slack_payload(report: NightlySessionReport, slack_config: dict[str, An
     blocks: list[dict[str, Any]] = [
         {
             "type": "header",
-            "text": {"type": "plain_text", "text": str(slack_config.get("title") or "nemo_retriever Nightly Harness")},
+            "text": {"type": "plain_text", "text": str(slack_config.get("title") or "nemo_retriever Harness Report")},
         },
         {
             "type": "section",
@@ -452,7 +466,7 @@ def resolve_slack_webhook_url(webhook_url: str | None = None) -> str:
 
 
 def post_report_to_slack(
-    report: NightlySessionReport,
+    report: HarnessSessionReport,
     slack_config: dict[str, Any],
     *,
     webhook_url: str | None = None,

--- a/nemo_retriever/src/nemo_retriever/harness/slack.py
+++ b/nemo_retriever/src/nemo_retriever/harness/slack.py
@@ -15,11 +15,27 @@ _BLANK_ROW = [
     {"type": "rich_text", "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": " "}]}]},
 ]
 METRIC_LABELS = {
+    "files": "files",
     "pages_per_sec_ingest": "pages/s",
     "ingest_secs": "ingest_s",
     "pages": "pages",
+    "query_count": "queries",
+    "query_latency_p50_ms": "query p50 ms",
+    "query_latency_p95_ms": "query p95 ms",
+    "ndcg_10": "ndcg@10",
     "recall_5": "recall@5",
+    "recall_10": "recall@10",
 }
+DEFAULT_SLACK_METRIC_KEYS = (
+    "files",
+    "pages",
+    "ingest_secs",
+    "pages_per_sec_ingest",
+    "query_count",
+    "ndcg_10",
+    "recall_5",
+    "recall_10",
+)
 
 
 @dataclass
@@ -44,6 +60,7 @@ class NightlySessionReport:
     timestamp: str | None
     latest_commit: str | None
     all_passed: bool
+    dry_run: bool
     results: list[NightlyRunReport]
 
 
@@ -69,6 +86,15 @@ def _load_results_payload(artifact_dir: Path | None) -> dict[str, Any]:
     return read_json_object(results_path)
 
 
+def _load_environment_payload(artifact_dir: Path | None) -> dict[str, Any]:
+    if artifact_dir is None:
+        return {}
+    environment_path = artifact_dir / "environment.json"
+    if not environment_path.exists():
+        return {}
+    return read_json_object(environment_path)
+
+
 def _load_preferred_metrics(payload: dict[str, Any]) -> dict[str, Any]:
     summary_metrics = payload.get("summary_metrics")
     if isinstance(summary_metrics, dict) and summary_metrics:
@@ -76,14 +102,48 @@ def _load_preferred_metrics(payload: dict[str, Any]) -> dict[str, Any]:
     return _normalize_metrics(payload.get("metrics", {}))
 
 
+def _failure_reason(payload: dict[str, Any]) -> str | None:
+    failure = payload.get("failure")
+    if not isinstance(failure, dict):
+        return None
+    for key in ("message", "failure_reason"):
+        value = failure.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _resolved_dataset_name(payload: dict[str, Any]) -> str | None:
+    resolved = payload.get("resolved_benchmark")
+    if not isinstance(resolved, dict):
+        return None
+    dataset = resolved.get("dataset")
+    if not isinstance(dataset, dict):
+        return None
+    value = dataset.get("name")
+    return str(value) if value else None
+
+
+def _run_metadata(results_payload: dict[str, Any], environment_payload: dict[str, Any]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    raw_run_metadata = results_payload.get("run_metadata")
+    if isinstance(raw_run_metadata, dict):
+        metadata.update(raw_run_metadata)
+    metadata.update(environment_payload)
+    if "python" in metadata and "python_version" not in metadata:
+        metadata["python_version"] = metadata["python"]
+    return metadata
+
+
 def _normalize_run_report(summary_entry: dict[str, Any]) -> NightlyRunReport:
     artifact_dir_str = summary_entry.get("artifact_dir")
     artifact_dir = Path(artifact_dir_str).expanduser().resolve() if artifact_dir_str else None
     results_payload = _load_results_payload(artifact_dir)
+    environment_payload = _load_environment_payload(artifact_dir)
     test_config = results_payload.get("test_config", {})
-    run_metadata = results_payload.get("run_metadata", {})
+    run_metadata = _run_metadata(results_payload, environment_payload)
 
-    metrics = summary_entry.get("metrics", {})
+    metrics = summary_entry.get("metrics") or summary_entry.get("summary_metrics") or {}
     if not isinstance(metrics, dict) or not metrics:
         metrics = _load_preferred_metrics(results_payload)
     if not isinstance(metrics, dict):
@@ -94,21 +154,43 @@ def _normalize_run_report(summary_entry: dict[str, Any]) -> NightlyRunReport:
     if not isinstance(run_metadata, dict):
         run_metadata = {}
 
+    return_code = summary_entry.get("return_code", summary_entry.get("exit_code", results_payload.get("exit_code")))
+    success = summary_entry.get("success", results_payload.get("success", False))
+    latest_commit = (
+        results_payload.get("latest_commit")
+        or environment_payload.get("git_sha")
+        or environment_payload.get("git_commit")
+    )
+
     return NightlyRunReport(
-        run_name=str(summary_entry.get("run_name") or (artifact_dir.name if artifact_dir else "unknown_run")),
-        dataset=str(summary_entry.get("dataset") or test_config.get("dataset_label") or "unknown_dataset"),
+        run_name=str(
+            summary_entry.get("run_name")
+            or summary_entry.get("benchmark")
+            or results_payload.get("benchmark")
+            or (artifact_dir.name if artifact_dir else "unknown_run")
+        ),
+        dataset=str(
+            summary_entry.get("dataset")
+            or _resolved_dataset_name(results_payload)
+            or test_config.get("dataset_label")
+            or "unknown_dataset"
+        ),
         preset=(
             str(summary_entry.get("preset") or test_config.get("preset"))
             if (summary_entry.get("preset") or test_config.get("preset"))
             else None
         ),
-        success=bool(summary_entry.get("success")),
-        return_code=int(summary_entry["return_code"]) if summary_entry.get("return_code") is not None else None,
-        failure_reason=str(summary_entry.get("failure_reason")) if summary_entry.get("failure_reason") else None,
+        success=bool(success),
+        return_code=int(return_code) if return_code is not None else None,
+        failure_reason=(
+            str(summary_entry.get("failure_reason"))
+            if summary_entry.get("failure_reason")
+            else _failure_reason(results_payload)
+        ),
         artifact_dir=artifact_dir,
         metrics=_normalize_metrics(metrics),
-        latest_commit=str(results_payload.get("latest_commit")) if results_payload.get("latest_commit") else None,
-        run_metadata=dict(run_metadata),
+        latest_commit=str(latest_commit) if latest_commit else None,
+        run_metadata=run_metadata,
     )
 
 
@@ -118,18 +200,26 @@ def load_session_report(session_summary_path: Path) -> NightlySessionReport:
         resolved_summary_path = resolved_summary_path / "session_summary.json"
 
     payload = read_json_object(resolved_summary_path)
-    raw_results = payload.get("results", [])
+    raw_results = payload.get("runs", payload.get("results", []))
     if not isinstance(raw_results, list):
-        raise ValueError(f"'results' must be a list in {resolved_summary_path}")
+        raise ValueError(f"'results' or 'runs' must be a list in {resolved_summary_path}")
+    results = [_normalize_run_report(dict(item)) for item in raw_results if isinstance(item, dict)]
+    latest_commit = (
+        payload.get("run_commit")
+        or payload.get("latest_commit")
+        or next((run.latest_commit for run in results if run.latest_commit), None)
+    )
+    all_passed = payload.get("all_passed", payload.get("success", False))
 
     return NightlySessionReport(
-        session_name=resolved_summary_path.parent.name,
+        session_name=str(payload.get("session_name") or payload.get("runset") or resolved_summary_path.parent.name),
         session_dir=resolved_summary_path.parent,
         session_type=str(payload.get("session_type") or "nightly"),
         timestamp=str(payload.get("timestamp")) if payload.get("timestamp") else None,
-        latest_commit=str(payload.get("latest_commit")) if payload.get("latest_commit") else None,
-        all_passed=bool(payload.get("all_passed")),
-        results=[_normalize_run_report(dict(item)) for item in raw_results if isinstance(item, dict)],
+        latest_commit=str(latest_commit) if latest_commit else None,
+        all_passed=bool(all_passed),
+        dry_run=bool(payload.get("dry_run", False)),
+        results=results,
     )
 
 
@@ -146,6 +236,7 @@ def load_replay_report(replay_paths: list[Path]) -> NightlySessionReport:
 
     run_reports: list[NightlyRunReport] = []
     latest_commit: str | None = None
+    dry_run = True
 
     for path in resolved_paths:
         results_path = path / "results.json" if path.is_dir() else path
@@ -153,26 +244,28 @@ def load_replay_report(replay_paths: list[Path]) -> NightlySessionReport:
             raise ValueError(f"Replay path must be a run directory, session directory, or results.json file: {path}")
         payload = read_json_object(results_path)
         artifact_dir = results_path.parent
+        environment_payload = _load_environment_payload(artifact_dir)
         test_config = payload.get("test_config", {})
         if not isinstance(test_config, dict):
             test_config = {}
-        run_metadata = payload.get("run_metadata", {})
-        if not isinstance(run_metadata, dict):
-            run_metadata = {}
+        run_metadata = _run_metadata(payload, environment_payload)
 
-        latest_commit = latest_commit or (str(payload.get("latest_commit")) if payload.get("latest_commit") else None)
+        payload_commit = payload.get("latest_commit") or environment_payload.get("git_sha")
+        return_code = payload.get("return_code", payload.get("exit_code"))
+        latest_commit = latest_commit or (str(payload_commit) if payload_commit else None)
+        dry_run = dry_run and bool(payload.get("dry_run", False))
         run_reports.append(
             NightlyRunReport(
-                run_name=artifact_dir.name,
-                dataset=str(test_config.get("dataset_label") or artifact_dir.name),
+                run_name=str(payload.get("benchmark") or artifact_dir.name),
+                dataset=str(_resolved_dataset_name(payload) or test_config.get("dataset_label") or artifact_dir.name),
                 preset=str(test_config.get("preset")) if test_config.get("preset") else None,
                 success=bool(payload.get("success")),
-                return_code=int(payload["return_code"]) if payload.get("return_code") is not None else None,
-                failure_reason=str(payload.get("failure_reason")) if payload.get("failure_reason") else None,
+                return_code=int(return_code) if return_code is not None else None,
+                failure_reason=_failure_reason(payload),
                 artifact_dir=artifact_dir,
                 metrics=_load_preferred_metrics(payload),
-                latest_commit=str(payload.get("latest_commit")) if payload.get("latest_commit") else None,
-                run_metadata=dict(run_metadata),
+                latest_commit=str(payload_commit) if payload_commit else None,
+                run_metadata=run_metadata,
             )
         )
 
@@ -184,6 +277,7 @@ def load_replay_report(replay_paths: list[Path]) -> NightlySessionReport:
         timestamp=now_timestr(),
         latest_commit=latest_commit,
         all_passed=all(run.success for run in run_reports),
+        dry_run=dry_run,
         results=run_reports,
     )
 
@@ -262,21 +356,25 @@ def build_slack_payload(report: NightlySessionReport, slack_config: dict[str, An
     post_artifact_paths = bool(slack_config.get("post_artifact_paths", True))
     passed_count = sum(1 for run in report.results if run.success)
     total_count = len(report.results)
-    overall_status = (
-        f"PASS ({passed_count}/{total_count})" if report.all_passed else f"FAIL ({passed_count}/{total_count} passed)"
-    )
+    if report.dry_run:
+        overall_status = f"DRY RUN ({total_count} planned)"
+    elif report.all_passed:
+        overall_status = f"PASS ({passed_count}/{total_count})"
+    else:
+        overall_status = f"FAIL ({passed_count}/{total_count} passed)"
     first_metadata = next((run.run_metadata for run in report.results if run.run_metadata), {})
 
     rows: list[list[dict[str, Any]]] = []
     rows.append(_two_column_row_bold("OVERALL STATUS", overall_status))
     for run in report.results:
-        run_status = "PASS" if run.success else "FAIL"
+        run_status = "DRY RUN" if report.dry_run else "PASS" if run.success else "FAIL"
         rows.append(_two_column_row_bold(f"-    {run.dataset}", run_status))
 
     rows.append(_BLANK_ROW)
     rows.append(_two_column_row_bold("ENVIRONMENT", " "))
     rows.append(_two_column_row("-    session", report.session_name))
-    rows.append(_two_column_row("-    session_dir", str(report.session_dir)))
+    if post_artifact_paths:
+        rows.append(_two_column_row("-    session_dir", str(report.session_dir)))
     if report.latest_commit:
         rows.append(_two_column_row("-    git_commit", report.latest_commit))
     for key in ["host", "gpu_count", "cuda_driver", "ray_version", "python_version"]:
@@ -287,7 +385,7 @@ def build_slack_payload(report: NightlySessionReport, slack_config: dict[str, An
     rows.append(_BLANK_ROW)
     rows.append(_two_column_row_bold("RESULTS", " "))
     for run in report.results:
-        run_status = "PASS" if run.success else "FAIL"
+        run_status = "DRY RUN" if report.dry_run else "PASS" if run.success else "FAIL"
         rows.append(_two_column_row_bold(run.dataset, run_status))
         if not run.success and run.return_code is not None:
             rows.append(_two_column_row("-    return_code", str(run.return_code)))
@@ -333,14 +431,17 @@ def post_slack_payload(payload: dict[str, Any], webhook_url: str) -> None:
     except ModuleNotFoundError as exc:
         raise RuntimeError("requests is required for Slack posting") from exc
 
-    response = requests.post(
-        webhook_url,
-        json=payload,
-        headers={"Content-Type": "application/json"},
-        timeout=30,
-    )
+    try:
+        response = requests.post(
+            webhook_url,
+            json=payload,
+            headers={"Content-Type": "application/json"},
+            timeout=30,
+        )
+    except requests.RequestException as exc:
+        raise RuntimeError("Slack post failed because the webhook request could not be completed") from exc
     if not response.ok:
-        raise RuntimeError(f"Slack post failed with status={response.status_code}: {response.text}")
+        raise RuntimeError(f"Slack post failed with status={response.status_code}")
 
 
 def post_report_to_slack(

--- a/nemo_retriever/src/nemo_retriever/harness/slack.py
+++ b/nemo_retriever/src/nemo_retriever/harness/slack.py
@@ -444,16 +444,19 @@ def post_slack_payload(payload: dict[str, Any], webhook_url: str) -> None:
         raise RuntimeError(f"Slack post failed with status={response.status_code}")
 
 
+def resolve_slack_webhook_url(webhook_url: str | None = None) -> str:
+    effective_webhook = webhook_url or os.environ.get("SLACK_WEBHOOK_URL")
+    if not effective_webhook:
+        raise RuntimeError("SLACK_WEBHOOK_URL is not set")
+    return effective_webhook
+
+
 def post_report_to_slack(
     report: NightlySessionReport,
     slack_config: dict[str, Any],
     *,
     webhook_url: str | None = None,
 ) -> dict[str, Any]:
-    effective_webhook = webhook_url or os.environ.get("SLACK_WEBHOOK_URL")
-    if not effective_webhook:
-        raise RuntimeError("SLACK_WEBHOOK_URL is not set")
-
     payload = build_slack_payload(report, slack_config)
-    post_slack_payload(payload, effective_webhook)
+    post_slack_payload(payload, resolve_slack_webhook_url(webhook_url))
     return payload

--- a/nemo_retriever/src/nemo_retriever/harness/slack.py
+++ b/nemo_retriever/src/nemo_retriever/harness/slack.py
@@ -223,7 +223,7 @@ def load_session_report(session_summary_path: Path) -> HarnessSessionReport:
     return HarnessSessionReport(
         session_name=str(payload.get("session_name") or payload.get("runset") or resolved_summary_path.parent.name),
         session_dir=resolved_summary_path.parent,
-        session_type=str(payload.get("session_type") or "nightly"),
+        session_type=str(payload.get("session_type") or "session"),
         timestamp=str(payload.get("timestamp")) if payload.get("timestamp") else None,
         latest_commit=str(latest_commit) if latest_commit else None,
         all_passed=bool(all_passed),

--- a/nemo_retriever/src/nemo_retriever/harness/slack.py
+++ b/nemo_retriever/src/nemo_retriever/harness/slack.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from nemo_retriever.harness.artifacts import now_timestr
 from nemo_retriever.harness.json_io import read_json_object
 
 DEFAULT_USERNAME = "nemo_retriever Harness"
@@ -208,11 +207,13 @@ def load_session_report(session_summary_path: Path) -> HarnessSessionReport:
     raw_results = payload.get("runs", payload.get("results", []))
     if not isinstance(raw_results, list):
         raise ValueError(f"'results' or 'runs' must be a list in {resolved_summary_path}")
-    results = [
-        _normalize_run_report(dict(item), session_dir=resolved_summary_path.parent)
-        for item in raw_results
-        if isinstance(item, dict)
-    ]
+    if not raw_results:
+        raise ValueError(f"Session contains no runs in {resolved_summary_path}")
+    results: list[HarnessRunReport] = []
+    for index, item in enumerate(raw_results):
+        if not isinstance(item, dict):
+            raise ValueError(f"Session run at index {index} must be an object in {resolved_summary_path}")
+        results.append(_normalize_run_report(item, session_dir=resolved_summary_path.parent))
     latest_commit = (
         payload.get("run_commit")
         or payload.get("latest_commit")
@@ -285,10 +286,10 @@ def load_replay_report(replay_paths: list[Path]) -> HarnessSessionReport:
 
     session_dir = resolved_paths[0].parent if resolved_paths else Path.cwd()
     return HarnessSessionReport(
-        session_name=f"replay_{now_timestr()}",
+        session_name="artifact_replay",
         session_dir=session_dir,
         session_type="artifact_replay",
-        timestamp=now_timestr(),
+        timestamp=None,
         latest_commit=latest_commit,
         all_passed=all(run.success for run in run_reports),
         dry_run=dry_run,

--- a/nemo_retriever/src/nemo_retriever/harness/slack.py
+++ b/nemo_retriever/src/nemo_retriever/harness/slack.py
@@ -35,6 +35,7 @@ DEFAULT_SLACK_METRIC_KEYS = (
     "recall_5",
     "recall_10",
 )
+MAX_SLACK_TABLE_ROWS = 100
 
 
 @dataclass
@@ -419,6 +420,11 @@ def build_slack_payload(report: HarnessSessionReport, slack_config: dict[str, An
 
     if report.results:
         rows.pop(-1)
+
+    if len(rows) > MAX_SLACK_TABLE_ROWS:
+        omitted_count = len(rows) - MAX_SLACK_TABLE_ROWS + 1
+        rows = rows[: MAX_SLACK_TABLE_ROWS - 1]
+        rows.append(_two_column_row_bold("TRUNCATED", f"{omitted_count} rows omitted; inspect session artifacts"))
 
     blocks: list[dict[str, Any]] = [
         {

--- a/nemo_retriever/src/nemo_retriever/operators/vdb.py
+++ b/nemo_retriever/src/nemo_retriever/operators/vdb.py
@@ -57,14 +57,26 @@ def _is_direct_embedding_column(column_name: object) -> bool:
     return "embedding" in name or name == "vector" or name.endswith("_vector")
 
 
+def _embedding_error(value: Any) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    error = value.get("error")
+    if error is None:
+        return None
+    message = str(error).strip()
+    return message or None
+
+
 def query_vectors_from_embedded_dataframe(df: pd.DataFrame) -> list[list[float]]:
     """Extract one query vector per row from batch-embed output (metadata or payload columns)."""
     vectors: list[list[float]] = []
     for _, row in df.iterrows():
         vec: list[float] | None = None
+        embedding_error: str | None = None
         md = row.get("metadata")
         if isinstance(md, dict):
             vec = _coerce_embedding_vector(md)
+            embedding_error = _embedding_error(md)
         if vec is None:
             for col in df.columns:
                 if col == "metadata":
@@ -72,12 +84,14 @@ def query_vectors_from_embedded_dataframe(df: pd.DataFrame) -> list[list[float]]
                 val = row.get(col)
                 if isinstance(val, dict) or _is_direct_embedding_column(col):
                     vec = _coerce_embedding_vector(val)
+                    embedding_error = embedding_error or _embedding_error(val)
                 if vec is not None:
                     break
         if vec is None:
+            error_suffix = f"; embedding error: {embedding_error}" if embedding_error else ""
             raise ValueError(
                 "Expected query embeddings in each row's metadata['embedding'] or a payload column "
-                f"with key 'embedding'; columns={list(df.columns)}"
+                f"with key 'embedding'; columns={list(df.columns)}{error_suffix}"
             )
         vectors.append(vec)
     return vectors

--- a/nemo_retriever/tests/test_harness_artifacts.py
+++ b/nemo_retriever/tests/test_harness_artifacts.py
@@ -10,6 +10,7 @@ from nemo_retriever.harness.artifact_writer import artifact_paths, ArtifactWrite
 from nemo_retriever.harness.contracts import (
     EXIT_ARTIFACT_WRITE_FAILURE,
     EXIT_INGEST_FAILURE,
+    EXIT_INTERNAL_ERROR,
     FailurePayload,
     HarnessRunError,
 )
@@ -165,6 +166,54 @@ def test_run_benchmark_classifies_artifact_write_failures(monkeypatch, tmp_path)
     assert outcome.exit_code == EXIT_ARTIFACT_WRITE_FAILURE
     assert outcome.results["failure"]["failure_reason"] == "artifact_write_failed"
     assert outcome.results["failure"]["message"] == "OSError: disk full"
+
+
+def test_run_benchmark_classifies_artifact_writer_initialization_failures(monkeypatch, tmp_path):
+    import nemo_retriever.harness.execution as execution
+
+    def fail_writer(**kwargs):
+        raise OSError("artifact directory unavailable")
+
+    monkeypatch.setattr(execution, "ArtifactWriter", fail_writer)
+
+    with pytest.raises(HarnessRunError) as error:
+        run_benchmark(
+            "jp20_beir",
+            output_dir=str(tmp_path / "run"),
+            overrides=(f'dataset.path="{tmp_path}"',),
+            dry_run=True,
+        )
+
+    assert error.value.exit_code == EXIT_ARTIFACT_WRITE_FAILURE
+    assert error.value.failure.failure_reason == "artifact_write_failed"
+    assert error.value.failure.message == "OSError: artifact directory unavailable"
+
+
+def test_run_benchmark_keeps_non_write_failures_internal(monkeypatch, tmp_path):
+    import nemo_retriever.harness.execution as execution
+
+    class FakeIngestPlan:
+        documents = ()
+
+    def fail_summary_metrics(*args, **kwargs):
+        raise RuntimeError("metrics exploded")
+
+    monkeypatch.setattr(execution, "resolve_ingest_plan", lambda request: FakeIngestPlan())
+    monkeypatch.setattr(execution, "run_ingest_workflow", lambda plan, dry_run: {})
+    monkeypatch.setattr(execution, "resolve_query_plan", lambda request: object())
+    monkeypatch.setattr(execution, "query_plan_payload", lambda plan: {})
+    monkeypatch.setattr(execution, "build_summary_metrics", fail_summary_metrics)
+
+    outcome = run_benchmark(
+        "jp20_beir",
+        output_dir=str(tmp_path / "run"),
+        overrides=(f'dataset.path="{tmp_path}"',),
+        dry_run=True,
+    )
+
+    assert outcome.exit_code == EXIT_INTERNAL_ERROR
+    assert outcome.results["failure"]["failure_reason"] == "unexpected_internal_error"
+    assert outcome.results["failure"]["message"] == "RuntimeError: metrics exploded"
 
 
 def test_concise_message_prefers_nested_root_exception():

--- a/nemo_retriever/tests/test_harness_artifacts.py
+++ b/nemo_retriever/tests/test_harness_artifacts.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-26, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import pytest
+
+from nemo_retriever.harness.artifact_writer import artifact_paths, ArtifactWriter, capture_output_to_log
+from nemo_retriever.harness.contracts import EXIT_INGEST_FAILURE, FailurePayload
+from nemo_retriever.harness.diff import diff_artifact_dirs
+from nemo_retriever.harness.environment import collect_environment
+from nemo_retriever.harness.execution import _concise_message, _run_result_payload, _write_failure_result
+
+
+def _write_json(path, payload):
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_artifact_manifest_uses_relative_paths_and_includes_lancedb(tmp_path):
+    writer = ArtifactWriter(artifact_dir=tmp_path, run_id="run-1", benchmark="jp20_beir")
+    writer.status(status="running", phase="ingest")
+    writer.path("environment.json").write_text("{}", encoding="utf-8")
+    writer.path("lancedb").mkdir()
+
+    assert artifact_paths(writer) == {
+        "status": "status.json",
+        "events": "events.jsonl",
+        "environment": "environment.json",
+        "lancedb": "lancedb",
+    }
+
+
+def test_artifact_writer_removes_only_stale_harness_outputs(tmp_path):
+    (tmp_path / "summary_metrics.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "beir_metrics.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "lancedb").mkdir()
+    (tmp_path / "lancedb" / "stale").write_text("old", encoding="utf-8")
+    (tmp_path / "keep-me.txt").write_text("user-owned", encoding="utf-8")
+
+    ArtifactWriter(artifact_dir=tmp_path, run_id="run-1", benchmark="jp20_beir")
+
+    assert not (tmp_path / "summary_metrics.json").exists()
+    assert not (tmp_path / "beir_metrics.json").exists()
+    assert not (tmp_path / "lancedb").exists()
+    assert (tmp_path / "keep-me.txt").read_text(encoding="utf-8") == "user-owned"
+
+
+def test_result_payload_is_a_small_terminal_manifest(tmp_path):
+    writer = ArtifactWriter(artifact_dir=tmp_path, run_id="run-1", benchmark="jp20_beir")
+    writer.status(status="running", phase="query")
+    writer.path("resolved_benchmark.json").write_text("{}", encoding="utf-8")
+    writer.path("beir_metrics.json").write_text("{}", encoding="utf-8")
+    writer.path("runfile.json").write_text("{}", encoding="utf-8")
+
+    payload = _run_result_payload(
+        writer,
+        status="complete",
+        success=True,
+        exit_code=0,
+        dry_run=False,
+        resolved={"dataset": {"name": "jp20"}, "ingest": {"run_mode": "batch"}},
+        summary_metrics={"files": 20},
+        failure=None,
+    )
+
+    assert payload == {
+        "run_id": "run-1",
+        "benchmark": "jp20_beir",
+        "dataset": "jp20",
+        "mode": "batch",
+        "status": "complete",
+        "success": True,
+        "exit_code": 0,
+        "dry_run": False,
+        "summary_metrics": {"files": 20},
+        "failure": None,
+        "artifacts": {
+            "status": "status.json",
+            "events": "events.jsonl",
+            "runfile": "runfile.json",
+            "resolved_benchmark": "resolved_benchmark.json",
+            "beir_metrics": "beir_metrics.json",
+        },
+    }
+
+
+def test_failure_result_is_concise_and_points_to_full_log(tmp_path):
+    writer = ArtifactWriter(artifact_dir=tmp_path, run_id="run-1", benchmark="jp20_beir")
+    writer.status(status="running", phase="ingest")
+    writer.path("run.log").write_text("full traceback evidence", encoding="utf-8")
+    long_message = "actor failed\n" + "traceback detail\n" * 1000
+
+    payload = _write_failure_result(
+        writer,
+        failure=FailurePayload(
+            failed_phase="ingest",
+            failure_reason="ingest_failed",
+            retryable=False,
+            message=long_message,
+            debug_artifacts=("ingest_plan.json", "run.log"),
+        ),
+        exit_code=EXIT_INGEST_FAILURE,
+        dry_run=False,
+        resolved={"dataset": {"name": "jp20"}, "ingest": {"run_mode": "inprocess"}},
+        summary_metrics=None,
+    )
+
+    status = json.loads(writer.path("status.json").read_text(encoding="utf-8"))
+    assert payload["failure"]["message"] == "actor failed"
+    assert "status_payload" not in payload
+    assert "resolved_benchmark" not in payload
+    assert status["failure"] == payload["failure"]
+    assert status["results_path"] == "results.json"
+    assert not writer.path("summary_metrics.json").exists()
+
+
+def test_concise_message_prefers_nested_root_exception():
+    message = """The actor died during startup
+Traceback (most recent call last):
+requests.exceptions.HTTPError: 429 Client Error
+huggingface_hub.errors.LocalEntryNotFoundError: model weights are not cached
+"""
+
+    assert _concise_message(message) == ("huggingface_hub.errors.LocalEntryNotFoundError: model weights are not cached")
+
+
+def test_capture_output_records_exception_traceback(tmp_path):
+    log_path = tmp_path / "run.log"
+
+    with pytest.raises(RuntimeError, match="model startup failed"):
+        with capture_output_to_log(log_path, label="ingest"):
+            raise RuntimeError("model startup failed")
+
+    text = log_path.read_text(encoding="utf-8")
+    assert "Traceback (most recent call last)" in text
+    assert "RuntimeError: model startup failed" in text
+    assert "ingest failed" in text
+
+
+def test_diff_prefers_results_but_reads_legacy_summary(tmp_path):
+    left = tmp_path / "left"
+    right = tmp_path / "right"
+    left.mkdir()
+    right.mkdir()
+    _write_json(left / "results.json", {"summary_metrics": {"recall_5": 0.8}})
+    _write_json(right / "summary_metrics.json", {"recall_5": 0.9})
+
+    payload = diff_artifact_dirs(left, right)
+
+    assert payload["left"].endswith("left/results.json")
+    assert payload["right"].endswith("right/summary_metrics.json")
+    assert payload["summary_metrics"]["recall_5"]["delta"] == pytest.approx(0.1)
+
+
+def test_environment_records_relevant_runtime_flags_without_credentials(monkeypatch):
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("NEMO_RETRIEVER_HF_CACHE_DIR", "/models/huggingface")
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.example.invalid/secret")
+
+    payload = collect_environment()
+
+    assert payload["runtime_environment"]["HF_HUB_OFFLINE"] == "1"
+    assert payload["runtime_environment"]["NEMO_RETRIEVER_HF_CACHE_DIR"] == "/models/huggingface"
+    assert "SLACK_WEBHOOK_URL" not in payload["runtime_environment"]

--- a/nemo_retriever/tests/test_harness_artifacts.py
+++ b/nemo_retriever/tests/test_harness_artifacts.py
@@ -7,7 +7,12 @@ import json
 import pytest
 
 from nemo_retriever.harness.artifact_writer import artifact_paths, ArtifactWriter, capture_output_to_log, redact
-from nemo_retriever.harness.contracts import EXIT_INGEST_FAILURE, FailurePayload, HarnessRunError
+from nemo_retriever.harness.contracts import (
+    EXIT_ARTIFACT_WRITE_FAILURE,
+    EXIT_INGEST_FAILURE,
+    FailurePayload,
+    HarnessRunError,
+)
 from nemo_retriever.harness.diff import diff_artifact_dirs
 from nemo_retriever.harness.environment import collect_environment
 from nemo_retriever.harness.execution import _concise_message, _run_result_payload, _write_failure_result, run_benchmark
@@ -136,6 +141,30 @@ def test_failure_result_is_concise_and_points_to_full_log(tmp_path):
     assert status["failure"] == payload["failure"]
     assert status["results_path"] == "results.json"
     assert not writer.path("summary_metrics.json").exists()
+
+
+def test_run_benchmark_classifies_artifact_write_failures(monkeypatch, tmp_path):
+    import nemo_retriever.harness.execution as execution
+
+    original_write_json = execution.write_json
+
+    def fail_results_write(path, payload):
+        if path.name == "results.json":
+            raise OSError("disk full")
+        original_write_json(path, payload)
+
+    monkeypatch.setattr(execution, "write_json", fail_results_write)
+
+    outcome = run_benchmark(
+        "jp20_beir",
+        output_dir=str(tmp_path / "run"),
+        overrides=(f'dataset.path="{tmp_path}"',),
+        dry_run=True,
+    )
+
+    assert outcome.exit_code == EXIT_ARTIFACT_WRITE_FAILURE
+    assert outcome.results["failure"]["failure_reason"] == "artifact_write_failed"
+    assert outcome.results["failure"]["message"] == "OSError: disk full"
 
 
 def test_concise_message_prefers_nested_root_exception():

--- a/nemo_retriever/tests/test_harness_artifacts.py
+++ b/nemo_retriever/tests/test_harness_artifacts.py
@@ -6,10 +6,10 @@ import json
 import pytest
 
 from nemo_retriever.harness.artifact_writer import artifact_paths, ArtifactWriter, capture_output_to_log
-from nemo_retriever.harness.contracts import EXIT_INGEST_FAILURE, FailurePayload
+from nemo_retriever.harness.contracts import EXIT_INGEST_FAILURE, FailurePayload, HarnessRunError
 from nemo_retriever.harness.diff import diff_artifact_dirs
 from nemo_retriever.harness.environment import collect_environment
-from nemo_retriever.harness.execution import _concise_message, _run_result_payload, _write_failure_result
+from nemo_retriever.harness.execution import _concise_message, _run_result_payload, _write_failure_result, run_benchmark
 
 
 def _write_json(path, payload):
@@ -43,6 +43,23 @@ def test_artifact_writer_removes_only_stale_harness_outputs(tmp_path):
     assert not (tmp_path / "beir_metrics.json").exists()
     assert not (tmp_path / "lancedb").exists()
     assert (tmp_path / "keep-me.txt").read_text(encoding="utf-8") == "user-owned"
+
+
+def test_invalid_run_config_preserves_existing_artifacts(tmp_path):
+    (tmp_path / "results.json").write_text('{"old": true}', encoding="utf-8")
+    (tmp_path / "lancedb").mkdir()
+    (tmp_path / "lancedb" / "old-index").write_text("existing", encoding="utf-8")
+
+    with pytest.raises(HarnessRunError):
+        run_benchmark(
+            "jp20_beir",
+            output_dir=str(tmp_path),
+            requirements=("not-a-gate",),
+            dry_run=True,
+        )
+
+    assert json.loads((tmp_path / "results.json").read_text(encoding="utf-8")) == {"old": True}
+    assert (tmp_path / "lancedb" / "old-index").read_text(encoding="utf-8") == "existing"
 
 
 def test_result_payload_is_a_small_terminal_manifest(tmp_path):

--- a/nemo_retriever/tests/test_harness_artifacts.py
+++ b/nemo_retriever/tests/test_harness_artifacts.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-26, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import json
 
 import pytest
 
-from nemo_retriever.harness.artifact_writer import artifact_paths, ArtifactWriter, capture_output_to_log
+from nemo_retriever.harness.artifact_writer import artifact_paths, ArtifactWriter, capture_output_to_log, redact
 from nemo_retriever.harness.contracts import EXIT_INGEST_FAILURE, FailurePayload, HarnessRunError
 from nemo_retriever.harness.diff import diff_artifact_dirs
 from nemo_retriever.harness.environment import collect_environment
@@ -43,6 +44,12 @@ def test_artifact_writer_removes_only_stale_harness_outputs(tmp_path):
     assert not (tmp_path / "beir_metrics.json").exists()
     assert not (tmp_path / "lancedb").exists()
     assert (tmp_path / "keep-me.txt").read_text(encoding="utf-8") == "user-owned"
+
+
+def test_redact_recurses_into_structured_override_values():
+    override = 'query={"reranker_api_key":"secret-value","top_k":10}'
+
+    assert redact(override) == 'query={"reranker_api_key": "<redacted>", "top_k": 10}'
 
 
 def test_invalid_run_config_preserves_existing_artifacts(tmp_path):

--- a/nemo_retriever/tests/test_harness_artifacts.py
+++ b/nemo_retriever/tests/test_harness_artifacts.py
@@ -52,6 +52,39 @@ def test_artifact_writer_removes_only_stale_harness_outputs(tmp_path):
     assert (tmp_path / "keep-me.txt").read_text(encoding="utf-8") == "user-owned"
 
 
+def test_write_json_preserves_previous_file_when_publish_fails(monkeypatch, tmp_path):
+    import nemo_retriever.harness.json_io as json_io
+
+    target = tmp_path / "status.json"
+    target.write_text('{"status": "old"}\n', encoding="utf-8")
+
+    def fail_replace(source, destination):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(json_io.os, "replace", fail_replace)
+
+    with pytest.raises(HarnessRunError) as error:
+        json_io.write_json(target, {"status": "new"})
+
+    assert error.value.exit_code == EXIT_ARTIFACT_WRITE_FAILURE
+    assert target.read_text(encoding="utf-8") == '{"status": "old"}\n'
+    assert list(tmp_path.glob(".status.json.*.tmp")) == []
+
+
+def test_write_json_classifies_serialization_failures(tmp_path):
+    from nemo_retriever.harness.json_io import write_json
+
+    class Unserializable:
+        def __str__(self):
+            raise ValueError("cannot serialize")
+
+    with pytest.raises(HarnessRunError) as error:
+        write_json(tmp_path / "status.json", {"value": Unserializable()})
+
+    assert error.value.exit_code == EXIT_ARTIFACT_WRITE_FAILURE
+    assert not (tmp_path / "status.json").exists()
+
+
 def test_redact_recurses_into_structured_override_values():
     override = 'query={"reranker_api_key":"secret-value","top_k":10}'
 

--- a/nemo_retriever/tests/test_harness_runfiles.py
+++ b/nemo_retriever/tests/test_harness_runfiles.py
@@ -144,7 +144,10 @@ def test_run_files_redacts_sensitive_overrides_from_session_plan(monkeypatch, tm
             "schema_version": 1,
             "name": "jp20_beir",
             "benchmark": "jp20_beir",
-            "set": ["query.reranker_api_key=runfile-secret"],
+            "set": [
+                "query.reranker_api_key=runfile-secret",
+                "notifications.webhook_url=https://hooks.example.invalid/runfile-secret",
+            ],
         },
     )
     calls = []
@@ -163,12 +166,14 @@ def test_run_files_redacts_sensitive_overrides_from_session_plan(monkeypatch, tm
 
     assert calls[0]["overrides"] == (
         "query.reranker_api_key=runfile-secret",
+        "notifications.webhook_url=https://hooks.example.invalid/runfile-secret",
         "query.reranker_api_key=cli-secret",
     )
     expanded_text = (outcome.artifact_dir / "expanded_runs.json").read_text(encoding="utf-8")
     assert "runfile-secret" not in expanded_text
     assert "cli-secret" not in expanded_text
-    assert expanded_text.count("<redacted>") == 2
+    assert "hooks.example.invalid" not in expanded_text
+    assert expanded_text.count("<redacted>") == 3
 
 
 @pytest.mark.parametrize(

--- a/nemo_retriever/tests/test_harness_runfiles.py
+++ b/nemo_retriever/tests/test_harness_runfiles.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import pytest
 
-from nemo_retriever.harness.benchmark_registry import get_runset
 from nemo_retriever.harness.contracts import HarnessRunError, RunOutcome
 from nemo_retriever.harness.runsets import run_runfiles
 
@@ -24,15 +23,6 @@ def _successful_outcome(benchmark: str, output_dir: str) -> RunOutcome:
         "failure": None,
     }
     return RunOutcome(exit_code=0, artifact_dir=artifact_dir, results=results)
-
-
-def test_library_nightly_runset_names_canonical_beir_benchmarks():
-    assert get_runset("library_nightly").runs == (
-        "jp20_beir",
-        "bo767_beir",
-        "earnings_beir",
-        "financebench_beir",
-    )
 
 
 def test_run_files_applies_machine_paths_then_cli_overrides(monkeypatch, tmp_path):
@@ -74,7 +64,7 @@ def test_run_files_applies_machine_paths_then_cli_overrides(monkeypatch, tmp_pat
     outcome = run_runfiles(
         [runfile],
         output_dir=str(tmp_path / "session"),
-        session_name="library_nightly",
+        session_name="library_beir",
         dataset_paths_file=dataset_paths,
         overrides=("query.top_k=20",),
         requirements=("pages==1940",),
@@ -91,7 +81,7 @@ def test_run_files_applies_machine_paths_then_cli_overrides(monkeypatch, tmp_pat
         f'evaluation.dataset_name="{query_file}"',
         "query.top_k=20",
     )
-    assert outcome.results["session_name"] == "library_nightly"
+    assert outcome.results["session_name"] == "library_beir"
     assert outcome.results["runs"][0]["dataset"] == "jp20"
     assert outcome.results["runs"][0]["artifact_dir"] == "001_jp20_beir"
     assert outcome.results["runs"][0]["results_path"] == "001_jp20_beir/results.json"

--- a/nemo_retriever/tests/test_harness_runfiles.py
+++ b/nemo_retriever/tests/test_harness_runfiles.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-26, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 from pathlib import Path
 
@@ -181,7 +185,10 @@ def test_run_files_redacts_sensitive_overrides_from_session_plan(monkeypatch, tm
             "schema_version": 1,
             "name": "jp20_beir",
             "benchmark": "jp20_beir",
-            "set": ["query.reranker_api_key=runfile-secret"],
+            "set": {
+                "query.reranker_api_key": "runfile-secret",
+                "query.content_types": {"webhook_url": "structured-secret"},
+            },
         },
     )
     calls = []
@@ -201,13 +208,15 @@ def test_run_files_redacts_sensitive_overrides_from_session_plan(monkeypatch, tm
 
     assert calls[0]["overrides"] == (
         "query.reranker_api_key=runfile-secret",
+        'query.content_types={"webhook_url": "structured-secret"}',
         f'dataset.path="{tmp_path}"',
         "query.reranker_api_key=cli-secret",
     )
     expanded_text = (outcome.artifact_dir / "expanded_runs.json").read_text(encoding="utf-8")
     assert "runfile-secret" not in expanded_text
+    assert "structured-secret" not in expanded_text
     assert "cli-secret" not in expanded_text
-    assert expanded_text.count("<redacted>") == 2
+    assert expanded_text.count("<redacted>") == 3
 
 
 @pytest.mark.parametrize(

--- a/nemo_retriever/tests/test_harness_runfiles.py
+++ b/nemo_retriever/tests/test_harness_runfiles.py
@@ -1,0 +1,193 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from nemo_retriever.harness.benchmark_registry import get_runset
+from nemo_retriever.harness.contracts import HarnessRunError, RunOutcome
+from nemo_retriever.harness.runsets import run_runfiles
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _successful_outcome(benchmark: str, output_dir: str) -> RunOutcome:
+    artifact_dir = Path(output_dir)
+    artifact_dir.mkdir(parents=True)
+    results = {
+        "benchmark": benchmark,
+        "success": True,
+        "exit_code": 0,
+        "resolved_benchmark": {"dataset": {"name": "jp20"}},
+        "summary_metrics": {"files": 20},
+        "failure": None,
+    }
+    return RunOutcome(exit_code=0, artifact_dir=artifact_dir, results=results)
+
+
+def test_library_nightly_runset_names_canonical_beir_benchmarks():
+    assert get_runset("library_nightly").runs == (
+        "jp20_beir",
+        "bo767_beir",
+        "earnings_beir",
+        "financebench_beir",
+    )
+
+
+def test_run_files_applies_machine_paths_then_cli_overrides(monkeypatch, tmp_path):
+    runfile = tmp_path / "jp20_beir.json"
+    _write_json(
+        runfile,
+        {
+            "schema_version": 1,
+            "name": "jp20_beir",
+            "benchmark": "jp20_beir",
+            "mode": "batch",
+            "require": ["files==20"],
+            "set": {"query.top_k": 10},
+        },
+    )
+    documents = tmp_path / "datasets" / "jp20"
+    query_file = tmp_path / "datasets" / "jp20_query_gt.csv"
+    dataset_paths = tmp_path / "dataset_paths.yaml"
+    dataset_paths.write_text(
+        "\n".join(
+            (
+                "schema_version: 1",
+                "datasets:",
+                "  jp20:",
+                f"    path: {documents}",
+                f"    query_file: {query_file}",
+            )
+        ),
+        encoding="utf-8",
+    )
+    calls = []
+
+    def fake_run_benchmark(benchmark, **kwargs):
+        calls.append((benchmark, kwargs))
+        return _successful_outcome(benchmark, kwargs["output_dir"])
+
+    monkeypatch.setattr("nemo_retriever.harness.runsets.run_benchmark", fake_run_benchmark)
+
+    outcome = run_runfiles(
+        [runfile],
+        output_dir=str(tmp_path / "session"),
+        session_name="library_nightly",
+        dataset_paths_file=dataset_paths,
+        overrides=("query.top_k=20",),
+        requirements=("pages==1940",),
+    )
+
+    benchmark, kwargs = calls[0]
+    assert benchmark == "jp20_beir"
+    assert kwargs["mode"] == "batch"
+    assert kwargs["requirements"] == ("files==20", "pages==1940")
+    assert kwargs["overrides"] == (
+        "query.top_k=10",
+        f'dataset.path="{documents}"',
+        f'dataset.query_file="{query_file}"',
+        f'evaluation.dataset_name="{query_file}"',
+        "query.top_k=20",
+    )
+    assert outcome.results["session_name"] == "library_nightly"
+    assert outcome.results["runs"][0]["dataset"] == "jp20"
+    assert "results" not in outcome.results
+
+    expanded = json.loads((outcome.artifact_dir / "expanded_runs.json").read_text(encoding="utf-8"))
+    assert expanded["runfiles"][0]["dataset_paths"] == {
+        "path": str(documents),
+        "query_file": str(query_file),
+    }
+
+
+def test_run_files_completes_remaining_runs_and_preserves_first_failure(monkeypatch, tmp_path):
+    runfiles = []
+    for name in ("jp20_beir", "bo767_beir"):
+        path = tmp_path / f"{name}.json"
+        _write_json(path, {"schema_version": 1, "name": name, "benchmark": name})
+        runfiles.append(path)
+
+    calls = []
+
+    def fake_run_benchmark(benchmark, **kwargs):
+        calls.append(benchmark)
+        if benchmark == "jp20_beir":
+            artifact_dir = Path(kwargs["output_dir"])
+            artifact_dir.mkdir(parents=True)
+            return RunOutcome(
+                exit_code=10,
+                artifact_dir=artifact_dir,
+                results={
+                    "summary_metrics": {},
+                    "failure": {"message": "ingest failed"},
+                },
+            )
+        return _successful_outcome(benchmark, kwargs["output_dir"])
+
+    monkeypatch.setattr("nemo_retriever.harness.runsets.run_benchmark", fake_run_benchmark)
+
+    outcome = run_runfiles(runfiles, output_dir=str(tmp_path / "session"))
+
+    assert calls == ["jp20_beir", "bo767_beir"]
+    assert outcome.exit_code == 10
+    assert outcome.results["all_passed"] is False
+    assert [run["exit_code"] for run in outcome.results["runs"]] == [10, 0]
+
+
+def test_run_files_redacts_sensitive_overrides_from_session_plan(monkeypatch, tmp_path):
+    runfile = tmp_path / "jp20_beir.json"
+    _write_json(
+        runfile,
+        {
+            "schema_version": 1,
+            "name": "jp20_beir",
+            "benchmark": "jp20_beir",
+            "set": ["query.reranker_api_key=runfile-secret"],
+        },
+    )
+    calls = []
+
+    def fake_run_benchmark(benchmark, **kwargs):
+        calls.append(kwargs)
+        return _successful_outcome(benchmark, kwargs["output_dir"])
+
+    monkeypatch.setattr("nemo_retriever.harness.runsets.run_benchmark", fake_run_benchmark)
+
+    outcome = run_runfiles(
+        [runfile],
+        output_dir=str(tmp_path / "session"),
+        overrides=("query.reranker_api_key=cli-secret",),
+    )
+
+    assert calls[0]["overrides"] == (
+        "query.reranker_api_key=runfile-secret",
+        "query.reranker_api_key=cli-secret",
+    )
+    expanded_text = (outcome.artifact_dir / "expanded_runs.json").read_text(encoding="utf-8")
+    assert "runfile-secret" not in expanded_text
+    assert "cli-secret" not in expanded_text
+    assert expanded_text.count("<redacted>") == 2
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("name", "unsafe/../../../escape"),
+        ("output_dir", "/tmp/run-owned-output"),
+        ("run_id", "run-owned-id"),
+    ),
+)
+def test_run_files_rejects_unsafe_or_run_owned_layout(field, value, tmp_path):
+    runfile = tmp_path / "jp20_beir.json"
+    payload = {"schema_version": 1, "name": "jp20_beir", "benchmark": "jp20_beir"}
+    payload[field] = value
+    _write_json(runfile, payload)
+    session_dir = tmp_path / "session"
+
+    with pytest.raises(HarnessRunError) as exc_info:
+        run_runfiles([runfile], output_dir=str(session_dir))
+
+    assert exc_info.value.exit_code == 2
+    assert not session_dir.exists()

--- a/nemo_retriever/tests/test_harness_runfiles.py
+++ b/nemo_retriever/tests/test_harness_runfiles.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 import pytest
 
-from nemo_retriever.harness.contracts import HarnessRunError, RunOutcome
-from nemo_retriever.harness.runsets import run_runfiles
+from nemo_retriever.harness.contracts import EXIT_MISSING_INPUT, FailurePayload, HarnessRunError, RunOutcome
+from nemo_retriever.harness.runsets import run_runfiles, run_runset
 
 
 def _write_json(path: Path, payload: dict) -> None:
@@ -138,6 +138,113 @@ def test_run_files_completes_remaining_runs_and_preserves_first_failure(monkeypa
     assert outcome.exit_code == 10
     assert outcome.results["all_passed"] is False
     assert [run["exit_code"] for run in outcome.results["runs"]] == [10, 0]
+
+
+def test_run_files_removes_stale_summary_before_child_execution(monkeypatch, tmp_path):
+    runfile = tmp_path / "jp20_beir.json"
+    _write_json(runfile, {"schema_version": 1, "name": "jp20_beir", "benchmark": "jp20_beir"})
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    _write_json(session_dir / "session_summary.json", {"success": True, "old": True})
+
+    def fake_run_benchmark(benchmark, **kwargs):
+        assert not (session_dir / "session_summary.json").exists()
+        return _successful_outcome(benchmark, kwargs["output_dir"])
+
+    monkeypatch.setattr("nemo_retriever.harness.runsets.run_benchmark", fake_run_benchmark)
+
+    outcome = run_runfiles(
+        [runfile],
+        output_dir=str(session_dir),
+        overrides=(f'dataset.path="{tmp_path}"',),
+        dry_run=True,
+    )
+
+    assert outcome.exit_code == 0
+    summary = json.loads((session_dir / "session_summary.json").read_text(encoding="utf-8"))
+    assert "old" not in summary
+    assert summary["success"] is True
+
+
+def test_run_files_converts_raised_child_failure_and_continues(monkeypatch, tmp_path):
+    runfiles = []
+    for name in ("jp20_beir", "bo767_beir"):
+        path = tmp_path / f"{name}.json"
+        _write_json(path, {"schema_version": 1, "name": name, "benchmark": name})
+        runfiles.append(path)
+    calls = []
+
+    def fake_run_benchmark(benchmark, **kwargs):
+        calls.append(benchmark)
+        if benchmark == "jp20_beir":
+            raise HarnessRunError(
+                EXIT_MISSING_INPUT,
+                FailurePayload(
+                    failed_phase="resolve",
+                    failure_reason="dataset_missing",
+                    retryable=False,
+                    message="dataset disappeared",
+                ),
+            )
+        return _successful_outcome(benchmark, kwargs["output_dir"])
+
+    monkeypatch.setattr("nemo_retriever.harness.runsets.run_benchmark", fake_run_benchmark)
+    session_dir = tmp_path / "session"
+
+    outcome = run_runfiles(
+        runfiles,
+        output_dir=str(session_dir),
+        overrides=(f'dataset.path="{tmp_path}"',),
+        dry_run=True,
+    )
+
+    assert calls == ["jp20_beir", "bo767_beir"]
+    assert outcome.exit_code == EXIT_MISSING_INPUT
+    assert [run["exit_code"] for run in outcome.results["runs"]] == [EXIT_MISSING_INPUT, 0]
+    assert (session_dir / "001_jp20_beir" / "results.json").exists()
+    assert (session_dir / "session_summary.json").exists()
+
+
+def test_runset_converts_raised_child_failure_and_continues(monkeypatch, tmp_path):
+    class FakeRunset:
+        name = "pair"
+        runs = ("jp20_beir", "bo767_beir")
+
+        def to_dict(self):
+            return {"name": self.name, "runs": list(self.runs)}
+
+    calls = []
+
+    def fake_run_benchmark(benchmark, **kwargs):
+        calls.append(benchmark)
+        if benchmark == "jp20_beir":
+            raise HarnessRunError(
+                EXIT_MISSING_INPUT,
+                FailurePayload(
+                    failed_phase="resolve",
+                    failure_reason="dataset_missing",
+                    retryable=False,
+                    message="dataset disappeared",
+                ),
+            )
+        return _successful_outcome(benchmark, kwargs["output_dir"])
+
+    monkeypatch.setattr("nemo_retriever.harness.runsets._runset_or_error", lambda name: FakeRunset())
+    monkeypatch.setattr("nemo_retriever.harness.runsets.run_benchmark", fake_run_benchmark)
+    session_dir = tmp_path / "session"
+
+    outcome = run_runset(
+        "pair",
+        output_dir=str(session_dir),
+        overrides=(f'dataset.path="{tmp_path}"',),
+        dry_run=True,
+    )
+
+    assert calls == ["jp20_beir", "bo767_beir"]
+    assert outcome.exit_code == EXIT_MISSING_INPUT
+    assert [run["exit_code"] for run in outcome.results["runs"]] == [EXIT_MISSING_INPUT, 0]
+    assert (session_dir / "001_jp20_beir" / "results.json").exists()
+    assert (session_dir / "session_summary.json").exists()
 
 
 def test_run_files_preflights_every_run_before_execution(monkeypatch, tmp_path):

--- a/nemo_retriever/tests/test_harness_runfiles.py
+++ b/nemo_retriever/tests/test_harness_runfiles.py
@@ -23,7 +23,7 @@ def _write_json(path: Path, payload: dict) -> None:
 
 def _successful_outcome(benchmark: str, output_dir: str) -> RunOutcome:
     artifact_dir = Path(output_dir)
-    artifact_dir.mkdir(parents=True)
+    artifact_dir.mkdir(parents=True, exist_ok=True)
     results = {
         "benchmark": benchmark,
         "dataset": "jp20",
@@ -32,7 +32,9 @@ def _successful_outcome(benchmark: str, output_dir: str) -> RunOutcome:
         "summary_metrics": {"files": 20},
         "failure": None,
     }
-    return RunOutcome(exit_code=0, artifact_dir=artifact_dir, results=results)
+    results_path = artifact_dir / "results.json"
+    _write_json(results_path, results)
+    return RunOutcome(exit_code=0, artifact_dir=artifact_dir, results=results, results_path=results_path)
 
 
 def test_run_files_applies_machine_paths_then_cli_overrides(monkeypatch, tmp_path):
@@ -67,11 +69,11 @@ def test_run_files_applies_machine_paths_then_cli_overrides(monkeypatch, tmp_pat
     )
     calls = []
 
-    def fake_run_benchmark(benchmark, **kwargs):
-        calls.append((benchmark, kwargs))
-        return _successful_outcome(benchmark, kwargs["output_dir"])
+    def fake_run_benchmark(prepared, **kwargs):
+        calls.append((prepared, kwargs))
+        return _successful_outcome(prepared.benchmark, kwargs["output_dir"])
 
-    monkeypatch.setattr("nemo_retriever.harness.runsets.run_benchmark", fake_run_benchmark)
+    monkeypatch.setattr("nemo_retriever.harness.runsets.run_prepared_benchmark", fake_run_benchmark)
 
     outcome = run_runfiles(
         [runfile],
@@ -82,11 +84,11 @@ def test_run_files_applies_machine_paths_then_cli_overrides(monkeypatch, tmp_pat
         requirements=("pages==1940",),
     )
 
-    benchmark, kwargs = calls[0]
-    assert benchmark == "jp20_beir"
-    assert kwargs["mode"] == "batch"
-    assert kwargs["requirements"] == ("files==20", "pages==1940")
-    assert kwargs["overrides"] == (
+    prepared, kwargs = calls[0]
+    assert prepared.benchmark == "jp20_beir"
+    assert prepared.mode == "batch"
+    assert prepared.requirements == ("files==20", "pages==1940")
+    assert prepared.overrides == (
         "query.top_k=10",
         f'dataset.path="{documents}"',
         f'dataset.query_file="{query_file}"',
@@ -116,11 +118,14 @@ def test_run_files_completes_remaining_runs_and_preserves_first_failure(monkeypa
 
     calls = []
 
-    def fake_run_benchmark(benchmark, **kwargs):
+    def fake_run_benchmark(prepared, **kwargs):
+        benchmark = prepared.benchmark
         calls.append(benchmark)
         if benchmark == "jp20_beir":
             artifact_dir = Path(kwargs["output_dir"])
             artifact_dir.mkdir(parents=True)
+            results_path = artifact_dir / "results.json"
+            _write_json(results_path, {"summary_metrics": {}, "failure": {"message": "ingest failed"}})
             return RunOutcome(
                 exit_code=10,
                 artifact_dir=artifact_dir,
@@ -128,10 +133,11 @@ def test_run_files_completes_remaining_runs_and_preserves_first_failure(monkeypa
                     "summary_metrics": {},
                     "failure": {"message": "ingest failed"},
                 },
+                results_path=results_path,
             )
         return _successful_outcome(benchmark, kwargs["output_dir"])
 
-    monkeypatch.setattr("nemo_retriever.harness.runsets.run_benchmark", fake_run_benchmark)
+    monkeypatch.setattr("nemo_retriever.harness.runsets.run_prepared_benchmark", fake_run_benchmark)
 
     outcome = run_runfiles(
         runfiles,
@@ -153,11 +159,12 @@ def test_run_files_removes_stale_summary_before_child_execution(monkeypatch, tmp
     session_dir.mkdir()
     _write_json(session_dir / "session_summary.json", {"success": True, "old": True})
 
-    def fake_run_benchmark(benchmark, **kwargs):
+    def fake_run_benchmark(prepared, **kwargs):
+        benchmark = prepared.benchmark
         assert not (session_dir / "session_summary.json").exists()
         return _successful_outcome(benchmark, kwargs["output_dir"])
 
-    monkeypatch.setattr("nemo_retriever.harness.runsets.run_benchmark", fake_run_benchmark)
+    monkeypatch.setattr("nemo_retriever.harness.runsets.run_prepared_benchmark", fake_run_benchmark)
 
     outcome = run_runfiles(
         [runfile],
@@ -172,6 +179,39 @@ def test_run_files_removes_stale_summary_before_child_execution(monkeypatch, tmp
     assert summary["success"] is True
 
 
+def test_run_files_classifies_session_summary_write_failure(monkeypatch, tmp_path):
+    import nemo_retriever.harness.json_io as json_io
+
+    runfile = tmp_path / "jp20_beir.json"
+    _write_json(runfile, {"schema_version": 1, "name": "jp20_beir", "benchmark": "jp20_beir"})
+
+    def fake_run_benchmark(prepared, **kwargs):
+        return _successful_outcome(prepared.benchmark, kwargs["output_dir"])
+
+    original_replace = json_io.os.replace
+
+    def fail_session_summary(source, destination):
+        if Path(destination).name == "session_summary.json":
+            raise OSError("disk full")
+        original_replace(source, destination)
+
+    monkeypatch.setattr("nemo_retriever.harness.runsets.run_prepared_benchmark", fake_run_benchmark)
+    monkeypatch.setattr(json_io.os, "replace", fail_session_summary)
+    session_dir = tmp_path / "session"
+
+    with pytest.raises(HarnessRunError) as error:
+        run_runfiles(
+            [runfile],
+            output_dir=str(session_dir),
+            overrides=(f'dataset.path="{tmp_path}"',),
+            dry_run=True,
+        )
+
+    assert error.value.exit_code == EXIT_ARTIFACT_WRITE_FAILURE
+    assert error.value.failure.failure_reason == "artifact_write_failed"
+    assert not (session_dir / "session_summary.json").exists()
+
+
 def test_run_files_converts_raised_child_failure_and_continues(monkeypatch, tmp_path):
     runfiles = []
     for name in ("jp20_beir", "bo767_beir"):
@@ -180,7 +220,8 @@ def test_run_files_converts_raised_child_failure_and_continues(monkeypatch, tmp_
         runfiles.append(path)
     calls = []
 
-    def fake_run_benchmark(benchmark, **kwargs):
+    def fake_run_benchmark(prepared, **kwargs):
+        benchmark = prepared.benchmark
         calls.append(benchmark)
         if benchmark == "jp20_beir":
             raise HarnessRunError(
@@ -194,7 +235,7 @@ def test_run_files_converts_raised_child_failure_and_continues(monkeypatch, tmp_
             )
         return _successful_outcome(benchmark, kwargs["output_dir"])
 
-    monkeypatch.setattr("nemo_retriever.harness.runsets.run_benchmark", fake_run_benchmark)
+    monkeypatch.setattr("nemo_retriever.harness.runsets.run_prepared_benchmark", fake_run_benchmark)
     session_dir = tmp_path / "session"
 
     outcome = run_runfiles(
@@ -221,7 +262,8 @@ def test_run_files_continues_when_failed_child_result_cannot_be_written(monkeypa
         runfiles.append(path)
     calls = []
 
-    def fake_run_benchmark(benchmark, **kwargs):
+    def fake_run_benchmark(prepared, **kwargs):
+        benchmark = prepared.benchmark
         calls.append(benchmark)
         if benchmark == "jp20_beir":
             raise HarnessRunError(
@@ -242,7 +284,7 @@ def test_run_files_continues_when_failed_child_result_cannot_be_written(monkeypa
             raise OSError("child result unavailable")
         original_write_json(path, payload)
 
-    monkeypatch.setattr(runsets, "run_benchmark", fake_run_benchmark)
+    monkeypatch.setattr(runsets, "run_prepared_benchmark", fake_run_benchmark)
     monkeypatch.setattr(runsets, "write_json", fail_first_child_result)
     session_dir = tmp_path / "session"
 
@@ -257,6 +299,7 @@ def test_run_files_continues_when_failed_child_result_cannot_be_written(monkeypa
     assert outcome.exit_code == EXIT_ARTIFACT_WRITE_FAILURE
     assert [run["exit_code"] for run in outcome.results["runs"]] == [EXIT_ARTIFACT_WRITE_FAILURE, 0]
     assert outcome.results["runs"][0]["failure_reason"] == "OSError: child result unavailable"
+    assert "results_path" not in outcome.results["runs"][0]
     assert not (session_dir / "001_jp20_beir" / "results.json").exists()
     assert (session_dir / "session_summary.json").exists()
 
@@ -271,7 +314,8 @@ def test_runset_converts_raised_child_failure_and_continues(monkeypatch, tmp_pat
 
     calls = []
 
-    def fake_run_benchmark(benchmark, **kwargs):
+    def fake_run_benchmark(prepared, **kwargs):
+        benchmark = prepared.benchmark
         calls.append(benchmark)
         if benchmark == "jp20_beir":
             raise HarnessRunError(
@@ -286,7 +330,7 @@ def test_runset_converts_raised_child_failure_and_continues(monkeypatch, tmp_pat
         return _successful_outcome(benchmark, kwargs["output_dir"])
 
     monkeypatch.setattr("nemo_retriever.harness.runsets._runset_or_error", lambda name: FakeRunset())
-    monkeypatch.setattr("nemo_retriever.harness.runsets.run_benchmark", fake_run_benchmark)
+    monkeypatch.setattr("nemo_retriever.harness.runsets.run_prepared_benchmark", fake_run_benchmark)
     session_dir = tmp_path / "session"
 
     outcome = run_runset(
@@ -326,11 +370,12 @@ def test_run_files_preflights_every_run_before_execution(monkeypatch, tmp_path):
     )
     calls = []
 
-    def fake_run_benchmark(benchmark, **kwargs):
+    def fake_run_benchmark(prepared, **kwargs):
+        benchmark = prepared.benchmark
         calls.append(benchmark)
         return _successful_outcome(benchmark, kwargs["output_dir"])
 
-    monkeypatch.setattr("nemo_retriever.harness.runsets.run_benchmark", fake_run_benchmark)
+    monkeypatch.setattr("nemo_retriever.harness.runsets.run_prepared_benchmark", fake_run_benchmark)
     session_dir = tmp_path / "session"
 
     with pytest.raises(HarnessRunError):
@@ -356,11 +401,11 @@ def test_run_files_redacts_sensitive_overrides_from_session_plan(monkeypatch, tm
     )
     calls = []
 
-    def fake_run_benchmark(benchmark, **kwargs):
-        calls.append(kwargs)
-        return _successful_outcome(benchmark, kwargs["output_dir"])
+    def fake_run_benchmark(prepared, **kwargs):
+        calls.append(prepared)
+        return _successful_outcome(prepared.benchmark, kwargs["output_dir"])
 
-    monkeypatch.setattr("nemo_retriever.harness.runsets.run_benchmark", fake_run_benchmark)
+    monkeypatch.setattr("nemo_retriever.harness.runsets.run_prepared_benchmark", fake_run_benchmark)
 
     outcome = run_runfiles(
         [runfile],
@@ -369,7 +414,7 @@ def test_run_files_redacts_sensitive_overrides_from_session_plan(monkeypatch, tm
         dry_run=True,
     )
 
-    assert calls[0]["overrides"] == (
+    assert calls[0].overrides == (
         "query.reranker_api_key=runfile-secret",
         'query.content_types={"webhook_url": "structured-secret"}',
         f'dataset.path="{tmp_path}"',

--- a/nemo_retriever/tests/test_harness_runfiles.py
+++ b/nemo_retriever/tests/test_harness_runfiles.py
@@ -17,9 +17,9 @@ def _successful_outcome(benchmark: str, output_dir: str) -> RunOutcome:
     artifact_dir.mkdir(parents=True)
     results = {
         "benchmark": benchmark,
+        "dataset": "jp20",
         "success": True,
         "exit_code": 0,
-        "resolved_benchmark": {"dataset": {"name": "jp20"}},
         "summary_metrics": {"files": 20},
         "failure": None,
     }
@@ -93,6 +93,8 @@ def test_run_files_applies_machine_paths_then_cli_overrides(monkeypatch, tmp_pat
     )
     assert outcome.results["session_name"] == "library_nightly"
     assert outcome.results["runs"][0]["dataset"] == "jp20"
+    assert outcome.results["runs"][0]["artifact_dir"] == "001_jp20_beir"
+    assert outcome.results["runs"][0]["results_path"] == "001_jp20_beir/results.json"
     assert "results" not in outcome.results
 
     expanded = json.loads((outcome.artifact_dir / "expanded_runs.json").read_text(encoding="utf-8"))
@@ -100,6 +102,7 @@ def test_run_files_applies_machine_paths_then_cli_overrides(monkeypatch, tmp_pat
         "path": str(documents),
         "query_file": str(query_file),
     }
+    assert expanded["runfiles"][0]["artifact_dir"] == "001_jp20_beir"
 
 
 def test_run_files_completes_remaining_runs_and_preserves_first_failure(monkeypatch, tmp_path):

--- a/nemo_retriever/tests/test_harness_runfiles.py
+++ b/nemo_retriever/tests/test_harness_runfiles.py
@@ -40,6 +40,8 @@ def test_run_files_applies_machine_paths_then_cli_overrides(monkeypatch, tmp_pat
     )
     documents = tmp_path / "datasets" / "jp20"
     query_file = tmp_path / "datasets" / "jp20_query_gt.csv"
+    documents.mkdir(parents=True)
+    query_file.write_text("query_id,query\n1,test\n", encoding="utf-8")
     dataset_paths = tmp_path / "dataset_paths.yaml"
     dataset_paths.write_text(
         "\n".join(
@@ -121,12 +123,54 @@ def test_run_files_completes_remaining_runs_and_preserves_first_failure(monkeypa
 
     monkeypatch.setattr("nemo_retriever.harness.runsets.run_benchmark", fake_run_benchmark)
 
-    outcome = run_runfiles(runfiles, output_dir=str(tmp_path / "session"))
+    outcome = run_runfiles(
+        runfiles,
+        output_dir=str(tmp_path / "session"),
+        overrides=(f'dataset.path="{tmp_path}"',),
+        dry_run=True,
+    )
 
     assert calls == ["jp20_beir", "bo767_beir"]
     assert outcome.exit_code == 10
     assert outcome.results["all_passed"] is False
     assert [run["exit_code"] for run in outcome.results["runs"]] == [10, 0]
+
+
+def test_run_files_preflights_every_run_before_execution(monkeypatch, tmp_path):
+    valid = tmp_path / "valid.json"
+    invalid = tmp_path / "invalid.json"
+    _write_json(
+        valid,
+        {
+            "schema_version": 1,
+            "name": "jp20",
+            "benchmark": "jp20_beir",
+            "set": {"dataset.path": str(tmp_path)},
+        },
+    )
+    _write_json(
+        invalid,
+        {
+            "schema_version": 1,
+            "name": "bo767",
+            "benchmark": "bo767_beir",
+            "set": {"dataset.path": str(tmp_path), "query.nope": 1},
+        },
+    )
+    calls = []
+
+    def fake_run_benchmark(benchmark, **kwargs):
+        calls.append(benchmark)
+        return _successful_outcome(benchmark, kwargs["output_dir"])
+
+    monkeypatch.setattr("nemo_retriever.harness.runsets.run_benchmark", fake_run_benchmark)
+    session_dir = tmp_path / "session"
+
+    with pytest.raises(HarnessRunError):
+        run_runfiles([valid, invalid], output_dir=str(session_dir), dry_run=True)
+
+    assert calls == []
+    assert not session_dir.exists()
 
 
 def test_run_files_redacts_sensitive_overrides_from_session_plan(monkeypatch, tmp_path):
@@ -137,10 +181,7 @@ def test_run_files_redacts_sensitive_overrides_from_session_plan(monkeypatch, tm
             "schema_version": 1,
             "name": "jp20_beir",
             "benchmark": "jp20_beir",
-            "set": [
-                "query.reranker_api_key=runfile-secret",
-                "notifications.webhook_url=https://hooks.example.invalid/runfile-secret",
-            ],
+            "set": ["query.reranker_api_key=runfile-secret"],
         },
     )
     calls = []
@@ -154,19 +195,19 @@ def test_run_files_redacts_sensitive_overrides_from_session_plan(monkeypatch, tm
     outcome = run_runfiles(
         [runfile],
         output_dir=str(tmp_path / "session"),
-        overrides=("query.reranker_api_key=cli-secret",),
+        overrides=(f'dataset.path="{tmp_path}"', "query.reranker_api_key=cli-secret"),
+        dry_run=True,
     )
 
     assert calls[0]["overrides"] == (
         "query.reranker_api_key=runfile-secret",
-        "notifications.webhook_url=https://hooks.example.invalid/runfile-secret",
+        f'dataset.path="{tmp_path}"',
         "query.reranker_api_key=cli-secret",
     )
     expanded_text = (outcome.artifact_dir / "expanded_runs.json").read_text(encoding="utf-8")
     assert "runfile-secret" not in expanded_text
     assert "cli-secret" not in expanded_text
-    assert "hooks.example.invalid" not in expanded_text
-    assert expanded_text.count("<redacted>") == 3
+    assert expanded_text.count("<redacted>") == 2
 
 
 @pytest.mark.parametrize(
@@ -175,6 +216,7 @@ def test_run_files_redacts_sensitive_overrides_from_session_plan(monkeypatch, tm
         ("name", "unsafe/../../../escape"),
         ("output_dir", "/tmp/run-owned-output"),
         ("run_id", "run-owned-id"),
+        ("dry_run", True),
     ),
 )
 def test_run_files_rejects_unsafe_or_run_owned_layout(field, value, tmp_path):

--- a/nemo_retriever/tests/test_harness_runfiles.py
+++ b/nemo_retriever/tests/test_harness_runfiles.py
@@ -7,7 +7,13 @@ from pathlib import Path
 
 import pytest
 
-from nemo_retriever.harness.contracts import EXIT_MISSING_INPUT, FailurePayload, HarnessRunError, RunOutcome
+from nemo_retriever.harness.contracts import (
+    EXIT_ARTIFACT_WRITE_FAILURE,
+    EXIT_MISSING_INPUT,
+    FailurePayload,
+    HarnessRunError,
+    RunOutcome,
+)
 from nemo_retriever.harness.runsets import run_runfiles, run_runset
 
 
@@ -202,6 +208,56 @@ def test_run_files_converts_raised_child_failure_and_continues(monkeypatch, tmp_
     assert outcome.exit_code == EXIT_MISSING_INPUT
     assert [run["exit_code"] for run in outcome.results["runs"]] == [EXIT_MISSING_INPUT, 0]
     assert (session_dir / "001_jp20_beir" / "results.json").exists()
+    assert (session_dir / "session_summary.json").exists()
+
+
+def test_run_files_continues_when_failed_child_result_cannot_be_written(monkeypatch, tmp_path):
+    import nemo_retriever.harness.runsets as runsets
+
+    runfiles = []
+    for name in ("jp20_beir", "bo767_beir"):
+        path = tmp_path / f"{name}.json"
+        _write_json(path, {"schema_version": 1, "name": name, "benchmark": name})
+        runfiles.append(path)
+    calls = []
+
+    def fake_run_benchmark(benchmark, **kwargs):
+        calls.append(benchmark)
+        if benchmark == "jp20_beir":
+            raise HarnessRunError(
+                EXIT_MISSING_INPUT,
+                FailurePayload(
+                    failed_phase="resolve",
+                    failure_reason="dataset_missing",
+                    retryable=False,
+                    message="dataset disappeared",
+                ),
+            )
+        return _successful_outcome(benchmark, kwargs["output_dir"])
+
+    original_write_json = runsets.write_json
+
+    def fail_first_child_result(path, payload):
+        if path.name == "results.json" and path.parent.name == "001_jp20_beir":
+            raise OSError("child result unavailable")
+        original_write_json(path, payload)
+
+    monkeypatch.setattr(runsets, "run_benchmark", fake_run_benchmark)
+    monkeypatch.setattr(runsets, "write_json", fail_first_child_result)
+    session_dir = tmp_path / "session"
+
+    outcome = run_runfiles(
+        runfiles,
+        output_dir=str(session_dir),
+        overrides=(f'dataset.path="{tmp_path}"',),
+        dry_run=True,
+    )
+
+    assert calls == ["jp20_beir", "bo767_beir"]
+    assert outcome.exit_code == EXIT_ARTIFACT_WRITE_FAILURE
+    assert [run["exit_code"] for run in outcome.results["runs"]] == [EXIT_ARTIFACT_WRITE_FAILURE, 0]
+    assert outcome.results["runs"][0]["failure_reason"] == "OSError: child result unavailable"
+    assert not (session_dir / "001_jp20_beir" / "results.json").exists()
     assert (session_dir / "session_summary.json").exists()
 
 

--- a/nemo_retriever/tests/test_harness_slack.py
+++ b/nemo_retriever/tests/test_harness_slack.py
@@ -3,7 +3,9 @@ from pathlib import Path
 
 import pytest
 import requests
+from typer.testing import CliRunner
 
+from nemo_retriever.harness.cli import app
 from nemo_retriever.harness.slack import (
     DEFAULT_SLACK_METRIC_KEYS,
     build_slack_payload,
@@ -127,3 +129,37 @@ def test_slack_transport_error_does_not_expose_webhook(monkeypatch):
 
     assert "TSECRET" not in str(exc_info.value)
     assert "webhook request could not be completed" in str(exc_info.value)
+
+
+def test_slack_preview_matches_posted_payload_without_requiring_webhook(monkeypatch, tmp_path):
+    session_dir = _write_session(tmp_path)
+    runner = CliRunner()
+    posted = []
+
+    def capture_post(payload, webhook_url):
+        posted.append((payload, webhook_url))
+
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    monkeypatch.setattr("nemo_retriever.harness.cli.post_slack_payload", capture_post)
+    common_args = [
+        "post-slack",
+        "--title",
+        "nemo-retriever library nightly",
+        "--no-artifact-paths",
+        str(session_dir),
+    ]
+
+    preview_result = runner.invoke(app, [*common_args, "--preview"])
+
+    assert preview_result.exit_code == 0
+    assert posted == []
+    preview_payload = json.loads(preview_result.stdout)
+
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.com/services/test")
+    post_result = runner.invoke(app, [*common_args, "--json"])
+
+    assert post_result.exit_code == 0
+    assert len(posted) == 1
+    assert posted[0][1] == "https://hooks.slack.com/services/test"
+    assert preview_payload == posted[0][0]
+    assert preview_payload == json.loads(post_result.stdout)

--- a/nemo_retriever/tests/test_harness_slack.py
+++ b/nemo_retriever/tests/test_harness_slack.py
@@ -25,10 +25,10 @@ def _write_session(tmp_path: Path, *, dry_run: bool = False) -> Path:
         artifact_dir / "results.json",
         {
             "benchmark": "jp20_beir",
+            "dataset": "jp20",
             "success": True,
             "exit_code": 0,
             "dry_run": dry_run,
-            "resolved_benchmark": {"dataset": {"name": "jp20"}},
             "summary_metrics": {
                 "files": 20,
                 "pages": 1940,
@@ -63,7 +63,7 @@ def _write_session(tmp_path: Path, *, dry_run: bool = False) -> Path:
                 {
                     "run_name": "jp20_beir",
                     "benchmark": "jp20_beir",
-                    "artifact_dir": str(artifact_dir),
+                    "artifact_dir": artifact_dir.name,
                     "exit_code": 0,
                     "success": True,
                     "summary_metrics": {"pages": 1940, "recall_5": 0.887},
@@ -116,6 +116,20 @@ def test_slack_report_labels_dry_run_without_reporting_pass(tmp_path):
     assert "PASS" not in payload_text
 
 
+def test_session_report_resolves_child_artifacts_after_session_is_moved(tmp_path):
+    original = tmp_path / "original"
+    original.mkdir()
+    _write_session(original)
+    moved = tmp_path / "moved"
+    original.rename(moved)
+
+    report = load_session_report(moved)
+
+    assert report.results[0].artifact_dir == moved / "001_jp20_beir"
+    assert report.results[0].dataset == "jp20"
+    assert report.results[0].run_metadata["gpu_count"] == 8
+
+
 def test_slack_transport_error_does_not_expose_webhook(monkeypatch):
     webhook = "https://hooks.slack.com/services/TSECRET/BSECRET/XSECRET"
 
@@ -145,7 +159,6 @@ def test_slack_preview_matches_posted_payload_without_requiring_webhook(monkeypa
         "post-slack",
         "--title",
         "nemo-retriever library nightly",
-        "--no-artifact-paths",
         str(session_dir),
     ]
 
@@ -163,3 +176,4 @@ def test_slack_preview_matches_posted_payload_without_requiring_webhook(monkeypa
     assert posted[0][1] == "https://hooks.slack.com/services/test"
     assert preview_payload == posted[0][0]
     assert preview_payload == json.loads(post_result.stdout)
+    assert str(session_dir) not in json.dumps(preview_payload)

--- a/nemo_retriever/tests/test_harness_slack.py
+++ b/nemo_retriever/tests/test_harness_slack.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-26, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 from pathlib import Path
 
@@ -8,6 +12,9 @@ from typer.testing import CliRunner
 from nemo_retriever.harness.cli import app
 from nemo_retriever.harness.slack import (
     DEFAULT_SLACK_METRIC_KEYS,
+    HarnessRunReport,
+    HarnessSessionReport,
+    MAX_SLACK_TABLE_ROWS,
     build_slack_payload,
     load_replay_report,
     load_session_report,
@@ -148,6 +155,42 @@ def test_run_artifact_replay_has_deterministic_identity(tmp_path):
 
     assert first.session_name == second.session_name == "artifact_replay"
     assert first.timestamp is second.timestamp is None
+
+
+def test_slack_payload_truncates_tables_at_slack_row_limit(tmp_path):
+    results = [
+        HarnessRunReport(
+            run_name=f"run-{index}",
+            dataset=f"dataset-{index}",
+            preset=None,
+            success=True,
+            return_code=0,
+            failure_reason=None,
+            artifact_dir=None,
+            metrics={key: index for key in DEFAULT_SLACK_METRIC_KEYS},
+        )
+        for index in range(12)
+    ]
+    report = HarnessSessionReport(
+        session_name="large-session",
+        session_dir=tmp_path,
+        session_type="runfiles",
+        timestamp=None,
+        latest_commit="abc1234",
+        all_passed=True,
+        dry_run=False,
+        results=results,
+    )
+
+    payload = build_slack_payload(
+        report,
+        {"metric_keys": DEFAULT_SLACK_METRIC_KEYS, "post_artifact_paths": False},
+    )
+    table = next(block for block in payload["blocks"] if block["type"] == "table")
+
+    assert len(table["rows"]) == MAX_SLACK_TABLE_ROWS
+    assert "TRUNCATED" in json.dumps(table["rows"][-1])
+    assert "rows omitted" in json.dumps(table["rows"][-1])
 
 
 def test_slack_transport_error_does_not_expose_webhook(monkeypatch):

--- a/nemo_retriever/tests/test_harness_slack.py
+++ b/nemo_retriever/tests/test_harness_slack.py
@@ -43,7 +43,7 @@ def _write_session(tmp_path: Path, *, dry_run: bool = False) -> Path:
         artifact_dir / "environment.json",
         {
             "git_sha": "abc1234",
-            "host": "nightly-host",
+            "host": "benchmark-host",
             "gpu_count": 8,
             "python": "3.12.12",
             "ray_version": "2.49.0",
@@ -52,7 +52,7 @@ def _write_session(tmp_path: Path, *, dry_run: bool = False) -> Path:
     _write_json(
         tmp_path / "session_summary.json",
         {
-            "session_name": "library_nightly",
+            "session_name": "library_beir",
             "session_type": "runfiles",
             "run_commit": "abc1234",
             "success": True,
@@ -81,21 +81,21 @@ def test_slack_report_loads_runfile_session_and_omits_local_paths(tmp_path):
     payload = build_slack_payload(
         report,
         {
-            "title": "nemo-retriever library nightly",
+            "title": "nemo-retriever library benchmarks",
             "metric_keys": DEFAULT_SLACK_METRIC_KEYS,
             "post_artifact_paths": False,
         },
     )
     payload_text = json.dumps(payload)
 
-    assert report.session_name == "library_nightly"
+    assert report.session_name == "library_beir"
     assert report.all_passed is True
     assert report.latest_commit == "abc1234"
     assert report.results[0].dataset == "jp20"
     assert report.results[0].return_code == 0
     assert report.results[0].metrics == {"pages": 1940, "recall_5": 0.887}
     assert report.results[0].run_metadata["python_version"] == "3.12.12"
-    assert "nemo-retriever library nightly" in payload_text
+    assert "nemo-retriever library benchmarks" in payload_text
     assert "recall@5" in payload_text
     assert str(tmp_path) not in payload_text
 
@@ -158,7 +158,7 @@ def test_slack_preview_matches_posted_payload_without_requiring_webhook(monkeypa
     common_args = [
         "post-slack",
         "--title",
-        "nemo-retriever library nightly",
+        "nemo-retriever library benchmarks",
         str(session_dir),
     ]
 

--- a/nemo_retriever/tests/test_harness_slack.py
+++ b/nemo_retriever/tests/test_harness_slack.py
@@ -9,6 +9,7 @@ from nemo_retriever.harness.cli import app
 from nemo_retriever.harness.slack import (
     DEFAULT_SLACK_METRIC_KEYS,
     build_slack_payload,
+    load_replay_report,
     load_session_report,
     post_slack_payload,
 )
@@ -128,6 +129,25 @@ def test_session_report_resolves_child_artifacts_after_session_is_moved(tmp_path
     assert report.results[0].artifact_dir == moved / "001_jp20_beir"
     assert report.results[0].dataset == "jp20"
     assert report.results[0].run_metadata["gpu_count"] == 8
+
+
+def test_session_report_rejects_malformed_run_entries(tmp_path):
+    summary = tmp_path / "session_summary.json"
+    _write_json(summary, {"session_name": "corrupt", "all_passed": True, "runs": ["not-an-object"]})
+
+    with pytest.raises(ValueError, match="run at index 0 must be an object"):
+        load_session_report(summary)
+
+
+def test_run_artifact_replay_has_deterministic_identity(tmp_path):
+    session_dir = _write_session(tmp_path)
+    results_path = session_dir / "001_jp20_beir" / "results.json"
+
+    first = load_replay_report([results_path])
+    second = load_replay_report([results_path])
+
+    assert first.session_name == second.session_name == "artifact_replay"
+    assert first.timestamp is second.timestamp is None
 
 
 def test_slack_transport_error_does_not_expose_webhook(monkeypatch):

--- a/nemo_retriever/tests/test_harness_slack.py
+++ b/nemo_retriever/tests/test_harness_slack.py
@@ -1,0 +1,129 @@
+import json
+from pathlib import Path
+
+import pytest
+import requests
+
+from nemo_retriever.harness.slack import (
+    DEFAULT_SLACK_METRIC_KEYS,
+    build_slack_payload,
+    load_session_report,
+    post_slack_payload,
+)
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_session(tmp_path: Path, *, dry_run: bool = False) -> Path:
+    artifact_dir = tmp_path / "001_jp20_beir"
+    artifact_dir.mkdir()
+    _write_json(
+        artifact_dir / "results.json",
+        {
+            "benchmark": "jp20_beir",
+            "success": True,
+            "exit_code": 0,
+            "dry_run": dry_run,
+            "resolved_benchmark": {"dataset": {"name": "jp20"}},
+            "summary_metrics": {
+                "files": 20,
+                "pages": 1940,
+                "query_count": 115,
+                "recall_5": 0.887,
+                "recall_10": 0.948,
+            },
+            "failure": None,
+        },
+    )
+    _write_json(
+        artifact_dir / "environment.json",
+        {
+            "git_sha": "abc1234",
+            "host": "nightly-host",
+            "gpu_count": 8,
+            "python": "3.12.12",
+            "ray_version": "2.49.0",
+        },
+    )
+    _write_json(
+        tmp_path / "session_summary.json",
+        {
+            "session_name": "library_nightly",
+            "session_type": "runfiles",
+            "run_commit": "abc1234",
+            "success": True,
+            "all_passed": True,
+            "exit_code": 0,
+            "dry_run": dry_run,
+            "runs": [
+                {
+                    "run_name": "jp20_beir",
+                    "benchmark": "jp20_beir",
+                    "artifact_dir": str(artifact_dir),
+                    "exit_code": 0,
+                    "success": True,
+                    "summary_metrics": {"pages": 1940, "recall_5": 0.887},
+                }
+            ],
+        },
+    )
+    return tmp_path
+
+
+def test_slack_report_loads_runfile_session_and_omits_local_paths(tmp_path):
+    session_dir = _write_session(tmp_path)
+
+    report = load_session_report(session_dir)
+    payload = build_slack_payload(
+        report,
+        {
+            "title": "nemo-retriever library nightly",
+            "metric_keys": DEFAULT_SLACK_METRIC_KEYS,
+            "post_artifact_paths": False,
+        },
+    )
+    payload_text = json.dumps(payload)
+
+    assert report.session_name == "library_nightly"
+    assert report.all_passed is True
+    assert report.latest_commit == "abc1234"
+    assert report.results[0].dataset == "jp20"
+    assert report.results[0].return_code == 0
+    assert report.results[0].metrics == {"pages": 1940, "recall_5": 0.887}
+    assert report.results[0].run_metadata["python_version"] == "3.12.12"
+    assert "nemo-retriever library nightly" in payload_text
+    assert "recall@5" in payload_text
+    assert str(tmp_path) not in payload_text
+
+
+def test_slack_report_labels_dry_run_without_reporting_pass(tmp_path):
+    report = load_session_report(_write_session(tmp_path, dry_run=True))
+
+    payload = build_slack_payload(
+        report,
+        {
+            "metric_keys": DEFAULT_SLACK_METRIC_KEYS,
+            "post_artifact_paths": False,
+        },
+    )
+    payload_text = json.dumps(payload)
+
+    assert "DRY RUN" in payload_text
+    assert "PASS" not in payload_text
+
+
+def test_slack_transport_error_does_not_expose_webhook(monkeypatch):
+    webhook = "https://hooks.slack.com/services/TSECRET/BSECRET/XSECRET"
+
+    def fail_post(*args, **kwargs):
+        raise requests.ConnectionError(f"connection failed for {webhook}")
+
+    monkeypatch.setattr(requests, "post", fail_post)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        post_slack_payload({"text": "test"}, webhook)
+
+    assert "TSECRET" not in str(exc_info.value)
+    assert "webhook request could not be completed" in str(exc_info.value)

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -562,17 +562,17 @@ class TestGraphExecute:
 
         assert g.execute(7) == [12]
 
-    def test_execute_resolved_reuses_archetype_delegate(self, monkeypatch):
+    def test_execute_in_place_reuses_archetype_delegate(self, monkeypatch):
         resources = Resources(cpu_count=8, gpu_count=0)
         monkeypatch.setattr(
             "nemo_retriever.common.ray_resource_hueristics.gather_local_resources",
             lambda: resources,
         )
         CountingCPUAdaptiveAddOperator.constructions = 0
-        resolved = (Graph() >> CountingAdaptiveAddOperator(5)).resolve(resources)
+        graph = Graph() >> CountingAdaptiveAddOperator(5)
 
-        assert resolved.execute_resolved(7) == [12]
-        assert resolved.execute_resolved(8) == [13]
+        assert graph.execute_in_place(7) == [12]
+        assert graph.execute_in_place(8) == [13]
         assert CountingCPUAdaptiveAddOperator.constructions == 1
 
     def test_single_node(self):

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -204,6 +204,22 @@ class AdaptiveAddOperator(ArchetypeOperator):
         self.value = value
 
 
+class CountingCPUAdaptiveAddOperator(CPUAdaptiveAddOperator):
+    constructions = 0
+
+    def __init__(self, value: int = 1) -> None:
+        type(self).constructions += 1
+        super().__init__(value=value)
+
+
+class CountingAdaptiveAddOperator(ArchetypeOperator):
+    _cpu_variant_class = CountingCPUAdaptiveAddOperator
+
+    def __init__(self, value: int = 1) -> None:
+        super().__init__(value=value)
+        self.value = value
+
+
 # =====================================================================
 # Node tests
 # =====================================================================
@@ -545,6 +561,19 @@ class TestGraphExecute:
         g = Graph() >> AdaptiveAddOperator(5)
 
         assert g.execute(7) == [12]
+
+    def test_execute_resolved_reuses_archetype_delegate(self, monkeypatch):
+        resources = Resources(cpu_count=8, gpu_count=0)
+        monkeypatch.setattr(
+            "nemo_retriever.common.ray_resource_hueristics.gather_local_resources",
+            lambda: resources,
+        )
+        CountingCPUAdaptiveAddOperator.constructions = 0
+        resolved = (Graph() >> CountingAdaptiveAddOperator(5)).resolve(resources)
+
+        assert resolved.execute_resolved(7) == [12]
+        assert resolved.execute_resolved(8) == [13]
+        assert CountingCPUAdaptiveAddOperator.constructions == 1
 
     def test_single_node(self):
         g = Graph()

--- a/nemo_retriever/tests/test_retriever_queries.py
+++ b/nemo_retriever/tests/test_retriever_queries.py
@@ -42,24 +42,18 @@ def _make_retriever(**overrides: Any) -> Retriever:
 
 def _install_mock_graph(monkeypatch: pytest.MonkeyPatch, hits: list[list[dict[str, Any]]]) -> MagicMock:
     """Avoid constructing real LanceDB / embed operators."""
-    resolved = MagicMock()
     # Resolved graph execution returns one entry per graph leaf; retrieval output
     # is ``list[list[dict]]``.
-    resolved.execute_resolved.return_value = [hits]
-
     graph = MagicMock()
-    graph.resolve_for_local_execution.return_value = resolved
-
-    monkeypatch.setattr(Retriever, "_build_default_graph", lambda self: graph)
+    graph.execute_in_place.return_value = [hits]
 
     # bypass instance cache from other tests
     def fresh_get(self: Retriever, *, embed_extra: Any = None) -> MagicMock:
-        graph.resolve_for_local_execution.return_value = resolved
         return graph
 
     monkeypatch.setattr(Retriever, "_get_graph", fresh_get)
     monkeypatch.setattr(Retriever, "_resolve_lancedb_query_mode", lambda self, runtime_vdb_kwargs: None)
-    return resolved
+    return graph
 
 
 class TestQueriesGraphExecution:
@@ -71,12 +65,12 @@ class TestQueriesGraphExecution:
 
     def test_queries_thread_top_k_and_vdb_kwargs(self, monkeypatch: pytest.MonkeyPatch) -> None:
         hit = [[{"text": "retrieved", "source": "doc.pdf", "page_number": 1}]]
-        resolved = _install_mock_graph(monkeypatch, hit)
+        graph = _install_mock_graph(monkeypatch, hit)
         retriever = _make_retriever(top_k=11)
         out = retriever.queries(["q"], vdb_kwargs={"where": "x"})
         assert out == hit
-        resolved.execute_resolved.assert_called_once()
-        _args, kw = resolved.execute_resolved.call_args
+        graph.execute_in_place.assert_called_once()
+        _args, kw = graph.execute_in_place.call_args
         assert kw["top_k"] == 11
         assert kw["query_texts"] == ["q"]
         assert kw["where"] == "x"
@@ -100,12 +94,12 @@ class TestQueriesGraphExecution:
         assert p.local_ingest_embed_backend == "vllm"
 
     def test_rerank_inflates_retrieval_top_k(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        resolved = _install_mock_graph(monkeypatch, [[{"text": "x"}]])
+        graph = _install_mock_graph(monkeypatch, [[{"text": "x"}]])
         retriever = _make_retriever(top_k=3, rerank=True, rerank_kwargs={"refine_factor": 4})
         retriever._cached_graph = None
         retriever._cache_key = None
         retriever.queries(["q"])
-        assert resolved.execute_resolved.call_args.kwargs["top_k"] == 12
+        assert graph.execute_in_place.call_args.kwargs["top_k"] == 12
 
     def test_rerank_dataframe_output_orders_hits_by_score(self, monkeypatch: pytest.MonkeyPatch) -> None:
         vector_hits = [
@@ -115,7 +109,7 @@ class TestQueriesGraphExecution:
         execute_kwargs: list[dict[str, Any]] = []
 
         class FakeResolvedGraph:
-            def execute_resolved(self, _df: pd.DataFrame, **kwargs: Any) -> list[Any]:
+            def execute(self, _df: pd.DataFrame, **kwargs: Any) -> list[Any]:
                 execute_kwargs.append(kwargs)
                 return [
                     pd.DataFrame(
@@ -158,18 +152,16 @@ class TestQueriesGraphExecution:
 
     def test_candidate_k_widens_retrieval_before_final_truncation(self, monkeypatch: pytest.MonkeyPatch) -> None:
         hits = [[{"text": f"hit {i}", "page_number": i} for i in range(5)]]
-        resolved = _install_mock_graph(monkeypatch, hits)
+        graph = _install_mock_graph(monkeypatch, hits)
         out = _make_retriever(top_k=2).queries(["q"], candidate_k=5)
 
         assert [hit["text"] for hit in out[0]] == ["hit 0", "hit 1"]
-        assert resolved.execute_resolved.call_args.kwargs["top_k"] == 5
+        assert graph.execute_in_place.call_args.kwargs["top_k"] == 5
 
-    def test_repeated_queries_reuse_resolved_graph(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_repeated_queries_reuse_cached_graph(self, monkeypatch: pytest.MonkeyPatch) -> None:
         hits = [[{"text": "retrieved", "source": "doc.pdf", "page_number": 1}]]
-        resolved = MagicMock()
-        resolved.execute_resolved.return_value = [hits]
         graph = MagicMock()
-        graph.resolve_for_local_execution.return_value = resolved
+        graph.execute_in_place.return_value = [hits]
         build = MagicMock(return_value=graph)
         monkeypatch.setattr(Retriever, "_build_default_graph", build)
         monkeypatch.setattr(Retriever, "_resolve_lancedb_query_mode", lambda self, runtime_vdb_kwargs: None)
@@ -179,8 +171,7 @@ class TestQueriesGraphExecution:
         assert retriever.query("second") == hits[0]
 
         build.assert_called_once()
-        graph.resolve_for_local_execution.assert_called_once()
-        assert resolved.execute_resolved.call_count == 2
+        assert graph.execute_in_place.call_count == 2
 
     def test_custom_graph_preserves_resolve_per_query_behavior(self, monkeypatch: pytest.MonkeyPatch) -> None:
         hits = [[{"text": "retrieved", "source": "doc.pdf", "page_number": 1}]]
@@ -199,16 +190,12 @@ class TestQueriesGraphExecution:
 
         assert graph.resolve_for_local_execution.call_count == 2
 
-    def test_embed_override_invalidates_resolved_graph_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_embed_override_invalidates_graph_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
         hits = [[{"text": "retrieved", "source": "doc.pdf", "page_number": 1}]]
-        resolved_one = MagicMock()
-        resolved_one.execute_resolved.return_value = [hits]
         graph_one = MagicMock()
-        graph_one.resolve_for_local_execution.return_value = resolved_one
-        resolved_two = MagicMock()
-        resolved_two.execute_resolved.return_value = [hits]
+        graph_one.execute_in_place.return_value = [hits]
         graph_two = MagicMock()
-        graph_two.resolve_for_local_execution.return_value = resolved_two
+        graph_two.execute_in_place.return_value = [hits]
         build = MagicMock(side_effect=(graph_one, graph_two))
         monkeypatch.setattr(Retriever, "_build_default_graph", build)
         monkeypatch.setattr(Retriever, "_resolve_lancedb_query_mode", lambda self, runtime_vdb_kwargs: None)
@@ -218,10 +205,8 @@ class TestQueriesGraphExecution:
         retriever.query("same configuration")
         retriever.query("different configuration", embed_kwargs={"model_name": "different"})
 
-        graph_one.resolve_for_local_execution.assert_called_once()
-        graph_two.resolve_for_local_execution.assert_called_once()
-        assert resolved_one.execute_resolved.call_count == 2
-        resolved_two.execute_resolved.assert_called_once()
+        assert graph_one.execute_in_place.call_count == 2
+        graph_two.execute_in_place.assert_called_once()
         assert build.call_count == 2
 
     def test_candidate_k_must_cover_top_k(self) -> None:

--- a/nemo_retriever/tests/test_retriever_queries.py
+++ b/nemo_retriever/tests/test_retriever_queries.py
@@ -43,8 +43,9 @@ def _make_retriever(**overrides: Any) -> Retriever:
 def _install_mock_graph(monkeypatch: pytest.MonkeyPatch, hits: list[list[dict[str, Any]]]) -> MagicMock:
     """Avoid constructing real LanceDB / embed operators."""
     resolved = MagicMock()
-    # :meth:`Graph.execute` returns one entry per graph leaf; retrieval output is ``list[list[dict]]``.
-    resolved.execute.return_value = [hits]
+    # Resolved graph execution returns one entry per graph leaf; retrieval output
+    # is ``list[list[dict]]``.
+    resolved.execute_resolved.return_value = [hits]
 
     graph = MagicMock()
     graph.resolve_for_local_execution.return_value = resolved
@@ -74,8 +75,8 @@ class TestQueriesGraphExecution:
         retriever = _make_retriever(top_k=11)
         out = retriever.queries(["q"], vdb_kwargs={"where": "x"})
         assert out == hit
-        resolved.execute.assert_called_once()
-        _args, kw = resolved.execute.call_args
+        resolved.execute_resolved.assert_called_once()
+        _args, kw = resolved.execute_resolved.call_args
         assert kw["top_k"] == 11
         assert kw["query_texts"] == ["q"]
         assert kw["where"] == "x"
@@ -104,7 +105,7 @@ class TestQueriesGraphExecution:
         retriever._cached_graph = None
         retriever._cache_key = None
         retriever.queries(["q"])
-        assert resolved.execute.call_args.kwargs["top_k"] == 12
+        assert resolved.execute_resolved.call_args.kwargs["top_k"] == 12
 
     def test_rerank_dataframe_output_orders_hits_by_score(self, monkeypatch: pytest.MonkeyPatch) -> None:
         vector_hits = [
@@ -114,7 +115,7 @@ class TestQueriesGraphExecution:
         execute_kwargs: list[dict[str, Any]] = []
 
         class FakeResolvedGraph:
-            def execute(self, _df: pd.DataFrame, **kwargs: Any) -> list[Any]:
+            def execute_resolved(self, _df: pd.DataFrame, **kwargs: Any) -> list[Any]:
                 execute_kwargs.append(kwargs)
                 return [
                     pd.DataFrame(
@@ -161,7 +162,67 @@ class TestQueriesGraphExecution:
         out = _make_retriever(top_k=2).queries(["q"], candidate_k=5)
 
         assert [hit["text"] for hit in out[0]] == ["hit 0", "hit 1"]
-        assert resolved.execute.call_args.kwargs["top_k"] == 5
+        assert resolved.execute_resolved.call_args.kwargs["top_k"] == 5
+
+    def test_repeated_queries_reuse_resolved_graph(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        hits = [[{"text": "retrieved", "source": "doc.pdf", "page_number": 1}]]
+        resolved = MagicMock()
+        resolved.execute_resolved.return_value = [hits]
+        graph = MagicMock()
+        graph.resolve_for_local_execution.return_value = resolved
+        build = MagicMock(return_value=graph)
+        monkeypatch.setattr(Retriever, "_build_default_graph", build)
+        monkeypatch.setattr(Retriever, "_resolve_lancedb_query_mode", lambda self, runtime_vdb_kwargs: None)
+
+        retriever = _make_retriever()
+        assert retriever.query("first") == hits[0]
+        assert retriever.query("second") == hits[0]
+
+        build.assert_called_once()
+        graph.resolve_for_local_execution.assert_called_once()
+        assert resolved.execute_resolved.call_count == 2
+
+    def test_custom_graph_preserves_resolve_per_query_behavior(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        hits = [[{"text": "retrieved", "source": "doc.pdf", "page_number": 1}]]
+
+        class LegacyResolvedGraph:
+            def execute(self, _df: pd.DataFrame, **_kwargs: Any) -> list[Any]:
+                return [hits]
+
+        graph = MagicMock()
+        graph.resolve_for_local_execution.side_effect = (LegacyResolvedGraph(), LegacyResolvedGraph())
+        monkeypatch.setattr(Retriever, "_resolve_lancedb_query_mode", lambda self, runtime_vdb_kwargs: None)
+
+        retriever = _make_retriever(graph=graph)
+        assert retriever.query("first") == hits[0]
+        assert retriever.query("second") == hits[0]
+
+        assert graph.resolve_for_local_execution.call_count == 2
+
+    def test_embed_override_invalidates_resolved_graph_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        hits = [[{"text": "retrieved", "source": "doc.pdf", "page_number": 1}]]
+        resolved_one = MagicMock()
+        resolved_one.execute_resolved.return_value = [hits]
+        graph_one = MagicMock()
+        graph_one.resolve_for_local_execution.return_value = resolved_one
+        resolved_two = MagicMock()
+        resolved_two.execute_resolved.return_value = [hits]
+        graph_two = MagicMock()
+        graph_two.resolve_for_local_execution.return_value = resolved_two
+        build = MagicMock(side_effect=(graph_one, graph_two))
+        monkeypatch.setattr(Retriever, "_build_default_graph", build)
+        monkeypatch.setattr(Retriever, "_resolve_lancedb_query_mode", lambda self, runtime_vdb_kwargs: None)
+
+        retriever = _make_retriever()
+        retriever.query("first")
+        retriever.query("same configuration")
+        retriever.query("different configuration", embed_kwargs={"model_name": "different"})
+
+        graph_one.resolve_for_local_execution.assert_called_once()
+        graph_two.resolve_for_local_execution.assert_called_once()
+        assert resolved_one.execute_resolved.call_count == 2
+        resolved_two.execute_resolved.assert_called_once()
+        assert build.call_count == 2
 
     def test_candidate_k_must_cover_top_k(self) -> None:
         with pytest.raises(ValueError, match=r"candidate_k \(2\).*top_k \(5\)"):
@@ -354,6 +415,20 @@ class TestRetrieveVdbOperatorPreprocess:
         op = RetrieveVdbOperator(vdb_op="lancedb", vdb_kwargs={"uri": "/tmp", "table_name": "t"})
         vec = op.preprocess(df)
         assert vec == [[0.7, 0.8]]
+
+    def test_dataframe_to_vectors_reports_embedding_error(self) -> None:
+        from nemo_retriever.operators.vdb import RetrieveVdbOperator
+
+        df = pd.DataFrame(
+            {
+                "text": ["a"],
+                "text_embeddings_1b_v2": [{"embedding": [], "error": "429 Client Error: Too Many Requests"}],
+            }
+        )
+        op = RetrieveVdbOperator(vdb_op="lancedb", vdb_kwargs={"uri": "/tmp", "table_name": "t"})
+
+        with pytest.raises(ValueError, match="429 Client Error: Too Many Requests"):
+            op.preprocess(df)
 
 
 class TestRerankLongDataframe:


### PR DESCRIPTION
## TL;DR

Add a portable, artifact-first workflow for running one or more checked-in Retriever benchmarks and optionally reporting the completed artifacts to Slack.

Users and agents can copy the dataset path-map example, point it at datasets available on their machine, run one runfile or the four-dataset library suite, inspect a compact terminal summary, and preview or post the same artifacts afterward. Harness execution never implicitly contacts Slack. This PR does not add recurring scheduling or machine-owned nightly infrastructure.

## What changed

### Portable benchmark sessions

- Add `retriever harness run-files` for one or more JSON/YAML runfiles.
- Apply an untracked, machine-local `--dataset-paths` map after runfile defaults and before CLI overrides.
- Give each session a stable layout with `expanded_runs.json`, `session_summary.json`, and one child artifact directory per run.
- Preserve each runfile's mode: JP20 remains local; the larger BO767, Earnings, FinanceBench, and ViDoRe runfiles use batch ingest.
- Preflight every run once before the session starts, then complete the remaining runs after an individual runtime failure while returning the first nonzero exit code.
- Keep dry-run behavior session-wide so one session cannot mix planned and executed children.

### Smaller artifact contract

- Publish JSON artifacts atomically so readers never observe a partially written payload.
- Poll `status.json` while a run is active.
- Read `results.json` when one run is terminal.
- Read `session_summary.json` when a multi-run session is terminal.
- Keep resolved plans, environment, full logs, per-query results, BEIR outputs, and LanceDB as separate drill-down evidence referenced by relative paths.
- Stop emitting a duplicate `summary_metrics.json` for new runs while retaining read compatibility in `diff` and Slack replay.
- Keep terminal failures concise and full tracebacks in `run.log`.
- Validate configuration before replacing known outputs in a reused artifact directory.

### Post-hoc Slack reporting

- Add `retriever harness post-slack` for a completed session or one or more run artifacts.
- Add `--preview`, which renders the exact payload without reading `SLACK_WEBHOOK_URL` or making a network request.
- Keep webhook credentials in the process environment, redact secret-like override values, and avoid exposing webhook values in transport failures.
- Omit runner-local artifact paths unless `--artifact-paths` is explicitly requested.
- Reject empty or malformed session summaries instead of silently posting a misleading report.
- Give raw-artifact replay a deterministic identity so preview and post render the same payload.
- Send a new message per invocation without mutating or rerunning the source artifacts.

### Repeated-query reliability

- Reuse the cached local query graph and its lazily resolved operator delegates so BEIR queries retain one embedding delegate instead of rebuilding the embedder and re-contacting Hugging Face for every query.
- Include the underlying embedding failure when vector extraction fails so query errors remain actionable.

## User-facing boundaries

- Use `retriever ingest` and `retriever query` for direct product workflows.
- Use `retriever harness run-files` for portable benchmark/evaluation sessions.
- Use `retriever harness post-slack` only as optional artifact post-processing.
- Treat `--dry-run` as configuration/planning preflight, not runtime evidence; use a real small benchmark when model startup or execution behavior changes.
- Scheduling, deployment, locking, retries, retention, and secret distribution remain outside this PR.
- Benchmark corpora and qrels are not distributed or downloaded by the harness.

## Suggested review order

1. **CLI and session resolution:** `harness/cli.py`, `harness/dataset_paths.py`, `harness/runsets.py`, and the checked-in runfiles.
2. **Artifact contract:** `harness/artifact_writer.py`, `harness/execution.py`, `harness/environment.py`, and `harness/diff.py`.
3. **Slack replay:** `harness/slack.py` and `test_harness_slack.py`.
4. **Query reuse and error propagation:** `graph/pipeline_graph.py`, `graph/retriever.py`, `operators/vdb.py`, and their focused tests.
5. **User contract:** `harness/README.md`, `EXPECTED_RESULTS.md`, and `HANDOFF.md`.

The commits already follow that dependency/order boundary; no history rewrite is needed.

## Validation

- `177 passed`: artifact/session/Slack contract, runfile sessions, graph execution, and repeated-query caching.
- `128 passed`: agentic, query workflow, root query CLI, comparator, and service-query regressions.
- Pre-commit passes on the final changed-file set.
- A dry run against tracked `data/multimodal_test.pdf` wrote status/result/planning artifacts, created no LanceDB, run log, or query output, and produced a valid Slack preview with no webhook configured.
- A four-run portable dry-run applied local mode to JP20 and batch mode to the three larger datasets, produced relative manifests, and previewed Slack with `SLACK_WEBHOOK_URL` unset.
- A real JP20 batch smoke processed 20 files / 1,940 pages, wrote a 22 MB LanceDB index, and emitted the compact terminal contract.
- Missing-input and metric-gate failures emitted concise terminal results.
- Current readers previewed a pre-change session and diffed current results against legacy `summary_metrics.json` artifacts.
- An earlier full eight-GPU all-batch suite completed with `success=true`, `all_passed=true`, and exit code `0`:
  - JP20: 115/115 queries
  - BO767: 991/991 queries
  - Earnings: 628/628 queries
  - FinanceBench: 150/150 queries
- That completed suite posted one real Slack report successfully.

## Known follow-up

Two oversized BO767 chunks exceeded the embedder context limit during the full run. The session and query gates passed; input truncation/splitting is separate follow-up work.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.