### PR TITLE
docs(extraction): clarify NVAIE scope beside NIM table (NVBugs 6462632)

### DIFF
--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -73,6 +73,10 @@ Optional advanced features—audio and video transcription, Nemotron Parse, Omni
 
 ### Default NIMs { #default-helm-nims }
 
+!!! important "NVAIE support applies to individual NIMs only"
+
+    A NIM or model listed in the default and optional NIM rows in the table below might be supported under NVIDIA AI Enterprise (NVAIE) as an individual product. That support does **not** cover its use through NeMo Retriever Library or extend to the library, its container image, its Helm chart, or the end-to-end extraction workflow.
+
 The production Helm chart reconciles NIM microservices through `nimOperator.<key>.enabled`. Four core NIMs are **enabled by default** and auto-wired into the retriever service; optional NIMs reconcile only when you opt in. For chart keys, image overrides, and enablement, refer to the [NeMo Retriever Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#nim-operator-sub-stack) and [Recommended minimal install](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#recommended-minimal-install-2605).
 
 | Helm flag | NIM | Default image (`repository:tag`) | Role | Enabled by default |


### PR DESCRIPTION
## Summary
Follow-up to #2367 (NVBugs 6462632). Adds a customer-visible admonition beside the combined Default NIMs table so readers do not infer NVAIE support for NeMo Retriever Library from individually NVAIE-supported NIM rows.

## Changes
- `prerequisites-support-matrix.md`: **NVAIE support applies to individual NIMs only** admonition under [Default NIMs](docs/docs/extraction/prerequisites-support-matrix.md#default-helm-nims), before the default/optional NIM table.

## Scope
Docs-only; single file; no runtime, Helm template, or CI changes.

## Related
- NVBugs 6462632
- #2367 (canonical NVAIE support boundary on overview, FAQ, getting started)