### PR TITLE
ci(docs): nightly + manual publish of 26.05 docs to docs.nvidia.com

### DIFF
--- a/.github/workflows/nrl-docs-nvidia-publish.yml
+++ b/.github/workflows/nrl-docs-nvidia-publish.yml
@@ -35,6 +35,12 @@ on:
       - "docs/**"
       - "nemo_retriever/**"
       - ".github/workflows/nrl-docs-nvidia-publish.yml"
+  schedule:
+    # Nightly rebuild and publish of the 26.05 docs to docs.nvidia.com (26.5.0 + latest).
+    # Scheduled workflows run only from the default branch (main), where this workflow
+    # lives; the build job checks out the 26.05 content. Doc changes land on 26.05 and are
+    # infrequent, so this cron keeps the published site current without a push to main.
+    - cron: "30 23 * * *"
   workflow_dispatch:
     inputs:
       dry-run:


### PR DESCRIPTION
## Summary
- Add a nightly `schedule` (cron `30 23 * * *`, 23:30 UTC) to `nrl-docs-nvidia-publish.yml` so the published docs at https://docs.nvidia.com/nemo/retriever/latest/ are refreshed automatically.
- Manual `workflow_dispatch` remains available for on-demand publishes.

## Why
Doc content lives on the `26.05` branch, but this workflow only auto-triggered on **push to `main`** (plus tags / manual). Edits to 26.05 docs therefore did not publish automatically. A `schedule` trigger runs from the default branch (`main`, where this workflow lives) and the build job checks out `26.05`, so nightly runs keep `26.5.0/` and `latest/` current without a push to `main`.

## Behavior
- Scheduled (and push/tag) events resolve to a **real** publish: `dry_run=false`, `publish-as-latest=true` (see the `resolve` job's non-`workflow_dispatch` branch).
- `workflow_dispatch` still defaults to `dry-run=true` for safe manual testing.
- No change to build/publish logic, version resolution, or secrets usage — only the trigger set.

## Operator action required (not code)
The `publish` job runs in the `docs-nvidia-prod` environment. For **fully unattended** nightly publishing, remove any **required reviewers** on that environment in **Settings → Environments → docs-nvidia-prod**. If the approval gate is kept, each nightly run will pause for manual approval.

## Test plan
- `nrl-docs-nvidia-publish.yml` parses as valid YAML; triggers are `push`, `schedule`, `workflow_dispatch`.
- After merge: confirm the workflow appears with the nightly schedule, and that the first scheduled run publishes 26.5.0 + latest (or dispatch manually with `dry-run=false` to validate immediately).