### PR TITLE
Add MCP service condition to skill eval

### DIFF
--- a/nemo_retriever/src/nemo_retriever/ingest/service.py
+++ b/nemo_retriever/src/nemo_retriever/ingest/service.py
@@ -29,6 +29,7 @@ from nemo_retriever.common.params import (
     StoreParams,
     TextChunkParams,
 )
+from nemo_retriever.common.params.models import NO_API_KEY
 from nemo_retriever.common.input_files import expand_input_file_patterns, input_type_for_path
 
 logger = logging.getLogger(__name__)
@@ -195,6 +196,12 @@ def resolve_service_ingest_request(request: ServiceIngestPlanRequest) -> Service
     )
     if request.extract.table_output_format == "markdown":
         extract_kwargs["use_table_structure"] = True
+    # Service mode owns extraction endpoints and credentials. Suppress the
+    # shared params model's client-side NVIDIA_API_KEY auto-resolution so a
+    # caller's shell environment does not become a per-request override.
+    extract_kwargs.setdefault("api_key", NO_API_KEY)
+    extract_kwargs.setdefault("page_elements_api_key", NO_API_KEY)
+    extract_kwargs.setdefault("ocr_api_key", NO_API_KEY)
 
     embed_kwargs = {
         key: value
@@ -206,6 +213,7 @@ def resolve_service_ingest_request(request: ServiceIngestPlanRequest) -> Service
         }.items()
         if value is not None
     }
+    embed_kwargs.setdefault("api_key", NO_API_KEY)
     enable_text_chunk, text_chunk_kwargs = build_text_chunk_kwargs(
         enabled=request.chunk.enabled,
         text_chunk_max_tokens=request.chunk.text_chunk_max_tokens,
@@ -217,7 +225,7 @@ def resolve_service_ingest_request(request: ServiceIngestPlanRequest) -> Service
         documents=documents,
         input_type=input_type,
         extract_params=ExtractParams(**extract_kwargs),
-        embed_params=EmbedParams(**embed_kwargs) if embed_kwargs else EmbedParams(),
+        embed_params=EmbedParams(**embed_kwargs),
         text_chunk_params=text_chunk_params,
         enable_text_chunk=enable_text_chunk,
         dedup_params=build_dedup_params(enabled=request.dedup.enabled, iou_threshold=request.dedup.iou_threshold),
@@ -261,7 +269,7 @@ def build_service_ingestor(request: ServiceIngestRequest) -> Any:
     if request.caption_params is not None:
         ingestor = ingestor.caption(_sanitize_service_caption_params(request.caption_params))
 
-    ingestor = ingestor.embed(request.embed_params)
+    ingestor = ingestor.embed(_strip_service_api_key_fields(request.embed_params, {"api_key"}))
 
     if request.store_params is not None:
         ingestor = ingestor.store(request.store_params)
@@ -332,6 +340,22 @@ def _service_extraction_mode(input_type: str) -> str:
     }.get(input_type, "auto")
 
 
+def _strip_service_api_key_fields(params: Any, keys: set[str]) -> Any:
+    """Return params without client-resolved API keys for service-owned stages."""
+
+    if params is None:
+        return None
+    if hasattr(params, "model_dump"):
+        data = params.model_dump(mode="json", exclude_none=True, exclude_unset=True)
+    elif isinstance(params, dict):
+        data = {key: value for key, value in params.items() if value is not None}
+    else:
+        return params
+    for key in keys:
+        data.pop(key, None)
+    return data
+
+
 def _service_text_chunk_dict(text_chunk_params: TextChunkParams) -> dict[str, Any]:
     """Serialize text-chunk knobs allowed by the service split_config policy."""
 
@@ -353,13 +377,17 @@ def _attach_service_extract_stage(
     """Wire the extraction stage for the remote service ingestor."""
 
     chunk_dict = _service_text_chunk_dict(text_chunk_params) if enable_text_chunk else None
+    service_extract_params = _strip_service_api_key_fields(
+        extract_params,
+        {"api_key", "page_elements_api_key", "ocr_api_key"},
+    )
     if input_type == "image":
         return ingestor.extract_image_files(
-            extract_params,
+            service_extract_params,
             split_config={"image": chunk_dict} if chunk_dict else None,
         )
     return ingestor.extract(
-        extract_params,
+        service_extract_params,
         split_config=_split_config_for_input_type(input_type, chunk_dict, documents=documents),
         extraction_mode=_service_extraction_mode(input_type),
     )

--- a/nemo_retriever/src/nemo_retriever/service/cli.py
+++ b/nemo_retriever/src/nemo_retriever/service/cli.py
@@ -184,14 +184,14 @@ def mcp_stdio(
         "--auth-header-name",
         help="Header used for bearer-token authentication.",
     ),
-    concurrency: int = typer.Option(8, "--concurrency", min=1, help="Max concurrent MCP document uploads."),
+    concurrency: int = typer.Option(8, "--concurrency", min=1, help="Max concurrent MCP content uploads."),
     request_timeout_s: float = typer.Option(60.0, "--request-timeout", min=0.1, help="HTTP request timeout."),
     ingest_timeout_s: float = typer.Option(1800.0, "--ingest-timeout", min=1.0, help="Document ingest timeout."),
     poll_interval_s: float = typer.Option(2.0, "--poll-interval", min=0.1, help="Status polling interval."),
     enable_write_tools: bool = typer.Option(
         True,
         "--write-tools/--read-only",
-        help="Expose write-capable MCP tools such as ingest_documents.",
+        help="Expose write-capable MCP tools such as ingest_content.",
     ),
 ) -> None:
     """Run the retriever service MCP server over stdio for local agents."""

--- a/nemo_retriever/src/nemo_retriever/service/mcp_server.py
+++ b/nemo_retriever/src/nemo_retriever/service/mcp_server.py
@@ -32,13 +32,17 @@ logger = logging.getLogger(__name__)
 
 
 class MCPDocumentInput(BaseModel):
-    """Document payload accepted by the MCP ``ingest_documents`` tool."""
+    """Content payload accepted by the MCP ingest tools."""
 
     model_config = ConfigDict(extra="forbid")
 
     path: str | None = Field(
         default=None,
-        description="Path to a document visible to the MCP server process.",
+        description=(
+            "Path to content visible to the MCP server process. Supports the same "
+            "file types as service ingestion, including PDFs, images, Office files, "
+            "HTML/TXT, audio, and video."
+        ),
     )
     filename: str | None = Field(
         default=None,
@@ -46,7 +50,7 @@ class MCPDocumentInput(BaseModel):
     )
     content_base64: str | None = Field(
         default=None,
-        description="Base64-encoded document bytes for remote agents.",
+        description="Base64-encoded content bytes for remote agents.",
     )
     content_type: str | None = Field(
         default=None,
@@ -248,6 +252,7 @@ class ServiceMCPClient:
         pipeline_spec: dict[str, Any] | None = None,
         retain_results: bool = False,
         include_result_data: bool = False,
+        wait_until_done: bool = True,
     ) -> dict[str, Any]:
         if not self._settings.enable_write_tools:
             raise RuntimeError("MCP write tools are disabled for this service.")
@@ -278,18 +283,20 @@ class ServiceMCPClient:
             document_ids = [
                 item["document_id"] for item in upload_results if item.get("ok") and item.get("document_id")
             ]
-            documents_page = await self._poll_documents_until_terminal(
-                client,
-                job_id,
-                document_ids,
-                timeout_at=timeout_at,
-            )
+            documents_page: dict[str, Any] = {"items": [], "total": 0, "timed_out": False}
+            if wait_until_done:
+                documents_page = await self._poll_documents_until_terminal(
+                    client,
+                    job_id,
+                    document_ids,
+                    timeout_at=timeout_at,
+                )
 
-            if include_result_data:
-                for item in documents_page.get("items", []):
-                    if item.get("status") in {"completed", "failed"}:
-                        detail = await self._get_document_with_client(client, job_id, item["document_id"])
-                        item["result_data"] = detail.get("result_data")
+                if include_result_data:
+                    for item in documents_page.get("items", []):
+                        if item.get("status") in {"completed", "failed"}:
+                            detail = await self._get_document_with_client(client, job_id, item["document_id"])
+                            item["result_data"] = detail.get("result_data")
 
         upload_errors = [item for item in upload_results if not item.get("ok")]
         return {
@@ -299,6 +306,7 @@ class ServiceMCPClient:
             "upload_errors": upload_errors,
             "documents": documents_page,
             "timed_out": bool(documents_page.get("timed_out")),
+            "wait_until_done": wait_until_done,
         }
 
     async def _upload_documents(
@@ -447,8 +455,8 @@ def build_mcp(settings: ServiceMCPSettings | None = None) -> FastMCP:
         "NeMo Retriever Service",
         instructions=(
             "Use these tools to interact with a running NVIDIA NeMo Retriever "
-            "service. Ingest documents, check job status, query the configured "
-            "VectorDB, and ask the configured answer-generation endpoint."
+            "service. Ingest multimodal content, check job status, query the "
+            "configured VectorDB, and ask the configured answer-generation endpoint."
         ),
     )
 
@@ -489,9 +497,10 @@ def build_mcp(settings: ServiceMCPSettings | None = None) -> FastMCP:
     @mcp.tool(
         name="query",
         description=(
-            "Search ingested documents through the service VectorDB endpoint. "
-            "format='hits' (default) returns raw retrieval hits; format='evidence' "
-            "returns the fidelity-tagged, citation-ready {evidence, coverage} shape."
+            "Search ingested content through the service VectorDB endpoint. "
+            "Use format='evidence' when an agent needs citation-ready evidence with "
+            "fidelity tags and coverage/thin-spot signals; use format='hits' for "
+            "raw retrieval hits. Extra /v1/query JSON fields can be passed in payload."
         ),
     )
     async def query(
@@ -502,7 +511,14 @@ def build_mcp(settings: ServiceMCPSettings | None = None) -> FastMCP:
     ) -> dict[str, Any]:
         return await service.query(query, top_k=top_k, format=format, payload=payload)
 
-    @mcp.tool(name="answer", description="Search ingested documents and generate an answer.")
+    @mcp.tool(
+        name="answer",
+        description=(
+            "Search ingested content and generate an answer with the service's "
+            "configured LLM endpoint. Use query(format='evidence') instead when "
+            "the agent should compose the answer itself from retrieved evidence."
+        ),
+    )
     async def answer(
         query: str,
         top_k: int = 5,
@@ -524,11 +540,60 @@ def build_mcp(settings: ServiceMCPSettings | None = None) -> FastMCP:
 
     if settings.enable_write_tools:
 
+        async def _ingest_content(
+            documents: list[MCPDocumentInput],
+            label: str | None = None,
+            job_metadata: dict[str, Any] | None = None,
+            pipeline_spec: dict[str, Any] | None = None,
+            retain_results: bool = False,
+            include_result_data: bool = False,
+            wait_until_done: bool = True,
+        ) -> dict[str, Any]:
+            return await service.ingest_documents(
+                documents,
+                label=label,
+                job_metadata=job_metadata,
+                pipeline_spec=pipeline_spec,
+                retain_results=retain_results,
+                include_result_data=include_result_data,
+                wait_until_done=wait_until_done,
+            )
+
+        ingest_description = (
+            "Upload multimodal content to the retriever service for ingestion. "
+            "Each item must provide exactly one source: a server-visible path or "
+            "base64 content bytes with a filename. Supported inputs follow the "
+            "service ingest stack: PDFs, images, Office files, HTML/TXT, audio, "
+            "and video. Optional pipeline_spec is forwarded to the service and "
+            "is still constrained by server-side policy. Set wait_until_done=false "
+            "to submit long jobs quickly, then poll get_job/list_job_documents."
+        )
+
+        @mcp.tool(name="ingest_content", description=ingest_description)
+        async def ingest_content(
+            documents: list[MCPDocumentInput],
+            label: str | None = None,
+            job_metadata: dict[str, Any] | None = None,
+            pipeline_spec: dict[str, Any] | None = None,
+            retain_results: bool = False,
+            include_result_data: bool = False,
+            wait_until_done: bool = True,
+        ) -> dict[str, Any]:
+            return await _ingest_content(
+                documents,
+                label=label,
+                job_metadata=job_metadata,
+                pipeline_spec=pipeline_spec,
+                retain_results=retain_results,
+                include_result_data=include_result_data,
+                wait_until_done=wait_until_done,
+            )
+
         @mcp.tool(
             name="ingest_documents",
             description=(
-                "Upload documents to the retriever service. Each document can "
-                "reference a server-visible path or provide base64 content."
+                "Compatibility alias for ingest_content. Prefer ingest_content "
+                "for new agents because the service handles more than documents."
             ),
         )
         async def ingest_documents(
@@ -538,14 +603,16 @@ def build_mcp(settings: ServiceMCPSettings | None = None) -> FastMCP:
             pipeline_spec: dict[str, Any] | None = None,
             retain_results: bool = False,
             include_result_data: bool = False,
+            wait_until_done: bool = True,
         ) -> dict[str, Any]:
-            return await service.ingest_documents(
+            return await _ingest_content(
                 documents,
                 label=label,
                 job_metadata=job_metadata,
                 pipeline_spec=pipeline_spec,
                 retain_results=retain_results,
                 include_result_data=include_result_data,
+                wait_until_done=wait_until_done,
             )
 
     return mcp

--- a/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
+++ b/nemo_retriever/src/nemo_retriever/service/routers/ingest.py
@@ -389,6 +389,7 @@ def _route_by_page_count(
     file_bytes: bytes,
     meta: IngestRequest,
     file_category: FileCategory | None = None,
+    file_suffix: str = "",
 ) -> PoolType:
     """Route uploads to realtime or batch based on file type and page count.
 
@@ -396,9 +397,10 @@ def _route_by_page_count(
       heavyweight ASR / frame-extraction pipelines.
     * Image files are always routed to **realtime** — they are single-page
       and latency-sensitive.
-    * Documents (PDF, DOCX, PPTX) and other types use the original
-      page-count heuristic: small docs (<threshold pages) go to realtime,
-      larger ones to batch.
+    * PDF documents use the original page-count heuristic: small docs
+      (<threshold pages) go to realtime, larger ones to batch.
+    * Other supported document/text formats route realtime, matching the
+      previous PDFium-error fallback without logging a misleading warning.
 
     When the client requested PDF page-chunking via
     :attr:`PipelineSpec.pdf_split`, we route to **batch** as soon as the
@@ -410,6 +412,8 @@ def _route_by_page_count(
     if file_category == FileCategory.IMAGE:
         return PoolType.REALTIME
     if meta.page_number is not None:
+        return PoolType.REALTIME
+    if file_category != FileCategory.DOCUMENT or file_suffix.lower() != ".pdf":
         return PoolType.REALTIME
     pages = _count_pdf_pages(file_bytes)
     if meta.pipeline and meta.pipeline.pdf_split is not None:
@@ -825,7 +829,12 @@ async def submit_document_to_job(
             file_size = _file_size_from_upload(file, request)
 
             file_bytes = await file.read()
-            route = _route_by_page_count(file_bytes, meta, file_category=classification.category)
+            route = _route_by_page_count(
+                file_bytes,
+                meta,
+                file_category=classification.category,
+                file_suffix=classification.suffix,
+            )
 
             document_id = uuid.uuid4().hex
             content_sha256 = hashlib.sha256(file_bytes).hexdigest()
@@ -878,7 +887,12 @@ async def submit_document_to_job(
         enforce_media_dependencies(classification)
 
         file_bytes = await file.read()
-        route = _route_by_page_count(file_bytes, meta, file_category=classification.category)
+        route = _route_by_page_count(
+            file_bytes,
+            meta,
+            file_category=classification.category,
+            file_suffix=classification.suffix,
+        )
         content_sha256 = hashlib.sha256(file_bytes).hexdigest()
         now = datetime.now(timezone.utc).isoformat()
 

--- a/nemo_retriever/src/nemo_retriever/tools/skill_eval/dataset.py
+++ b/nemo_retriever/src/nemo_retriever/tools/skill_eval/dataset.py
@@ -139,5 +139,5 @@ def load_eval_manifest(path: Path) -> list[DatasetEntry]:
 
 def load_config(path: Path | None = None) -> dict[str, Any]:
     if path is None:
-        path = Path(str(pkg_files("nemo_retriever.skill_eval").joinpath("configs/skill_eval.yaml")))
+        path = Path(str(pkg_files("nemo_retriever.tools.skill_eval").joinpath("configs/skill_eval.yaml")))
     return _read_yaml_mapping(Path(path))

--- a/nemo_retriever/src/nemo_retriever/tools/skill_eval/prompts/setup_mcp.j2
+++ b/nemo_retriever/src/nemo_retriever/tools/skill_eval/prompts/setup_mcp.j2
@@ -1,0 +1,7 @@
+I have a folder of {{ domain_label }} at ./pdfs/. Set up a way to search and answer questions over them using the native Retriever MCP tools exposed to this agent.
+
+Use the Retriever MCP `health` tool first. Then ingest every PDF in ./pdfs/ with the Retriever MCP `ingest_content` tool using server-visible `path` inputs. Pass `wait_until_done=false` so long ingestion jobs return a `job_id` quickly. After each submit, poll `get_job` or `list_job_documents` until every submitted document is completed or failed.
+
+Do not run the `retriever` CLI. Do not use `curl`, raw HTTP, or manual JSON-RPC calls to the MCP endpoint. This condition is testing whether native MCP tools help the agent use Retriever correctly. If native Retriever MCP tools are not available, stop and report that; do not work around it.
+
+When ingestion is complete, simply stop. Do not write output.json during setup.

--- a/nemo_retriever/src/nemo_retriever/tools/skill_eval/prompts/trial_user_mcp.j2
+++ b/nemo_retriever/src/nemo_retriever/tools/skill_eval/prompts/trial_user_mcp.j2
@@ -1,0 +1,21 @@
+{{ paraphrased_prompt }}
+
+Use the native Retriever MCP tools to answer. Prefer `query` with `format="evidence"` and `top_k=10` so you can inspect citation-ready evidence. Use `answer` only if it helps, but still populate `ranked_retrieved` from retrieved evidence pages.
+
+Do not run the `retriever` CLI. Do not use `curl`, raw HTTP, or manual JSON-RPC calls to the MCP endpoint. This condition is testing native MCP tool use. If native Retriever MCP tools are not available, write an output.json with an empty `final_answer`, empty `ranked_retrieved`, and an explanation in an `error` field.
+
+When complete, write the final result to ./output.json with EXACTLY this schema:
+
+{
+  "final_answer": "<natural-language answer to the question>",
+  "ranked_retrieved": [
+    {"doc_id": "<PDF filename without .pdf>", "page_number": <0-indexed int>, "rank": 1},
+    ... up to 10 entries, ranked by relevance to the question
+  ]
+}
+
+Notes:
+- `doc_id` is the base filename of the source PDF without the `.pdf` extension. Example: for a file named `Foo_Report.pdf`, the doc_id is `Foo_Report`.
+- `page_number` in output.json is 0-indexed: the first page of a PDF is page 0. Retriever MCP evidence citations like `p.42` or locators like `{"kind": "page", "value": 42}` are 1-indexed PDF page labels, so subtract 1 before writing `page_number`.
+- `ranked_retrieved` must be ordered by relevance and contain up to 10 (doc_id, page_number) pairs.
+- After writing the file, simply stop. Do not print the file contents or summarize.

--- a/nemo_retriever/src/nemo_retriever/tools/skill_eval/runner.py
+++ b/nemo_retriever/src/nemo_retriever/tools/skill_eval/runner.py
@@ -12,6 +12,8 @@ import logging
 import os
 import re
 import shutil
+import signal
+import socket
 import stat
 import subprocess
 import time
@@ -21,13 +23,16 @@ from dataclasses import asdict, dataclass, field
 from importlib.resources import files as pkg_files
 from pathlib import Path
 from typing import Any
+from urllib import request as urlrequest
 
+from nemo_retriever.harness.config import REPO_ROOT
 from nemo_retriever.tools.skill_eval.dataset import DatasetEntry
 
 logger = logging.getLogger(__name__)
 
 BASE_CONDITION = "c1_base"
-CONDITIONS = ("c1_base", "c2_retriever", "c3_retriever_skill")
+MCP_CONDITION = "c4_mcp_service"
+CONDITIONS = ("c1_base", "c2_retriever", "c3_retriever_skill", MCP_CONDITION)
 SUPPORTED_AGENTS = ("claude", "codex")
 DEFAULT_AGENT_MODELS = {
     "claude": "claude-opus-4-7",
@@ -37,7 +42,7 @@ DEFAULT_AGENT_MODELS = {
 
 @functools.lru_cache(maxsize=8)
 def _load_prompt_template(name: str) -> str:
-    return Path(str(pkg_files("nemo_retriever.skill_eval").joinpath(f"prompts/{name}"))).read_text(encoding="utf-8")
+    return Path(str(pkg_files("nemo_retriever.tools.skill_eval").joinpath(f"prompts/{name}"))).read_text(encoding="utf-8")
 
 
 @dataclass
@@ -104,7 +109,12 @@ def _remap_pdf_paths(text: str, prefixes: tuple[str, ...]) -> str:
 
 
 def _render_prompt(entry: DatasetEntry, condition: str, testdata_prefixes: tuple[str, ...] = ()) -> str:
-    tpl_name = "trial_user_slash.j2" if condition == "c3_retriever_skill" else "trial_user_nl.j2"
+    if condition == MCP_CONDITION:
+        tpl_name = "trial_user_mcp.j2"
+    elif condition == "c3_retriever_skill":
+        tpl_name = "trial_user_slash.j2"
+    else:
+        tpl_name = "trial_user_nl.j2"
     text = _load_prompt_template(tpl_name)
     return text.replace(
         "{{ paraphrased_prompt }}", _remap_pdf_paths(entry.paraphrased_prompt, testdata_prefixes)
@@ -112,7 +122,12 @@ def _render_prompt(entry: DatasetEntry, condition: str, testdata_prefixes: tuple
 
 
 def _render_setup_prompt(condition: str, domain_label: str = "PDFs") -> str:
-    tpl_name = "setup_slash.j2" if condition == "c3_retriever_skill" else "setup_nl.j2"
+    if condition == MCP_CONDITION:
+        tpl_name = "setup_mcp.j2"
+    elif condition == "c3_retriever_skill":
+        tpl_name = "setup_slash.j2"
+    else:
+        tpl_name = "setup_nl.j2"
     text = _load_prompt_template(tpl_name)
     return text.replace("{{ domain_label }}", domain_label)
 
@@ -159,6 +174,8 @@ def _write_setup_context(workdir: Path, *, agent: str, condition: str) -> Path:
     ]
     if condition == BASE_CONDITION:
         lines.append("- The `retriever` CLI is intentionally blocked for this baseline condition.")
+    elif condition == MCP_CONDITION:
+        lines.append("- A local Retriever service is running. Use the Retriever MCP tools, not the `retriever` CLI.")
     else:
         lines.append("- The `retriever` CLI and nemo-retriever skill are available for this condition.")
     lines += ["", "## Top-level setup artifacts"]
@@ -299,6 +316,223 @@ def _env_for(condition: str, workdir: Path) -> dict[str, str]:
     return env
 
 
+
+
+@dataclass
+class MCPServiceRun:
+    service_url: str
+    vdb_url: str
+    service_proc: subprocess.Popen[str] | None = None
+    vdb_proc: subprocess.Popen[str] | None = None
+    service_log: Any = None
+    vdb_log: Any = None
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _get_json(url: str, timeout: float = 5.0) -> dict[str, Any]:
+    with urlrequest.urlopen(url, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _wait_health(url: str, *, timeout_s: float, require_warm: bool = False) -> dict[str, Any]:
+    started = time.monotonic()
+    last_error: str | None = None
+    while time.monotonic() - started < timeout_s:
+        try:
+            body = _get_json(url, timeout=5.0)
+            if body.get("status") == "ok" and (not require_warm or body.get("models_warm") is True):
+                return body
+        except Exception as exc:  # noqa: BLE001 - health polling should keep retrying.
+            last_error = str(exc)
+        time.sleep(2.0)
+    raise TimeoutError(f"Timed out waiting for {url}; last_error={last_error}")
+
+
+def _start_logged_process(args: list[str], log_path: Path, *, env: dict[str, str] | None = None) -> tuple[subprocess.Popen[str], Any]:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log = log_path.open("w", encoding="utf-8")
+    proc = subprocess.Popen(
+        args,
+        cwd=str(REPO_ROOT),
+        env=env,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        text=True,
+        start_new_session=True,
+    )
+    return proc, log
+
+
+def _stop_process(proc: subprocess.Popen[str] | None, log: Any = None, *, timeout: float = 30.0) -> None:
+    if proc is not None and proc.poll() is None:
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+            proc.wait(timeout=timeout)
+        except Exception:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except Exception:
+                pass
+    if log is not None:
+        try:
+            log.close()
+        except Exception:
+            pass
+
+
+def _start_mcp_service(workdir: Path, *, condition: str) -> MCPServiceRun | None:
+    if condition != MCP_CONDITION:
+        return None
+
+    uv = Path(os.environ.get("NEMO_RETRIEVER_SKILL_EVAL_UV", "/home/nfs/mwason/.local/bin/uv"))
+    project = Path(os.environ.get("NEMO_RETRIEVER_SKILL_EVAL_PROJECT", str(REPO_ROOT / "nemo_retriever")))
+    hf_cache = Path(os.environ.get("NEMO_RETRIEVER_SKILL_EVAL_HF_CACHE", "/raid/mwason/.cache/huggingface"))
+    gpu = os.environ.get("NEMO_RETRIEVER_SKILL_EVAL_GPU", "5")
+    model = os.environ.get("NEMO_RETRIEVER_SKILL_EVAL_EMBED_MODEL", "nvidia/llama-nemotron-embed-vl-1b-v2")
+    warmup = os.environ.get("NEMO_RETRIEVER_SKILL_EVAL_MCP_WARMUP", "false").lower() in {"1", "true", "yes"}
+    startup_timeout = float(os.environ.get("NEMO_RETRIEVER_SKILL_EVAL_MCP_STARTUP_TIMEOUT", "900"))
+
+    service_port = _free_port()
+    vdb_port = _free_port()
+    service_url = f"http://127.0.0.1:{service_port}"
+    vdb_url = f"http://127.0.0.1:{vdb_port}"
+    service_dir = workdir / ".mcp_service"
+    service_dir.mkdir(parents=True, exist_ok=True)
+    config_path = service_dir / "service.yaml"
+    config_text = f'''mode: standalone
+
+server:
+  host: "127.0.0.1"
+  port: {service_port}
+
+logging:
+  level: "INFO"
+  file: "{service_dir / 'service-file.log'}"
+
+local_models:
+  enabled: true
+  hf_cache_dir: "{hf_cache}"
+  warmup_on_startup: {str(warmup).lower()}
+  max_process_pool_workers: 1
+  extract:
+    enabled: true
+    use_table_structure: false
+    use_graphic_elements: false
+    ocr_version: v2
+  embed:
+    enabled: true
+    model_name: {model}
+    local_ingest_embed_backend: hf
+  asr:
+    enabled: false
+
+pipeline:
+  realtime_workers: 1
+  realtime_queue_size: 64
+  batch_workers: 1
+  batch_queue_size: 64
+
+resources:
+  gpu_devices: ["{gpu}"]
+
+vectordb:
+  enabled: true
+  lancedb_uri: "{service_dir / 'lancedb'}"
+  table_name: "nemo_retriever_mcp_eval"
+  embed_model: {model}
+  vectordb_url: "{vdb_url}"
+
+mcp:
+  enabled: true
+  path: "/mcp"
+  base_url: "{service_url}"
+  enable_write_tools: true
+  max_concurrency: 4
+  request_timeout_s: 240.0
+  ingest_timeout_s: 7200.0
+  poll_interval_s: 0.5
+'''
+    config_path.write_text(config_text, encoding="utf-8")
+
+    vdb_env = os.environ.copy()
+    vdb_env["CUDA_VISIBLE_DEVICES"] = gpu
+    run = MCPServiceRun(service_url=service_url, vdb_url=vdb_url)
+    run.vdb_proc, run.vdb_log = _start_logged_process(
+        [
+            str(uv),
+            "run",
+            "--project",
+            str(project),
+            "python",
+            "-m",
+            "nemo_retriever.service.vectordb_app",
+            "--lancedb-uri",
+            str(service_dir / "lancedb"),
+            "--table-name",
+            "nemo_retriever_mcp_eval",
+            "--local-embed",
+            "--local-embed-backend",
+            "hf",
+            "--hf-cache-dir",
+            str(hf_cache),
+            "--device",
+            "cuda:0",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(vdb_port),
+            "--log-level",
+            "INFO",
+        ],
+        service_dir / "vectordb.log",
+        env=vdb_env,
+    )
+    _wait_health(vdb_url + "/v1/health", timeout_s=startup_timeout)
+
+    run.service_proc, run.service_log = _start_logged_process(
+        [
+            str(uv),
+            "run",
+            "--project",
+            str(project),
+            "retriever",
+            "service",
+            "start",
+            "--config",
+            str(config_path),
+        ],
+        service_dir / "service.log",
+    )
+    _wait_health(service_url + "/v1/health", timeout_s=startup_timeout, require_warm=warmup)
+    (workdir / "mcp_service_context.md").write_text(
+        "\n".join(
+            [
+                "# Retriever MCP Service Context",
+                "",
+                f"- Service URL: `{service_url}`",
+                f"- VectorDB URL: `{vdb_url}`",
+                "- Use Retriever MCP tools for ingest/query/answer.",
+                "- Do not use the `retriever` CLI in this condition.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return run
+
+
+def _stop_mcp_service(run: MCPServiceRun | None) -> None:
+    if run is None:
+        return
+    _stop_process(run.service_proc, run.service_log)
+    _stop_process(run.vdb_proc, run.vdb_log)
+
+
 def _build_claude_command(
     condition: str,
     model: str,
@@ -351,6 +585,8 @@ def _build_codex_command(
     workdir: Path,
     *,
     resume: bool = False,
+    condition: str = "",
+    mcp_service_url: str | None = None,
 ) -> list[str]:
     """Build a non-interactive Codex command.
 
@@ -366,6 +602,13 @@ def _build_codex_command(
         "--ignore-rules",
         "--dangerously-bypass-approvals-and-sandbox",
     ]
+    if condition == MCP_CONDITION and mcp_service_url:
+        common.extend(
+            [
+                "-c",
+                f'mcp_servers.retriever.url="{mcp_service_url}/mcp/"',
+            ]
+        )
     if resume:
         return ["codex", "exec", "resume", *common, session_uuid, "-"]
     return [
@@ -393,7 +636,14 @@ def _build_command(
     if agent == "claude":
         return _build_claude_command(condition, model, budget_usd, session_uuid, workdir, resume=resume)
     if agent == "codex":
-        return _build_codex_command(model, session_uuid, workdir, resume=resume)
+        return _build_codex_command(
+            model,
+            session_uuid,
+            workdir,
+            resume=resume,
+            condition=condition,
+            mcp_service_url=os.environ.get("NEMO_RETRIEVER_ACTIVE_MCP_SERVICE_URL"),
+        )
     raise ValueError(f"unsupported agent: {agent}")
 
 
@@ -1038,6 +1288,26 @@ def _scan_codex_transcript_for_signals(
         payload = ev.get("payload") or {}
         if not isinstance(payload, dict) or payload.get("type") != "function_call":
             continue
+        tool_name = str(payload.get("name") or "")
+        if condition == MCP_CONDITION:
+            is_retriever_tool = tool_name.startswith("mcp__retriever__") or tool_name in {
+                "health",
+                "pipeline_config",
+                "get_job",
+                "list_job_documents",
+                "get_document",
+                "query",
+                "answer",
+                "ingest_content",
+                "ingest_documents",
+            }
+            if not is_retriever_tool:
+                continue
+            attempted = True
+            call_id = payload.get("call_id")
+            if isinstance(call_id, str) and call_id in outputs_by_call and "error" not in outputs_by_call[call_id].lower():
+                succeeded = True
+            continue
         if not _retriever_in_command(_codex_tool_command(payload), condition):
             continue
         attempted = True
@@ -1239,7 +1509,7 @@ def _run_one_turn(
     result.retriever_succeeded = succeeded
     # c1 has the skill unavailable; leave skill_fired=None to distinguish from
     # "loaded but didn't fire".
-    if condition in ("c2_retriever", "c3_retriever_skill"):
+    if condition in ("c2_retriever", "c3_retriever_skill", MCP_CONDITION):
         result.skill_fired = attempted and (first_use is not None) and first_use <= 2
     return result
 
@@ -1305,6 +1575,19 @@ def run_condition(
     execution_mode = "parallel_isolated" if query_parallelism > 1 else "linear_session"
 
     workdir = _build_condition_workdir(agent, condition, workdir_root, pdf_source, skill_source, domain=domain)
+    mcp_service = _start_mcp_service(workdir, condition=condition)
+    previous_mcp_service_url = os.environ.get("NEMO_RETRIEVER_ACTIVE_MCP_SERVICE_URL")
+    if mcp_service is not None:
+        os.environ["NEMO_RETRIEVER_ACTIVE_MCP_SERVICE_URL"] = mcp_service.service_url
+
+    def _finish(run: ConditionRun) -> ConditionRun:
+        if previous_mcp_service_url is None:
+            os.environ.pop("NEMO_RETRIEVER_ACTIVE_MCP_SERVICE_URL", None)
+        else:
+            os.environ["NEMO_RETRIEVER_ACTIVE_MCP_SERVICE_URL"] = previous_mcp_service_url
+        _stop_mcp_service(mcp_service)
+        return run
+
     session_uuid = str(uuid.uuid4())
     env = _env_for(condition, workdir)
     logger.info(
@@ -1369,7 +1652,7 @@ def run_condition(
             domain or "default",
             len(entries),
         )
-        return run
+        return _finish(run)
 
     _write_setup_context(workdir, agent=agent, condition=condition)
     session_uuid = setup_result.session_id or session_uuid
@@ -1408,7 +1691,7 @@ def run_condition(
             _apply_judge(judge, entry, result)
             results.append(result)
             result_workdirs[result.trial_id] = workdir
-        return run
+        return _finish(run)
 
     query_contexts: list[dict[str, Any]] = []
     for i, entry in enumerate(entries):
@@ -1500,7 +1783,7 @@ def run_condition(
         if entry is not None:
             _apply_judge(judge, entry, result)
     results.extend(query_results)
-    return run
+    return _finish(run)
 
 
 def save_trial(result: TrialResult, session_dir: Path) -> Path:

--- a/nemo_retriever/tests/test_pipeline_helpers.py
+++ b/nemo_retriever/tests/test_pipeline_helpers.py
@@ -11,7 +11,13 @@ import pytest
 import typer
 
 import nemo_retriever.cli.pipeline as pipeline_pkg
-from nemo_retriever.ingest.service import ServiceIngestRequest, build_service_ingestor
+from nemo_retriever.ingest.service import (
+    ServiceIngestPlanRequest,
+    ServiceIngestRequest,
+    ServiceIngestSourceOptions,
+    build_service_ingestor,
+    resolve_service_ingest_request,
+)
 from nemo_retriever.common.params import EmbedParams, ExtractParams, TextChunkParams
 from nemo_retriever.cli.pipeline.__main__ import (
     _build_embed_params,
@@ -90,6 +96,27 @@ def test_build_service_ingestor_wires_extract_embed_and_chunking(tmp_path: Path)
         PipelineSpec.model_validate(ingestor._pipeline_spec),
         PipelineOverridesConfig().to_policy(),
     )
+
+
+def test_service_ingest_request_suppresses_env_api_keys(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("NVIDIA_API_KEY", "dummy-client-key")
+    monkeypatch.setenv("NGC_API_KEY", "dummy-client-key")
+    txt = tmp_path / "doc.txt"
+    txt.write_text("hello", encoding="utf-8")
+
+    request = resolve_service_ingest_request(
+        ServiceIngestPlanRequest(
+            source=ServiceIngestSourceOptions(documents=[str(txt)], input_type="txt"),
+        )
+    )
+    ingestor = build_service_ingestor(request)
+    payload = ingestor._pipeline_payload()
+
+    assert payload is not None
+    assert "api_key" not in payload.get("extract_params", {})
+    assert "page_elements_api_key" not in payload.get("extract_params", {})
+    assert "ocr_api_key" not in payload.get("extract_params", {})
+    assert "api_key" not in payload.get("embed_params", {})
 
 
 def test_resolve_file_patterns_returns_existing_file_verbatim(tmp_path: Path) -> None:

--- a/nemo_retriever/tests/test_service_ingest_router.py
+++ b/nemo_retriever/tests/test_service_ingest_router.py
@@ -33,13 +33,33 @@ from nemo_retriever.service.config import (
     ServiceConfig,
 )
 from nemo_retriever.service import tracing
+from nemo_retriever.common.schemas.requests import IngestRequest
+from nemo_retriever.service.routers import ingest as ingest_router
 from nemo_retriever.service.services.pipeline_pool import WorkItem
+from nemo_retriever.service.services.pipeline_pool import PoolType
+from nemo_retriever.service.utils.file_type import FileCategory
 from .conftest import create_test_job
 
 
 @pytest.fixture
 def captured_items() -> list[WorkItem]:
     return []
+
+
+def test_route_by_page_count_skips_pdf_probe_for_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fail_pdf_probe(_file_bytes: bytes) -> int:
+        raise AssertionError("non-PDF uploads should not be opened by PDFium")
+
+    monkeypatch.setattr(ingest_router, "_count_pdf_pages", _fail_pdf_probe)
+
+    route = ingest_router._route_by_page_count(
+        b"hello",
+        IngestRequest(filename="doc.txt"),
+        file_category=FileCategory.TEXT,
+        file_suffix=".txt",
+    )
+
+    assert route is PoolType.REALTIME
 
 
 class _CollectingExporter:

--- a/nemo_retriever/tests/test_service_mcp.py
+++ b/nemo_retriever/tests/test_service_mcp.py
@@ -24,6 +24,7 @@ from nemo_retriever.service.mcp_server import (
     MCPDocumentInput,
     ServiceMCPClient,
     ServiceMCPSettings,
+    build_mcp,
     settings_from_service_config,
 )
 from nemo_retriever.service.services.pipeline_pool import WorkItem
@@ -168,6 +169,17 @@ def test_ingest_documents_accepts_inline_base64_upload() -> None:
         ("POST", "/v1/ingest/job/job-1/document"),
         ("GET", "/v1/ingest/job/job-1/documents"),
     ]
+
+
+def test_mcp_tools_expose_generic_ingest_content_and_legacy_alias() -> None:
+    tools = _run(build_mcp().list_tools())
+    by_name = {tool.name: tool for tool in tools}
+
+    assert "ingest_content" in by_name
+    assert "ingest_documents" in by_name
+    assert "PDFs, images, Office files, HTML/TXT, audio, and video" in by_name["ingest_content"].description
+    assert "Compatibility alias" in by_name["ingest_documents"].description
+    assert "format='evidence'" in by_name["query"].description
 
 
 def test_service_start_mounts_mcp_and_auth_protects_it(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
  ## Summary

  Adds a native MCP-service condition (`c4_mcp_service`) to the skill-eval harness so we can compare Retriever usage through first-class MCP tools against the existing CLI/skill conditions.

  ## What Changed

  - Add `c4_mcp_service` as a supported skill-eval condition.
  - Start a local Retriever service + VectorDB for MCP eval runs and wire Codex to the service MCP endpoint.
  - Add MCP-specific setup/query prompts that require native Retriever MCP tools instead of the `retriever` CLI.
  - Add generic `ingest_content` MCP tool, keeping `ingest_documents` as a compatibility alias.
  - Add `wait_until_done=false` support so agents can submit long ingest jobs and poll status explicitly.
  - Improve MCP tool descriptions for ingestion, querying, and answering.
  - Fix service-ingest behavior so client env API keys do not leak into service-owned extract/embed params.
  - Avoid PDF page-count probing for non-PDF uploads.

  ## Validation

  ```bash
  PYTHONPATH=/raid/mwason/nrl-mcp-skill-eval-pr/nemo_retriever/src \
    /raid/mwason/nrl-mcp-skills-service-eval/nemo_retriever/.venv/bin/python -m pytest \
    /raid/mwason/nrl-mcp-skill-eval-pr/nemo_retriever/tests/test_service_mcp.py \
    /raid/mwason/nrl-mcp-skill-eval-pr/nemo_retriever/tests/test_service_ingest_router.py \
    /raid/mwason/nrl-mcp-skill-eval-pr/nemo_retriever/tests/test_pipeline_helpers.py

  