### PR TITLE
Reserve Ray CPU headroom in PDF planning

### DIFF
--- a/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
+++ b/nemo_retriever/src/nemo_retriever/graph/ingestor_runtime.py
@@ -47,6 +47,8 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_STORE_WORKERS = 4
 DEFAULT_STORE_CPUS_PER_ACTOR = 0.1
+# Preserve one logical CPU in sixteen for Ray scheduling and actor-pool growth.
+PDF_PIPELINE_CPU_HEADROOM_FRACTION = 1 / 16
 
 
 def _batch_tuning(params: Any) -> Any:
@@ -342,8 +344,14 @@ def batch_tuning_to_node_overrides(
             # the content-reshape UDF before embedding. Caption adds its actor
             # and one additional UDF.
             fixed_cpu_overhead = 6 + (2 if caption_params is not None else 0)
+            # Keep part of the cluster free for Ray scheduling and actor-pool
+            # scale-up. The 224-CPU QA topology reserves 14 CPUs, matching the
+            # last known-good allocation without relying on a removed actor.
+            total_cpus = cluster_resources.total_cpu_count()
+            ray_cpu_headroom = max(1, int(total_cpus * PDF_PIPELINE_CPU_HEADROOM_FRACTION))
             non_pdf_cpu_overhead = (
                 fixed_cpu_overhead
+                + ray_cpu_headroom
                 + page_elements_concurrency * page_elements_cpus
                 + ocr_concurrency * ocr_cpus
                 + embed_concurrency * embed_cpus
@@ -351,7 +359,7 @@ def batch_tuning_to_node_overrides(
             )
             pdf_extract_tasks = min(
                 pdf_extract_tasks,
-                max(1, int((cluster_resources.total_cpu_count() - non_pdf_cpu_overhead) // pdf_extract_cpus)),
+                max(1, int((total_cpus - non_pdf_cpu_overhead) // pdf_extract_cpus)),
             )
 
         _set(PDFExtractionActor.__name__, "batch_size", pdf_bs)

--- a/nemo_retriever/tests/test_ingest_plans.py
+++ b/nemo_retriever/tests/test_ingest_plans.py
@@ -333,7 +333,7 @@ def test_batch_tuning_to_node_overrides_scales_local_caption_on_multi_gpu() -> N
     assert overrides["_BatchEmbedActor"]["num_gpus"] == 0.5
 
 
-def test_batch_tuning_to_node_overrides_keeps_default_pdf_pipeline_within_cpu_budget() -> None:
+def test_batch_tuning_to_node_overrides_reserves_ray_headroom_for_default_pdf_pipeline() -> None:
     cluster = ClusterResources(
         total_resources=Resources(cpu_count=224, gpu_count=8),
         available_resources=Resources(cpu_count=224, gpu_count=8),
@@ -358,7 +358,7 @@ def test_batch_tuning_to_node_overrides_keeps_default_pdf_pipeline_within_cpu_bu
         )
     )
 
-    assert requested_cpu <= cluster.total_cpu_count()
+    assert cluster.total_cpu_count() - requested_cpu == 14
 
 
 def test_batch_tuning_to_node_overrides_honors_table_structure_tuning() -> None:


### PR DESCRIPTION
## Summary

- Reserve one logical CPU in sixteen for Ray scheduling and actor-pool growth.
- Leave 14 CPUs free on the reported 224-CPU/8-GPU topology, reducing PDF extraction concurrency from 69 to 62.
- Update the regression test to protect that known-good scheduling envelope.

## Why

#2350 fixes the active-stage undercount but fills the QA runner's logical CPU budget exactly. This follow-up makes the previously reported passing headroom explicit and scales it proportionally instead of relying on the removed graphic-elements actor.

## Validation

- 73 passed, 3 skipped across ingest-plan and resource-heuristic tests.
- Pre-commit passed for both changed files.
