### PR TITLE
chore: remove unused INGEST_DISABLE_DYNAMIC_SCALING references

### DIFF
--- a/config/custom_summarization_pipeline.yaml
+++ b/config/custom_summarization_pipeline.yaml
@@ -502,7 +502,6 @@ edges:
 
 # Pipeline Runtime Configuration
 pipeline:
-  disable_dynamic_scaling: $INGEST_DISABLE_DYNAMIC_SCALING|false
   dynamic_memory_threshold: $INGEST_DYNAMIC_MEMORY_THRESHOLD|0.75
   static_memory_threshold: $INGEST_STATIC_MEMORY_THRESHOLD|0.75
   pid_controller:

--- a/config/default_pipeline.yaml
+++ b/config/default_pipeline.yaml
@@ -487,7 +487,6 @@ edges:
 
 # Pipeline Runtime Configuration
 pipeline:
-  disable_dynamic_scaling: $INGEST_DISABLE_DYNAMIC_SCALING|false
   dynamic_memory_threshold: $INGEST_DYNAMIC_MEMORY_THRESHOLD|0.75
   static_memory_threshold: $INGEST_STATIC_MEMORY_THRESHOLD|0.75
   pid_controller:

--- a/docs/sphinx_docs/source/index.rst
+++ b/docs/sphinx_docs/source/index.rst
@@ -23,7 +23,7 @@ starts the pipline
     # Start the pipeline subprocess for library mode
     config = PipelineCreationSchema()
 
-    run_pipeline(config, block=False, disable_dynamic_scaling=True, run_in_subprocess=True)
+    run_pipeline(config, block=False, run_in_subprocess=True)
 
 Then, connect the client to the pipeline with :func:`~nv_ingest_client.client.NvIngestClient`
 

--- a/examples/launch_libmode_and_run_ingestor.py
+++ b/examples/launch_libmode_and_run_ingestor.py
@@ -70,7 +70,6 @@ def main():
         # Use quiet=False to see verbose startup logs
         pipeline = run_pipeline(
             block=False,
-            disable_dynamic_scaling=True,
             run_in_subprocess=True,
         )
         time.sleep(10)

--- a/examples/launch_libmode_service.py
+++ b/examples/launch_libmode_service.py
@@ -28,7 +28,6 @@ def main():
         # Use quiet=False to see verbose startup logs
         _ = run_pipeline(
             block=True,
-            disable_dynamic_scaling=True,
             run_in_subprocess=True,
         )
     except KeyboardInterrupt:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes all remaining references to `INGEST_DISABLE_DYNAMIC_SCALING` and the related `disable_dynamic_scaling` pipeline/config option, which is no longer used.

## Findings

The **current** `nemo_retriever/helm` chart had no references to this env var. It was previously wired through the **legacy** root `helm/` chart (removed in #1997) and `docker-compose.yaml` (removed in #2193), which set:

- `helm/values.yaml`: `envVars.INGEST_DISABLE_DYNAMIC_SCALING: true`
- `docker-compose.yaml`: `INGEST_DISABLE_DYNAMIC_SCALING=${INGEST_DISABLE_DYNAMIC_SCALING:-true}`

## Changes

- **`config/default_pipeline.yaml`** — drop `disable_dynamic_scaling` from pipeline runtime config
- **`config/custom_summarization_pipeline.yaml`** — same
- **`examples/launch_libmode_service.py`** — remove `disable_dynamic_scaling=True` from `run_pipeline()`
- **`examples/launch_libmode_and_run_ingestor.py`** — same
- **`docs/sphinx_docs/source/index.rst`** — update API usage example

Verified with repo-wide search: zero remaining matches for `INGEST_DISABLE_DYNAMIC_SCALING` or `disable_dynamic_scaling`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f80ff-62b7-7ef0-a9d0-c79585252380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f80ff-62b7-7ef0-a9d0-c79585252380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

