### PR TITLE
Default VLM captioning to Nemotron 3 Nano Omni

### DIFF
--- a/config/custom_summarization_pipeline.yaml
+++ b/config/custom_summarization_pipeline.yaml
@@ -303,7 +303,7 @@ stages:
     actor: "nv_ingest.framework.orchestration.ray.stages.transforms.image_caption:ImageCaptionTransformStage"
     config:
       api_key: $NGC_API_KEY|$NVIDIA_API_KEY
-      model_name: $VLM_CAPTION_MODEL_NAME|"nvidia/llama-3.1-nemotron-nano-vl-8b-v1"
+      model_name: $VLM_CAPTION_MODEL_NAME|"nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
       prompt: "Caption the content of this image:"
     replicas:
       min_replicas: 0

--- a/config/default_pipeline.yaml
+++ b/config/default_pipeline.yaml
@@ -299,7 +299,7 @@ stages:
     actor: "nv_ingest.framework.orchestration.ray.stages.transforms.image_caption:ImageCaptionTransformStage"
     config:
       api_key: $NGC_API_KEY|$NVIDIA_API_KEY
-      model_name: $VLM_CAPTION_MODEL_NAME|"nvidia/nemotron-nano-12b-v2-vl"
+      model_name: $VLM_CAPTION_MODEL_NAME|"nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
       endpoint_url: $VLM_CAPTION_ENDPOINT|"http://vlm:8000/v1/chat/completions"
       prompt: $VLM_CAPTION_PROMPT|"Caption the content of this image:"
       system_prompt: $VLM_CAPTION_SYSTEM_PROMPT|"/no_think"

--- a/docs/docs/extraction/multimodal-extraction.md
+++ b/docs/docs/extraction/multimodal-extraction.md
@@ -88,6 +88,8 @@ Image captioning generates natural-language descriptions for unstructured image 
 
 **Captioning is optional** — enable it in your ingest configuration (for example, the `caption` API or pipeline flag) when you need natural-language descriptions of image content. Reasoning traces are disabled by default for captioning.
 
+Direct local captioning defaults to `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16`. Its BF16 weights are approximately 62 GiB, so plan for a larger GPU footprint than the Nano caption profiles, which remain available through explicit model overrides. Hosted captioning defaults to `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` at the NVIDIA API endpoint.
+
 Chart-classified PDF regions stay on the layout/OCR path; only non-chart image regions and optional infographics (`caption_infographics=True`) receive Omni captions.
 
 **Related**

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -39,6 +39,7 @@ Highlights for the 26.05 release include:
 - Nemotron OCR v2 is the default OCR engine for HuggingFace, with CLI language selectors and unified OCR actors. For Helm NIM deployments, Nemotron OCR v1 is the default.  
 - Nemotron Parse is available as an alternate PDF extraction method (v1.2 HTTP interface; optional Helm NIM; local inference via vLLM where configured)  
 - VLM image captioning via vLLM (including Omni caption model profiles) addresses the capability deferred in 26.03  
+- Nemotron 3 Nano Omni 30B BF16 is the default local caption model, and the Omni API model is the default for hosted and shipped pipeline captioning. The local BF16 checkpoint has approximately 62 GiB of weights; Nano caption profiles remain supported as explicit overrides.
 - vLLM-backed text and vision-language embedders, multimodal VL reranker, and torch 2.11 for local GPU installs  
 
 ### Multimodal extraction

--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -39,7 +39,6 @@ Highlights for the 26.05 release include:
 - Nemotron OCR v2 is the default OCR engine for HuggingFace, with CLI language selectors and unified OCR actors. For Helm NIM deployments, Nemotron OCR v1 is the default.  
 - Nemotron Parse is available as an alternate PDF extraction method (v1.2 HTTP interface; optional Helm NIM; local inference via vLLM where configured)  
 - VLM image captioning via vLLM (including Omni caption model profiles) addresses the capability deferred in 26.03  
-- Nemotron 3 Nano Omni 30B BF16 is the default local caption model, and the Omni API model is the default for hosted and shipped pipeline captioning. The local BF16 checkpoint has approximately 62 GiB of weights; Nano caption profiles remain supported as explicit overrides.
 - vLLM-backed text and vision-language embedders, multimodal VL reranker, and torch 2.11 for local GPU installs  
 
 ### Multimodal extraction

--- a/nemo_retriever/docs/cli/README.md
+++ b/nemo_retriever/docs/cli/README.md
@@ -248,6 +248,7 @@ These options apply to `retriever ingest`, `retriever ingest local`, and
 | `--ocr-version` | planner default | OCR engine version for local extraction. |
 | `--ocr-lang` | planner default | OCR v2 language selector for local extraction. |
 | `--caption` | off | Add a captioning stage. |
+| `--caption-model-name` | `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16` | Local vLLM caption model. The default has approximately 62 GiB of BF16 weights and requires correspondingly larger GPU capacity; Nano models remain available as explicit overrides. For remote endpoints, pass the endpoint API model ID. |
 | `--dedup` | off | Add image deduplication before captioning and embedding. |
 | `--text-chunk` | off | Enable token chunking during extraction. |
 | `--store-images-uri` | unset | Store extracted images at a local path or fsspec-compatible URI. |

--- a/nemo_retriever/src/nemo_retriever/cli/pipeline/__main__.py
+++ b/nemo_retriever/src/nemo_retriever/cli/pipeline/__main__.py
@@ -77,6 +77,8 @@ from nemo_retriever.ingest.plan import (
     resolve_ingest_plan,
 )
 from nemo_retriever.models import VL_EMBED_MODEL, VL_RERANK_MODEL
+from nemo_retriever.common.input_files import resolve_input_patterns
+from nemo_retriever.common.modality.caption.model_profiles import DEFAULT_LOCAL_CAPTION_MODEL_ID
 from nemo_retriever.common.params import (
     CaptionParams,
     DedupParams,
@@ -87,7 +89,6 @@ from nemo_retriever.common.params import (
     VdbUploadParams,
 )
 from nemo_retriever.common.params.models import BatchTuningParams
-from nemo_retriever.common.input_files import resolve_input_patterns
 from nemo_retriever.common.remote_auth import resolve_remote_api_key
 
 logger = logging.getLogger(__name__)
@@ -806,8 +807,12 @@ def run(
         None, "--caption-invoke-url", rich_help_panel=_PANEL_DEDUP_CAPTION
     ),
     caption_model_name: str = typer.Option(
-        "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16",
+        DEFAULT_LOCAL_CAPTION_MODEL_ID,
         "--caption-model-name",
+        help=(
+            "VLM caption model. Defaults to Nemotron 3 Nano Omni 30B BF16 for local vLLM execution; "
+            "use an API model ID when --caption-invoke-url targets a hosted or deployed endpoint."
+        ),
         rich_help_panel=_PANEL_DEDUP_CAPTION,
     ),
     caption_device: Optional[str] = typer.Option(None, "--caption-device", rich_help_panel=_PANEL_DEDUP_CAPTION),

--- a/nemo_retriever/src/nemo_retriever/common/modality/caption/model_profiles.py
+++ b/nemo_retriever/src/nemo_retriever/common/modality/caption/model_profiles.py
@@ -24,6 +24,12 @@ OMNI_FP8_MODEL_ID = "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8"
 OMNI_NVFP4_MODEL_ID = "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4"
 OMNI_REMOTE_MODEL_ID = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
 
+# Canonical defaults for caption call sites. Keep local and remote defaults
+# separate because hosted/NIM endpoints use the API model ID, while direct
+# vLLM execution loads the Hugging Face BF16 checkpoint.
+DEFAULT_LOCAL_CAPTION_MODEL_ID = OMNI_BF16_MODEL_ID
+DEFAULT_REMOTE_CAPTION_MODEL_ID = OMNI_REMOTE_MODEL_ID
+
 _NANO_BF16_REMOTE_MODEL_ID = NANO_REMOTE_MODEL_ID
 _NANO_FP8_REMOTE_MODEL_ID = f"{NANO_REMOTE_MODEL_ID}-fp8"
 _NANO_NVFP4_QAD_REMOTE_MODEL_ID = f"{NANO_REMOTE_MODEL_ID}-nvfp4-qad"
@@ -380,6 +386,8 @@ __all__ = [
     "CaptionCapabilities",
     "CaptionModelProfile",
     "CaptionTarget",
+    "DEFAULT_LOCAL_CAPTION_MODEL_ID",
+    "DEFAULT_REMOTE_CAPTION_MODEL_ID",
     "NANO_BF16_MODEL_ID",
     "NANO_FP8_MODEL_ID",
     "NANO_NVFP4_QAD_MODEL_ID",

--- a/nemo_retriever/src/nemo_retriever/common/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/common/params/models.py
@@ -966,7 +966,13 @@ class TextGenerationParams(_ParamsModel):
 
 class CaptionParams(LLMInferenceParams):
     endpoint_url: Optional[str] = None
-    model_name: str = DEFAULT_LOCAL_CAPTION_MODEL_ID
+    model_name: str = Field(
+        default=DEFAULT_LOCAL_CAPTION_MODEL_ID,
+        description=(
+            "Caption model identifier. The default local BF16 checkpoint has approximately 62 GiB of weights; "
+            "set this explicitly to select a smaller local model or an API model for a remote endpoint."
+        ),
+    )
     api_key: Optional[str] = None
     prompt: str = "Caption the content of this image:"
     system_prompt: Optional[str] = "/no_think"

--- a/nemo_retriever/src/nemo_retriever/common/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/common/params/models.py
@@ -24,6 +24,7 @@ from pydantic import (
     model_validator,
 )
 
+from nemo_retriever.common.modality.caption.model_profiles import DEFAULT_LOCAL_CAPTION_MODEL_ID
 from nemo_retriever.common.remote_auth import resolve_remote_api_key
 
 IngestorRunMode = Literal["inprocess", "batch", "service"]
@@ -965,7 +966,7 @@ class TextGenerationParams(_ParamsModel):
 
 class CaptionParams(LLMInferenceParams):
     endpoint_url: Optional[str] = None
-    model_name: str = "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"
+    model_name: str = DEFAULT_LOCAL_CAPTION_MODEL_ID
     api_key: Optional[str] = None
     prompt: str = "Caption the content of this image:"
     system_prompt: Optional[str] = "/no_think"

--- a/nemo_retriever/src/nemo_retriever/models/local/nemotron_vlm_captioner.py
+++ b/nemo_retriever/src/nemo_retriever/models/local/nemotron_vlm_captioner.py
@@ -13,6 +13,7 @@ from PIL import Image
 
 from nemo_retriever.common.modality.caption.model_profiles import (
     CaptionTarget,
+    DEFAULT_LOCAL_CAPTION_MODEL_ID,
     caption_model_aliases,
     caption_model_revisions,
     get_caption_model_profile,
@@ -49,11 +50,13 @@ class NemotronVLMCaptioner(BaseModel):
 
     Supported models:
 
-    * ``nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16`` (default, BFloat16)
+    * ``nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16`` (default,
+      BFloat16; approximately 62 GiB of model weights)
+    * ``nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16`` (BFloat16)
     * ``nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-FP8``  (FP8 quantised)
     * ``nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-NVFP4-QAD`` (NVFP4 quantised,
       requires GPU compute capability >= 8.9, e.g. Ada Lovelace / Hopper)
-    * Nemotron 3 Nano Omni BF16, FP8, and NVFP4 profiles and aliases
+    * Nemotron 3 Nano Omni FP8 and NVFP4 profiles and aliases
 
     Uses vLLM for inference with batched scheduling.
 
@@ -72,7 +75,7 @@ class NemotronVLMCaptioner(BaseModel):
 
     def __init__(
         self,
-        model_path: str = "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16",
+        model_path: str = DEFAULT_LOCAL_CAPTION_MODEL_ID,
         device: Optional[str] = None,
         hf_cache_dir: Optional[str] = None,
         max_new_tokens: int = 1024,

--- a/nemo_retriever/src/nemo_retriever/operators/extract/caption/caption.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/caption/caption.py
@@ -12,6 +12,7 @@ import pandas as pd
 from PIL import Image
 
 from nemo_retriever.common.modality.caption.model_profiles import (
+    DEFAULT_LOCAL_CAPTION_MODEL_ID,
     get_caption_model_profile,
     merge_request_extras,
     resolve_caption_model_name,
@@ -25,7 +26,7 @@ from nemo_retriever.operators.extract.ocr.ocr import _crop_b64_image_by_norm_bbo
 from nemo_retriever.common.params import CaptionParams
 from nemo_retriever.common.remote_auth import resolve_remote_api_key
 
-_DEFAULT_MODEL_NAME = "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16"
+_DEFAULT_MODEL_NAME = DEFAULT_LOCAL_CAPTION_MODEL_ID
 _DEFAULT_REMOTE_ENDPOINT_URL = "https://integrate.api.nvidia.com/v1/chat/completions"
 _MAX_CONTEXT_TEXT_CHARS = 4096
 _MIN_IMAGE_DIMENSION = 32

--- a/nemo_retriever/tests/test_caption.py
+++ b/nemo_retriever/tests/test_caption.py
@@ -415,7 +415,7 @@ def test_caption_cpu_actor_defaults_to_hosted_endpoint_when_api_key_is_configure
     mock_create_client.assert_called_once()
     assert mock_create_client.call_args.args[0] == "https://integrate.api.nvidia.com/v1/chat/completions"
     infer_kwargs = mock_nim.infer.call_args.kwargs
-    assert infer_kwargs["model_name"] == "nvidia/nemotron-nano-12b-v2-vl"
+    assert infer_kwargs["model_name"] == "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
 
 
 @patch("nemo_retriever.operators.extract.caption.caption._create_remote_client")
@@ -667,7 +667,7 @@ def test_caption_images_local_cache_keys_by_resolved_loader_kwargs(monkeypatch):
     assert omni_result.iloc[0]["images"][0]["text"] == "local cap 2"
     assert omni_again.iloc[0]["images"][0]["text"] == "local cap 2"
     assert [kwargs["model_name"] for kwargs in created_kwargs] == [
-        "nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16",
+        "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16",
         "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8",
     ]
 

--- a/nemo_retriever/tests/test_caption_model_profiles.py
+++ b/nemo_retriever/tests/test_caption_model_profiles.py
@@ -32,6 +32,7 @@ def test_canonical_caption_defaults_are_omni():
     assert DEFAULT_LOCAL_CAPTION_MODEL_ID == OMNI_BF16
     assert DEFAULT_REMOTE_CAPTION_MODEL_ID == OMNI_REMOTE
     assert CaptionParams().model_name == OMNI_BF16
+    assert "approximately 62 GiB" in CaptionParams.model_json_schema()["properties"]["model_name"]["description"]
 
 
 _LOCAL_CAPTIONER_NEMO_IMPORT_MODULES = (

--- a/nemo_retriever/tests/test_caption_model_profiles.py
+++ b/nemo_retriever/tests/test_caption_model_profiles.py
@@ -20,6 +20,20 @@ OMNI_BF16 = "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16"
 OMNI_FP8 = "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8"
 OMNI_NVFP4 = "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4"
 OMNI_REMOTE = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+
+
+def test_canonical_caption_defaults_are_omni():
+    from nemo_retriever.common.modality.caption.model_profiles import (
+        DEFAULT_LOCAL_CAPTION_MODEL_ID,
+        DEFAULT_REMOTE_CAPTION_MODEL_ID,
+    )
+    from nemo_retriever.common.params import CaptionParams
+
+    assert DEFAULT_LOCAL_CAPTION_MODEL_ID == OMNI_BF16
+    assert DEFAULT_REMOTE_CAPTION_MODEL_ID == OMNI_REMOTE
+    assert CaptionParams().model_name == OMNI_BF16
+
+
 _LOCAL_CAPTIONER_NEMO_IMPORT_MODULES = (
     "nemo_retriever.models.local.nemotron_vlm_captioner",
     "nemo_retriever.common.nvtx",
@@ -450,7 +464,9 @@ def test_local_captioner_passes_omni_no_think_chat_kwargs(isolated_local_caption
 
     from nemo_retriever.models.local.nemotron_vlm_captioner import NemotronVLMCaptioner
 
-    captioner = NemotronVLMCaptioner(model_path=OMNI_BF16)
+    captioner = NemotronVLMCaptioner()
+
+    assert captioner.model_name == OMNI_BF16
 
     assert captioner.caption_batch(["abc123"]) == ["generated caption"]
     chat_kwargs = FakeLLM.instances[-1].chat_calls[-1]["kwargs"]

--- a/nemo_retriever/tests/test_graph_pipeline_cli.py
+++ b/nemo_retriever/tests/test_graph_pipeline_cli.py
@@ -2,8 +2,9 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import sys
+import inspect
 import json
+import sys
 from types import SimpleNamespace
 from typing import Any
 
@@ -11,15 +12,24 @@ import pandas as pd
 import pytest
 from typer.testing import CliRunner
 
-import nemo_retriever.ingest.execution as ingest_execution
-import nemo_retriever.examples.graph_pipeline as batch_pipeline
-import nemo_retriever.models as model_module
 import nemo_retriever.cli.pipeline.__main__ as pipeline_main
-import nemo_retriever.tools.recall.beir as beir_module
 import nemo_retriever.common.detection_summary as detection_summary_module
+import nemo_retriever.examples.graph_pipeline as batch_pipeline
+import nemo_retriever.ingest.execution as ingest_execution
+import nemo_retriever.models as model_module
+import nemo_retriever.tools.recall.beir as beir_module
 from nemo_retriever.common.input_files import resolve_input_patterns
 
 RUNNER = CliRunner()
+
+
+def test_staged_pipeline_caption_default_and_help_are_omni() -> None:
+    option = inspect.signature(pipeline_main.run).parameters["caption_model_name"].default
+    result = RUNNER.invoke(pipeline_main.app, ["run", "--help"])
+
+    assert option.default == "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16"
+    assert result.exit_code == 0
+    assert "Omni 30B BF16" in result.output
 
 
 class _FakeDataset:

--- a/nemo_retriever/tests/test_pipeline_image_caption_concurrency.py
+++ b/nemo_retriever/tests/test_pipeline_image_caption_concurrency.py
@@ -88,6 +88,9 @@ _MIN_STATIC_REPLICAS = 2
 # provisioned.
 _MIN_MAX_REPLICAS = 4
 
+_CANONICAL_REMOTE_CAPTION_MODEL = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+_CAPTION_MODEL_ENV_EXPRESSION = f'$VLM_CAPTION_MODEL_NAME|"{_CANONICAL_REMOTE_CAPTION_MODEL}"'
+
 
 # ---------------------------------------------------------------------
 # YAML helpers
@@ -156,6 +159,23 @@ def _replica_value(stage: dict[str, Any], slot: str) -> int:
 # ---------------------------------------------------------------------
 # Per-pipeline assertions
 # ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "yaml_name, yaml_path",
+    sorted(_PIPELINE_YAMLS.items()),
+    ids=sorted(_PIPELINE_YAMLS.keys()),
+)
+def test_image_caption_uses_canonical_remote_model_with_env_override(
+    yaml_name: str, yaml_path: Path
+) -> None:
+    pipeline = _load_pipeline(yaml_path)
+    stage = _find_stage(pipeline, _STAGE_NAME)
+
+    assert stage["config"]["model_name"] == _CAPTION_MODEL_ENV_EXPRESSION, (
+        f"{yaml_name}: keep VLM_CAPTION_MODEL_NAME as the highest-precedence override "
+        f"and use {_CANONICAL_REMOTE_CAPTION_MODEL!r} as the shipped fallback."
+    )
 
 
 @pytest.mark.parametrize(

--- a/nemo_retriever/tests/test_pipeline_image_caption_concurrency.py
+++ b/nemo_retriever/tests/test_pipeline_image_caption_concurrency.py
@@ -57,6 +57,8 @@ from typing import Any
 import pytest
 import yaml
 
+from nemo_retriever.common.modality.caption.model_profiles import DEFAULT_REMOTE_CAPTION_MODEL_ID
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CONFIG_DIR = REPO_ROOT / "config"
@@ -88,7 +90,7 @@ _MIN_STATIC_REPLICAS = 2
 # provisioned.
 _MIN_MAX_REPLICAS = 4
 
-_CANONICAL_REMOTE_CAPTION_MODEL = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+_CANONICAL_REMOTE_CAPTION_MODEL = DEFAULT_REMOTE_CAPTION_MODEL_ID
 _CAPTION_MODEL_ENV_EXPRESSION = f'$VLM_CAPTION_MODEL_NAME|"{_CANONICAL_REMOTE_CAPTION_MODEL}"'
 
 
@@ -166,9 +168,7 @@ def _replica_value(stage: dict[str, Any], slot: str) -> int:
     sorted(_PIPELINE_YAMLS.items()),
     ids=sorted(_PIPELINE_YAMLS.keys()),
 )
-def test_image_caption_uses_canonical_remote_model_with_env_override(
-    yaml_name: str, yaml_path: Path
-) -> None:
+def test_image_caption_uses_canonical_remote_model_with_env_override(yaml_name: str, yaml_path: Path) -> None:
     pipeline = _load_pipeline(yaml_path)
     stage = _find_stage(pipeline, _STAGE_NAME)
 


### PR DESCRIPTION
## Description

Default VLM image captioning to Nemotron 3 Nano Omni across hosted, local, and shipped NIM pipeline paths. Captioning remains opt-in, and explicit model selections and `VLM_CAPTION_MODEL_NAME` overrides continue to take precedence.

### Caption model defaults

| Caption path | Before this PR | After this PR |
|---|---|---|
| Remote/hosted captioner (`https://integrate.api.nvidia.com/v1/chat/completions`) | `nvidia/nemotron-nano-12b-v2-vl` | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` |
| Local vLLM captioner | `nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16` | `nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16` |
| NIM VLM captioner in `config/default_pipeline.yaml` | `nvidia/nemotron-nano-12b-v2-vl` | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` |
| NIM VLM captioner in `config/custom_summarization_pipeline.yaml` | `nvidia/llama-3.1-nemotron-nano-vl-8b-v1` | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` |

The new local default is the BF16 Omni checkpoint with approximately 62 GiB of weights, so local captioning requires correspondingly larger GPU capacity. Nano BF16, FP8, and NVFP4 profiles, aliases, revision pins, and explicit custom model overrides remain supported.

This PR also:

- Defines canonical local and remote caption model constants and uses them in `CaptionParams`, the caption operator, `NemotronVLMCaptioner`, and the staged pipeline CLI.
- Keeps the NVIDIA-hosted endpoint fallback and environment-variable override precedence unchanged while resolving the default hosted model to Omni.
- Updates CLI and extraction documentation for the new defaults and local model footprint.
- Adds coverage for the canonical defaults, local and hosted behavior, CLI help/defaults, and both shipped pipeline YAML fallbacks.

Validation:

- `uv run pytest -q tests/test_caption.py tests/test_caption_model_profiles.py tests/test_root_cli_workflow.py tests/test_graph_pipeline_cli.py tests/test_graph_pipeline_registry.py tests/test_pipeline_image_caption_concurrency.py tests/test_service_caption.py tests/test_helm_caption_endpoint.py tests/test_hf_model_registry.py`
- Result: 439 passed with one pre-existing deprecation warning.
- `git diff --check`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

