### PR TITLE
docs(extraction): clarify additional GPU for non-core pipeline features

### DIFF
--- a/docs/docs/extraction/api-keys.md
+++ b/docs/docs/extraction/api-keys.md
@@ -21,7 +21,7 @@ export NVIDIA_API_KEY="nvapi-..."
 
 On Windows PowerShell you can use `$env:NVIDIA_API_KEY = "nvapi-..."`.
 
-For a full list of related variables, see [Environment configuration variables](environment-config.md).
+For a full list of related variables, refer to [Environment configuration variables](environment-config.md).
 
 !!! note
 

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -108,7 +108,7 @@ These NIM microservices are **optional** for the default extraction pipeline. Th
 
 Use **`nemotron_3_nano_omni_30b_a3b_reasoning`** when you enable the caption stage (hosted model ID `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`). The Helm key is in the [optional NIMs](#optional-helm-nims-not-auto-wired-by-default) table above.
 
-Optional features in the table above require capacity **beyond the four default NIMs**. Audio and video transcription, Nemotron Parse, and Omni captioning each need a **dedicated additional GPU** (or two, for Omni on L40S) separate from the core pipeline GPU. The VL reranker may share the core GPU only when that GPU has at least 80 GB VRAM; otherwise treat it as a standalone workload. Each optional feature also needs extra disk space and feature-specific system dependencies.
+Optional features in the table above require GPU capacity **beyond the four default NIMs**. Audio and video transcription, Nemotron Parse, and Omni image captioning each need a **dedicated additional GPU** (or two, for Omni on L40S) separate from the core pipeline GPU. The VL reranker can share the core GPU only when that GPU has at least 80 GB of VRAM. Otherwise, treat the reranker as a standalone workload. Each optional feature also needs extra disk space and feature-specific system dependencies.
 
 For published NIM model IDs and deployment-specific constraints, use the product support matrices linked under [Related Topics](#related-topics) below.
 
@@ -116,7 +116,7 @@ For published NIM model IDs and deployment-specific constraints, use the product
 
 NeMo Retriever Library supports the following GPU hardware given system constraints in the table.
 
-**Additional Dedicated GPUs** counts GPUs required **in addition to** the one GPU reserved for the [core pipeline](#core-and-advanced-pipeline-features) (the four default NIMs). For example, a deployment with the core pipeline on one H100 and self-hosted Parakeet ASR needs **two GPUs total** (1 core + 1 additional).
+**Additional Dedicated GPUs** counts GPUs required **in addition to** the one GPU reserved for the [core pipeline](#core-and-advanced-pipeline-features) (the four default NIMs). For example, a deployment that runs the core pipeline on one H100 and self-hosted Parakeet ASR needs **two GPUs total**: one for the core pipeline and one additional.
 
 - **HF model weights** — approximate Hugging Face checkpoint footprint (files such as `model*.safetensors`, `weights.pth`, or other published weight bundles in the model repository). Values are rounded from the current public file listing and can change when the repository is updated.
 - **NIM disk space** — approximate container and on-disk model cache for self-hosted NIM microservices (not the same as HF download size). For Nemotron 3 Nano Omni captioning, refer to the [NVIDIA NIM for Vision Language Models support matrix](https://docs.nvidia.com/nim/vision-language-models/latest/support-matrix.html#nemotron-3-nano-omni-30b-a3b-reasoning).

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -63,6 +63,8 @@ Ensure your deployment environment meets these specifications before running the
 
 The NeMo Retriever Library extraction core pipeline features run on a single A10G or better GPU.
 
+Optional advanced features—audio and video transcription, Nemotron Parse, Omni image captioning, and (on most GPUs) the VL reranker—are **not** part of that core footprint. Plan **one or more additional dedicated GPUs** beyond the GPU running the four core NIMs. Capacity requirements are listed in the **Additional Dedicated GPUs** column of the [model hardware requirements](#model-hardware-requirements) table below.
+
 ### Default Helm NIMs { #default-helm-nims }
 
 The production Helm chart enables these NIM microservices **by default** (for example through `nimOperator.*.enabled=true`):
@@ -106,13 +108,15 @@ These NIM microservices are **optional** for the default extraction pipeline. Th
 
 Use **`nemotron_3_nano_omni_30b_a3b_reasoning`** when you enable the caption stage (hosted model ID `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`). The Helm key is in the [optional NIMs](#optional-helm-nims-not-auto-wired-by-default) table above.
 
-Optional features listed in the table above require additional GPU support, disk space, and feature-specific system dependencies beyond the four default NIMs.
+Optional features in the table above require capacity **beyond the four default NIMs**. Audio and video transcription, Nemotron Parse, and Omni captioning each need a **dedicated additional GPU** (or two, for Omni on L40S) separate from the core pipeline GPU. The VL reranker may share the core GPU only when that GPU has at least 80 GB VRAM; otherwise treat it as a standalone workload. Each optional feature also needs extra disk space and feature-specific system dependencies.
 
 For published NIM model IDs and deployment-specific constraints, use the product support matrices linked under [Related Topics](#related-topics) below.
 
 ## Model Hardware Requirements { #model-hardware-requirements }
 
 NeMo Retriever Library supports the following GPU hardware given system constraints in the table.
+
+**Additional Dedicated GPUs** counts GPUs required **in addition to** the one GPU reserved for the [core pipeline](#core-and-advanced-pipeline-features) (the four default NIMs). For example, a deployment with the core pipeline on one H100 and self-hosted Parakeet ASR needs **two GPUs total** (1 core + 1 additional).
 
 - **HF model weights** — approximate Hugging Face checkpoint footprint (files such as `model*.safetensors`, `weights.pth`, or other published weight bundles in the model repository). Values are rounded from the current public file listing and can change when the repository is updated.
 - **NIM disk space** — approximate container and on-disk model cache for self-hosted NIM microservices (not the same as HF download size). For Nemotron 3 Nano Omni captioning, refer to the [NVIDIA NIM for Vision Language Models support matrix](https://docs.nvidia.com/nim/vision-language-models/latest/support-matrix.html#nemotron-3-nano-omni-30b-a3b-reasoning).

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -63,7 +63,7 @@ Ensure your deployment environment meets these specifications before running the
 
 The NeMo Retriever Library extraction core pipeline features run on a single A10G or better GPU.
 
-Optional advanced features—audio and video transcription, Nemotron Parse, Omni image captioning, and the VL reranker—are **not** part of that core footprint. Audio, video, Nemotron Parse, and Omni captioning each need **one or more additional dedicated GPUs** beyond the GPU running the four core NIMs; the VL reranker can share the core GPU when it has at least 80 GB VRAM. Capacity requirements are listed in the **Additional Dedicated GPUs** column of the [model hardware requirements](#model-hardware-requirements) table below.
+Optional advanced features—audio and video transcription, Nemotron Parse, Omni image captioning, and the VL reranker—are **not** part of that core footprint. Audio, video, Nemotron Parse, and Omni captioning each need **one or more additional dedicated GPUs** beyond the GPU running the four core NIMs; the VL reranker can share the core GPU when it has at least 80 GB VRAM. Capacity requirements are listed in the **Additional Dedicated GPUs** rows of the [model hardware requirements](#model-hardware-requirements) table below.
 
 ### Default Helm NIMs { #default-helm-nims }
 

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -63,7 +63,7 @@ Ensure your deployment environment meets these specifications before running the
 
 The NeMo Retriever Library extraction core pipeline features run on a single A10G or better GPU.
 
-Optional advanced features—audio and video transcription, Nemotron Parse, Omni image captioning, and (on most GPUs) the VL reranker—are **not** part of that core footprint. Plan **one or more additional dedicated GPUs** beyond the GPU running the four core NIMs. Capacity requirements are listed in the **Additional Dedicated GPUs** column of the [model hardware requirements](#model-hardware-requirements) table below.
+Optional advanced features—audio and video transcription, Nemotron Parse, Omni image captioning, and the VL reranker—are **not** part of that core footprint. Audio, video, Nemotron Parse, and Omni captioning each need **one or more additional dedicated GPUs** beyond the GPU running the four core NIMs; the VL reranker can share the core GPU when it has at least 80 GB VRAM. Capacity requirements are listed in the **Additional Dedicated GPUs** column of the [model hardware requirements](#model-hardware-requirements) table below.
 
 ### Default Helm NIMs { #default-helm-nims }
 

--- a/nemo_retriever/docs/cli/benchmarking.md
+++ b/nemo_retriever/docs/cli/benchmarking.md
@@ -1,10 +1,9 @@
 # Benchmarking with the `retriever` CLI
 
 `retriever benchmark` and `retriever harness` are development and experimental subcommands
-with no guarantees — see [Supported vs development / experimental subcommands](README.md#supported-vs-development--experimental-subcommands).
+with no guarantees — refer to [Supported vs development / experimental subcommands](README.md#supported-vs-development--experimental-subcommands).
 
-This page covers benchmark workflows for NeMo Retriever Library. See also
-`docs/docs/extraction/benchmarking.md` for published extraction benchmark notes and
+This page covers benchmark workflows for NeMo Retriever Library. Also refer to
 [`nemo_retriever/harness/HANDOFF.md`](../../harness/HANDOFF.md) for operator-oriented
 notes on `retriever harness`.
 


### PR DESCRIPTION
## Summary

Clarifies on [Pre-Requisites & Support Matrix](docs/docs/extraction/prerequisites-support-matrix.md) that optional (non-core) pipeline features require **additional dedicated GPU(s)** beyond the single GPU used for the four default core NIMs.

- Adds upfront guidance in **Core and Advanced Pipeline Features** that optional features (audio/video, Nemotron Parse, Omni caption, reranker) are not part of the core single-GPU footprint.
- Replaces vague "additional GPU support" wording with explicit **dedicated additional GPU** requirements per optional feature, including reranker co-residency rules on 80 GB GPUs.
- Defines **Additional Dedicated GPUs** in the hardware matrix section with a concrete H100 + Parakeet example (2 GPUs total).

Context: Slack thread in #nrl-docs (2026-07-10) — readers were missing that non-core features need GPUs separate from the core pipeline.

### Style/docs cleanup (bundled)

While running the doc rules (audit / polish / style guide) on the touched pages, two adjacent NVIDIA-style-guide fixes were included:

- `docs/docs/extraction/api-keys.md` and `nemo_retriever/docs/cli/benchmarking.md` — use **refer to** instead of **see** before links.
- `nemo_retriever/docs/cli/benchmarking.md` — remove a stale reference to `docs/docs/extraction/benchmarking.md` (that file does not exist) and keep the valid `HANDOFF.md` link.

## Test plan

- [ ] Review updated prose in `prerequisites-support-matrix.md` (`#core-and-advanced-pipeline-features` and `#model-hardware-requirements`).
- [ ] Confirm no deploy-leakage or duplicate enablement prose was added outside the matrix hardware zones.
- [ ] Confirm `api-keys.md` and `cli/benchmarking.md` link CTAs read "refer to" and no broken references remain.
- [ ] Published docs preview (if available) renders the new paragraphs and table intro correctly.

## Self-review

- [x] Customer-facing scope only (`docs/docs/extraction` + `nemo_retriever/docs/cli`)
- [x] Page-role / leakage check passed (`check-nrl-doc-leakage.ps1`)
- [x] Style-guide CTA check passed (refer to, not see)
