### PR TITLE
fix(ci): enable manual 26.05 container publish

### DIFF
--- a/.github/workflows/docker-nightly-publish.yml
+++ b/.github/workflows/docker-nightly-publish.yml
@@ -1,10 +1,7 @@
-name: Nv-Ingest Nightly Container Publish
+name: Nv-Ingest 26.05 Container Publish
 
-# Nightly container publish for 26.05 (schedule runs from default branch; manual dispatch available)
+# Manual 26.05 container publish. The scheduled nightly is defined on main.
 on:
-  schedule:
-    # Runs every day at 11:30PM (UTC)
-    - cron: "30 23 * * *"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/docker-nightly-publish.yml
+++ b/.github/workflows/docker-nightly-publish.yml
@@ -1,13 +1,13 @@
 name: Nv-Ingest Nightly Container Publish
 
-# Trigger for pull requests and pushing to main
+# Nightly and push builds for the 26.05 release branch
 on:
   schedule:
     # Runs every day at 11:30PM (UTC)
     - cron: "30 23 * * *"
   push:
     branches:
-      - main
+      - "26.05"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -19,7 +19,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: "26.05"
+
+      - name: Resolve checked-out commit SHA
+        id: sha
+        run: |
+          set -euo pipefail
+          # github.sha points at the workflow ref (default branch for scheduled
+          # runs), not the branch we checked out above. Stamp the image with the
+          # commit that was actually built so it stays traceable.
+          resolved_sha="$(git rev-parse HEAD)"
+          echo "sha=${resolved_sha}" >> "$GITHUB_OUTPUT"
+          echo "Building from commit: ${resolved_sha}"
 
       - name: Get current date (yyyy.mm.dd)
         run: echo "CURRENT_DATE=$(date +'%Y.%m.%d')" >> $GITHUB_ENV
@@ -45,7 +56,7 @@ jobs:
       - name: Build Docker image
         run: |
           docker buildx create --use
-          docker buildx build -f Dockerfile --platform linux/amd64 --push --target service --build-arg GIT_COMMIT=${GITHUB_SHA} --build-arg DOWNLOAD_LLAMA_TOKENIZER=True --secret id=hf_token,src=./scripts/private_local/hf_token.txt -t ${{ secrets.DOCKER_REGISTRY }}/nrl-service:${{ env.CURRENT_DATE }} .
+          docker buildx build -f Dockerfile --platform linux/amd64 --push --target service --build-arg GIT_COMMIT=${{ steps.sha.outputs.sha }} --build-arg DOWNLOAD_LLAMA_TOKENIZER=True --secret id=hf_token,src=./scripts/private_local/hf_token.txt -t ${{ secrets.DOCKER_REGISTRY }}/nrl-service:${{ env.CURRENT_DATE }} .
 
       - name: Cleanup HF token file
         if: always()

--- a/.github/workflows/docker-nightly-publish.yml
+++ b/.github/workflows/docker-nightly-publish.yml
@@ -1,13 +1,10 @@
 name: Nv-Ingest Nightly Container Publish
 
-# Nightly and push builds for the 26.05 release branch
+# Nightly container publish for 26.05 (schedule runs from default branch; manual dispatch available)
 on:
   schedule:
     # Runs every day at 11:30PM (UTC)
     - cron: "30 23 * * *"
-  push:
-    branches:
-      - "26.05"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Keep the `26.05` branch copy of the container publish workflow available for manual `workflow_dispatch` runs.
- Remove automatic push-triggered publishing so secrets and registry push access are not exposed to unreviewed commits.
- Stamp the image `GIT_COMMIT` with the checked-out `26.05` SHA so manually published images remain traceable.

## Relationship to scheduled nightly
Scheduled nightlies are handled by #2308 on `main`, because GitHub scheduled workflows only run from the default branch. This PR intentionally does **not** provide push-to-branch publishing.

## Test plan
- Verified workflow YAML has no linter errors.
- Verified PR scope is a single file (`docker-nightly-publish.yml`).
- After merge: manually dispatch this workflow from `26.05` and confirm it builds `26.05`.