### PR TITLE
Adopt Typer 0.27 help formatting

### DIFF
--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -39,7 +39,8 @@ dependencies = [
   "pandas>=2.0,<3",
   "sqlglot>=30.0.0",
   "tqdm>=4.66.0",
-  "typer>=0.12.0",
+  # Typer 0.27 replaces argument names with "..." in generated CLI usage text.
+  "typer>=0.12.0,<0.27",
   "click>=8.2.0",
   "pyyaml>=6.0",
   # Service layer

--- a/nemo_retriever/pyproject.toml
+++ b/nemo_retriever/pyproject.toml
@@ -39,8 +39,7 @@ dependencies = [
   "pandas>=2.0,<3",
   "sqlglot>=30.0.0",
   "tqdm>=4.66.0",
-  # Typer 0.27 replaces argument names with "..." in generated CLI usage text.
-  "typer>=0.12.0,<0.27",
+  "typer>=0.12.0",
   "click>=8.2.0",
   "pyyaml>=6.0",
   # Service layer

--- a/nemo_retriever/tests/test_root_cli_workflow.py
+++ b/nemo_retriever/tests/test_root_cli_workflow.py
@@ -1050,7 +1050,7 @@ def test_root_ingest_help_defaults_to_local_workflow(monkeypatch: pytest.MonkeyP
     )
 
     assert result.exit_code == 0
-    assert "Usage: retriever ingest [OPTIONS] DOCUMENTS..." in result.output
+    assert "Usage: retriever ingest [OPTIONS] {documents}..." in result.output
     assert "input formats, not commands" in result.output
     assert "CPU-only hosts use NVIDIA's hosted embedding endpoint" in result.output
     assert "retriever ingest batch --help" in result.output
@@ -1097,7 +1097,7 @@ def test_root_ingest_batch_help_remains_mode_specific(monkeypatch: pytest.Monkey
     result = RUNNER.invoke(cli_main.app, ["ingest", "batch", "--help"])
 
     assert result.exit_code == 0
-    assert "Usage: root ingest batch [OPTIONS] DOCUMENTS..." in result.output
+    assert "Usage: root ingest batch [OPTIONS] {documents}..." in result.output
     assert "--ray-address" in result.output
     assert "--pdf-extract-workers" in result.output
     assert "--lancedb-uri" in result.output
@@ -1109,14 +1109,14 @@ def test_root_ingest_local_help_uses_shared_graph_contract() -> None:
     result = RUNNER.invoke(cli_main.app, ["ingest", "local", "--help"], prog_name="retriever")
 
     assert result.exit_code == 0
-    assert "Usage: retriever ingest [OPTIONS] DOCUMENTS..." in result.output
+    assert "Usage: retriever ingest [OPTIONS] {documents}..." in result.output
     assert "retriever ingest local" not in result.output
     assert "--input-type" not in result.output
     assert "--run-mode" not in result.output
     assert "--service-url" not in result.output
     assert "--ray-address" in result.output
     assert "--profile" in result.output
-    assert "[auto|fast-text]" in result.output
+    assert "<auto|fast-text>" in result.output
     assert "--extract-images" in result.output
     assert "--use-page" not in result.output
     assert "--use-graphic" not in result.output
@@ -1170,7 +1170,7 @@ def test_root_ingest_service_help_hides_local_only_options() -> None:
     result = RUNNER.invoke(cli_main.app, ["ingest", "service", "--help"], env={"COLUMNS": "200"})
 
     assert result.exit_code == 0
-    assert "Usage: root ingest service [OPTIONS] DOCUMENTS..." in result.output
+    assert "Usage: root ingest service [OPTIONS] {documents}..." in result.output
     assert "--service-url" in result.output
     assert "--extract-images" in result.output
     assert "--embed-granular" in result.output

--- a/nemo_retriever/tests/test_root_query_cli.py
+++ b/nemo_retriever/tests/test_root_query_cli.py
@@ -554,7 +554,7 @@ def test_root_query_help_defaults_to_local_command(monkeypatch: pytest.MonkeyPat
     )
 
     assert result.exit_code == 0
-    assert "Usage: retriever query [OPTIONS] QUERY" in result.output
+    assert "Usage: retriever query [OPTIONS] {query}" in result.output
     assert "_local" not in result.output
     assert "retriever ingest local" not in result.output
     assert "retriever ingest --lancedb-uri" in result.output

--- a/nemo_retriever/uv.lock
+++ b/nemo_retriever/uv.lock
@@ -2633,7 +2633,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.66.0" },
     { name = "transformers", marker = "extra == 'local'", specifier = ">=4.57.6,<5" },
     { name = "tritonclient", marker = "extra == 'local'" },
-    { name = "typer", specifier = ">=0.12.0" },
+    { name = "typer", specifier = ">=0.12.0,<0.27" },
     { name = "universal-pathlib", specifier = ">=0.2.0" },
     { name = "urllib3", specifier = "==2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },

--- a/nemo_retriever/uv.lock
+++ b/nemo_retriever/uv.lock
@@ -2633,7 +2633,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.66.0" },
     { name = "transformers", marker = "extra == 'local'", specifier = ">=4.57.6,<5" },
     { name = "tritonclient", marker = "extra == 'local'" },
-    { name = "typer", specifier = ">=0.12.0,<0.27" },
+    { name = "typer", specifier = ">=0.12.0" },
     { name = "universal-pathlib", specifier = ">=0.2.0" },
     { name = "urllib3", specifier = "==2.7.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
@@ -4973,17 +4973,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.25.1"
+version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/78/fda3361b56efc27944f24225f6ecd13d96d6fcfe37bd0eb34e2f4c63f9fc/typer-0.27.0.tar.gz", hash = "sha256:629bd12ea5d13a17148125d9a264f949eb171fb3f120f9b04d85873cab054fa5", size = 203430, upload-time = "2026-07-15T19:21:07.007Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
+    { url = "https://files.pythonhosted.org/packages/40/03/26a383c9e58c213199d1aad1c3d353cfc22d4444ec6d2c0bf8ad02523843/typer-0.27.0-py3-none-any.whl", hash = "sha256:6f4b27631e47f077871b7dc30e933ec0131c1390fbe0e387ea5574b5bac9ccf1", size = 122716, upload-time = "2026-07-15T19:21:05.553Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Typer 0.27 intentionally changed generated metavar formatting. The unit-test workflow resolved the new release, while five CLI help-contract tests still expected the previous format.

This adopts the upstream format instead of constraining Typer. CLI arguments and behavior are unchanged.

## What changed

- Upgrade the lockfile from Typer 0.25.1 to 0.27.0.
- Update ingest and query usage expectations from uppercase argument names to Typer's new `{argument}` format.
- Update the profile choice expectation from `[auto|fast-text]` to `<auto|fast-text>`.

The CLI documentation continues to use uppercase placeholders such as `DOCUMENTS...` as human-facing command notation; those are not captured help snapshots.

## Validation

- Focused CLI help tests under Typer 0.27.0: `5 passed`
- Full unit suite under Typer 0.27.0: `2603 passed, 23 skipped, 10 deselected`
- Pre-commit hooks, including lockfile verification: passed
