### PR TITLE
Fix PDF batch CPU budget accounting

### DIFF
--- a/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
+++ b/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
@@ -337,9 +337,11 @@ def batch_tuning_to_node_overrides(
         # PDFSplit, UDFOperator(s), ReadBinary) cannot exhaust the cluster
         # CPU budget.
         if pdf_extract_tasks is not None and cluster_resources is not None:
-            # Fixed overhead: ReadBinary + DocToPdf + PDFSplit + UDFOperator.
-            # Caption adds CaptionGPUActor + a second UDFOperator.
-            fixed_cpu_overhead = 4 + (2 if caption_params is not None else 0)
+            # Conservative fixed overhead for the documented PDF flow:
+            # ReadBinary + DocToPdf + PDFSplit + TextChunk + DedupImages +
+            # the content-reshape UDF before embedding. Caption adds its actor
+            # and one additional UDF.
+            fixed_cpu_overhead = 6 + (2 if caption_params is not None else 0)
             non_pdf_cpu_overhead = (
                 fixed_cpu_overhead
                 + page_elements_concurrency * page_elements_cpus

--- a/nemo_retriever/tests/test_ingest_plans.py
+++ b/nemo_retriever/tests/test_ingest_plans.py
@@ -333,6 +333,34 @@ def test_batch_tuning_to_node_overrides_scales_local_caption_on_multi_gpu() -> N
     assert overrides["_BatchEmbedActor"]["num_gpus"] == 0.5
 
 
+def test_batch_tuning_to_node_overrides_keeps_default_pdf_pipeline_within_cpu_budget() -> None:
+    cluster = ClusterResources(
+        total_resources=Resources(cpu_count=224, gpu_count=8),
+        available_resources=Resources(cpu_count=224, gpu_count=8),
+    )
+
+    overrides = batch_tuning_to_node_overrides(
+        extract_params=ExtractParams(extract_tables=True, use_table_structure=True),
+        embed_params=EmbedParams(model_name="nvidia/llama-nemotron-embed-1b-v2"),
+        cluster_resources=cluster,
+    )
+
+    # The documented extract -> chunk -> dedup -> reshape -> embed pipeline
+    # has six additional one-CPU tasks alongside these persistent actor pools.
+    requested_cpu = 6 + sum(
+        overrides[actor]["concurrency"] * overrides[actor].get("num_cpus", 1)
+        for actor in (
+            "PDFExtractionActor",
+            "PageElementDetectionActor",
+            "TableStructureActor",
+            "OCRActor",
+            "_BatchEmbedActor",
+        )
+    )
+
+    assert requested_cpu <= cluster.total_cpu_count()
+
+
 def test_batch_tuning_to_node_overrides_honors_table_structure_tuning() -> None:
     extract_params = ExtractParams(
         use_table_structure=True,


### PR DESCRIPTION
## Summary

- Account for the active PDF chunk and UDF stages in the fixed CPU budget.
- Reduce PDF extraction concurrency from 70 to 69 on the reported 224-CPU/8-GPU topology.
- Add a regression test asserting the complete pipeline stays within the cluster budget.

## Root cause

PR #2334 correctly removed the obsolete graphic-elements reservation, exposing a pre-existing two-CPU undercount. The resulting plan requested 226 CPUs on a 224-CPU runner and stalled before processing data.

## Validation

- 73 passed, 3 skipped across ingest-plan and resource-heuristic tests.
- Pre-commit passed for both changed files.
