### PR TITLE
docs: clarify NeMo Retriever Library is not NVAIE-supported (NVBugs 6462632)

### DIFF
--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -4,7 +4,9 @@ This documentation contains the Frequently Asked Questions (FAQ) for [NeMo Retri
 
 ## Is the NeMo Retriever Library supported under NVIDIA AI Enterprise (NVAIE)?
 
-No. The NeMo Retriever Library, including its container image and Helm chart artifacts, is not supported under NVIDIA AI Enterprise (NVAIE). Some NIM microservices and models that the library calls may be individually covered by NVAIE, but that coverage does not extend to the NeMo Retriever Library or its end-to-end extraction workflow. For more information, refer to [NVIDIA AI Enterprise (NVAIE) support](overview.md#nvidia-ai-enterprise-nvaie-support).
+No. The NeMo Retriever Library, including its container image and Helm chart artifacts, is not supported under NVIDIA AI Enterprise (NVAIE).
+
+Some NIM microservices and models that the library calls may be individually covered by NVAIE. That coverage does not extend to the NeMo Retriever Library or its end-to-end extraction workflow. For more information, refer to [NVIDIA AI Enterprise (NVAIE) support](overview.md#nvidia-ai-enterprise-nvaie-support).
 
 ## What if I already have a retrieval pipeline? Can I just use NeMo Retriever Library? 
 

--- a/docs/docs/extraction/faq.md
+++ b/docs/docs/extraction/faq.md
@@ -2,6 +2,10 @@
 
 This documentation contains the Frequently Asked Questions (FAQ) for [NeMo Retriever Library](overview.md).
 
+## Is the NeMo Retriever Library supported under NVIDIA AI Enterprise (NVAIE)?
+
+No. The NeMo Retriever Library, including its container image and Helm chart artifacts, is not supported under NVIDIA AI Enterprise (NVAIE). Some NIM microservices and models that the library calls may be individually covered by NVAIE, but that coverage does not extend to the NeMo Retriever Library or its end-to-end extraction workflow. For more information, refer to [NVIDIA AI Enterprise (NVAIE) support](overview.md#nvidia-ai-enterprise-nvaie-support).
+
 ## What if I already have a retrieval pipeline? Can I just use NeMo Retriever Library? 
 
 You can use the CLI or Python APIs to perform extraction only, and then consume the results.

--- a/docs/docs/extraction/getting-started-about.md
+++ b/docs/docs/extraction/getting-started-about.md
@@ -8,7 +8,9 @@ Typical order:
 2. Confirm the [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md) for your OS, GPU, and software stack.
 3. Deploy using one of:
     - [Deployment options](deployment-options.md) for library, hosted NIMs, and Kubernetes paths
-    - **Supported:** [Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) for Kubernetes cluster install and upgrade
+    - [Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) for Kubernetes cluster install and upgrade
 4. Explore [Jupyter Notebooks](starter-kits.md) for end-to-end examples.
+
+The NeMo Retriever Library and its Helm chart are not supported under NVIDIA AI Enterprise (NVAIE). For more information, refer to [NVIDIA AI Enterprise (NVAIE) support](overview.md#nvidia-ai-enterprise-nvaie-support).
 
 If you are new to the product, read [What is NeMo Retriever Library?](overview.md) and [Concepts](concepts.md) under **Introduction** first.

--- a/docs/docs/extraction/getting-started-about.md
+++ b/docs/docs/extraction/getting-started-about.md
@@ -6,9 +6,7 @@ Typical order:
 
 1. [Get your API key](api-keys.md) (NGC / API access as required by your workflow).
 2. Confirm the [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md) for your OS, GPU, and software stack.
-3. Deploy using one of:
-    - [Deployment options](deployment-options.md) for library, hosted NIMs, and Kubernetes paths
-    - [Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) for Kubernetes cluster install and upgrade
+3. Choose a path in [Deployment options](deployment-options.md) — local library, hosted NIMs, the Helm chart for Kubernetes, or a standalone Docker service.
 4. Explore [Jupyter Notebooks](starter-kits.md) for end-to-end examples.
 
 The NeMo Retriever Library and its Helm chart are not supported under NVIDIA AI Enterprise (NVAIE). For more information, refer to [NVIDIA AI Enterprise (NVAIE) support](overview.md#nvidia-ai-enterprise-nvaie-support).

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -11,7 +11,7 @@ and can store vectors in [LanceDB](https://lancedb.com/) for the recommended emb
 
     NVIDIA AI Enterprise (NVAIE) support does **not** cover the NeMo Retriever Library. This applies to the NeMo Retriever Library Python package, its container image, and its Helm chart artifacts.
 
-    Some individual NIM microservices and models that the library calls—for example, the default NIMs in the [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md#default-helm-nims)—may be covered by NVAIE on their own. That coverage applies only to those individual NIMs and models; it does **not** extend to the NeMo Retriever Library or its end-to-end extraction workflow. Using NVAIE-supported NIMs or models through the NeMo Retriever Library does not make the library, its container, or its chart NVAIE-supported.
+    Some individual NIM microservices and models that the library calls—for example, the default NIMs in the [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md#default-helm-nims)—may be covered by NVAIE on their own. That coverage applies only to those individual NIMs and models. It does **not** extend to the NeMo Retriever Library or its end-to-end extraction workflow. Using NVAIE-supported NIMs or models through the NeMo Retriever Library does not make the library, its container, or its chart NVAIE-supported.
 
 ## What NeMo Retriever Library Is ✔️
 

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -5,6 +5,14 @@ NVIDIA NeMo Retriever Library (NRL) is a high retrieval accuracy, performant, an
 NeMo Retriever Library enables parallelization of splitting documents into pages where sub-page content is classified (such as text paragraphs, tables, charts, and infographics), extracted, and further contextualized through optical character recognition (OCR) into a standard schema. From there, NeMo Retriever Library manages computation of embeddings for the extracted content,
 and can store vectors in [LanceDB](https://lancedb.com/) for the recommended embedded path when you pass `vdb_op="lancedb"` to upload (refer to [Vector databases](vdbs.md)).
 
+## NVIDIA AI Enterprise (NVAIE) support { #nvidia-ai-enterprise-nvaie-support }
+
+!!! warning "The NeMo Retriever Library is not supported under NVIDIA AI Enterprise (NVAIE)"
+
+    NVIDIA AI Enterprise (NVAIE) support does **not** cover the NeMo Retriever Library. This applies to the NeMo Retriever Library Python package, its container image, and its Helm chart artifacts.
+
+    Some individual NIM microservices and models that the library calls—for example, the default NIMs in the [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md#default-helm-nims)—may be covered by NVAIE on their own. That coverage applies only to those individual NIMs and models; it does **not** extend to the NeMo Retriever Library or its end-to-end extraction workflow. Using NVAIE-supported NIMs or models through the NeMo Retriever Library does not make the library, its container, or its chart NVAIE-supported.
+
 ## What NeMo Retriever Library Is ✔️
 
 The following diagram shows the retriever pipeline.

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -4,7 +4,7 @@ Before you begin using [NeMo Retriever Library](overview.md), confirm your softw
 
 !!! note "NVIDIA AI Enterprise (NVAIE) support"
 
-    The NeMo Retriever Library, including its container image and Helm chart artifacts, is not supported under NVIDIA AI Enterprise (NVAIE), even though some NIM microservices and models it uses may be individually covered by NVAIE. For details, refer to [NVIDIA AI Enterprise (NVAIE) support](overview.md#nvidia-ai-enterprise-nvaie-support).
+    The NeMo Retriever Library, including its container image and Helm chart artifacts, is not supported under NVIDIA AI Enterprise (NVAIE), even though some NIM microservices and models it uses may be individually covered by NVAIE. For more information, refer to [NVIDIA AI Enterprise (NVAIE) support](overview.md#nvidia-ai-enterprise-nvaie-support).
 
 ## Software Requirements { #software-requirements }
 

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -2,6 +2,10 @@
 
 Before you begin using [NeMo Retriever Library](overview.md), confirm your software stack, deployment hardware, and—if you use them—advanced features (audio and video, Nemotron Parse, VLM image captioning, reranking) against the guidance in this page.
 
+!!! note "NVIDIA AI Enterprise (NVAIE) support"
+
+    The NeMo Retriever Library, including its container image and Helm chart artifacts, is not supported under NVIDIA AI Enterprise (NVAIE), even though some NIM microservices and models it uses may be individually covered by NVAIE. For details, refer to [NVIDIA AI Enterprise (NVAIE) support](overview.md#nvidia-ai-enterprise-nvaie-support).
+
 ## Software Requirements { #software-requirements }
 
 - Linux operating systems (Ubuntu 22.04 or later recommended)


### PR DESCRIPTION
## Summary
Clarifies that the NeMo Retriever Library is **not** supported under NVIDIA AI Enterprise (NVAIE), including its container image and Helm chart artifacts, while some individual NIMs/models it uses may be covered by NVAIE on their own.

Addresses NVBugs 6462632: customers see NVAIE-supported models/resources referenced in NeMo Retriever docs and expect NVAIE support for the overall library workflow. This adds a clear, customer-visible statement so support can point customers to it.

## Changes
- `overview.md`: canonical **NVIDIA AI Enterprise (NVAIE) support** section (anchored) stating the library, container, and chart are not NVAIE-supported.
- `prerequisites-support-matrix.md`: short note + link to the canonical section.
- `faq.md`: new FAQ entry linking to the canonical section.

Docs-only; no runtime, chart template, or CI changes.