### PR TITLE
docs clarify NVAIE NIM support and fix staged links and clarify NVAIE NIM support

### DIFF
--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -73,6 +73,10 @@ Optional advanced features—audio and video transcription, Nemotron Parse, Omni
 
 ### Default NIMs { #default-helm-nims }
 
+!!! important "NVAIE support applies to individual NIMs only"
+
+    A NIM or model listed in the default and optional NIM rows in the table below might be supported under NVIDIA AI Enterprise (NVAIE) as an individual product. That support does **not** cover its use through NeMo Retriever Library or extend to the library, its container image, its Helm chart, or the end-to-end extraction workflow.
+
 The production Helm chart reconciles NIM microservices through `nimOperator.<key>.enabled`. Four core NIMs are **enabled by default** and auto-wired into the retriever service; optional NIMs reconcile only when you opt in. For chart keys, image overrides, and enablement, refer to the [NeMo Retriever Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#nim-operator-sub-stack) and [Recommended minimal install](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#recommended-minimal-install-2605).
 
 | Helm flag | NIM | Default image (`repository:tag`) | Role | Enabled by default |

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -77,16 +77,18 @@ Highlights for the 26.05 release include:
 
 ## Release Notes for Previous Versions
 
-| [26.03](https://docs.nvidia.com/nemo/retriever/26.3.0/extraction/releasenotes-nv-ingest/)
-| [26.1.2](https://docs.nvidia.com/nemo/retriever/26.1.2/extraction/releasenotes-nv-ingest/)
-| [26.1.1](https://docs.nvidia.com/nemo/retriever/26.1.1/extraction/releasenotes-nv-ingest/)
-| [25.9.0](https://docs.nvidia.com/nemo/retriever/25.9.0/extraction/releasenotes-nv-ingest/) 
-| [25.6.3](https://docs.nvidia.com/nemo/retriever/25.6.3/extraction/releasenotes-nv-ingest/) 
-| [25.6.2](https://docs.nvidia.com/nemo/retriever/25.6.2/extraction/releasenotes-nv-ingest/) 
-| [25.4.2](https://docs.nvidia.com/nemo/retriever/25.4.2/extraction/releasenotes-nv-ingest/) 
-| [25.3.0](https://docs.nvidia.com/nemo/retriever/25.3.0/extraction/releasenotes-nv-ingest/) 
-| [24.12.1](https://docs.nvidia.com/nemo/retriever/25.3.0/extraction/releasenotes-nv-ingest/#release-24121) 
-| [24.12.0](https://docs.nvidia.com/nemo/retriever/25.3.0/extraction/releasenotes-nv-ingest/#release-2412) 
+- [26.03](https://docs.nvidia.com/nemo/retriever/26.3.0/extraction/releasenotes-nv-ingest/)
+- 26.1.2
+- 26.1.1
+- 25.9.0
+- 25.6.3
+- 25.6.2
+- 25.4.2
+- 25.3.0
+- 24.12.1
+- 24.12.0
+
+Release notes before 26.03 are being archived. Links will be restored when the archive pages are available.
 
 ## Related Topics
 

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -77,18 +77,10 @@ Highlights for the 26.05 release include:
 
 ## Release Notes for Previous Versions
 
+- [26.05](https://docs.nvidia.com/nemo/retriever/26.5.0/extraction/releasenotes-nv-ingest/)
 - [26.03](https://docs.nvidia.com/nemo/retriever/26.3.0/extraction/releasenotes-nv-ingest/)
-- 26.1.2
-- 26.1.1
-- 25.9.0
-- 25.6.3
-- 25.6.2
-- 25.4.2
-- 25.3.0
-- 24.12.1
-- 24.12.0
 
-Release notes before 26.03 are being archived. Links will be restored when the archive pages are available.
+Release notes for earlier versions (26.1.2, 26.1.1, 25.9.0, 25.6.3, 25.6.2, 25.4.2, 25.3.0, 24.12.1, and 24.12.0) — *These links have been archived.*
 
 ## Related Topics
 

--- a/docs/docs/extraction/vdbs.md
+++ b/docs/docs/extraction/vdbs.md
@@ -134,7 +134,7 @@ Some deployments use a different vector store than the default LanceDB path on t
 | Vector store | Where to configure or implement |
 |--------------|--------------------------------|
 | **[Elasticsearch](https://www.elastic.co/elasticsearch)** | [Configure Elasticsearch as Your Vector Database for NVIDIA RAG Blueprint](https://docs.nvidia.com/rag/latest/change-vectordb.html) — compose profiles, environment variables, and Helm notes for the RAG Blueprint. |
-| **[Pinecone](https://www.pinecone.io/)** | [Customize your vector database (Pinecone + NVIDIA RAG)](https://github.com/pinecone-io/nvidia-pinecone-rag/blob/main/docs/vector-database.md) in the [`pinecone-io/nvidia-pinecone-rag`](https://github.com/pinecone-io/nvidia-pinecone-rag) repository. |
+| **[Pinecone](https://www.pinecone.io/)** | [Pinecone Configuration for Pinecone Enterprise RAG Blueprint](https://github.com/pinecone-io/nvidia-rag/blob/main/docs/pinecone-configuration.md) in the [`pinecone-io/nvidia-rag`](https://github.com/pinecone-io/nvidia-rag) repository. |
 | **[Teradata](https://www.teradata.com/)** | [TeradataVDB (NVIDIA NIM Ingest integration)](https://docs.teradata.com/r/VMware/Teradata-Package-for-Generative-AI-Function-Reference/Vector-Store/NVIDIA-NIM-Ingest-Integration/TeradataVDB) — `teradatagenai.vector_store.teradataVDB.TeradataVDB` implements the NeMo Retriever ingestion `VDB` abstract class for Teradata Vector Store. |
 
 Testing and release cadence for these integrations follow the owning project (RAG Blueprint, Pinecone sample repo, or Teradata Generative AI package), not the first-party LanceDB operator validated for NeMo Retriever Library on this page.


### PR DESCRIPTION
## Summary

This docs-only cleanup groups three small reader-facing fixes for a single review:

- Align **Release Notes for Previous Versions** with the live 26.05 page: link the 26.05 and 26.03 release-note pages, and replace dead pre-26.03 links with archived-versions guidance until redirects land.
- Update the Pinecone vector-store reference to the current public `pinecone-io/nvidia-rag` repository.
- Clarify beside the Default NIMs table that NVAIE support for an individual NIM or model does not extend to NeMo Retriever Library, its container, Helm chart, or end-to-end workflow (NVBugs 6462632; follow-up to #2367).

## Files

- `docs/docs/extraction/releasenotes.md`
- `docs/docs/extraction/vdbs.md`
- `docs/docs/extraction/prerequisites-support-matrix.md`

## Test plan

- [x] `uv run mkdocs build -f mkdocs.yml --strict`
- [x] Focused PR scope check against current `upstream/main`
- [x] Only the three documentation files above are changed
- [x] Verified 26.05 and 26.03 release-note URLs return HTTP 200

## Follow-up

Per-link restoration for older archived release trains still depends on infrastructure redirects from `docs.nvidia.com/nemo/retriever/*` to `archive.docs.nvidia.com/nemo/retriever/*`.