### PR TITLE
[harness] Compact ViDoRe v3 Slack reports

### DIFF
--- a/nemo_retriever/harness/README.md
+++ b/nemo_retriever/harness/README.md
@@ -290,6 +290,13 @@ pages/sec, query count, recall, nDCG, and environment details when those values
 are available. Use repeated `--metric-key` options to select a different metric
 set. Use `--artifact-paths` when recipients can access the runner's local paths.
 
+ViDoRe v3 results always use a compact suite layout: total ingest time,
+aggregate pages/sec, and a separate Recall@5/nDCG@10 table. A complete
+eight-domain suite also reports macro averages across the seven English
+datasets and across all datasets. Per-domain timing and other metadata remain
+available in the session artifacts. This format also applies when previewing or
+reposting completed artifacts; reporting never reruns ingestion or queries.
+
 ### Preview Report Formatting
 
 Use `--preview` to render the exact Slack payload without reading

--- a/nemo_retriever/src/nemo_retriever/harness/slack.py
+++ b/nemo_retriever/src/nemo_retriever/harness/slack.py
@@ -36,6 +36,16 @@ DEFAULT_SLACK_METRIC_KEYS = (
     "recall_10",
 )
 MAX_SLACK_TABLE_ROWS = 100
+VIDORE_V3_REPORT_DATASETS = {
+    "vidore_v3_finance_en": ("finance_en", True),
+    "vidore_v3_industrial": ("industrial", True),
+    "vidore_v3_computer_science": ("computer_science", True),
+    "vidore_v3_pharmaceuticals": ("pharmaceuticals", True),
+    "vidore_v3_hr": ("hr", True),
+    "vidore_v3_energy": ("energy", True),
+    "vidore_v3_physics": ("physics", True),
+    "vidore_v3_finance_fr": ("finance_fr", False),
+}
 
 
 @dataclass
@@ -339,37 +349,122 @@ def _select_metric_names(metrics: dict[str, Any], metric_keys: list[str]) -> lis
     return metric_names
 
 
+def _table_cell(value: str, *, bold: bool = False) -> dict[str, Any]:
+    text_element: dict[str, Any] = {"type": "text", "text": value}
+    if bold:
+        text_element["style"] = {"bold": True}
+    return {
+        "type": "rich_text",
+        "elements": [{"type": "rich_text_section", "elements": [text_element]}],
+    }
+
+
 def _two_column_row(left: str, right: str) -> list[dict[str, Any]]:
-    return [
-        {
-            "type": "rich_text",
-            "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": left}]}],
-        },
-        {
-            "type": "rich_text",
-            "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": right}]}],
-        },
-    ]
+    return [_table_cell(left), _table_cell(right)]
 
 
 def _two_column_row_bold(left: str, right: str) -> list[dict[str, Any]]:
+    return [_table_cell(left, bold=True), _table_cell(right)]
+
+
+def _three_column_row(left: str, middle: str, right: str, *, bold: bool = False) -> list[dict[str, Any]]:
     return [
-        {
-            "type": "rich_text",
-            "elements": [
-                {"type": "rich_text_section", "elements": [{"type": "text", "text": left, "style": {"bold": True}}]}
-            ],
-        },
-        {
-            "type": "rich_text",
-            "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": right}]}],
-        },
+        _table_cell(left, bold=bold),
+        _table_cell(middle, bold=bold),
+        _table_cell(right, bold=bold),
     ]
+
+
+def _vidore_v3_runs(results: list[HarnessRunReport]) -> list[HarnessRunReport]:
+    runs_by_dataset: dict[str, list[HarnessRunReport]] = {}
+    for run in results:
+        if run.dataset in VIDORE_V3_REPORT_DATASETS:
+            runs_by_dataset.setdefault(run.dataset, []).append(run)
+    return [run for dataset in VIDORE_V3_REPORT_DATASETS for run in runs_by_dataset.get(dataset, [])]
+
+
+def _is_complete_vidore_v3_suite(runs: list[HarnessRunReport]) -> bool:
+    return len(runs) == len(VIDORE_V3_REPORT_DATASETS) and {run.dataset for run in runs} == set(
+        VIDORE_V3_REPORT_DATASETS
+    )
+
+
+def _numeric_metric(run: HarnessRunReport, metric_name: str) -> float | None:
+    value = run.metrics.get(metric_name)
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _macro_average(runs: list[HarnessRunReport], metric_name: str) -> float | None:
+    if any(not run.success for run in runs):
+        return None
+    values = [_numeric_metric(run, metric_name) for run in runs]
+    if any(value is None for value in values):
+        return None
+    numeric_values = [value for value in values if value is not None]
+    return sum(numeric_values) / len(numeric_values)
+
+
+def _format_accuracy_value(value: float | None) -> str:
+    return "N/A" if value is None else f"{value:.3f}"
+
+
+def _vidore_v3_accuracy_rows(runs: list[HarnessRunReport]) -> list[list[dict[str, Any]]]:
+    rows = [_three_column_row("DATASET", "RECALL@5", "NDCG@10", bold=True)]
+    if _is_complete_vidore_v3_suite(runs):
+        english_runs = [run for run in runs if VIDORE_V3_REPORT_DATASETS[run.dataset][1]]
+        for label, selected_runs in (("Avg (English)", english_runs), ("Avg (all)", runs)):
+            rows.append(
+                _three_column_row(
+                    label,
+                    _format_accuracy_value(_macro_average(selected_runs, "recall_5")),
+                    _format_accuracy_value(_macro_average(selected_runs, "ndcg_10")),
+                    bold=True,
+                )
+            )
+    for run in runs:
+        label = VIDORE_V3_REPORT_DATASETS[run.dataset][0]
+        rows.append(
+            _three_column_row(
+                label,
+                _format_accuracy_value(_numeric_metric(run, "recall_5")),
+                _format_accuracy_value(_numeric_metric(run, "ndcg_10")),
+            )
+        )
+    return rows
+
+
+def _vidore_v3_status(runs: list[HarnessRunReport], *, dry_run: bool) -> str:
+    if dry_run:
+        return f"DRY RUN ({len(runs)} planned)"
+    passed_count = sum(1 for run in runs if run.success)
+    if passed_count == len(runs):
+        return f"PASS ({passed_count}/{len(runs)})"
+    return f"FAIL ({passed_count}/{len(runs)} passed)"
+
+
+def _vidore_v3_performance(runs: list[HarnessRunReport]) -> tuple[float | None, float | None]:
+    pages = [_numeric_metric(run, "pages") for run in runs]
+    ingest_secs = [_numeric_metric(run, "ingest_secs") for run in runs]
+    if any(value is None for value in pages) or any(value is None for value in ingest_secs):
+        return None, None
+
+    total_pages = sum(value for value in pages if value is not None)
+    total_ingest_secs = sum(value for value in ingest_secs if value is not None)
+    pages_per_sec = total_pages / total_ingest_secs if total_ingest_secs > 0 else None
+    return total_ingest_secs, pages_per_sec
 
 
 def build_slack_payload(report: HarnessSessionReport, slack_config: dict[str, Any]) -> dict[str, Any]:
     metric_keys = [str(key) for key in slack_config.get("metric_keys", [])]
     post_artifact_paths = bool(slack_config.get("post_artifact_paths", False))
+    vidore_v3_runs = _vidore_v3_runs(report.results)
+    vidore_v3_datasets = {run.dataset for run in vidore_v3_runs}
+    detailed_runs = [run for run in report.results if run.dataset not in vidore_v3_datasets]
     passed_count = sum(1 for run in report.results if run.success)
     total_count = len(report.results)
     if report.dry_run:
@@ -382,9 +477,16 @@ def build_slack_payload(report: HarnessSessionReport, slack_config: dict[str, An
 
     rows: list[list[dict[str, Any]]] = []
     rows.append(_two_column_row_bold("OVERALL STATUS", overall_status))
-    for run in report.results:
+    for run in detailed_runs:
         run_status = "DRY RUN" if report.dry_run else "PASS" if run.success else "FAIL"
         rows.append(_two_column_row_bold(f"-    {run.dataset}", run_status))
+    if vidore_v3_runs:
+        rows.append(
+            _two_column_row_bold(
+                "-    ViDoRe v3",
+                _vidore_v3_status(vidore_v3_runs, dry_run=report.dry_run),
+            )
+        )
 
     rows.append(_BLANK_ROW)
     rows.append(_two_column_row_bold("ENVIRONMENT", " "))
@@ -400,7 +502,7 @@ def build_slack_payload(report: HarnessSessionReport, slack_config: dict[str, An
 
     rows.append(_BLANK_ROW)
     rows.append(_two_column_row_bold("RESULTS", " "))
-    for run in report.results:
+    for run in detailed_runs:
         run_status = "DRY RUN" if report.dry_run else "PASS" if run.success else "FAIL"
         rows.append(_two_column_row_bold(run.dataset, run_status))
         if not run.success and run.return_code is not None:
@@ -416,6 +518,36 @@ def build_slack_payload(report: HarnessSessionReport, slack_config: dict[str, An
             rows.append(_two_column_row("-    failure_reason", run.failure_reason))
         if post_artifact_paths and run.artifact_dir is not None:
             rows.append(_two_column_row("-    artifact_dir", str(run.artifact_dir)))
+        rows.append(_BLANK_ROW)
+
+    if vidore_v3_runs:
+        total_ingest_secs, pages_per_sec = _vidore_v3_performance(vidore_v3_runs)
+        rows.append(
+            _two_column_row_bold(
+                "ViDoRe v3",
+                _vidore_v3_status(vidore_v3_runs, dry_run=report.dry_run),
+            )
+        )
+        rows.append(
+            _two_column_row(
+                "-    total ingest time",
+                _format_metric_value("ingest_secs", total_ingest_secs),
+            )
+        )
+        rows.append(
+            _two_column_row(
+                "-    aggregate pages/s",
+                _format_metric_value("pages_per_sec_ingest", pages_per_sec),
+            )
+        )
+        for run in vidore_v3_runs:
+            if run.success:
+                continue
+            label = VIDORE_V3_REPORT_DATASETS[run.dataset][0]
+            failure = run.failure_reason or (
+                f"return code {run.return_code}" if run.return_code is not None else "run failed"
+            )
+            rows.append(_two_column_row(f"-    {label} failure", failure))
         rows.append(_BLANK_ROW)
 
     if report.results:
@@ -438,6 +570,20 @@ def build_slack_payload(report: HarnessSessionReport, slack_config: dict[str, An
         {"type": "divider"},
         {"type": "table", "rows": rows},
     ]
+    if vidore_v3_runs:
+        blocks.extend(
+            [
+                {"type": "divider"},
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "*ViDoRe v3 accuracy*",
+                    },
+                },
+                {"type": "table", "rows": _vidore_v3_accuracy_rows(vidore_v3_runs)},
+            ]
+        )
 
     return {
         "username": DEFAULT_USERNAME,

--- a/nemo_retriever/tests/test_harness_slack.py
+++ b/nemo_retriever/tests/test_harness_slack.py
@@ -9,12 +9,14 @@ import pytest
 import requests
 from typer.testing import CliRunner
 
+from nemo_retriever.harness.benchmark_registry import VIDORE_V3_PUBLIC_DATASETS
 from nemo_retriever.harness.cli import app
 from nemo_retriever.harness.slack import (
     DEFAULT_SLACK_METRIC_KEYS,
     HarnessRunReport,
     HarnessSessionReport,
     MAX_SLACK_TABLE_ROWS,
+    VIDORE_V3_REPORT_DATASETS,
     build_slack_payload,
     load_replay_report,
     load_session_report,
@@ -80,6 +82,41 @@ def _write_session(tmp_path: Path, *, dry_run: bool = False) -> Path:
         },
     )
     return tmp_path
+
+
+def _vidore_run(dataset: str, index: int = 0, *, success: bool = True) -> HarnessRunReport:
+    return HarnessRunReport(
+        run_name=f"{dataset}_beir",
+        dataset=dataset,
+        preset=None,
+        success=success,
+        return_code=0 if success else 1,
+        failure_reason=None if success else "benchmark failed",
+        artifact_dir=None,
+        metrics={
+            "pages": 100,
+            "ingest_secs": 5.0 * (index + 1),
+            "recall_5": 0.1 * (index + 1),
+            "ndcg_10": 0.8 - 0.1 * index,
+        },
+    )
+
+
+def _vidore_report(tmp_path: Path, results: list[HarnessRunReport]) -> HarnessSessionReport:
+    return HarnessSessionReport(
+        session_name="vidore-v3",
+        session_dir=tmp_path,
+        session_type="runfiles",
+        timestamp=None,
+        latest_commit="abc1234",
+        all_passed=all(run.success for run in results),
+        dry_run=False,
+        results=results,
+    )
+
+
+def _table_rows(table: dict) -> list[list[str]]:
+    return [[cell["elements"][0]["elements"][0]["text"] for cell in row] for row in table["rows"]]
 
 
 def test_slack_report_loads_runfile_session_and_omits_local_paths(tmp_path):
@@ -191,6 +228,63 @@ def test_slack_payload_truncates_tables_at_slack_row_limit(tmp_path):
     assert len(table["rows"]) == MAX_SLACK_TABLE_ROWS
     assert "TRUNCATED" in json.dumps(table["rows"][-1])
     assert "rows omitted" in json.dumps(table["rows"][-1])
+
+
+def test_slack_payload_summarizes_complete_vidore_v3_suite(tmp_path):
+    assert set(VIDORE_V3_REPORT_DATASETS) == set(VIDORE_V3_PUBLIC_DATASETS)
+    results = [_vidore_run(dataset, index) for index, dataset in enumerate(VIDORE_V3_REPORT_DATASETS)]
+
+    payload = build_slack_payload(
+        _vidore_report(tmp_path, results),
+        {"metric_keys": DEFAULT_SLACK_METRIC_KEYS, "post_artifact_paths": False},
+    )
+    tables = [block for block in payload["blocks"] if block["type"] == "table"]
+
+    assert len(tables) == 2
+    main_rows = _table_rows(tables[0])
+    assert ["-    ViDoRe v3", "PASS (8/8)"] in main_rows
+    assert ["-    total ingest time", "180.00s (03m : 00.00s)"] in main_rows
+    assert ["-    aggregate pages/s", "4.44"] in main_rows
+    assert not any("vidore_v3_" in cell for row in main_rows for cell in row)
+
+    accuracy_rows = _table_rows(tables[1])
+    assert accuracy_rows[:3] == [
+        ["DATASET", "RECALL@5", "NDCG@10"],
+        ["Avg (English)", "0.400", "0.500"],
+        ["Avg (all)", "0.450", "0.450"],
+    ]
+    assert accuracy_rows[3] == ["finance_en", "0.100", "0.800"]
+    assert accuracy_rows[-1] == ["finance_fr", "0.800", "0.100"]
+
+
+def test_slack_payload_uses_compact_table_for_partial_vidore_v3_session(tmp_path):
+    run = _vidore_run("vidore_v3_finance_en")
+
+    payload = build_slack_payload(
+        _vidore_report(tmp_path, [run]),
+        {"metric_keys": DEFAULT_SLACK_METRIC_KEYS, "post_artifact_paths": False},
+    )
+    tables = [block for block in payload["blocks"] if block["type"] == "table"]
+
+    assert len(tables) == 2
+    assert _table_rows(tables[1]) == [
+        ["DATASET", "RECALL@5", "NDCG@10"],
+        ["finance_en", "0.100", "0.800"],
+    ]
+
+
+def test_slack_payload_does_not_average_failed_vidore_v3_suite(tmp_path):
+    results = [_vidore_run(dataset, index) for index, dataset in enumerate(VIDORE_V3_REPORT_DATASETS)]
+    results[-1] = _vidore_run("vidore_v3_finance_fr", len(results) - 1, success=False)
+
+    payload = build_slack_payload(
+        _vidore_report(tmp_path, results),
+        {"metric_keys": DEFAULT_SLACK_METRIC_KEYS, "post_artifact_paths": False},
+    )
+    tables = [block for block in payload["blocks"] if block["type"] == "table"]
+
+    assert ["Avg (all)", "N/A", "N/A"] in _table_rows(tables[1])
+    assert ["-    finance_fr failure", "benchmark failed"] in _table_rows(tables[0])
 
 
 def test_slack_transport_error_does_not_expose_webhook(monkeypatch):

--- a/nemo_retriever/tests/test_harness_slack.py
+++ b/nemo_retriever/tests/test_harness_slack.py
@@ -287,6 +287,25 @@ def test_slack_payload_does_not_average_failed_vidore_v3_suite(tmp_path):
     assert ["-    finance_fr failure", "benchmark failed"] in _table_rows(tables[0])
 
 
+def test_slack_payload_keeps_duplicate_vidore_runs_without_claiming_suite_averages(tmp_path):
+    results = [_vidore_run(dataset, index) for index, dataset in enumerate(VIDORE_V3_REPORT_DATASETS)]
+    results.append(_vidore_run("vidore_v3_finance_en"))
+
+    payload = build_slack_payload(
+        _vidore_report(tmp_path, results),
+        {"metric_keys": DEFAULT_SLACK_METRIC_KEYS, "post_artifact_paths": False},
+    )
+    tables = [block for block in payload["blocks"] if block["type"] == "table"]
+    main_rows = _table_rows(tables[0])
+    accuracy_rows = _table_rows(tables[1])
+
+    assert ["-    ViDoRe v3", "PASS (9/9)"] in main_rows
+    assert ["-    total ingest time", "185.00s (03m : 05.00s)"] in main_rows
+    assert ["-    aggregate pages/s", "4.86"] in main_rows
+    assert not any(row[0].startswith("Avg") for row in accuracy_rows)
+    assert sum(row[0] == "finance_en" for row in accuracy_rows) == 2
+
+
 def test_slack_transport_error_does_not_expose_webhook(monkeypatch):
     webhook = "https://hooks.slack.com/services/TSECRET/BSECRET/XSECRET"
 


### PR DESCRIPTION
## Summary

- automatically render every recognized ViDoRe v3 run in one standard compact Slack layout
- report ViDoRe status, total ingest time, and weighted aggregate pages/sec once
- render a separate accuracy table with per-domain Recall@5 and nDCG@10
- add English and all-domain macro averages only for the complete eight-domain suite; failed or partial suites do not publish a misleading numeric suite average
- document that the same layout applies when previewing or reposting completed artifacts without a benchmark rerun

## Why

The combined library and ViDoRe nightly report reached Slack's 100-row table limit and truncated the end of the message. Per-domain files, query counts, timings, and other metadata already remain in the harness artifacts; the Slack view should emphasize the ViDoRe suite's release-facing accuracy metrics without discarding those artifacts.

The formatter recognizes ViDoRe datasets directly. There is no CLI flag or alternate ViDoRe report mode to configure; non-ViDoRe reporting remains unchanged.

## Validation

- `uv run --frozen --project nemo_retriever pytest -q nemo_retriever/tests/test_harness_slack.py` (`11 passed`)
- changed-file pre-commit hooks passed
- replayed the completed 2026-07-13 twelve-run nightly artifacts: the old report produced one 100-row truncated table; the compact report produced a 60-row general table and an 11-row ViDoRe accuracy table
- posted the reformatted replay successfully through the existing Slack artifact sink without rerunning ingestion or queries

## Scope

This PR changes only the harness Slack formatter, focused tests, and harness documentation. It does not add user-facing configuration or change benchmark execution, ViDoRe datasets, quality gates, nightly scheduling, systemd units, or host configuration.
