### PR TITLE
Fix hosted Nemotron Parse contract

### DIFF
--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -617,9 +617,14 @@ ingestor = (
 )
 ```
 
-You can use a different ingestion pipeline based on [Nemotron-Parse](https://huggingface.co/nvidia/NVIDIA-Nemotron-Parse-v1.2) combined with the default embedder:
+You can use a different ingestion pipeline based on [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse) hosted on NVIDIA Build and combined with the default embedder:
+
 ```python
-ingestor = ingestor.files(documents).extract(method="nemotron_parse")
+ingestor = ingestor.files(documents).extract(
+  method="nemotron_parse",
+  nemotron_parse_invoke_url="https://integrate.api.nvidia.com/v1/chat/completions",
+  nemotron_parse_model="nvidia/nemotron-parse",
+)
 ```
 
 ## Run with remote inference, no local GPU required:

--- a/nemo_retriever/src/nemo_retriever/common/params/models.py
+++ b/nemo_retriever/src/nemo_retriever/common/params/models.py
@@ -568,6 +568,13 @@ class ExtractParams(_ParamsModel):
             self.table_output_format = "markdown" if self.use_table_structure else "pseudo_markdown"
         if self.ocr_version == "v1" and self.ocr_lang is not None:
             raise ValueError("ocr_lang is only supported when ocr_version='v2'.")
+        if self.method != "nemotron_parse" and (
+            self.nemotron_parse_invoke_url is not None or self.nemotron_parse_model is not None
+        ):
+            raise ValueError(
+                "`nemotron_parse_invoke_url` and `nemotron_parse_model` require "
+                "`method='nemotron_parse'`; Parse-specific configuration is otherwise ignored."
+            )
         if not self.use_page_elements:
             consumers = [("use_table_structure", self.use_table_structure and self.extract_tables)]
             enabled = [name for name, on in consumers if on]

--- a/nemo_retriever/src/nemo_retriever/models/nim/chat_completions.py
+++ b/nemo_retriever/src/nemo_retriever/models/nim/chat_completions.py
@@ -159,7 +159,7 @@ def invoke_chat_completions_images(
     timeout_s: float = 120.0,
     task_prompt: Optional[str] = None,
     temperature: float = 0.0,
-    repetition_penalty: float = 1.1,
+    repetition_penalty: Optional[float] = 1.1,
     extra_body: Optional[Dict[str, Any]] = None,
     max_pool_workers: int = 16,
     max_retries: int = 10,

--- a/nemo_retriever/src/nemo_retriever/models/nim/nim.py
+++ b/nemo_retriever/src/nemo_retriever/models/nim/nim.py
@@ -450,7 +450,7 @@ class NIMClient:
         timeout_s: float = 120.0,
         task_prompt: Optional[str] = None,
         temperature: float = 0.0,
-        repetition_penalty: float = 1.1,
+        repetition_penalty: Optional[float] = 1.1,
         extra_body: Optional[Dict[str, Any]] = None,
         max_retries: int = 10,
         max_429_retries: int = 5,
@@ -473,7 +473,9 @@ class NIMClient:
             )
             messages_list.append([{"role": "user", "content": content}])
 
-        merged_extra: Dict[str, Any] = {"repetition_penalty": repetition_penalty}
+        merged_extra: Dict[str, Any] = {}
+        if repetition_penalty is not None:
+            merged_extra["repetition_penalty"] = repetition_penalty
         if extra_body:
             merged_extra.update(extra_body)
 

--- a/nemo_retriever/src/nemo_retriever/operators/extract/parse/nemotron_parse.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/parse/nemotron_parse.py
@@ -433,13 +433,15 @@ def nemotron_parse_pages(
                 and contract.profile == _NemotronParseContractProfile.V1_2_TAGGED
                 and "text input" in str(e).lower()
             ):
-                e = ValueError(
+                hint = ValueError(
                     "Nemotron Parse model/contract mismatch: NVIDIA Build model "
                     "`nvidia/nemotron-parse` uses an image-only tool-call contract, but "
                     f"`{contract.model}` selected the v1.2 text-control-token contract. "
                     "Use `nemotron_parse_model='nvidia/nemotron-parse'` with Build, or send "
                     "the versioned v1.2 model to a compatible self-hosted endpoint."
                 )
+                hint.__cause__ = e
+                e = hint
             print(f"Warning: Nemotron Parse batch failed: {type(e).__name__}: {e}")
             err = {
                 "stage": "nemotron_parse_pages",

--- a/nemo_retriever/src/nemo_retriever/operators/extract/parse/nemotron_parse.py
+++ b/nemo_retriever/src/nemo_retriever/operators/extract/parse/nemotron_parse.py
@@ -12,7 +12,10 @@ replacing the page-elements → OCR multi-stage pipeline.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlsplit
 
 import base64
 import io
@@ -47,6 +50,7 @@ except Exception:  # pragma: no cover
 # ---------------------------------------------------------------------------
 
 NEMOTRON_PARSE_REMOTE_DEFAULT_MODEL = "nvidia/nemotron-parse-v1.2"
+NEMOTRON_PARSE_HOSTED_MODEL = "nvidia/nemotron-parse"
 NEMOTRON_PARSE_LOCAL_DEFAULT_MODEL = "nvidia/NVIDIA-Nemotron-Parse-v1.2"
 NEMOTRON_PARSE_DEFAULT_TASK_PROMPT = "</s><s><predict_bbox><predict_classes><output_markdown><predict_no_text_in_pic>"
 
@@ -147,19 +151,79 @@ def _route_parsed_elements(
     return table_items, chart_items, infographic_items, page_text
 
 
+class _NemotronParseContractProfile(str, Enum):
+    HOSTED_TOOL_CALL = "hosted_tool_call"
+    LEGACY_TOOL_CALL = "legacy_tool_call"
+    V1_2_TAGGED = "v1_2_tagged"
+
+
+@dataclass(frozen=True)
+class _ResolvedNemotronParseContract:
+    model: str
+    profile: _NemotronParseContractProfile
+    has_build_endpoint: bool
+
+    @property
+    def uses_tool_call_routing(self) -> bool:
+        return self.profile in {
+            _NemotronParseContractProfile.HOSTED_TOOL_CALL,
+            _NemotronParseContractProfile.LEGACY_TOOL_CALL,
+        }
+
+
 def _is_legacy_nemotron_parse_model(model_name: str) -> bool:
     normalized = model_name.lower()
     return bool(re.search(r"v1[._][01](?!\d)", normalized))
 
 
-def _route_parsed_elements_v1(
+def _is_nvidia_build_endpoint(invoke_url: str) -> bool:
+    return (urlsplit(invoke_url).hostname or "").lower() == "integrate.api.nvidia.com"
+
+
+def _resolve_nemotron_parse_contract(
+    invoke_url: str,
+    model_name: Optional[str],
+) -> _ResolvedNemotronParseContract:
+    """Resolve the internal request/response contract for a chat endpoint."""
+
+    invoke_urls = [part.strip() for part in str(invoke_url or "").split(",") if part.strip()]
+    if not invoke_urls:
+        raise ValueError("Nemotron Parse invoke_url is required.")
+
+    build_endpoints = [_is_nvidia_build_endpoint(url) for url in invoke_urls]
+    explicit_model = str(model_name or "").strip()
+    if not explicit_model and any(build_endpoints) and not all(build_endpoints):
+        raise ValueError(
+            "Nemotron Parse endpoint lists cannot mix NVIDIA Build and self-hosted endpoints "
+            "unless `nemotron_parse_model` is set explicitly."
+        )
+
+    resolved_model = explicit_model or (
+        NEMOTRON_PARSE_HOSTED_MODEL if all(build_endpoints) else NEMOTRON_PARSE_REMOTE_DEFAULT_MODEL
+    )
+    normalized_model = resolved_model.lower()
+    if normalized_model == NEMOTRON_PARSE_HOSTED_MODEL:
+        profile = _NemotronParseContractProfile.HOSTED_TOOL_CALL
+    elif _is_legacy_nemotron_parse_model(normalized_model):
+        profile = _NemotronParseContractProfile.LEGACY_TOOL_CALL
+    else:
+        profile = _NemotronParseContractProfile.V1_2_TAGGED
+
+    return _ResolvedNemotronParseContract(
+        model=resolved_model,
+        profile=profile,
+        has_build_endpoint=any(build_endpoints),
+    )
+
+
+def _route_tool_call_elements(
     raw_json_text: str,
     *,
     extract_tables: bool,
     extract_charts: bool,
     extract_infographics: bool,
 ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], Optional[str]]:
-    """Route v1.0/v1.1 tool-call JSON into pipeline content channels."""
+    """Route hosted or legacy tool-call JSON into pipeline content channels."""
 
     try:
         parsed = json.loads(raw_json_text)
@@ -167,12 +231,19 @@ def _route_parsed_elements_v1(
         return [], [], [], None
 
     elements: List[Dict[str, Any]] = []
-    if isinstance(parsed, list):
-        for item in parsed:
-            if isinstance(item, list):
-                elements.extend(elem for elem in item if isinstance(elem, dict))
-            elif isinstance(item, dict):
-                elements.append(item)
+
+    def _collect(value: Any) -> None:
+        if isinstance(value, dict):
+            if "type" in value and ("text" in value or "bbox" in value):
+                elements.append(value)
+                return
+            for nested in value.values():
+                _collect(nested)
+        elif isinstance(value, list):
+            for nested in value:
+                _collect(nested)
+
+    _collect(parsed)
 
     table_items: List[Dict[str, Any]] = []
     chart_items: List[Dict[str, Any]] = []
@@ -297,23 +368,27 @@ def nemotron_parse_pages(
 
     # -- Phase 2: run model inference in a single batch ------------------
     raw_texts: List[str] = [""] * len(batch_indices)
-    used_v1_api = False
+    uses_tool_call_routing = False
+    contract: _ResolvedNemotronParseContract | None = None
     if batch_images:
         try:
             if use_remote:
                 if "/v1/chat/completions" in invoke_url:
-                    _model_name = nemotron_parse_model or NEMOTRON_PARSE_REMOTE_DEFAULT_MODEL
-                    used_v1_api = _is_legacy_nemotron_parse_model(_model_name)
+                    contract = _resolve_nemotron_parse_contract(invoke_url, nemotron_parse_model)
+                    uses_tool_call_routing = contract.uses_tool_call_routing
                     extra_body: Dict[str, Any] = {"max_tokens": 8192}
-                    if used_v1_api:
+                    if contract.profile == _NemotronParseContractProfile.LEGACY_TOOL_CALL:
                         extra_body["tools"] = [{"type": "function", "function": {"name": "markdown_bbox"}}]
                     _chat_kw = dict(
                         invoke_url=invoke_url,
                         image_b64_list=batch_images,
-                        model=_model_name,
+                        model=contract.model,
                         api_key=api_key,
                         timeout_s=float(request_timeout_s),
-                        task_prompt=None if used_v1_api else task_prompt,
+                        task_prompt=None if uses_tool_call_routing else task_prompt,
+                        repetition_penalty=(
+                            None if contract.profile == _NemotronParseContractProfile.HOSTED_TOOL_CALL else 1.1
+                        ),
                         extra_body=extra_body,
                         max_retries=int(retry.remote_max_retries),
                         max_429_retries=int(retry.remote_max_429_retries),
@@ -351,6 +426,20 @@ def nemotron_parse_pages(
                 else:
                     raw_texts = [str(model.invoke(img, task_prompt=task_prompt) or "").strip() for img in batch_images]
         except BaseException as e:
+            if (
+                contract is not None
+                and nemotron_parse_model
+                and contract.has_build_endpoint
+                and contract.profile == _NemotronParseContractProfile.V1_2_TAGGED
+                and "text input" in str(e).lower()
+            ):
+                e = ValueError(
+                    "Nemotron Parse model/contract mismatch: NVIDIA Build model "
+                    "`nvidia/nemotron-parse` uses an image-only tool-call contract, but "
+                    f"`{contract.model}` selected the v1.2 text-control-token contract. "
+                    "Use `nemotron_parse_model='nvidia/nemotron-parse'` with Build, or send "
+                    "the versioned v1.2 model to a compatible self-hosted endpoint."
+                )
             print(f"Warning: Nemotron Parse batch failed: {type(e).__name__}: {e}")
             err = {
                 "stage": "nemotron_parse_pages",
@@ -363,7 +452,7 @@ def nemotron_parse_pages(
             raw_texts = []
 
     # -- Phase 3: route parsed elements into content channels ------------
-    route_fn = _route_parsed_elements_v1 if used_v1_api else _route_parsed_elements
+    route_fn = _route_tool_call_elements if uses_tool_call_routing else _route_parsed_elements
     for pos, raw_text in enumerate(raw_texts):
         idx = batch_indices[pos]
         try:

--- a/nemo_retriever/tests/test_actor_operators.py
+++ b/nemo_retriever/tests/test_actor_operators.py
@@ -5,9 +5,11 @@
 """Unit tests verifying all pipeline actors inherit from AbstractOperator."""
 
 import inspect
+import json
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
+import pytest
 
 from nemo_retriever.operators.abstract_operator import AbstractOperator
 
@@ -441,6 +443,7 @@ class TestNemotronParseActor:
         assert client.kwargs["model"] == NEMOTRON_PARSE_REMOTE_DEFAULT_MODEL
         assert client.kwargs["task_prompt"] == NEMOTRON_PARSE_DEFAULT_TASK_PROMPT
         assert client.kwargs["extra_body"] == {"max_tokens": 8192}
+        assert client.kwargs["repetition_penalty"] == 1.1
 
     def test_remote_chat_completions_supports_legacy_tool_call_protocol(self):
         from nemo_retriever.operators.extract.parse.nemotron_parse import nemotron_parse_pages
@@ -472,6 +475,7 @@ class TestNemotronParseActor:
             "max_tokens": 8192,
             "tools": [{"type": "function", "function": {"name": "markdown_bbox"}}],
         }
+        assert client.kwargs["repetition_penalty"] == 1.1
 
     def test_remote_chat_completions_does_not_treat_v1_10_as_legacy(self):
         from nemo_retriever.operators.extract.parse.nemotron_parse import nemotron_parse_pages
@@ -498,6 +502,120 @@ class TestNemotronParseActor:
         assert result["text"].tolist() == ["Future text"]
         assert client.kwargs["task_prompt"] is not None
         assert client.kwargs["extra_body"] == {"max_tokens": 8192}
+
+    def test_hosted_build_contract_is_image_only_and_routes_nested_tool_json(self):
+        from nemo_retriever.operators.extract.parse.nemotron_parse import nemotron_parse_pages
+
+        class _FakeNIMClient:
+            def __init__(self):
+                self.kwargs = None
+
+            def invoke_chat_completions_images(self, **kwargs):
+                self.kwargs = kwargs
+                elements = [
+                    {"type": "Text", "bbox": {"xmin": 0, "ymin": 0, "xmax": 1, "ymax": 1}, "text": "Hosted text"},
+                    {"type": "Table", "bbox": {"xmin": 1, "ymin": 1, "xmax": 2, "ymax": 2}, "text": "A | B"},
+                    {"type": "Chart", "bbox": {"xmin": 2, "ymin": 2, "xmax": 3, "ymax": 3}, "text": "Chart text"},
+                    {"type": "Picture", "bbox": {"xmin": 3, "ymin": 3, "xmax": 4, "ymax": 4}, "text": "Picture text"},
+                ]
+                return [json.dumps({"result": [elements]})]
+
+        client = _FakeNIMClient()
+        df = pd.DataFrame({"page_image": [{"image_b64": "aW1hZ2U="}]})
+        result = nemotron_parse_pages(
+            df,
+            invoke_url="https://integrate.api.nvidia.com/v1/chat/completions",
+            extract_text=True,
+            extract_tables=True,
+            extract_charts=True,
+            extract_infographics=True,
+            nim_client=client,
+        )
+
+        assert client.kwargs["model"] == "nvidia/nemotron-parse"
+        assert client.kwargs["task_prompt"] is None
+        assert client.kwargs["repetition_penalty"] is None
+        assert client.kwargs["extra_body"] == {"max_tokens": 8192}
+        assert result["text"].tolist() == ["Hosted text"]
+        assert len(result.at[0, "table"]) == 1
+        assert len(result.at[0, "chart"]) == 1
+        assert len(result.at[0, "infographic"]) == 1
+
+    @pytest.mark.parametrize(
+        ("endpoint", "model", "expected_model", "expected_profile"),
+        [
+            ("https://integrate.api.nvidia.com/v1/chat/completions", None, "nvidia/nemotron-parse", "hosted_tool_call"),
+            ("http://parse:8000/v1/chat/completions", None, "nvidia/nemotron-parse-v1.2", "v1_2_tagged"),
+            ("http://parse:8000/v1/chat/completions", "nvidia/nemotron-parse", "nvidia/nemotron-parse", "hosted_tool_call"),
+            ("http://parse:8000/v1/chat/completions", "nvidia/nemotron-parse-v1.0", "nvidia/nemotron-parse-v1.0", "legacy_tool_call"),
+            ("http://parse:8000/v1/chat/completions", "nvidia/nemotron-parse-v1.1", "nvidia/nemotron-parse-v1.1", "legacy_tool_call"),
+            ("http://parse:8000/v1/chat/completions", "nvidia/nemotron-parse-v1.2", "nvidia/nemotron-parse-v1.2", "v1_2_tagged"),
+            ("http://parse:8000/v1/chat/completions", "nvidia/nemotron-parse-v1.10", "nvidia/nemotron-parse-v1.10", "v1_2_tagged"),
+            ("http://parse:8000/v1/chat/completions", "custom/parse", "custom/parse", "v1_2_tagged"),
+        ],
+    )
+    def test_contract_resolution(self, endpoint, model, expected_model, expected_profile):
+        from nemo_retriever.operators.extract.parse.nemotron_parse import _resolve_nemotron_parse_contract
+
+        contract = _resolve_nemotron_parse_contract(endpoint, model)
+
+        assert contract.model == expected_model
+        assert contract.profile.value == expected_profile
+
+    def test_contract_resolution_rejects_mixed_endpoints_without_model(self):
+        from nemo_retriever.operators.extract.parse.nemotron_parse import _resolve_nemotron_parse_contract
+
+        endpoints = (
+            "https://integrate.api.nvidia.com/v1/chat/completions,"
+            "http://parse:8000/v1/chat/completions"
+        )
+        with pytest.raises(ValueError, match="cannot mix NVIDIA Build and self-hosted"):
+            _resolve_nemotron_parse_contract(endpoints, None)
+
+        contract = _resolve_nemotron_parse_contract(endpoints, "nvidia/nemotron-parse-v1.2")
+        assert contract.profile.value == "v1_2_tagged"
+
+    def test_forced_v1_2_build_text_rejection_reports_contract_mismatch(self):
+        from nemo_retriever.operators.extract.parse.nemotron_parse import nemotron_parse_pages
+
+        class _RejectingNIMClient:
+            def invoke_chat_completions_images(self, **kwargs):
+                raise RuntimeError("Content cannot be a plain string; model does not support text input")
+
+        df = pd.DataFrame({"page_image": [{"image_b64": "aW1hZ2U="}]})
+        result = nemotron_parse_pages(
+            df,
+            invoke_url="https://integrate.api.nvidia.com/v1/chat/completions",
+            nemotron_parse_model="nvidia/nemotron-parse-v1.2",
+            nim_client=_RejectingNIMClient(),
+        )
+
+        error = result.at[0, "nemotron_parse_v1_2"]["error"]
+        assert error["type"] == "ValueError"
+        assert "model/contract mismatch" in error["message"]
+        assert "nvidia/nemotron-parse" in error["message"]
+
+    def test_image_wrapper_can_omit_repetition_penalty(self):
+        from nemo_retriever.models.nim.nim import NIMClient
+
+        client = NIMClient(max_pool_workers=1)
+        try:
+            with patch.object(client, "invoke_chat_completions", return_value=["ok"]) as invoke:
+                result = client.invoke_chat_completions_images(
+                    invoke_url="https://integrate.api.nvidia.com/v1/chat/completions",
+                    image_b64_list=["aW1hZ2U="],
+                    model="nvidia/nemotron-parse",
+                    repetition_penalty=None,
+                    extra_body={"max_tokens": 8192},
+                )
+            assert result == ["ok"]
+            payload_args = invoke.call_args.kwargs
+            assert payload_args["messages_list"][0][0]["content"] == [
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,aW1hZ2U="}}
+            ]
+            assert payload_args["extra_body"] == {"max_tokens": 8192}
+        finally:
+            client.shutdown()
 
     @patch(
         "nemo_retriever.operators.extract.parse.nemotron_parse.nemotron_parse_pages", side_effect=RuntimeError("boom")

--- a/nemo_retriever/tests/test_actor_operators.py
+++ b/nemo_retriever/tests/test_actor_operators.py
@@ -616,6 +616,8 @@ class TestNemotronParseActor:
         assert error["type"] == "ValueError"
         assert "model/contract mismatch" in error["message"]
         assert "nvidia/nemotron-parse" in error["message"]
+        assert "RuntimeError: Content cannot be a plain string" in error["traceback"]
+        assert "ValueError: Nemotron Parse model/contract mismatch" in error["traceback"]
 
     def test_image_wrapper_can_omit_repetition_penalty(self):
         from nemo_retriever.models.nim.nim import NIMClient

--- a/nemo_retriever/tests/test_actor_operators.py
+++ b/nemo_retriever/tests/test_actor_operators.py
@@ -546,11 +546,36 @@ class TestNemotronParseActor:
         [
             ("https://integrate.api.nvidia.com/v1/chat/completions", None, "nvidia/nemotron-parse", "hosted_tool_call"),
             ("http://parse:8000/v1/chat/completions", None, "nvidia/nemotron-parse-v1.2", "v1_2_tagged"),
-            ("http://parse:8000/v1/chat/completions", "nvidia/nemotron-parse", "nvidia/nemotron-parse", "hosted_tool_call"),
-            ("http://parse:8000/v1/chat/completions", "nvidia/nemotron-parse-v1.0", "nvidia/nemotron-parse-v1.0", "legacy_tool_call"),
-            ("http://parse:8000/v1/chat/completions", "nvidia/nemotron-parse-v1.1", "nvidia/nemotron-parse-v1.1", "legacy_tool_call"),
-            ("http://parse:8000/v1/chat/completions", "nvidia/nemotron-parse-v1.2", "nvidia/nemotron-parse-v1.2", "v1_2_tagged"),
-            ("http://parse:8000/v1/chat/completions", "nvidia/nemotron-parse-v1.10", "nvidia/nemotron-parse-v1.10", "v1_2_tagged"),
+            (
+                "http://parse:8000/v1/chat/completions",
+                "nvidia/nemotron-parse",
+                "nvidia/nemotron-parse",
+                "hosted_tool_call",
+            ),
+            (
+                "http://parse:8000/v1/chat/completions",
+                "nvidia/nemotron-parse-v1.0",
+                "nvidia/nemotron-parse-v1.0",
+                "legacy_tool_call",
+            ),
+            (
+                "http://parse:8000/v1/chat/completions",
+                "nvidia/nemotron-parse-v1.1",
+                "nvidia/nemotron-parse-v1.1",
+                "legacy_tool_call",
+            ),
+            (
+                "http://parse:8000/v1/chat/completions",
+                "nvidia/nemotron-parse-v1.2",
+                "nvidia/nemotron-parse-v1.2",
+                "v1_2_tagged",
+            ),
+            (
+                "http://parse:8000/v1/chat/completions",
+                "nvidia/nemotron-parse-v1.10",
+                "nvidia/nemotron-parse-v1.10",
+                "v1_2_tagged",
+            ),
             ("http://parse:8000/v1/chat/completions", "custom/parse", "custom/parse", "v1_2_tagged"),
         ],
     )
@@ -565,10 +590,7 @@ class TestNemotronParseActor:
     def test_contract_resolution_rejects_mixed_endpoints_without_model(self):
         from nemo_retriever.operators.extract.parse.nemotron_parse import _resolve_nemotron_parse_contract
 
-        endpoints = (
-            "https://integrate.api.nvidia.com/v1/chat/completions,"
-            "http://parse:8000/v1/chat/completions"
-        )
+        endpoints = "https://integrate.api.nvidia.com/v1/chat/completions," "http://parse:8000/v1/chat/completions"
         with pytest.raises(ValueError, match="cannot mix NVIDIA Build and self-hosted"):
             _resolve_nemotron_parse_contract(endpoints, None)
 

--- a/nemo_retriever/tests/test_params_models.py
+++ b/nemo_retriever/tests/test_params_models.py
@@ -18,6 +18,24 @@ class TestVideoFrameParams:
 
 
 class TestExtractParams:
+    def test_parse_specific_configuration_requires_parse_method(self) -> None:
+        for field, value in (
+            ("nemotron_parse_invoke_url", "http://parse:8000/v1/chat/completions"),
+            ("nemotron_parse_model", "nvidia/nemotron-parse"),
+        ):
+            with pytest.raises(ValidationError, match="method='nemotron_parse'"):
+                ExtractParams(**{field: value})
+
+    def test_normal_and_selected_parse_configurations_are_valid(self) -> None:
+        assert ExtractParams().method == "pdfium"
+        assert ExtractParams(invoke_url="http://generic").method == "pdfium"
+        params = ExtractParams(
+            method="nemotron_parse",
+            nemotron_parse_invoke_url="https://integrate.api.nvidia.com/v1/chat/completions",
+            nemotron_parse_model="nvidia/nemotron-parse",
+        )
+        assert params.method == "nemotron_parse"
+
     def test_graphic_elements_controls_are_removed(self) -> None:
         assert "use_graphic_elements" not in ExtractParams.model_fields
         assert "graphic_elements_invoke_url" not in ExtractParams.model_fields

--- a/nemo_retriever/tests/test_pipeline_graph.py
+++ b/nemo_retriever/tests/test_pipeline_graph.py
@@ -72,6 +72,40 @@ def test_text_build_graph_does_not_use_modal_content_reshape() -> None:
     assert "ExplodeContentToRows" not in _graph_node_names(graph)
 
 
+def test_batch_graph_forwards_resolvable_hosted_parse_contract() -> None:
+    from nemo_retriever.operators.extract.parse.nemotron_parse import _resolve_nemotron_parse_contract
+
+    endpoint = "https://integrate.api.nvidia.com/v1/chat/completions"
+    model = "nvidia/nemotron-parse"
+    graph = build_graph(
+        extraction_mode="pdf",
+        extract_params=ExtractParams(
+            method="nemotron_parse",
+            nemotron_parse_invoke_url=endpoint,
+            nemotron_parse_model=model,
+        ),
+    )
+
+    nodes: list[Node] = []
+
+    def collect(node: Node) -> None:
+        nodes.append(node)
+        for child in node.children:
+            collect(child)
+
+    for root in graph.roots:
+        collect(root)
+    parse_node = next(node for node in nodes if node.operator.__class__.__name__ == "NemotronParseActor")
+
+    assert parse_node.operator_kwargs["nemotron_parse_invoke_url"] == endpoint
+    assert parse_node.operator_kwargs["nemotron_parse_model"] == model
+    contract = _resolve_nemotron_parse_contract(
+        parse_node.operator_kwargs["nemotron_parse_invoke_url"],
+        parse_node.operator_kwargs["nemotron_parse_model"],
+    )
+    assert (contract.model, contract.profile.value) == (model, "hosted_tool_call")
+
+
 def test_auto_extract_extension_sets_share_manifest_registry() -> None:
     assert PDF_EXTENSIONS == INPUT_TYPE_EXTENSIONS["pdf"] | INPUT_TYPE_EXTENSIONS["doc"]
     assert TEXT_EXTENSIONS == INPUT_TYPE_EXTENSIONS["txt"]
@@ -902,7 +936,7 @@ class TestMultiTypeExtractOperator:
         )
 
         def _fake_resolve(operator_class, resources, operator_kwargs=None):
-            calls.append((operator_class.__name__, resources))
+            calls.append((operator_class.__name__, resources, operator_kwargs))
             return _IdentityStage
 
         monkeypatch.setattr(
@@ -913,16 +947,31 @@ class TestMultiTypeExtractOperator:
             lambda: Resources(cpu_count=8, gpu_count=1),
         )
 
+        endpoint = "https://integrate.api.nvidia.com/v1/chat/completions"
+        model = "nvidia/nemotron-parse"
         op = MultiTypeExtractCPUActor(
             extraction_mode="pdf",
-            extract_params=ExtractParams(method="nemotron_parse"),
+            extract_params=ExtractParams(
+                method="nemotron_parse",
+                nemotron_parse_invoke_url=endpoint,
+                nemotron_parse_model=model,
+            ),
         )
 
         batch_df = pd.DataFrame({"path": ["/tmp/test.pdf"]})
         result = op._run_pdf_pipeline(batch_df)
 
         pd.testing.assert_frame_equal(result, batch_df)
-        assert [name for name, _resources in calls] == ["NemotronParseActor"]
+        assert [name for name, _resources, _kwargs in calls] == ["NemotronParseActor"]
+        parse_kwargs = calls[0][2]
+        assert parse_kwargs["nemotron_parse_invoke_url"] == endpoint
+        assert parse_kwargs["nemotron_parse_model"] == model
+        from nemo_retriever.operators.extract.parse.nemotron_parse import _resolve_nemotron_parse_contract
+
+        contract = _resolve_nemotron_parse_contract(
+            parse_kwargs["nemotron_parse_invoke_url"], parse_kwargs["nemotron_parse_model"]
+        )
+        assert (contract.model, contract.profile.value) == (model, "hosted_tool_call")
 
 
 class TestFileListLoaderOperator:


### PR DESCRIPTION
## Description

Fix the public SDK integration with the hosted NVIDIA Build Nemotron Parse model at `https://integrate.api.nvidia.com/v1/chat/completions` using model ID `nvidia/nemotron-parse`.

The SDK previously sent the self-hosted v1.2 control-token text prompt before the page image. The hosted model is image-only and rejected that request with HTTP 400: `The model does not support text input.` This change resolves an internal request/response contract from the endpoint and model:

- Hosted `nvidia/nemotron-parse` sends image-only content, omits tools and repetition penalty, and routes returned tool-call JSON.
- Legacy v1.0/v1.1 models preserve their `markdown_bbox` tool declaration and tool-call routing.
- Versioned v1.2 and later models preserve control-token input and tagged-text routing.
- Omitted models resolve to the hosted model on NVIDIA Build and retain the v1.2 default elsewhere; mixed hosted/self-hosted endpoint lists require an explicit model.
- Parse-specific endpoint/model configuration now requires `method="nemotron_parse"` so silently ignored configuration fails early.

This restores hosted advanced PDF parsing in both inprocess and batch SDK modes while preserving existing self-hosted and local v1.2 behavior. SDK examples and the support matrix now document the distinct hosted and self-hosted model contracts.

Validation:

- `263 passed` across Nemotron Parse actor, graph, parameter, chat-client, CPU-actor, ingest-plan, and local v1.2 suites.
- Ruff and `git diff --check` passed.
- Live NVIDIA Build smoke test: image-only control returned HTTP 200 with structured `markdown_bbox` output; inprocess and batch each returned three pages without Parse errors and equivalent text, two tables, and two infographic-routed pictures. The old text-plus-image request retained the expected HTTP 400 as a negative control.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
