### PR TITLE
fix(ci): build nightlies from 26.05

### DIFF
--- a/.github/workflows/docker-nightly-publish.yml
+++ b/.github/workflows/docker-nightly-publish.yml
@@ -21,6 +21,17 @@ jobs:
         with:
           ref: "26.05"
 
+      - name: Resolve checked-out commit SHA
+        id: sha
+        run: |
+          set -euo pipefail
+          # github.sha points at the workflow ref (default branch for scheduled
+          # runs), not the branch we checked out above. Stamp the image with the
+          # commit that was actually built so it stays traceable.
+          resolved_sha="$(git rev-parse HEAD)"
+          echo "sha=${resolved_sha}" >> "$GITHUB_OUTPUT"
+          echo "Building from commit: ${resolved_sha}"
+
       - name: Get current date (yyyy.mm.dd)
         run: echo "CURRENT_DATE=$(date +'%Y.%m.%d')" >> $GITHUB_ENV
 
@@ -45,7 +56,7 @@ jobs:
       - name: Build Docker image
         run: |
           docker buildx create --use
-          docker buildx build -f Dockerfile --platform linux/amd64 --push --target service --build-arg GIT_COMMIT=${GITHUB_SHA} --build-arg DOWNLOAD_LLAMA_TOKENIZER=True --secret id=hf_token,src=./scripts/private_local/hf_token.txt -t ${{ secrets.DOCKER_REGISTRY }}/nrl-service:${{ env.CURRENT_DATE }} .
+          docker buildx build -f Dockerfile --platform linux/amd64 --push --target service --build-arg GIT_COMMIT=${{ steps.sha.outputs.sha }} --build-arg DOWNLOAD_LLAMA_TOKENIZER=True --secret id=hf_token,src=./scripts/private_local/hf_token.txt -t ${{ secrets.DOCKER_REGISTRY }}/nrl-service:${{ env.CURRENT_DATE }} .
 
       - name: Cleanup HF token file
         if: always()

--- a/.github/workflows/docker-nightly-publish.yml
+++ b/.github/workflows/docker-nightly-publish.yml
@@ -1,13 +1,13 @@
 name: Nv-Ingest Nightly Container Publish
 
-# Trigger for pull requests and pushing to main
+# Nightly and push builds for the 26.05 release branch
 on:
   schedule:
     # Runs every day at 11:30PM (UTC)
     - cron: "30 23 * * *"
   push:
     branches:
-      - main
+      - "26.05"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: "26.05"
 
       - name: Get current date (yyyy.mm.dd)
         run: echo "CURRENT_DATE=$(date +'%Y.%m.%d')" >> $GITHUB_ENV

--- a/.github/workflows/pypi-nightly-publish.yml
+++ b/.github/workflows/pypi-nightly-publish.yml
@@ -94,6 +94,18 @@ jobs:
         with:
           ref: ${{ env.ENVIRONMENT }}
 
+      - name: Resolve checked-out commit SHA
+        id: sha
+        shell: bash
+        run: |
+          set -euo pipefail
+          # github.sha points at the workflow ref (default branch for scheduled
+          # runs), not the branch we checked out above. Stamp artifacts with the
+          # commit that was actually packaged so wheels stay traceable.
+          resolved_sha="$(git rev-parse HEAD)"
+          echo "sha=${resolved_sha}" >> "$GITHUB_OUTPUT"
+          echo "Building from commit: ${resolved_sha}"
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -113,7 +125,7 @@ jobs:
 
           Path("src/nemo_retriever/_build_info.py").write_text(
               '"""Build metadata written by CI before packaging."""\n\n'
-              'BUILD_GIT_SHA = "${{ github.sha }}"\n'
+              'BUILD_GIT_SHA = "${{ steps.sha.outputs.sha }}"\n'
               f'BUILD_DATE = "{datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")}"\n',
               encoding="utf-8",
           )
@@ -121,7 +133,7 @@ jobs:
           RETRIEVER_RELEASE_TYPE=${{ env.RELEASE_TYPE }} \
           RETRIEVER_VERSION=${{ env.VERSION }} \
           RETRIEVER_BUILD_NUMBER=${{ github.run_number }} \
-          RETRIEVER_GIT_SHA=${{ github.sha }} \
+          RETRIEVER_GIT_SHA=${{ steps.sha.outputs.sha }} \
           python -m build
 
       - name: Publish wheels

--- a/.github/workflows/pypi-nightly-publish.yml
+++ b/.github/workflows/pypi-nightly-publish.yml
@@ -9,7 +9,7 @@ on:
       environment:
         description: 'Source branch to build wheel from'
         required: true
-        default: 'main'
+        default: '26.05'
         type: string
       VERSION:
         description: 'Version string for the release (e.g., 25.4.0)'
@@ -68,8 +68,8 @@ jobs:
             echo "Setting build source to ${{ github.event.inputs.environment }}"
             echo "ENVIRONMENT=${{ github.event.inputs.environment }}" >> $GITHUB_ENV
           else
-            echo "Setting build source to main. DEFAULT"
-            echo "ENVIRONMENT=main" >> $GITHUB_ENV
+            echo "Setting build source to 26.05. DEFAULT"
+            echo "ENVIRONMENT=26.05" >> $GITHUB_ENV
           fi
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then

--- a/.github/workflows/reusable-pypi-build.yml
+++ b/.github/workflows/reusable-pypi-build.yml
@@ -51,6 +51,18 @@ jobs:
           git fetch --depth=1 origin "${{ inputs.workflow-ref }}"
           git checkout FETCH_HEAD -- nemo_retriever/pyproject.toml
 
+      - name: Resolve checked-out commit SHA
+        id: sha
+        shell: bash
+        run: |
+          set -euo pipefail
+          # github.sha points at the workflow ref, not the source-ref we checked
+          # out above. Stamp artifacts with the commit that was actually packaged
+          # so wheels stay traceable.
+          resolved_sha="$(git rev-parse HEAD)"
+          echo "sha=${resolved_sha}" >> "$GITHUB_OUTPUT"
+          echo "Building from commit: ${resolved_sha}"
+
       - name: Determine version
         id: set-version
         run: |
@@ -86,7 +98,7 @@ jobs:
 
           Path("src/nemo_retriever/_build_info.py").write_text(
               '"""Build metadata written by CI before packaging."""\n\n'
-              'BUILD_GIT_SHA = "${{ github.sha }}"\n'
+              'BUILD_GIT_SHA = "${{ steps.sha.outputs.sha }}"\n'
               f'BUILD_DATE = "{datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")}"\n',
               encoding="utf-8",
           )
@@ -94,7 +106,7 @@ jobs:
           RETRIEVER_RELEASE_TYPE=${{ inputs.release-type }} \
           RETRIEVER_VERSION=${{ steps.set-version.outputs.version }} \
           RETRIEVER_BUILD_NUMBER=${{ inputs.release-type == 'release' && '0' || github.run_number }} \
-          RETRIEVER_GIT_SHA=${{ github.sha }} \
+          RETRIEVER_GIT_SHA=${{ steps.sha.outputs.sha }} \
           python -m build
 
       - name: Debug — wheels after build

--- a/.github/workflows/scheduled-nightly.yml
+++ b/.github/workflows/scheduled-nightly.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: "26.05"
 
       - name: Setup Docker Buildx
         uses: ./.github/actions/setup-docker-buildx
@@ -80,7 +80,7 @@ jobs:
     with:
       version: ${{ needs.determine-version.outputs.version }}
       release-type: 'dev'
-      source-ref: 'main'
+      source-ref: '26.05'
       runner: 'linux-large-disk'
 
   pypi-publish:

--- a/.github/workflows/scheduled-nightly.yml
+++ b/.github/workflows/scheduled-nightly.yml
@@ -46,6 +46,17 @@ jobs:
         with:
           ref: "26.05"
 
+      - name: Resolve checked-out commit SHA
+        id: sha
+        run: |
+          set -euo pipefail
+          # github.sha points at the workflow ref (default branch for scheduled
+          # runs), not the branch we checked out above. Stamp the image with the
+          # commit that was actually built so it stays traceable.
+          resolved_sha="$(git rev-parse HEAD)"
+          echo "sha=${resolved_sha}" >> "$GITHUB_OUTPUT"
+          echo "Building from commit: ${resolved_sha}"
+
       - name: Setup Docker Buildx
         uses: ./.github/actions/setup-docker-buildx
         with:
@@ -67,7 +78,7 @@ jobs:
             --target service \
             --build-arg HF_ACCESS_TOKEN=${{ secrets.HF_ACCESS_TOKEN }} \
             --build-arg DOWNLOAD_LLAMA_TOKENIZER=True \
-            --build-arg GIT_COMMIT=${GITHUB_SHA} \
+            --build-arg GIT_COMMIT=${{ steps.sha.outputs.sha }} \
             -t ${{ secrets.DOCKER_REGISTRY }}/nrl-service:${{ needs.determine-version.outputs.docker-tag }} \
             .
 


### PR DESCRIPTION
## Summary
- Point nightly Docker and PyPI build workflows at the `26.05` release branch instead of `main`.
- Update manual PyPI dispatch defaults so ad hoc nightly builds also default to `26.05`.
- Keep workflow branch/ref values quoted so GitHub Actions receives `26.05` as a string.

## Test plan
- Verified workflow YAML diagnostics report no linter errors.
- Verified PR scope contains only the three nightly workflow files.
- Manual validation after merge: dispatch the nightly container or PyPI workflow and confirm checkout source is `26.05`.