### PR TITLE
docs: Fix README computation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ NeMo Retriever Library is a scalable, performance-oriented framework for documen
 > [!Note]
 > NeMo Retriever extraction is also referred to as **NVIDIA Ingest** in some NVIDIA product materials.
 
-NeMo Retriever Library enables parallelization of splitting documents into pages where artifacts are classified (such as text, tables, charts, and infographics), extracted, and further contextualized through optical character recognition (OCR) into a well defined JSON schema. From there, NeMo Retriever Library manages computaiton of embeddings for the extracted content as well as storing them in [LanceDB](https://lancedb.com/).
+NeMo Retriever Library enables parallelization of splitting documents into pages where artifacts are classified (such as text, tables, charts, and infographics), extracted, and further contextualized through optical character recognition (OCR) into a well defined JSON schema. From there, NeMo Retriever Library manages computation of embeddings for the extracted content as well as storing them in [LanceDB](https://lancedb.com/).
 
 The following diagram shows the NeMo Retriever Library pipeline.
 


### PR DESCRIPTION
  ## Summary
  - Fix typo in the top-level README: `computaiton` -> `computation`.

  ## Testing
  - Not run; documentation-only change.