### PR TITLE
docs(extraction): standardize product name casing to NeMo Retriever

### DIFF
--- a/docs/docs/extraction/embedding.md
+++ b/docs/docs/extraction/embedding.md
@@ -87,5 +87,5 @@ results = ingestor.ingest()
 ## Related Topics
 
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
-- [Troubleshoot Nemo Retriever Extraction](troubleshoot.md)
+- [Troubleshoot NeMo Retriever](troubleshoot.md)
 - [Use the Python API](nemo-retriever-api-reference.md)

--- a/docs/docs/extraction/vdbs.md
+++ b/docs/docs/extraction/vdbs.md
@@ -160,4 +160,4 @@ To implement a custom operator, follow the `VDB` abstract interface described in
 - [Use the NeMo Retriever Library Python API](nemo-retriever-api-reference.md)
 - [Store Extracted Images](nemo-retriever-api-reference.md)
 - [Environment Variables](environment-config.md)
-- [Troubleshoot Nemo Retriever Extraction](troubleshoot.md)
+- [Troubleshoot NeMo Retriever](troubleshoot.md)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -30,7 +30,7 @@ NVIDIA NeMo Retriever comes with enterprise-ready features, including the follow
 
 ## Applications
 
-The following are some applications that use NVIDIA Nemo Retriever:
+The following are some applications that use NVIDIA NeMo Retriever:
 
 - [AI Virtual Assistant for Customer Service](https://github.com/NVIDIA-AI-Blueprints/ai-virtual-assistant) (NVIDIA AI Blueprint)
 - [Build an Enterprise RAG pipeline](https://build.nvidia.com/nvidia/build-an-enterprise-rag-pipeline/blueprintcard) (NVIDIA AI Blueprint)


### PR DESCRIPTION
## Summary

Fixes product-name **capitalization drift** flagged by the content IA audit (Chapter 3 — Naming Convention). This is a small, prose-only cleanup that standardizes user-facing text on the canonical **NeMo Retriever** casing and retires the free-form **"Nemo Retriever Extraction"** variant.

This is the second in a series of scoped, audit-driven docs PRs (follows #2330).

## Changes

- `docs/docs/index.md` — "NVIDIA Nemo Retriever" -> "NVIDIA **NeMo** Retriever"
- `docs/docs/extraction/vdbs.md` — Related Topics link text "Troubleshoot Nemo Retriever Extraction" -> "Troubleshoot **NeMo Retriever**"
- `docs/docs/extraction/embedding.md` — same Related Topics link-text fix

Three occurrences total; these were the only miscased `Nemo Retriever` instances in `docs/docs`.

## Scope / safety

- **Prose-only.** No code identifiers (`nemo-retriever`, `nemo_retriever`), environment variables, URLs, file paths, or link **targets** are changed — only visible link text and body copy.
- Strict build passes: `mkdocs build --strict`.

## Deferred (needs a naming decision, not in this PR)

The audit also recommends broader canonicalization — picking one long form (`NVIDIA NeMo Retriever Library`) vs. short form (`NeMo Retriever`) consistently, and retiring the `NRL` abbreviation (defined once in `overview.md`, otherwise unused). Those are editorial/branding calls left for a follow-up once the canonical form is confirmed.

## Test plan

- [x] `mkdocs build --strict` succeeds
- [ ] Reviewer confirms canonical casing preference
