### PR TITLE
[harness] Add ViDoRe v3 benchmark suite

### DIFF
--- a/nemo_retriever/harness/EXPECTED_RESULTS.md
+++ b/nemo_retriever/harness/EXPECTED_RESULTS.md
@@ -166,17 +166,93 @@ Benchmark:
 |-----------|---------|----------------|---------|------------------|
 | `earnings_beir` | End-to-end retrieval quality | `auto` | `628` | TBD after canonical run |
 
-## ViDoRe V3 Finance EN
+## ViDoRe V3
 
-Dataset:
+The eight public ViDoRe v3 benchmarks use original PDFs for ingest and load
+queries and qrels from the corresponding `vidore/<dataset>` Hugging Face
+dataset. The canonical configuration uses:
 
-- Corpus path: `/datasets/nv-ingest/vidore_v3/vidore_v3_finance_en`
-- Query/qrels source: HuggingFace dataset `vidore/vidore_v3_finance_en`
-- Files: `6`
-- Pages: `2942`
+- `nvidia/llama-nemotron-embed-vl-1b-v2`
+- `text_image` embedding at page granularity
+- page-image and infographic extraction
+- page-level BEIR document IDs
 
-Benchmark:
+Dataset integrity gates:
 
-| Benchmark | Purpose | Ingest Profile | Queries | Expected Quality |
-|-----------|---------|----------------|---------|------------------|
-| `vidore_v3_finance_en_beir` | Canonical end-to-end page-level ViDoRe retrieval quality | `auto` | `1854` | TBD after canonical run |
+| Dataset | Files | Pages | Queries |
+|---------|------:|------:|--------:|
+| `vidore_v3_computer_science` | 2 | 1360 | 1290 |
+| `vidore_v3_energy` | 41 | 2225 | 1848 |
+| `vidore_v3_finance_en` | 6 | 2942 | 1854 |
+| `vidore_v3_finance_fr` | 5 | 2384 | 1920 |
+| `vidore_v3_hr` | 14 | 1110 | 1908 |
+| `vidore_v3_industrial` | 27 | 5244 | 1698 |
+| `vidore_v3_pharmaceuticals` | 52 | 2313 | 2184 |
+| `vidore_v3_physics` | 42 | 1674 | 1812 |
+
+Canonical benchmarks:
+
+| Benchmark | Purpose | Ingest Profile | Expected Quality |
+|-----------|---------|----------------|------------------|
+| `vidore_v3_computer_science_beir` | Computer science page retrieval | `auto` | Observed `ndcg_10` about `0.708` to `0.709` |
+| `vidore_v3_energy_beir` | Energy page retrieval | `auto` | Observed `ndcg_10` about `0.581` |
+| `vidore_v3_finance_en_beir` | English finance page retrieval | `auto` | Observed `ndcg_10` about `0.547` |
+| `vidore_v3_finance_fr_beir` | French finance page retrieval | `auto` | Observed `ndcg_10` about `0.345`; see coverage warning below |
+| `vidore_v3_hr_beir` | Human-resources page retrieval | `auto` | Observed `ndcg_10` about `0.530` |
+| `vidore_v3_industrial_beir` | Industrial page retrieval | `auto` | Observed `ndcg_10` about `0.381` |
+| `vidore_v3_pharmaceuticals_beir` | Pharmaceuticals page retrieval | `auto` | Observed `ndcg_10` about `0.607` |
+| `vidore_v3_physics_beir` | Physics page retrieval | `auto` | Observed `ndcg_10` about `0.451` |
+
+Use the checked-in runfiles for executable file, page, and query-count gates.
+Add quality and performance observations here only after a complete run on the
+canonical default configuration.
+
+Observed metrics from complete batch runs on an eight-H100 DGX with the default
+benchmark configuration:
+
+| Dataset | Rows Processed | Indexed Rows | Ingest Seconds | Pages/s | Query p50 ms | Query p95 ms | Recall@5 | Recall@10 | nDCG@10 |
+|---------|---------------:|-------------:|---------------:|--------:|-------------:|-------------:|---------:|----------:|--------:|
+| Computer Science | 1360 | 1358 | 100.2-123.5 | 11.0-13.6 | 40.3-40.7 | 66.7-66.9 | 0.599-0.600 | 0.729-0.730 | 0.708-0.709 |
+| Energy | 2225 | 2211 | 116.7 | 19.1 | 43.3 | 51.4 | 0.575 | 0.674 | 0.581 |
+| Finance EN | 2942 | 2927 | 149.4 | 19.7 | 45.1 | 53.7 | 0.496 | 0.609 | 0.547 |
+| Finance FR | 2384 | 2149 | 106.4 | 22.4 | 44.8 | 52.0 | 0.324 | 0.426 | 0.345 |
+| HR | 1110 | 1091 | 82.6 | 13.4 | 39.7 | 46.3 | 0.452 | 0.574 | 0.530 |
+| Industrial | 5244 | 5039 | 137.5 | 38.1 | 51.0 | 61.8 | 0.348 | 0.426 | 0.381 |
+| Pharmaceuticals | 2313 | 2290 | 93.7 | 24.7 | 46.0 | 54.9 | 0.547 | 0.647 | 0.607 |
+| Physics | 1674 | 1674 | 89.2 | 18.8 | 45.0 | 52.5 | 0.369 | 0.485 | 0.451 |
+
+Computer Science was run twice; the other domains have one complete observation
+each. Computer Science quality was stable to within `0.0011` nDCG@10. The
+eight-domain macro-average nDCG@10 was about `0.519`, using the mean of the two
+Computer Science runs.
+
+The NeMo Retriever 26.05 image-plus-text release baseline reports average
+Recall@5 of `0.490` over the English datasets and `0.465` over all datasets.
+The default harness run reproduces the domain-level release results to within
+`0.0032` absolute Recall@5:
+
+| Dataset | 26.05 Release Recall@5 | Observed Recall@5 | Delta |
+|---------|------------------------:|------------------:|------:|
+| Finance EN | 0.499 | 0.496 | -0.003 |
+| Industrial | 0.348 | 0.348 | +0.000 |
+| Computer Science | 0.600 | 0.599 | -0.001 |
+| Pharmaceuticals | 0.549 | 0.547 | -0.002 |
+| HR | 0.453 | 0.452 | -0.001 |
+| Energy | 0.577 | 0.575 | -0.002 |
+| Physics | 0.367 | 0.369 | +0.002 |
+| Finance FR | 0.324 | 0.324 | +0.000 |
+
+The observed simple macro-average Recall@5 was `0.464` over all eight domains.
+
+The indexed-row audit found that every omitted page had empty corpus text. No
+judged pages were omitted for seven of the eight datasets. Finance FR omitted
+`235` empty-text pages, including `69` judged image-only pages, because the
+current dense LanceDB write path drops records without text even when an image
+embedding exists. Its Recall@5 still matches the 26.05 release baseline, which
+suggests the release exercised the same behavior, but retaining those judged
+image-only pages remains a correctness prerequisite before nightly scheduling.
+
+Do not apply default hard quality gates across machine profiles or GPU SKUs.
+Keep the checked-in file, page, and query-count requirements as hard integrity
+gates, record quality metrics on every run, and establish comparison ranges
+from each nightly environment's own history.

--- a/nemo_retriever/harness/README.md
+++ b/nemo_retriever/harness/README.md
@@ -148,6 +148,43 @@ uv run --project nemo_retriever retriever harness run-files \
   nemo_retriever/harness/runfiles/financebench_beir.json
 ```
 
+The ViDoRe v3 library follows the same runfile-first contract. Each benchmark
+uses the VL embed model with `text_image` page embeddings and page-level BEIR
+scoring. Run one domain while validating a machine or configuration:
+
+```bash
+uv run --project nemo_retriever retriever harness run-files \
+  --session-name vidore_v3_computer_science \
+  --output-dir /local/path/to/retriever-artifacts/vidore-v3-computer-science \
+  --dataset-paths /local/path/to/dataset_paths.yaml \
+  --json \
+  nemo_retriever/harness/runfiles/vidore_v3_computer_science_beir.json
+```
+
+After single-domain validation, run all eight public ViDoRe v3 domains as one
+portable session:
+
+```bash
+uv run --project nemo_retriever retriever harness run-files \
+  --session-name vidore_v3_all \
+  --output-dir /local/path/to/retriever-artifacts/vidore-v3-all \
+  --dataset-paths /local/path/to/dataset_paths.yaml \
+  --json \
+  nemo_retriever/harness/runfiles/vidore_v3_computer_science_beir.json \
+  nemo_retriever/harness/runfiles/vidore_v3_energy_beir.json \
+  nemo_retriever/harness/runfiles/vidore_v3_finance_en_beir.json \
+  nemo_retriever/harness/runfiles/vidore_v3_finance_fr_beir.json \
+  nemo_retriever/harness/runfiles/vidore_v3_hr_beir.json \
+  nemo_retriever/harness/runfiles/vidore_v3_industrial_beir.json \
+  nemo_retriever/harness/runfiles/vidore_v3_pharmaceuticals_beir.json \
+  nemo_retriever/harness/runfiles/vidore_v3_physics_beir.json
+```
+
+The code-owned `vidore_v3_all` runset is also available when the registry's
+default dataset paths are mounted. Prefer the checked-in runfiles for nightly
+or other orchestrated sessions because they carry per-dataset integrity gates
+and accept a machine-local path map.
+
 `run-files` owns the session layout and execution mode. Runfiles passed to this
 command cannot set their own `output_dir`, `run_id`, or `dry_run`; use the
 session-level `--dry-run` flag instead. The session uses the following paths and

--- a/nemo_retriever/harness/dataset_paths.example.yaml
+++ b/nemo_retriever/harness/dataset_paths.example.yaml
@@ -12,5 +12,19 @@ datasets:
   financebench:
     path: /path/to/datasets/nv-ingest/foundation_rag/financebench
     query_file: /path/to/NeMo-Retriever/data/financebench_train.json
+  vidore_v3_computer_science:
+    path: /path/to/datasets/nv-ingest/vidore_v3/vidore_v3_computer_science
+  vidore_v3_energy:
+    path: /path/to/datasets/nv-ingest/vidore_v3/vidore_v3_energy
   vidore_v3_finance_en:
     path: /path/to/datasets/nv-ingest/vidore_v3/vidore_v3_finance_en
+  vidore_v3_finance_fr:
+    path: /path/to/datasets/nv-ingest/vidore_v3/vidore_v3_finance_fr
+  vidore_v3_hr:
+    path: /path/to/datasets/nv-ingest/vidore_v3/vidore_v3_hr
+  vidore_v3_industrial:
+    path: /path/to/datasets/nv-ingest/vidore_v3/vidore_v3_industrial
+  vidore_v3_pharmaceuticals:
+    path: /path/to/datasets/nv-ingest/vidore_v3/vidore_v3_pharmaceuticals
+  vidore_v3_physics:
+    path: /path/to/datasets/nv-ingest/vidore_v3/vidore_v3_physics

--- a/nemo_retriever/harness/runfiles/vidore_v3_computer_science_beir.json
+++ b/nemo_retriever/harness/runfiles/vidore_v3_computer_science_beir.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "name": "vidore_v3_computer_science_beir",
+  "benchmark": "vidore_v3_computer_science_beir",
+  "mode": "batch",
+  "require": [
+    "files==2",
+    "pages==1360",
+    "query_count==1290"
+  ],
+  "set": {}
+}

--- a/nemo_retriever/harness/runfiles/vidore_v3_energy_beir.json
+++ b/nemo_retriever/harness/runfiles/vidore_v3_energy_beir.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "name": "vidore_v3_energy_beir",
+  "benchmark": "vidore_v3_energy_beir",
+  "mode": "batch",
+  "require": [
+    "files==41",
+    "pages==2225",
+    "query_count==1848"
+  ],
+  "set": {}
+}

--- a/nemo_retriever/harness/runfiles/vidore_v3_finance_fr_beir.json
+++ b/nemo_retriever/harness/runfiles/vidore_v3_finance_fr_beir.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "name": "vidore_v3_finance_fr_beir",
+  "benchmark": "vidore_v3_finance_fr_beir",
+  "mode": "batch",
+  "require": [
+    "files==5",
+    "pages==2384",
+    "query_count==1920"
+  ],
+  "set": {}
+}

--- a/nemo_retriever/harness/runfiles/vidore_v3_hr_beir.json
+++ b/nemo_retriever/harness/runfiles/vidore_v3_hr_beir.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "name": "vidore_v3_hr_beir",
+  "benchmark": "vidore_v3_hr_beir",
+  "mode": "batch",
+  "require": [
+    "files==14",
+    "pages==1110",
+    "query_count==1908"
+  ],
+  "set": {}
+}

--- a/nemo_retriever/harness/runfiles/vidore_v3_industrial_beir.json
+++ b/nemo_retriever/harness/runfiles/vidore_v3_industrial_beir.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "name": "vidore_v3_industrial_beir",
+  "benchmark": "vidore_v3_industrial_beir",
+  "mode": "batch",
+  "require": [
+    "files==27",
+    "pages==5244",
+    "query_count==1698"
+  ],
+  "set": {}
+}

--- a/nemo_retriever/harness/runfiles/vidore_v3_pharmaceuticals_beir.json
+++ b/nemo_retriever/harness/runfiles/vidore_v3_pharmaceuticals_beir.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "name": "vidore_v3_pharmaceuticals_beir",
+  "benchmark": "vidore_v3_pharmaceuticals_beir",
+  "mode": "batch",
+  "require": [
+    "files==52",
+    "pages==2313",
+    "query_count==2184"
+  ],
+  "set": {}
+}

--- a/nemo_retriever/harness/runfiles/vidore_v3_physics_beir.json
+++ b/nemo_retriever/harness/runfiles/vidore_v3_physics_beir.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "name": "vidore_v3_physics_beir",
+  "benchmark": "vidore_v3_physics_beir",
+  "mode": "batch",
+  "require": [
+    "files==42",
+    "pages==1674",
+    "query_count==1812"
+  ],
+  "set": {}
+}

--- a/nemo_retriever/src/nemo_retriever/harness/benchmark_registry.py
+++ b/nemo_retriever/src/nemo_retriever/harness/benchmark_registry.py
@@ -12,7 +12,18 @@ from nemo_retriever.harness.benchmark_specs import BenchmarkSpec, DatasetSpec, R
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 DEFAULT_EMBED_MODEL = "nvidia/llama-nemotron-embed-1b-v2"
+VIDORE_V3_EMBED_MODEL = "nvidia/llama-nemotron-embed-vl-1b-v2"
 DEFAULT_TABLE_NAME = "nemo-retriever"
+VIDORE_V3_PUBLIC_DATASETS: dict[str, str] = {
+    "vidore_v3_computer_science": "computer science",
+    "vidore_v3_energy": "energy",
+    "vidore_v3_finance_en": "English finance",
+    "vidore_v3_finance_fr": "French finance",
+    "vidore_v3_hr": "human resources",
+    "vidore_v3_industrial": "industrial",
+    "vidore_v3_pharmaceuticals": "pharmaceuticals",
+    "vidore_v3_physics": "physics",
+}
 DEFAULT_SUMMARY_KEYS: tuple[str, ...] = (
     "files",
     "pages",
@@ -30,6 +41,18 @@ DEFAULT_SUMMARY_KEYS: tuple[str, ...] = (
 
 def _data_path(name: str) -> str:
     return str(Path("data") / name)
+
+
+def _vidore_v3_dataset(name: str, domain: str) -> DatasetSpec:
+    return DatasetSpec(
+        name=name,
+        path=f"/datasets/nv-ingest/vidore_v3/{name}",
+        query_file=None,
+        input_type="pdf",
+        beir_loader="vidore_hf",
+        beir_doc_id_field="pdf_page",
+        description=f"ViDoRe v3 {domain} benchmark slice.",
+    )
 
 
 DATASETS: dict[str, DatasetSpec] = {
@@ -85,15 +108,7 @@ DATASETS: dict[str, DatasetSpec] = {
         beir_doc_id_field="pdf_page",
         description="Earnings consulting multimodal benchmark corpus.",
     ),
-    "vidore_v3_finance_en": DatasetSpec(
-        name="vidore_v3_finance_en",
-        path="/datasets/nv-ingest/vidore_v3/vidore_v3_finance_en",
-        query_file=None,
-        input_type="pdf",
-        beir_loader="vidore_hf",
-        beir_doc_id_field="pdf_page",
-        description="ViDoRe v3 English finance benchmark slice.",
-    ),
+    **{name: _vidore_v3_dataset(name, domain) for name, domain in VIDORE_V3_PUBLIC_DATASETS.items()},
 }
 
 
@@ -117,14 +132,14 @@ def _base_ingest(*, profile: str = "auto") -> dict[str, Any]:
     }
 
 
-def _base_query(*, top_k: int = 10) -> dict[str, Any]:
+def _base_query(*, top_k: int = 10, embed_model_name: str = DEFAULT_EMBED_MODEL) -> dict[str, Any]:
     return {
         "top_k": top_k,
         "candidate_k": None,
         "page_dedup": False,
         "content_types": None,
         "retrieval_mode": "auto",
-        "embed_model_name": DEFAULT_EMBED_MODEL,
+        "embed_model_name": embed_model_name,
         "embed_invoke_url": None,
         "rerank": False,
         "reranker_invoke_url": None,
@@ -143,6 +158,39 @@ def _beir_eval(dataset: DatasetSpec) -> dict[str, Any]:
         "doc_id_field": dataset.beir_doc_id_field,
         "ks": dataset.beir_ks,
     }
+
+
+def _vidore_v3_ingest() -> dict[str, Any]:
+    ingest = _base_ingest(profile="auto")
+    ingest["extract"] = {
+        "extract_infographics": True,
+        "extract_page_as_image": True,
+    }
+    ingest["embed"] = {
+        "embed_model_name": VIDORE_V3_EMBED_MODEL,
+        "embed_modality": "text_image",
+        "embed_granularity": "page",
+    }
+    return ingest
+
+
+def _vidore_v3_benchmark(dataset_name: str) -> BenchmarkSpec:
+    dataset = DATASETS[dataset_name]
+    domain = VIDORE_V3_PUBLIC_DATASETS[dataset_name]
+    domain_tags = ("finance",) if dataset_name.startswith("vidore_v3_finance_") else ()
+    return BenchmarkSpec(
+        name=f"{dataset_name}_beir",
+        dataset=dataset_name,
+        ingest=_vidore_v3_ingest(),
+        query=_base_query(top_k=10, embed_model_name=VIDORE_V3_EMBED_MODEL),
+        evaluation={
+            **_beir_eval(dataset),
+            "dataset_name": dataset_name,
+        },
+        summary_keys=DEFAULT_SUMMARY_KEYS,
+        tags=("beir", "vidore", *domain_tags, "pdf"),
+        description=f"ViDoRe v3 {domain} BEIR retrieval benchmark.",
+    )
 
 
 BENCHMARKS: dict[str, BenchmarkSpec] = {
@@ -196,19 +244,7 @@ BENCHMARKS: dict[str, BenchmarkSpec] = {
         tags=("beir", "earnings", "pdf"),
         description="Earnings consulting end-to-end BEIR retrieval benchmark.",
     ),
-    "vidore_v3_finance_en_beir": BenchmarkSpec(
-        name="vidore_v3_finance_en_beir",
-        dataset="vidore_v3_finance_en",
-        ingest=_base_ingest(profile="auto"),
-        query=_base_query(top_k=10),
-        evaluation={
-            **_beir_eval(DATASETS["vidore_v3_finance_en"]),
-            "dataset_name": "vidore_v3_finance_en",
-        },
-        summary_keys=DEFAULT_SUMMARY_KEYS,
-        tags=("beir", "vidore", "finance", "pdf"),
-        description="ViDoRe v3 English finance BEIR retrieval benchmark.",
-    ),
+    **{f"{dataset_name}_beir": _vidore_v3_benchmark(dataset_name) for dataset_name in VIDORE_V3_PUBLIC_DATASETS},
     "bo10k_beir_fast_text": BenchmarkSpec(
         name="bo10k_beir_fast_text",
         dataset="bo10k",
@@ -237,6 +273,12 @@ RUNSETS: dict[str, RunSet] = {
         runs=("jp20_smoke", "jp20_beir"),
         tags=("jp20", "core"),
         description="Small jp20 smoke plus BEIR validation set.",
+    ),
+    "vidore_v3_all": RunSet(
+        name="vidore_v3_all",
+        runs=tuple(f"{dataset_name}_beir" for dataset_name in VIDORE_V3_PUBLIC_DATASETS),
+        tags=("vidore", "beir", "all"),
+        description="All eight public ViDoRe v3 BEIR retrieval benchmarks.",
     ),
 }
 

--- a/nemo_retriever/src/nemo_retriever/harness/benchmark_registry.py
+++ b/nemo_retriever/src/nemo_retriever/harness/benchmark_registry.py
@@ -177,7 +177,7 @@ def _vidore_v3_ingest() -> dict[str, Any]:
 def _vidore_v3_benchmark(dataset_name: str) -> BenchmarkSpec:
     dataset = DATASETS[dataset_name]
     domain = VIDORE_V3_PUBLIC_DATASETS[dataset_name]
-    domain_tags = ("finance",) if dataset_name.startswith("vidore_v3_finance_") else ()
+    domain_tags = ("finance",) if "finance" in domain.lower() else ()
     return BenchmarkSpec(
         name=f"{dataset_name}_beir",
         dataset=dataset_name,

--- a/nemo_retriever/tests/test_harness_benchmark_registry.py
+++ b/nemo_retriever/tests/test_harness_benchmark_registry.py
@@ -50,6 +50,7 @@ def test_vidore_v3_benchmarks_use_page_level_multimodal_defaults(dataset_name: s
     assert benchmark.query["embed_model_name"] == VIDORE_V3_EMBED_MODEL
     assert benchmark.evaluation["dataset_name"] == dataset_name
     assert benchmark.evaluation["doc_id_field"] == "pdf_page"
+    assert ("finance" in benchmark.tags) is ("finance" in VIDORE_V3_PUBLIC_DATASETS[dataset_name].lower())
 
 
 @pytest.mark.parametrize(("dataset_name", "facts"), VIDORE_V3_DATASET_FACTS.items())

--- a/nemo_retriever/tests/test_harness_benchmark_registry.py
+++ b/nemo_retriever/tests/test_harness_benchmark_registry.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-26, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+
+from nemo_retriever.harness.benchmark_registry import (
+    get_benchmark,
+    get_dataset,
+    get_runset,
+    VIDORE_V3_EMBED_MODEL,
+    VIDORE_V3_PUBLIC_DATASETS,
+)
+from nemo_retriever.harness.runfile import load_runfile
+
+
+VIDORE_V3_DATASET_FACTS = {
+    "vidore_v3_computer_science": (2, 1360, 1290),
+    "vidore_v3_energy": (41, 2225, 1848),
+    "vidore_v3_finance_en": (6, 2942, 1854),
+    "vidore_v3_finance_fr": (5, 2384, 1920),
+    "vidore_v3_hr": (14, 1110, 1908),
+    "vidore_v3_industrial": (27, 5244, 1698),
+    "vidore_v3_pharmaceuticals": (52, 2313, 2184),
+    "vidore_v3_physics": (42, 1674, 1812),
+}
+RUNFILES_DIR = Path(__file__).resolve().parents[1] / "harness" / "runfiles"
+
+
+@pytest.mark.parametrize("dataset_name", VIDORE_V3_DATASET_FACTS)
+def test_vidore_v3_benchmarks_use_page_level_multimodal_defaults(dataset_name: str) -> None:
+    dataset = get_dataset(dataset_name)
+    benchmark = get_benchmark(f"{dataset_name}_beir")
+
+    assert dataset.beir_loader == "vidore_hf"
+    assert dataset.beir_doc_id_field == "pdf_page"
+    assert Path(dataset.path).name == dataset_name
+    assert benchmark.dataset == dataset_name
+    assert benchmark.ingest["extract"] == {
+        "extract_infographics": True,
+        "extract_page_as_image": True,
+    }
+    assert benchmark.ingest["embed"] == {
+        "embed_model_name": VIDORE_V3_EMBED_MODEL,
+        "embed_modality": "text_image",
+        "embed_granularity": "page",
+    }
+    assert benchmark.query["embed_model_name"] == VIDORE_V3_EMBED_MODEL
+    assert benchmark.evaluation["dataset_name"] == dataset_name
+    assert benchmark.evaluation["doc_id_field"] == "pdf_page"
+
+
+@pytest.mark.parametrize(("dataset_name", "facts"), VIDORE_V3_DATASET_FACTS.items())
+def test_vidore_v3_runfiles_carry_dataset_integrity_gates(dataset_name: str, facts: tuple[int, int, int]) -> None:
+    files, pages, queries = facts
+    request = load_runfile(RUNFILES_DIR / f"{dataset_name}_beir.json")
+
+    assert request.benchmark == f"{dataset_name}_beir"
+    assert request.mode == "batch"
+    assert request.requirements == (
+        f"files=={files}",
+        f"pages=={pages}",
+        f"query_count=={queries}",
+    )
+
+
+def test_vidore_v3_all_runset_contains_every_public_dataset() -> None:
+    runset = get_runset("vidore_v3_all")
+
+    assert runset.runs == tuple(f"{name}_beir" for name in VIDORE_V3_PUBLIC_DATASETS)


### PR DESCRIPTION
## Summary

- expand the harness from the existing ViDoRe v3 Finance EN entry to all eight public ViDoRe v3 domains
- use the release-aligned `nvidia/llama-nemotron-embed-vl-1b-v2` page-level `text_image` configuration for ingest and query
- add checked-in runfiles with file, page, and query-count integrity gates plus a `vidore_v3_all` runset
- document portable dataset-path configuration, one-domain and full-suite commands, and observed DGX baselines

## Why

This gives the library harness complete, reproducible ViDoRe v3 coverage before nightly scheduling. The default harness run reproduced the 26.05 release Recall@5 values within `0.0032` absolute for every domain and records ingest throughput, query latency, Recall@5/10, and nDCG@10 for future comparisons.

## Scope

This PR intentionally does **not**:

- add nightly scheduling
- add SKU-independent hard quality gates
- change the core VDB adapter
- enable OCR for scanned pages

During validation, Finance FR exposed a separate core behavior: the dense VDB path drops empty-text records even when a valid image embedding exists. That omits 235 Finance FR pages, including 69 judged pages. The limitation and diagnostic baseline are documented here; the core image-only record contract will be handled separately before Finance FR is treated as a nightly quality gate.

## Validation

- `72 passed` across harness registry, runfile, artifact, and BEIR evaluation tests
- changed-file pre-commit hooks passed
- all eight checked-in runfiles passed a single-session dry run after rebasing onto current `upstream/main`
- complete live batch runs on an eight-H100 DGX for all eight domains
- Computer Science repeated twice; nDCG@10 was stable within `0.0011`

## Reviewer guidance

The core review surfaces are:

1. the shared ViDoRe dataset/benchmark construction in `benchmark_registry.py`
2. the per-domain integrity facts encoded in the runfiles and registry tests
3. the distinction in `EXPECTED_RESULTS.md` between observed metrics and enforceable gates
4. the explicit Finance FR coverage warning before nightly integration
