### PR TITLE
Fix OCR v2 revision pinning and validate nightly wheel contents

### DIFF
--- a/.github/workflows/huggingface-nightly.yml
+++ b/.github/workflows/huggingface-nightly.yml
@@ -293,6 +293,8 @@ jobs:
             --auditwheel-exclude libc10.so \
             --auditwheel-exclude libc10_cuda.so \
             --auditwheel-exclude libtorch_python.so \
+            --require-wheel-member "nemotron_ocr/inference/pipeline.py" \
+            --require-wheel-member "nemotron_ocr/inference/pipeline_v2.py" \
             --build-no-isolation \
             --venv-pip-install "hatchling" \
             --venv-pip-install "setuptools>=68" \

--- a/ci/scripts/nightly_build_publish.py
+++ b/ci/scripts/nightly_build_publish.py
@@ -23,6 +23,7 @@ import shutil
 import subprocess
 import sys
 import tomllib
+import zipfile
 from pathlib import Path
 
 
@@ -700,6 +701,31 @@ def _auditwheel_repair_dist_dir(dist_dir: Path, *, exclude_libs: list[str] | Non
     shutil.rmtree(repair_out)
 
 
+def _validate_required_wheel_members(dist_dir: Path, required_members: list[str]) -> None:
+    """Require exact archive members in every wheel before publication."""
+    if not required_members:
+        return
+
+    wheels = sorted(dist_dir.glob("*.whl"))
+    if not wheels:
+        raise RuntimeError(f"No wheels found in {dist_dir} to validate required members")
+
+    invalid_members = [member for member in required_members if not member or member.startswith("/")]
+    if invalid_members:
+        raise ValueError(f"Required wheel members must be non-empty relative paths: {invalid_members!r}")
+
+    failures: list[str] = []
+    for wheel in wheels:
+        with zipfile.ZipFile(wheel) as zf:
+            wheel_members = set(zf.namelist())
+        missing = [member for member in required_members if member not in wheel_members]
+        if missing:
+            failures.append(f"{wheel.name}: missing {', '.join(missing)}")
+
+    if failures:
+        raise RuntimeError("Required wheel member validation failed:\n" + "\n".join(failures))
+
+
 def _twine_upload(
     dist_dir: Path,
     repository_url: str,
@@ -830,6 +856,12 @@ def main() -> int:
         help="Shared library to exclude from auditwheel bundling (repeatable). "
         "Use for runtime deps like libtorch_cpu.so that should not be vendored.",
     )
+    ap.add_argument(
+        "--require-wheel-member",
+        action="append",
+        default=[],
+        help="Exact archive member required in every built wheel before upload (repeatable).",
+    )
     args = ap.parse_args()
     if args.release_version is not None and args.nightly_base_version:
         ap.error("--release-version cannot be used with --nightly-base-version")
@@ -903,6 +935,8 @@ def main() -> int:
     if args.auditwheel_repair:
         print("=== auditwheel repair ===")
         _auditwheel_repair_dist_dir(out_dir, exclude_libs=args.auditwheel_exclude)
+
+    _validate_required_wheel_members(out_dir, args.require_wheel_member)
 
     if args.upload:
         token = os.environ.get(args.token_env)

--- a/ci/tests/test_huggingface_release_workflow.py
+++ b/ci/tests/test_huggingface_release_workflow.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import zipfile
 from pathlib import Path
 from types import ModuleType
 
@@ -130,3 +131,52 @@ def test_huggingface_nightly_builder_defaults_to_public_pypi() -> None:
 
     assert 'default="https://upload.pypi.org/legacy/"' in script
     assert 'default="PYPI_API_TOKEN"' in script
+
+
+def _write_wheel(path: Path, members: list[str]) -> None:
+    with zipfile.ZipFile(path, "w") as zf:
+        for member in members:
+            zf.writestr(member, "")
+
+
+def test_nightly_builder_validates_required_members_in_every_wheel(tmp_path: Path) -> None:
+    nightly_build_publish = _load_nightly_build_publish_module()
+    required_members = [
+        "nemotron_ocr/inference/pipeline.py",
+        "nemotron_ocr/inference/pipeline_v2.py",
+    ]
+    _write_wheel(tmp_path / "x86.whl", required_members)
+    _write_wheel(tmp_path / "arm.whl", required_members + ["nemotron_ocr_cpp/extension.so"])
+
+    nightly_build_publish._validate_required_wheel_members(tmp_path, required_members)
+
+
+def test_nightly_builder_reports_wheel_and_missing_required_member(tmp_path: Path) -> None:
+    nightly_build_publish = _load_nightly_build_publish_module()
+    _write_wheel(tmp_path / "nemotron_ocr.whl", ["nemotron_ocr/inference/pipeline_v2.py"])
+
+    with pytest.raises(RuntimeError, match=r"nemotron_ocr\.whl: missing nemotron_ocr/inference/pipeline\.py"):
+        nightly_build_publish._validate_required_wheel_members(
+            tmp_path,
+            ["nemotron_ocr/inference/pipeline.py", "nemotron_ocr/inference/pipeline_v2.py"],
+        )
+
+
+def test_nightly_builder_skips_wheel_validation_without_requirements(tmp_path: Path) -> None:
+    nightly_build_publish = _load_nightly_build_publish_module()
+
+    nightly_build_publish._validate_required_wheel_members(tmp_path, [])
+
+
+def test_nightly_builder_validates_wheels_before_upload() -> None:
+    script = (REPO_ROOT / "ci" / "scripts" / "nightly_build_publish.py").read_text(encoding="utf-8")
+    main_source = script.split("def main() -> int:", 1)[1]
+
+    assert main_source.index("_validate_required_wheel_members(") < main_source.index("if args.upload:")
+
+
+def test_huggingface_ocr_wheels_require_base_and_v2_pipeline_modules() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "huggingface-nightly.yml").read_text(encoding="utf-8")
+
+    assert '--require-wheel-member "nemotron_ocr/inference/pipeline.py"' in workflow
+    assert '--require-wheel-member "nemotron_ocr/inference/pipeline_v2.py"' in workflow

--- a/nemo_retriever/src/nemo_retriever/models/local/nemotron_ocr_v2.py
+++ b/nemo_retriever/src/nemo_retriever/models/local/nemotron_ocr_v2.py
@@ -53,6 +53,7 @@ class NemotronOCRV2(BaseModel):
         super().__init__()
         configure_global_hf_cache_base()
         try:
+            from nemotron_ocr.inference import pipeline as _nemotron_ocr_pipeline  # local-only import
             from nemotron_ocr.inference import pipeline_v2 as _nemotron_ocr_pipeline_v2  # local-only import
         except ImportError as exc:
             raise ImportError(
@@ -64,7 +65,9 @@ class NemotronOCRV2(BaseModel):
                 "--ocr-version v1 still uses this package and selects its legacy mode."
             ) from exc
 
-        install_pinned_hf_hub_download(_nemotron_ocr_pipeline_v2)
+        # NemotronOCRV2 inherits checkpoint loading from NemotronOCR, whose
+        # module owns the hf_hub_download global used by _download_checkpoints.
+        install_pinned_hf_hub_download(_nemotron_ocr_pipeline)
         _NemotronOCRV2 = _nemotron_ocr_pipeline_v2.NemotronOCRV2
 
         if model_dir:

--- a/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
+++ b/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
@@ -49,16 +49,27 @@ def _install_upstream_ocr_v2_stub(monkeypatch: pytest.MonkeyPatch) -> list[dict[
             if kwargs.get("lang") not in _WrapperOCRV2._VALID_LANG_SELECTORS:
                 raise ValueError(f"unsupported upstream lang selector: {kwargs.get('lang')!r}")
             captured_kwargs.append(kwargs)
+            if getattr(pipeline_mod, "_download_on_init", False):
+                repo_id = (
+                    "nvidia/nemotron-ocr-v1"
+                    if kwargs.get("lang") in {"v1", "legacy"}
+                    else "nvidia/nemotron-ocr-v2"
+                )
+                pipeline_mod.hf_hub_download(repo_id=repo_id, filename="checkpoints/detector.pth")
 
     nemotron_ocr_mod = ModuleType("nemotron_ocr")
     inference_mod = ModuleType("nemotron_ocr.inference")
+    pipeline_mod = ModuleType("nemotron_ocr.inference.pipeline")
     pipeline_v2_mod = ModuleType("nemotron_ocr.inference.pipeline_v2")
+    setattr(pipeline_mod, "hf_hub_download", lambda *args, **kwargs: "/unpatched/model.bin")
     pipeline_v2_mod.NemotronOCRV2 = _NemotronOCRV2
+    inference_mod.pipeline = pipeline_mod
     inference_mod.pipeline_v2 = pipeline_v2_mod
     nemotron_ocr_mod.inference = inference_mod
 
     monkeypatch.setitem(sys.modules, "nemotron_ocr", nemotron_ocr_mod)
     monkeypatch.setitem(sys.modules, "nemotron_ocr.inference", inference_mod)
+    monkeypatch.setitem(sys.modules, "nemotron_ocr.inference.pipeline", pipeline_mod)
     monkeypatch.setitem(sys.modules, "nemotron_ocr.inference.pipeline_v2", pipeline_v2_mod)
     monkeypatch.delenv("RETRIEVER_ENABLE_TORCH_TRT", raising=False)
 
@@ -150,7 +161,10 @@ def test_local_ocr_v2_wrapper_uses_original_namespace_and_package_lang_selectors
         encoding="utf-8"
     )
 
+    assert "from nemotron_ocr.inference import pipeline as _nemotron_ocr_pipeline" in source
     assert "from nemotron_ocr.inference import pipeline_v2" in source
+    assert "install_pinned_hf_hub_download(_nemotron_ocr_pipeline)" in source
+    assert "install_pinned_hf_hub_download(_nemotron_ocr_pipeline_v2)" not in source
     assert 'lang: str = "multi"' in source
     assert "_NEMOTRON_OCR_LANG_ALIASES" not in source
     assert "package_lang" not in source
@@ -212,6 +226,48 @@ def test_local_ocr_v2_wrapper_passes_package_lang_selector_with_model_dir(monkey
     NemotronOCRV2(model_dir="/models/ocr", lang="english")
 
     assert captured_kwargs == [{"model_dir": "/models/ocr", "lang": "english"}]
+
+
+@pytest.mark.parametrize(
+    ("selector", "repo_id", "revision"),
+    [
+        ("multi", "nvidia/nemotron-ocr-v2", "86cacb0467fa4f7ce54342fdb250825e0d928ae7"),
+        ("legacy", "nvidia/nemotron-ocr-v1", "8657d08d3279f4864002d5fd3fdcd47ad8c96bcb"),
+    ],
+)
+def test_local_ocr_v2_wrapper_patches_base_pipeline_downloads_with_registered_revision(
+    monkeypatch: pytest.MonkeyPatch,
+    selector: str,
+    repo_id: str,
+    revision: str,
+) -> None:
+    _install_ocr_import_stubs(monkeypatch)
+    _install_upstream_ocr_v2_stub(monkeypatch)
+
+    from nemo_retriever.models import hf_model_registry as registry
+    from nemo_retriever.models.local.nemotron_ocr_v2 import NemotronOCRV2
+
+    calls: list[dict[str, object]] = []
+
+    def fake_download(*args: object, **kwargs: object) -> str:
+        calls.append(kwargs)
+        return "/cache/model.bin"
+
+    monkeypatch.setattr(registry, "hf_hub_download", fake_download)
+    pipeline_mod = sys.modules["nemotron_ocr.inference.pipeline"]
+    pipeline_v2_mod = sys.modules["nemotron_ocr.inference.pipeline_v2"]
+    setattr(pipeline_mod, "_download_on_init", True)
+
+    NemotronOCRV2(lang=selector)
+
+    assert not hasattr(pipeline_v2_mod, "hf_hub_download")
+    assert calls == [
+        {
+            "repo_id": repo_id,
+            "filename": "checkpoints/detector.pth",
+            "revision": revision,
+        }
+    ]
 
 
 def test_huggingface_ocr_nightly_does_not_carry_namespace_patch_knobs() -> None:

--- a/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
+++ b/nemo_retriever/tests/test_nemotron_ocr_v2_nightly.py
@@ -51,9 +51,7 @@ def _install_upstream_ocr_v2_stub(monkeypatch: pytest.MonkeyPatch) -> list[dict[
             captured_kwargs.append(kwargs)
             if getattr(pipeline_mod, "_download_on_init", False):
                 repo_id = (
-                    "nvidia/nemotron-ocr-v1"
-                    if kwargs.get("lang") in {"v1", "legacy"}
-                    else "nvidia/nemotron-ocr-v2"
+                    "nvidia/nemotron-ocr-v1" if kwargs.get("lang") in {"v1", "legacy"} else "nvidia/nemotron-ocr-v2"
                 )
                 pipeline_mod.hf_hub_download(repo_id=repo_id, filename="checkpoints/detector.pth")
 


### PR DESCRIPTION
## Description
Fix Nemotron OCR v2 Hugging Face downloads so they use the immutable revisions registered by NeMo Retriever. `NemotronOCRV2` inherits checkpoint loading from `nemotron_ocr.inference.pipeline`, so the wrapper now patches that base module's `hf_hub_download` instead of `pipeline_v2`. Regression coverage verifies that both OCR v1 legacy mode and OCR v2 downloads receive their registered revisions.

Harden the Hugging Face nightly publication workflow by adding a repeatable `--require-wheel-member` validation to the build-and-publish script. Validation runs before upload, reports missing members per wheel, and requires Nemotron OCR wheels to contain both `nemotron_ocr/inference/pipeline.py` and `nemotron_ocr/inference/pipeline_v2.py`.

Validation performed:
- 20 OCR wrapper and Hugging Face registry tests passed.
- 16 nightly publisher and workflow tests passed.
- The modified workflow parsed successfully as YAML.
- Ruff and `git diff --check` passed.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
