### PR TITLE
docs(nemo-retriever): 26.07 RC readiness corrections for NeMo Retriever Library

### DIFF
--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -16,7 +16,7 @@ This documentation describes two ways to run [NeMo Retriever Library](overview.m
 Supported file types for speech extraction today:
 
 - `mp3`, `wav`
-- `mp4`, `mov`, `mkv`, `avi` — common video containers; the audio track is transcribed (same extensions as in [What is NeMo Retriever Library?](overview.md))
+- `mp4`, `mov`, `mkv`, `avi` — common video containers; the audio track is transcribed (same extensions as in [NeMo Retriever Library Overview](overview.md))
 
 [NeMo Retriever Library](overview.md) supports extracting speech from audio for Retrieval Augmented Generation (RAG). Similar to how the multimodal document pipeline uses detection and OCR microservices, NeMo Retriever Library uses the [parakeet-1-1b-ctc-en-us ASR NIM](https://docs.nvidia.com/nim/speech/latest/asr/deploy-asr-models/parakeet-ctc-en-us.html) to transcribe speech to text, then embeddings through the NeMo Retriever embedding path.
 
@@ -131,7 +131,7 @@ For video assets, NeMo Retriever Library can combine audio or speech processing 
 
 For OCR-oriented extract methods on scanned or image-heavy content, refer to [OCR and scanned documents](multimodal-extraction.md#ocr-and-scanned-documents), [text and layout extraction](multimodal-extraction.md#text-and-layout-extraction), and [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse) for advanced visual parsing.
 
-Container formats and early-access video types are listed under [supported file types and formats](multimodal-extraction.md#supported-file-types-and-formats) (refer to [What is NeMo Retriever Library?](overview.md) for the full list).
+Container formats and early-access video types are listed under [supported file types and formats](multimodal-extraction.md#supported-file-types-and-formats) (refer to [NeMo Retriever Library Overview](overview.md) for the full list).
 
 For end-to-end RAG stacks that include multimodal ingestion, refer to the [NVIDIA AI Blueprints catalog](https://build.nvidia.com/explore/discover) and related solution pages on [NVIDIA Build](https://build.nvidia.com/).
 

--- a/docs/docs/extraction/getting-started-about.md
+++ b/docs/docs/extraction/getting-started-about.md
@@ -5,7 +5,7 @@ This section walks you from **access and prerequisites** through **first deploym
 Typical order:
 
 1. [Get your API key](api-keys.md) (NGC / API access as required by your workflow).
-2. Confirm the [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md) for your OS, GPU, and software stack.
+2. Confirm the [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md) for your OS, GPU, and software stack. Local GPU inference requires Linux; remote NIM workflows can use the base package on Windows x64 and macOS as well.
 3. Choose a path in [Deployment options](deployment-options.md) — local library, hosted NIMs, the Helm chart for Kubernetes, or a standalone Docker service.
 4. Explore [Jupyter Notebooks](https://github.com/NVIDIA/NeMo-Retriever/blob/main/examples/README.md) for end-to-end examples.
 

--- a/docs/docs/extraction/getting-started-about.md
+++ b/docs/docs/extraction/getting-started-about.md
@@ -11,4 +11,4 @@ Typical order:
 
 The NeMo Retriever Library and its Helm chart are not supported under NVIDIA AI Enterprise (NVAIE). For more information, refer to [NVIDIA AI Enterprise (NVAIE) support](overview.md#nvidia-ai-enterprise-nvaie-support).
 
-If you are new to the product, read [What is NeMo Retriever Library?](overview.md) and [Concepts](concepts.md) under **Introduction** first.
+If you are new to the product, read [NeMo Retriever Library Overview](overview.md) and [Concepts](concepts.md) under **Introduction** first.

--- a/docs/docs/extraction/multimodal-extraction.md
+++ b/docs/docs/extraction/multimodal-extraction.md
@@ -15,7 +15,7 @@ NeMo Retriever Library classifies and extracts text, tables, charts, infographic
 
 ## Supported file types and formats { #supported-file-types-and-formats }
 
-NeMo Retriever Library accepts multiple document and media types. A current list (including PDF, Office formats, HTML, images, audio, and video, some early access) appears in [What is NeMo Retriever Library?](overview.md) under **NeMo Retriever Library supports the following file types**.
+NeMo Retriever Library accepts multiple document and media types. A current list (including PDF, Office formats, HTML, images, audio, and video, some early access) appears in [NeMo Retriever Library Overview](overview.md) under **NeMo Retriever Library supports the following file types**.
 
 **Related**
 
@@ -31,7 +31,7 @@ For PDFs, NeMo Retriever Library typically uses **pdfium**-based extraction with
 
 **Related**
 
-- [What is NeMo Retriever Library?](overview.md)
+- [NeMo Retriever Library Overview](overview.md)
 - [OCR and scanned documents](#ocr-and-scanned-documents)
 - [Chunking](concepts.md#chunking)
 
@@ -41,7 +41,7 @@ NeMo Retriever Library detects tables as structured page elements, processes the
 
 **Related**
 
-- [What is NeMo Retriever Library?](overview.md) for artifact classification
+- [NeMo Retriever Library Overview](overview.md) for artifact classification
 - [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse) for advanced visual parsing
 - [Metadata reference](content-metadata.md)
 
@@ -66,7 +66,7 @@ For natural-language infographic descriptions, optionally enable [image captioni
 
 **Related**
 
-- [What is NeMo Retriever Library?](overview.md)
+- [NeMo Retriever Library Overview](overview.md)
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
 - [Multimodal embeddings (VLM)](embedding.md) when you treat graphics as images for embedding
 

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -27,7 +27,7 @@ NeMo Retriever Library does the following:
 - Support various types of pre- and post- processing operations, including text splitting and chunking, transform and filtering, embedding generation, and image offloading to storage.
 
 !!! note
-    To use `method="nemotron_parse"` with PDFs, install the Nemotron Parse client dependencies with the `nemotron-parse` extra, for example `pip install "nemo-retriever[nemotron-parse]"`.
+    To use `method="nemotron_parse"` with PDFs, install the Nemotron Parse client dependencies with the `nemotron-parse` extra, for example `uv pip install "nemo-retriever[nemotron-parse]"`. You can use the equivalent `pip install` command if you do not use UV.
 
 NeMo Retriever Library supports the following file types:
 

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -1,9 +1,8 @@
 # What is NeMo Retriever Library?
 
-NVIDIA NeMo Retriever Library (NRL) is a high retrieval accuracy, performant, and scalable framework for content and metadata extraction from various media types (PDFs, HTML, Word docs, Powerpoint, audio, video, and image files). It supports both NVIDIA NIM microservices and a range of models to find, contextualize, and extract text, tables, charts, infographics, and transcripts for use in downstream generative and retrieval-augmented applications.
+NVIDIA NeMo Retriever Library (NRL) extracts text, tables, charts, infographics, and transcripts from PDFs, HTML, Office documents, audio, video, and images. Run it as a Python library or Kubernetes deployment, and route inference through NVIDIA NIM microservices or local Nemotron models for downstream RAG and generative applications.
 
-NeMo Retriever Library enables parallelization of splitting documents into pages where sub-page content is classified (such as text paragraphs, tables, charts, and infographics), extracted, and further contextualized through optical character recognition (OCR) into a standard schema. From there, NeMo Retriever Library manages computation of embeddings for the extracted content,
-and can store vectors in [LanceDB](https://lancedb.com/) for the recommended embedded path when you pass `vdb_op="lancedb"` to upload (refer to [Vector databases](vdbs.md)).
+NeMo Retriever Library splits documents into pages, classifies sub-page content (text, tables, charts, and infographics), extracts it, and applies optical character recognition (OCR) where needed into a standard schema. It can compute embeddings for extracted content and store vectors in [LanceDB](https://lancedb.com/) when you pass `vdb_op="lancedb"` to upload (refer to [Vector databases](vdbs.md)).
 
 ## NVIDIA AI Enterprise (NVAIE) support { #nvidia-ai-enterprise-nvaie-support }
 
@@ -21,10 +20,10 @@ The following diagram shows the retriever pipeline.
 
 NeMo Retriever Library does the following:
 
-- Accept directories of input files and a series of configurable ingestion tasks to perform on that input
-- Allow the extracted content be retrieved from a VDB containing discrete metadata element
+- Accept directories of input files and configurable ingestion tasks
+- Store extracted content in a vector database (VDB) with discrete metadata elements
 - Support multiple extraction methods per document type—for example, PDFs can use **pdfium** or [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse) as an alternate method (`method="nemotron_parse"`)
-- Support various types of pre- and post- processing operations, including text splitting and chunking, transform and filtering, embedding generation, and image offloading to storage.
+- Apply pre- and post-processing: text splitting and chunking, transforms and filtering, embedding generation, and image offloading to storage
 
 !!! note
     To use `method="nemotron_parse"` with PDFs, install the Nemotron Parse client dependencies with the `nemotron-parse` extra, for example `uv pip install "nemo-retriever[nemotron-parse]"`. You can use the equivalent `pip install` command if you do not use UV.

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -1,4 +1,4 @@
-# What is NeMo Retriever Library?
+# NeMo Retriever Library Overview { #what-is-nemo-retriever-library }
 
 NVIDIA NeMo Retriever Library (NRL) extracts text, tables, charts, infographics, and transcripts from PDFs, HTML, Office documents, audio, video, and images. Run it as a Python library or Kubernetes deployment, and route inference through NVIDIA NIM microservices or local Nemotron models for downstream RAG and generative applications.
 

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -8,8 +8,8 @@ Before you begin using [NeMo Retriever Library](overview.md), confirm your softw
 
 ## Software Requirements { #software-requirements }
 
-- Linux operating systems (Ubuntu 22.04 or later recommended)
-- [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads) (NVIDIA Driver >= `580`, CUDA >= `13.0`)
+- Linux operating systems (Ubuntu 22.04 or later recommended) for supported local GPU inference. For remote NIM inference, the base package can also be installed on Windows x64 and macOS x64/ARM64; local GPU inference is not supported on those platforms.
+- [CUDA Toolkit](https://developer.nvidia.com/cuda-downloads) (local GPU inference only; NVIDIA Driver >= `580`, CUDA >= `13.0`)
 - [Python](https://www.python.org/downloads/) `3.12` — required to install and run the NeMo Retriever Library Python API, CLI, and related packages from PyPI (for example `pip` or `uv`). Older Python versions will fail dependency resolution without a clear error.
 - [UV Python package and environment manager](https://docs.astral.sh/uv/getting-started/installation/) (optional; recommended for creating isolated environments)
 - For audio and video, `ffmpeg` and `ffprobe` must be on `PATH` (for example

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -1,6 +1,8 @@
 # Pre-Requisites & Support Matrix
 
-Before you begin using [NeMo Retriever Library](overview.md), confirm your software stack, deployment hardware, and—if you use them—advanced features (audio and video, Nemotron Parse, VLM image captioning, reranking) against the guidance in this page.
+Before you begin using [NeMo Retriever Library](overview.md), confirm your software stack, deployment hardware, and—if you use them—advanced features (audio and video, Nemotron Parse, VLM image captioning, reranking) against the guidance on this page.
+
+**Platform summary:** Supported **local GPU inference** requires **Linux** and CUDA 13. For **remote NIM inference**, the base Python package also installs on **Windows x64** and **macOS x64/ARM64**; local GPU inference is not supported on those platforms.
 
 !!! note "NVIDIA AI Enterprise (NVAIE) support"
 

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -4,9 +4,9 @@ Before you begin using [NeMo Retriever Library](overview.md), confirm your softw
 
 **Platform summary:** Supported **local GPU inference** requires **Linux** and CUDA 13. For **remote NIM inference**, the base Python package also installs on **Windows x64** and **macOS x64/ARM64**; local GPU inference is not supported on those platforms.
 
-!!! note "NVIDIA AI Enterprise (NVAIE) support"
-
-    The NeMo Retriever Library, including its container image and Helm chart artifacts, is not supported under NVIDIA AI Enterprise (NVAIE), even though some NIM microservices and models it uses may be individually covered by NVAIE. For more information, refer to [NVIDIA AI Enterprise (NVAIE) support](overview.md#nvidia-ai-enterprise-nvaie-support).
+> **Note — NVIDIA AI Enterprise (NVAIE) support**
+>
+> The NeMo Retriever Library, including its container image and Helm chart artifacts, is not supported under NVIDIA AI Enterprise (NVAIE), even though some NIM microservices and models it uses may be individually covered by NVAIE. For more information, refer to [NVIDIA AI Enterprise (NVAIE) support](overview.md#nvidia-ai-enterprise-nvaie-support).
 
 ## Software Requirements { #software-requirements }
 
@@ -24,9 +24,9 @@ Before you begin using [NeMo Retriever Library](overview.md), confirm your softw
   NIM client). The base `nemo-retriever` install and `[local]` extra do not include this
   package. You can use the equivalent `pip install` command if you do not use UV.
 
-!!! note
-
-    When you use UV, create the environment with Python 3.12 — for example, `uv venv --python 3.12`. This matches the `requires-python` metadata in the library packages.
+> **Note**
+>
+> When you use UV, create the environment with Python 3.12 — for example, `uv venv --python 3.12`. This matches the `requires-python` metadata in the library packages.
 
 ## Hardware Requirements { #hardware-requirements }
 
@@ -42,9 +42,9 @@ For per-feature GPU memory, disk, and co-residency rules, refer to [Model hardwa
 - **CPU Cores**: At least 32 CPU cores
 - **GPU**: NVIDIA GPU with at least 24 GB VRAM (for example, A100, H100, L40S, or equivalent)
 
-!!! note
-
-    Using less powerful systems or lower resource limits is still viable, but performance will suffer.
+> **Note**
+>
+> Using less powerful systems or lower resource limits is still viable, but performance will suffer.
 
 ### Resource Consumption Notes
 
@@ -75,9 +75,9 @@ Optional advanced features—audio and video transcription, Nemotron Parse, Omni
 
 ### Default NIMs { #default-helm-nims }
 
-!!! important "NVAIE support applies to individual NIMs only"
-
-    A NIM or model listed in the default and optional NIM rows in the table below might be supported under NVIDIA AI Enterprise (NVAIE) as an individual product. That support does **not** cover its use through NeMo Retriever Library or extend to the library, its container image, its Helm chart, or the end-to-end extraction workflow.
+> **Important — NVAIE support applies to individual NIMs only**
+>
+> A NIM or model listed in the default and optional NIM rows in the table below might be supported under NVIDIA AI Enterprise (NVAIE) as an individual product. That support does **not** cover its use through NeMo Retriever Library or extend to the library, its container image, its Helm chart, or the end-to-end extraction workflow.
 
 The production Helm chart reconciles NIM microservices through `nimOperator.<key>.enabled`. Four core NIMs are **enabled by default** and auto-wired into the retriever service; optional NIMs reconcile only when you opt in. For chart keys, image overrides, and enablement, refer to the [NeMo Retriever Helm chart README](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#nim-operator-sub-stack) and [Recommended minimal install](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md#recommended-minimal-install-2605).
 

--- a/docs/docs/extraction/prerequisites-support-matrix.md
+++ b/docs/docs/extraction/prerequisites-support-matrix.md
@@ -17,10 +17,10 @@ Before you begin using [NeMo Retriever Library](overview.md), confirm your softw
   `ffmpeg-python` and `nemo-retriever[multimedia]` do not install these binaries.
   For container and Kubernetes guidance, refer to [Audio and video](audio-video.md).
 - For PDF extraction with `method="nemotron_parse"`, install the Nemotron Parse
-  client dependencies with `pip install "nemo-retriever[nemotron-parse]"` (pulls
+  client dependencies with `uv pip install "nemo-retriever[nemotron-parse]"` (pulls
   `open-clip-torch`, which provides the `open_clip` module required by the Nemotron Parse
   NIM client). The base `nemo-retriever` install and `[local]` extra do not include this
-  package.
+  package. You can use the equivalent `pip install` command if you do not use UV.
 
 !!! note
 

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -126,7 +126,7 @@ For local GPU inference with Nemotron Parse, combine extras:
 pip install "nemo-retriever[local,nemotron-parse]"
 ```
 
-Also refer to [What is NeMo Retriever Library?](overview.md) and [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md#software-requirements).
+Also refer to [NeMo Retriever Library Overview](overview.md) and [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md#software-requirements).
 
 ## Extract method nemotron-parse doesn't support image files
 

--- a/docs/docs/extraction/vdbs.md
+++ b/docs/docs/extraction/vdbs.md
@@ -5,7 +5,7 @@ Use this documentation to learn how [NeMo Retriever Library](overview.md) stores
 ## On this page { #on-this-page }
 
 - [Overview](#overview)
-- [Why LanceDB?](#why-lancedb)
+- [LanceDB Overview](#why-lancedb)
 - [Upload to LanceDB](#upload-to-lancedb)
 - [Semantic retrieval](#semantic-retrieval)
 - [Metadata and filtering](#metadata-and-filtering)
@@ -37,7 +37,7 @@ Currently, data upload is not supported through the [CLI](https://github.com/NVI
 
 
 
-## Why LanceDB? { #why-lancedb }
+## LanceDB Overview { #why-lancedb }
 
 LanceDB is optimized for low-latency retrieval in this stack:
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,4 +1,4 @@
-# What is NVIDIA NeMo Retriever?
+# NVIDIA NeMo Retriever Overview { #what-is-nvidia-nemo-retriever }
 
 NVIDIA NeMo Retriever is a collection of microservices 
 for building and scaling multimodal data extraction, embedding, and reranking pipelines 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -74,7 +74,7 @@ extra_css:
 # bar when there is only one top-level tab.
 nav:
   - "1. Introduction":
-      - "What is NeMo Retriever?": extraction/overview.md
+      - "NeMo Retriever Library Overview": extraction/overview.md
       - Key concepts: extraction/concepts.md
       - Release notes: extraction/releasenotes.md
   - "2. Get started":

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -2,11 +2,12 @@
 
 NeMo Retriever Library is a retrieval-augmented generation (RAG) ingestion pipeline for documents that can parse text, tables, charts, and infographics. NeMo Retriever Library parses documents, creates embeddings, optionally stores embeddings in LanceDB, and performs recall evaluation.
 
-This quick start guide shows how to run NeMo Retriever Library as a library all within local Python processes without containers. NeMo Retriever Library supports two inference options:
-- Pull and run [Nemotron RAG models from Hugging Face](https://huggingface.co/collections/nvidia/nemotron-rag) on your local GPU(s).
-- Make over the network inference calls to build.nvidia.com hosted or locally deployed NeMo Retriever NIM endpoints.
+This quick start guide shows how to run NeMo Retriever Library as a library in local Python processes without containers. Choose one inference path:
 
-You’ll set up a CUDA 13–compatible environment, install the library and its dependencies, and run GPU‑accelerated ingestion pipelines that convert PDFs, HTML, plain text, audio, or video into vector embeddings stored in LanceDB (on local disk), with Ray‑based scaling and built‑in recall benchmarking.
+- **Local GPU (Linux):** Pull and run [Nemotron RAG models from Hugging Face](https://huggingface.co/collections/nvidia/nemotron-rag) on your GPU(s). Requires CUDA 13.x and the `[local]` extra.
+- **Remote NIM:** Call build.nvidia.com hosted or self-hosted NeMo Retriever NIM endpoints over the network. The base package installs on Linux, Windows x64, and macOS; no local GPU is required.
+
+The steps below cover environment setup, installation, and a first ingestion run. For Kubernetes or container deployments, refer to [Deployment at a glance](#deployment-at-a-glance) and the [Pre-Requisites & Support Matrix](https://docs.nvidia.com/nemo/retriever/latest/extraction/prerequisites-support-matrix/).
 
 ## Deployment at a glance
 
@@ -16,12 +17,12 @@ For standalone service-image builds and local container runs, see **[`docker.md`
 
 ## Prerequisites
 
-Before starting, make sure your system meets the following requirements:
+Before starting, confirm requirements for your inference path (refer to the [Pre-Requisites & Support Matrix](https://docs.nvidia.com/nemo/retriever/latest/extraction/prerequisites-support-matrix/)):
 
-- The host is running CUDA 13.x so that `libcudart.so.13` is available.
-- Your GPUs are visible to the system and compatible with CUDA 13.x.
-​
-If optical character recognition (OCR) fails with a `libcudart.so.13` error, install the CUDA 13 runtime for your platform and update `LD_LIBRARY_PATH` to include the CUDA lib64 directory, then rerun the pipeline.
+- **Local GPU inference (Linux):** CUDA 13.x with `libcudart.so.13` available, and GPUs visible to the system.
+- **Remote NIM inference:** Python 3.12 and network access to your NIM endpoints; CUDA is not required on the client host.
+
+If optical character recognition (OCR) fails with a `libcudart.so.13` error on a local GPU path, install the CUDA 13 runtime for your platform and update `LD_LIBRARY_PATH` to include the CUDA lib64 directory, then rerun the pipeline.
 
 For example, the following command can be used to update the `LD_LIBRARY_PATH` value.
 
@@ -31,7 +32,7 @@ export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/lib64
 
 ## Setup your environment
 
-Complete the following steps to setup your environment. You will create and activate isolated Python and project virtual environments, install the NeMo Retriever Library and its dependencies, and then run the provided ingestion snippets to validate your setup.
+Complete the following steps to set up your environment. You will create and activate isolated Python and project virtual environments, install the NeMo Retriever Library and its dependencies, and then run the provided ingestion snippets to validate your setup.
 
 1. Create and activate the NeMo Retriever Library environment
 
@@ -39,7 +40,9 @@ Before installing NeMo Retriever Library, create an isolated Python environment 
 
 In your terminal, run the following commands from any location.
 
-For **local GPU inference** (Nemotron models running on your GPU), install with the `[local]` extra, which includes the model packages, transformers, and GPU tooling:
+**Local GPU (Linux)**
+
+Install with the `[local]` extra, which includes Nemotron model packages, transformers, and GPU tooling:
 
 ```bash
 uv venv retriever --python 3.12
@@ -55,9 +58,9 @@ major-version windows, opt in with `--pre`:
 uv pip install --pre "nemo-retriever[local]==26.05-RC1"
 ```
 
-Install matching **ingestion client** and **ingestion runtime** wheels at the same version when your workflow expects them (refer to the [NeMo Retriever Library prerequisites](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the exact PyPI coordinates for your release).
+**Remote NIM (no local GPU)**
 
-For **remote NIM inference only** (no local GPU required), the base package is sufficient:
+The base package is sufficient when all inference runs through hosted or self-hosted NIM endpoints:
 
 ```bash
 uv python install 3.12

--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -427,7 +427,7 @@ query vectors land in the same embedding space as the stored chunks.
 
 ```python
 from nemo_retriever.graph.retriever import Retriever
-from nemo_retriever.llm import LiteLLMClient
+from nemo_retriever.models.llm import LiteLLMClient
 
 retriever = Retriever(
     vdb_kwargs={"uri": "lancedb", "table_name": "nemo-retriever"},
@@ -457,7 +457,7 @@ the bundled `VL_EMBED_MODEL`.
 
 Live RAG with scoring and an LLM judge (requires a ground-truth `reference`):
 ```python
-from nemo_retriever.llm import LLMJudge
+from nemo_retriever.models.llm import LLMJudge
 
 judge = LLMJudge.from_kwargs(
     model="nvidia_nim/nvidia/llama-3.3-nemotron-super-49b-v1.5",


### PR DESCRIPTION
## Description

Fix customer-facing RC documentation issues:

- **Live RAG imports (NVBugs 6492587):** Import `LiteLLMClient` and `LLMJudge` from the supported public API, `nemo_retriever.models.llm`. The documented `nemo_retriever.llm` module is not included in current `nemo-retriever` wheels and fails with `ModuleNotFoundError`.
- **Local GPU install:** Align the CUDA 13 override command with the frozen `[local]` dependency metadata in `nemo_retriever/pyproject.toml`: `torch==2.11.0` and `torchvision==0.26.0`.
- **Nemotron Parse installer wording:** Make `uv pip install nemo-retriever[nemotron-parse]` the primary command in the extraction overview and support matrix, consistent with the UV-first README, while explicitly identifying plain `pip install` as equivalent for users who do not use UV.
- **Remote NIM platform support:** Clarify that supported local GPU inference requires Linux and CUDA, while the base package for remote NIM inference can also be installed on Windows x64 and macOS x64/ARM64.
- **Statement-style headings:** Rename non-FAQ question-style headings to statement titles per NVIDIA Template Library guidance (overview H1, root index H1, LanceDB section, MkDocs nav). FAQ headings stay as questions. Existing heading anchors are preserved.

The branch was rebased onto current `main`. Earlier NVAIE clarification and obsolete QA-link cleanup commits were dropped because equivalent updates are already present on `main`. Heading renames were folded in from #2409 (now closed).

## Validation

- DORI code-block validation: passed (13 README blocks checked, no issues)
- DORI documentation/link validation: passed (no broken links)
- `pre-commit run` for changed documentation files: passed
- NRL extraction page-role and link-CTA leakage checks: passed
- README Torch/Torchvision pins match `nemo_retriever/pyproject.toml`
- Full strict MkDocs build is blocked by the pre-existing missing `THIRD_PARTY_LICENSES.md` snippet referenced by `docs/docs/license.md`; the failure is unrelated to this diff

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] The documentation is up to date with these changes.
- [x] Changed-file validation passes.