### PR TITLE
docs: fix index links and Page Elements image limits (NVBugs 6179242, 5456115)

### DIFF
--- a/docs/docs/extraction/api-keys.md
+++ b/docs/docs/extraction/api-keys.md
@@ -23,6 +23,8 @@ On Windows PowerShell you can use `$env:NVIDIA_API_KEY = "nvapi-..."`.
 
 For a full list of related variables, refer to [Environment configuration variables](environment-config.md).
 
+When you call hosted object-detection NIMs (Page Elements, Table Structure, Graphic Elements) with images larger than about 180,000 characters (roughly 180 KB) inline, you also use this key with the [NVCF Asset API](https://docs.api.nvidia.com/cloud-functions/reference/createasset) to upload inputs and reference them by `asset_id`. Refer to [Hosted Page Elements NIM image size limits](troubleshoot.md#hosted-page-elements-nim-image-size-limits) for the workflow and example code.
+
 !!! note
 
     The `NVIDIA_API_KEY` from build.nvidia.com is not the same string as your NGC personal key used for Helm and `nvcr.io` access. Do not substitute one for the other unless your tooling explicitly documents that mapping.

--- a/docs/docs/extraction/multimodal-extraction.md
+++ b/docs/docs/extraction/multimodal-extraction.md
@@ -110,6 +110,10 @@ Extracted objects follow the schema and field descriptions in the [Metadata refe
 
 ## Extraction limitations and quality { #extraction-limitations-and-quality }
 
+Hosted Page Elements, Table Structure, and Graphic Elements NIM endpoints cap inline base64 image payloads at about **180,000 characters** (roughly 180 KB). The NeMo Retriever pipeline downscales large page renders before remote NIM calls. Direct API integrations must use the NVCF Asset API for larger inputs. For limits, `dpi` and `render_mode` tuning, and a step-by-step asset upload example, refer to [Hosted Page Elements NIM image size limits](troubleshoot.md#hosted-page-elements-nim-image-size-limits).
+
+Image payload limits are separate from the throughput metrics in the rest of this section.
+
 A single headline metric can drastically misrepresent system efficiency. The amount of compute that you need to process a dataset depends far more on its content and how your pipeline operates than on its disk size. This section explains why, and offers better ways to measure and report throughput.
 
 Some common throughput measures, and their problems, include the following:

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -133,8 +133,6 @@ Also refer to [What is NeMo Retriever Library?](overview.md) and [Pre-Requisites
 Currently, extraction with Nemotron parse doesn't support image files, only scanned PDFs.
 To work around this issue, convert image files to PDFs before you use `extract_method="nemotron_parse"`.
 
-
-
 ## Hosted Page Elements NIM image size limits { #hosted-page-elements-nim-image-size-limits }
 
 [NVIDIA-hosted Page Elements NIM](https://build.nvidia.com/nvidia/nemotron-page-elements-v3) endpoints on `ai.api.nvidia.com` (and the matching build.nvidia.com model experience) enforce a strict limit on **inline** image payloads. The same limit applies to hosted **Table Structure** and **Graphic Elements** object-detection NIMs because they share the same `/v1/infer` request shape.

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -135,6 +135,100 @@ To work around this issue, convert image files to PDFs before you use `extract_m
 
 
 
+## Hosted Page Elements NIM image size limits { #hosted-page-elements-nim-image-size-limits }
+
+[NVIDIA-hosted Page Elements NIM](https://build.nvidia.com/nvidia/nemotron-page-elements-v3) endpoints on `ai.api.nvidia.com` (and the matching build.nvidia.com model experience) enforce a strict limit on **inline** image payloads. The same limit applies to hosted **Table Structure** and **Graphic Elements** object-detection NIMs because they share the same `/v1/infer` request shape.
+
+The following table summarizes inline payload limits by deployment:
+
+| Deployment | Inline base64 limit | Oversized images |
+|------------|---------------------|------------------|
+| Hosted (`build.nvidia.com`, `ai.api.nvidia.com`) | About **180,000 characters** on the base64 portion of the data URL (roughly 180 KB; build.nvidia.com validates `len(image_b64) < 180_000`) | Upload with the [NVCF Asset API](https://docs.api.nvidia.com/cloud-functions/reference/createasset), then reference `data:image/<format>;asset_id,<asset_id>` in the `url` field |
+| Self-hosted NIM container | Higher; the NeMo Retriever client downscales HTTP payloads above **512,000 characters** before calling the NIM | Resize or re-encode the source image, or rely on the client downscaling |
+
+The [Object Detection NIM API reference](https://docs.nvidia.com/nim/ingestion/object-detection/latest/api-reference.html) states only that “very large images may cause processing issues.” For hosted integrations, treat **180,000 characters** as the inline cap unless NVIDIA publishes a different limit for your endpoint.
+
+### NeMo Retriever Library pipeline users
+
+When you route extraction to hosted Page Elements NIM URLs (for example `page_elements_invoke_url="https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-page-elements-v3"`), the library:
+
+- Renders PDF pages with default `render_mode="fit_to_model"` (targets about 1024 px on the long edge instead of full raster DPI).
+- Downscales base64 page images before remote object-detection NIM HTTP calls when payloads exceed the client limit (512,000 characters for Page Elements and Table Structure).
+
+!!! important
+
+    The library downscales payloads to **512,000** characters before HTTP calls to object-detection NIMs. Hosted endpoints still reject inline base64 above **180,000** characters. Treat the lower hosted cap as the effective limit when `page_elements_invoke_url` points at `ai.api.nvidia.com`.
+
+If you still receive **422** responses mentioning invalid image URLs on hosted endpoints, lower `dpi` in `ExtractParams`, keep `render_mode="fit_to_model"`, or preprocess very large standalone image inputs before ingest. For parameter details, refer to the [Python API guide](nemo-retriever-api-reference.md).
+
+### Direct Page Elements NIM API calls (build.nvidia.com or custom clients)
+
+When you call Page Elements NIM **directly** (build playground, curl, or a custom integration—not through the NeMo Retriever pipeline), use inline base64 only when `len(base64_image) < 180_000`. For larger PNG or JPEG inputs, upload once with the NVCF Asset API and pass an asset reference in the inference payload.
+
+1. **Create an asset** — `POST https://api.nvcf.nvidia.com/v2/nvcf/assets` with `Authorization: Bearer $NVIDIA_API_KEY`, plus JSON `contentType` (for example `image/png`) and `description`.
+2. **Upload the file** — `PUT` the image bytes to the `uploadUrl` from step 1. Set `Content-Type` to match `contentType`, and set `x-amz-meta-nvcf-asset-description` to the same description string.
+3. **Infer** — `POST` to your Page Elements invoke URL with `"url": "data:image/png;asset_id,<assetId>"` inside each `input[]` item (same `type: image_url` schema as inline base64).
+
+For the full asset workflow (including reuse across requests), refer to [NVCF assets](https://docs.nvidia.com/cloud-functions/user-guide/latest/cloud-function/assets.html) in the Cloud Functions user guide and the [Create Asset](https://docs.api.nvidia.com/cloud-functions/reference/createasset) API reference. Hosted calls require the same [`NVIDIA_API_KEY`](api-keys.md#nvidia-api-key) you use for other build.nvidia.com NIM endpoints.
+
+For the request schema, refer to the [Object Detection NIM API reference](https://docs.nvidia.com/nim/ingestion/object-detection/latest/api-reference.html).
+
+??? example "Create an NVCF asset, upload a PNG, and call Page Elements"
+
+    ```python
+    import os
+    import requests
+
+    API_KEY = os.environ["NVIDIA_API_KEY"]
+    PAGE_ELEMENTS_URL = "https://ai.api.nvidia.com/v1/cv/nvidia/nemotron-page-elements-v3"
+    IMAGE_PATH = "large_page.png"
+
+    create = requests.post(
+        "https://api.nvcf.nvidia.com/v2/nvcf/assets",
+        headers={
+            "Authorization": f"Bearer {API_KEY}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        },
+        json={"contentType": "image/png", "description": "page-elements-large-input"},
+        timeout=60,
+    )
+    create.raise_for_status()
+    asset = create.json()
+
+    with open(IMAGE_PATH, "rb") as image_file:
+        upload = requests.put(
+            asset["uploadUrl"],
+            headers={
+                "Content-Type": "image/png",
+                "x-amz-meta-nvcf-asset-description": "page-elements-large-input",
+            },
+            data=image_file.read(),
+            timeout=120,
+        )
+    upload.raise_for_status()
+
+    payload = {
+        "input": [{
+            "type": "image_url",
+            "url": f"data:image/png;asset_id,{asset['assetId']}",
+        }]
+    }
+    response = requests.post(
+        PAGE_ELEMENTS_URL,
+        headers={
+            "Authorization": f"Bearer {API_KEY}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        },
+        json=payload,
+        timeout=120,
+    )
+    response.raise_for_status()
+    ```
+
+Supported inline formats remain **PNG** and **JPEG**, encoded as `data:image/<format>;base64,<data>` or `data:image/<format>;asset_id,<uuid>`. OpenAPI specs for Page Elements v2 and v3 are linked from the [Object Detection NIM API reference](https://docs.nvidia.com/nim/ingestion/object-detection/latest/api-reference.html#openapi-reference-for-page-elements).
+
 ## Too many open files error
 
 In rare cases, when you run a job you might an see an error similar to `too many open files` or `max open file descriptor`.

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -203,7 +203,7 @@ For the request schema, refer to the [Object Detection NIM API reference](https:
                 "Content-Type": "image/png",
                 "x-amz-meta-nvcf-asset-description": "page-elements-large-input",
             },
-            data=image_file.read(),
+            data=image_file,
             timeout=120,
         )
     upload.raise_for_status()

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -36,7 +36,7 @@ The following are some applications that use NVIDIA Nemo Retriever:
 - [Build an Enterprise RAG pipeline](https://build.nvidia.com/nvidia/build-an-enterprise-rag-pipeline/blueprintcard) (NVIDIA AI Blueprint)
 - [Building Code Documentation Agents with CrewAI](https://github.com/crewAIInc/nvidia-demo) (CrewAI Demo)
 - [Digital Human for Customer Service](https://github.com/NVIDIA-AI-Blueprints/digital-human) (NVIDIA AI Blueprint)
-- [Document Research Assistant for Blog Creation](https://github.com/run-llama/llama_index/blob/main/docs/docs/examples/agent/nvidia_document_research_assistant_for_blog_creation.ipynb) (LlamaIndex Jupyter Notebook)
+- [Document Research Assistant for Blog Creation](https://docs.llamaindex.ai/en/stable/examples/agent/nvidia_document_research_assistant_for_blog_creation/) (LlamaIndex Jupyter Notebook)
 - [Video Search and Summarization](https://github.com/NVIDIA-AI-Blueprints/video-search-and-summarization) (NVIDIA AI Blueprint)
 
 
@@ -47,4 +47,4 @@ The following are some applications that use NVIDIA Nemo Retriever:
 - [NeMo Retriever Text Embedding NIM](https://docs.nvidia.com/nim/nemo-retriever/text-embedding/latest/overview.html)
 - [NeMo Retriever Text Reranking NIM](https://docs.nvidia.com/nim/nemo-retriever/text-reranking/latest/overview.html)
 - [NVIDIA NIM for Object Detection](https://docs.nvidia.com/nim/ingestion/object-detection/latest/overview.html)
-- [NVIDIA NIM for Image OCR](https://docs.nvidia.com/nim/ingestion/table-extraction/latest/overview.html)
+- [NVIDIA NIM for Image OCR](https://docs.nvidia.com/nim/ingestion/image-ocr/latest/overview.html)


### PR DESCRIPTION
## Summary

Combines former PRs #2289 and #2288 into one docs-only review.

### NVBugs 6179242 — Retriever index broken links
- Fix **21 broken links** from the 2026-05-14 embed/rerank/OCR scan by updating two URL patterns in `docs/docs/index.md`.
- **Image OCR:** replace obsolete `table-extraction` NIM URL with [NeMo Retriever OCR](https://docs.nvidia.com/nim/ingestion/image-ocr/latest/overview.html).
- **Applications:** replace dead LlamaIndex GitHub notebook blob with the [stable LlamaIndex docs example](https://docs.llamaindex.ai/en/stable/examples/agent/nvidia_document_research_assistant_for_blog_creation/).

### NVBugs 5456115 — Page Elements NIM image size limits
- Document hosted Page Elements (and related object-detection) NIM inline base64 limit (~180,000 characters) and the NVCF Asset API workflow for oversized images.
- Add canonical guidance in `troubleshoot.md` with limits table, NRL pipeline behavior, and a Python upload + infer example.
- Cross-link from `api-keys.md` and `multimodal-extraction.md`.

## Files changed (4)
- `docs/docs/index.md`
- `docs/docs/extraction/troubleshoot.md`
- `docs/docs/extraction/api-keys.md`
- `docs/docs/extraction/multimodal-extraction.md`

## Test plan
- [ ] `.\.cursor\scripts\check-nrl-doc-leakage.ps1` passes on this branch
- [ ] Review anchor `troubleshoot.md#hosted-page-elements-nim-image-size-limits` renders in MkDocs preview
- [ ] Re-crawl `/nemo/retriever/<version>/index.html` — Related Topics and Applications links should resolve
- [ ] Verify external links resolve (Object Detection NIM API reference, NVCF Create Asset, NVCF assets user guide)

## Supersedes
- Closes #2289
- Closes #2288