### PR TITLE
Preserve valid titles during page element postprocessing

### DIFF
--- a/nemo_retriever/src/nemo_retriever/models/nim/primitives/model_interface/yolox.py
+++ b/nemo_retriever/src/nemo_retriever/models/nim/primitives/model_interface/yolox.py
@@ -669,7 +669,11 @@ class YoloxPageElementsModelInterface(YoloxModelInterfaceBase):
 
         if annotation_dicts and running_v3:
             annotation_dicts = [
-                postprocess_page_elements_v3(annotation_dict, labels=YOLOX_PAGE_V3_CLASS_LABELS)
+                postprocess_page_elements_v3(
+                    annotation_dict,
+                    labels=YOLOX_PAGE_V3_CLASS_LABELS,
+                    final_score=final_score,
+                )
                 for annotation_dict in annotation_dicts
             ]
         else:
@@ -857,12 +861,14 @@ def expand_chart_bboxes(annotation_dict, labels=None):
     return annotation_dict
 
 
-def postprocess_page_elements_v3(annotation_dict, labels=None):
+def postprocess_page_elements_v3(annotation_dict, labels=None, final_score=None):
     """
     Expand bounding boxes of tables/charts/infographics and titles based on the bounding boxes of the other class.
     Args:
         annotation_dict: output of postprocess_results, a dictionary with keys:
         "table", "chart", "infographics", "title", "paragraph", "header_footer".
+        labels: ordered class labels corresponding to the annotation dictionary.
+        final_score: per-class thresholds used by the final output filter.
 
     Returns:
         annotation_dict: same as input, with expanded bboxes for page elements.
@@ -870,6 +876,8 @@ def postprocess_page_elements_v3(annotation_dict, labels=None):
     """
     if not labels:
         labels = list(annotation_dict.keys())
+    if final_score is None:
+        final_score = YOLOX_PAGE_V3_FINAL_SCORE
 
     if not annotation_dict:
         return annotation_dict
@@ -897,6 +905,17 @@ def postprocess_page_elements_v3(annotation_dict, labels=None):
     label_idxs = np.concatenate(label_idxs)
 
     bboxes, confidences, label_idxs = remove_overlapping_boxes_using_wbf(bboxes, confidences, label_idxs)
+
+    # Boxes that cannot survive the final per-class score gate must not
+    # participate in cross-class matching. In particular, a low-confidence
+    # page-sized table can otherwise consume a valid title and then be removed
+    # itself by the final filter, silently dropping both detections.
+    final_thresholds = np.array([final_score.get(labels[int(label_idx)], 0.0) for label_idx in label_idxs])
+    keep = confidences >= final_thresholds
+    bboxes, confidences, label_idxs = bboxes[keep], confidences[keep], label_idxs[keep]
+    if not len(bboxes):
+        return {label: [] for label in labels}
+
     bboxes, confidences, label_idxs, found_title = match_structured_boxes_with_title(
         bboxes, confidences, label_idxs, labels
     )

--- a/nemo_retriever/src/nemo_retriever/models/nim/primitives/model_interface/yolox.py
+++ b/nemo_retriever/src/nemo_retriever/models/nim/primitives/model_interface/yolox.py
@@ -861,7 +861,11 @@ def expand_chart_bboxes(annotation_dict, labels=None):
     return annotation_dict
 
 
-def postprocess_page_elements_v3(annotation_dict, labels=None, final_score=None):
+def postprocess_page_elements_v3(
+    annotation_dict: Dict[str, List[List[float]]],
+    labels: Optional[List[str]] = None,
+    final_score: Optional[Dict[str, float]] = None,
+) -> Dict[str, List[List[float]]]:
     """
     Expand bounding boxes of tables/charts/infographics and titles based on the bounding boxes of the other class.
     Args:
@@ -906,13 +910,16 @@ def postprocess_page_elements_v3(annotation_dict, labels=None, final_score=None)
 
     bboxes, confidences, label_idxs = remove_overlapping_boxes_using_wbf(bboxes, confidences, label_idxs)
 
-    # Boxes that cannot survive the final per-class score gate must not
-    # participate in cross-class matching. In particular, a low-confidence
-    # page-sized table can otherwise consume a valid title and then be removed
-    # itself by the final filter, silently dropping both detections.
-    final_thresholds = np.array([final_score.get(labels[int(label_idx)], 0.0) for label_idx in label_idxs])
-    keep = confidences >= final_thresholds
-    bboxes, confidences, label_idxs = bboxes[keep], confidences[keep], label_idxs[keep]
+    # Apply final thresholds here only to determine matching eligibility; the
+    # caller still owns final output filtering. A low-confidence page-sized table
+    # can otherwise consume a valid title before both detections are removed.
+    matching_thresholds = np.array([final_score.get(labels[int(label_idx)], 0.0) for label_idx in label_idxs])
+    eligible_for_matching = confidences >= matching_thresholds
+    bboxes, confidences, label_idxs = (
+        bboxes[eligible_for_matching],
+        confidences[eligible_for_matching],
+        label_idxs[eligible_for_matching],
+    )
     if not len(bboxes):
         return {label: [] for label in labels}
 

--- a/nemo_retriever/tests/test_page_elements_postprocess.py
+++ b/nemo_retriever/tests/test_page_elements_postprocess.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-26, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from nemo_retriever.common.modality.page_elements.shared import (
+    _apply_final_score_filter,
+    _apply_page_elements_v3_postprocess,
+)
+
+
+def test_rejected_structured_box_cannot_suppress_surviving_title() -> None:
+    raw_detections = [
+        {
+            "bbox_xyxy_norm": [0.081876, 0.077799, 0.738124, 0.111654],
+            "label": 2,
+            "label_name": "title",
+            "score": 0.912088,
+        },
+        {
+            "bbox_xyxy_norm": [0.056368, 0.004097, 0.965700, 0.972466],
+            "label": 0,
+            "label_name": "table",
+            "score": 0.052635,
+        },
+    ]
+
+    postprocessed = _apply_page_elements_v3_postprocess(raw_detections)
+    final_detections = _apply_final_score_filter(postprocessed)
+
+    assert [detection["label_name"] for detection in final_detections] == ["title"]
+
+
+def test_surviving_structured_box_can_still_absorb_title() -> None:
+    raw_detections = [
+        {
+            "bbox_xyxy_norm": [0.081876, 0.077799, 0.738124, 0.111654],
+            "label": 2,
+            "label_name": "title",
+            "score": 0.912088,
+        },
+        {
+            "bbox_xyxy_norm": [0.056368, 0.004097, 0.965700, 0.972466],
+            "label": 0,
+            "label_name": "table",
+            "score": 0.9,
+        },
+    ]
+
+    postprocessed = _apply_page_elements_v3_postprocess(raw_detections)
+    final_detections = _apply_final_score_filter(postprocessed)
+
+    assert [detection["label_name"] for detection in final_detections] == ["table"]


### PR DESCRIPTION
## Summary

- Exclude page-element detections that cannot pass their configured final class threshold before cross-class title matching.
- Preserve the existing title-matching behavior for structured detections that do survive final filtering.
- Add regression coverage for both a rejected table and a surviving table.

## Root cause

For the scanned-only fixture, Page Elements v3 detected the title at 0.912 confidence and also produced a page-sized table at 0.053 confidence. Postprocessing matched the title to that table and removed the standalone title before the existing 0.10 table threshold removed the table. The final result therefore contained neither detection.

This change applies the same configured final thresholds before title matching, after weighted box fusion, so a detection that cannot appear in final output cannot consume a valid title.

## Testing

- Focused page-element/PDF actor suite: 24 passed, 88 deselected.
- Pre-commit hooks passed on both changed files.
- Reproduced the missing title before the fix with `english_scanned_only.pdf`.
- After the fix, public `retriever ingest --method ocr --ocr-version v2` validation passed in both inprocess and batch modes: all controlled title/body anchors were present, page metadata remained page 1, and vectors were 2048-dimensional.