### PR TITLE
docs(theme): fix outdated banner to open /latest/ not Docs Hub

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,40 +1,26 @@
-{% extends "base.html" %}
+﻿{% extends "base.html" %}
 
-
-
-{% block extrahead %}
- 
-    <script src="https://assets.adobedtm.com/5d4962a43b79/c1061d2c5e7b/launch-191c2462b890.min.js"></script>
-
-{% endblock %}
-
-
-
-<!-- {% block outdated %}
+{#
+  docs.nvidia.com serves /nemo/retriever/ from Brightspot (product hub), not the
+  Mike root redirect. Material's default outdated banner climbs to site root
+  (href="../../.."), which lands on that hub. Point at /latest/ and preserve the
+  page path under the version segment.
+#}
+{% block outdated %}
   You're not viewing the latest version.
-  <a href="{{ '../' ~ base_url }}"> 
+  <a id="nrl-go-latest" href="/nemo/retriever/latest/">
     <strong>Click here to go to latest.</strong>
   </a>
-{% endblock %} -->
-
-
-
-{% block content %}
-
-    <div style="text-align: right;">
-        <a href="https://surveys.hotjar.com/4904bf71-6484-47a7-83ff-4715cceabdb5" id="openPopupButton">Is this page helpful?</a>
-    </div>
-
-    {{ super() }}
-
-{% endblock %}
-
-
-
-{% block footer %}
-
-    {{ super() }}
-
-    <script type="text/javascript">if (typeof _satellite !== "undefined") {_satellite.pageBottom();}</script>
- 
+  <script>
+    (function () {
+      var a = document.getElementById("nrl-go-latest");
+      if (!a) return;
+      var path = window.location.pathname || "";
+      var match = path.match(/^(.*?\/)(?:\d+\.\d+(?:\.\d+)?)\/(.*)$/);
+      if (match) {
+        a.href = match[1] + "latest/" + match[2] +
+          window.location.search + window.location.hash;
+      }
+    })();
+  </script>
 {% endblock %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,10 +1,14 @@
 ﻿{% extends "base.html" %}
 
+{% block extrahead %}
+  <script src="https://assets.adobedtm.com/5d4962a43b79/c1061d2c5e7b/launch-191c2462b890.min.js"></script>
+{% endblock %}
+
 {#
   docs.nvidia.com serves /nemo/retriever/ from Brightspot (product hub), not the
   Mike root redirect. Material's default outdated banner climbs to site root
-  (href="../../.."), which lands on that hub. Point at /latest/ and preserve the
-  page path under the version segment.
+  (../../..), which lands on that hub. Link to /latest/ and preserve the page
+  path under the version segment.
 #}
 {% block outdated %}
   You're not viewing the latest version.
@@ -23,4 +27,16 @@
       }
     })();
   </script>
+{% endblock %}
+
+{% block content %}
+  <div style="text-align: right;">
+    <a href="https://surveys.hotjar.com/4904bf71-6484-47a7-83ff-4715cceabdb5" id="openPopupButton">Is this page helpful?</a>
+  </div>
+  {{ super() }}
+{% endblock %}
+
+{% block footer %}
+  {{ super() }}
+  <script type="text/javascript">if (typeof _satellite !== "undefined") {_satellite.pageBottom();}</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Updates `docs/overrides/main.html` so the Material outdated banner links to `/nemo/retriever/latest/...` with path preservation.
- Preserves existing Adobe Analytics and Hotjar feedback overrides.
- Fixes the failure mode where `href="../../.."` lands on the Brightspot Docs Hub at `/nemo/retriever/` instead of the latest docs tree.

## Why
On docs.nvidia.com, `/nemo/retriever/` is owned by Brightspot. Mike/Material assume site root redirects into `latest/`, which is not true on this host.

## Test plan
- [ ] Build MkDocs locally and confirm `overrides/main.html` renders the `nrl-go-latest` link
- [ ] After publish (or S3 HTML patch for 26.3.0), from a non-latest page click the banner and land on the matching `/latest/...` page, not the Docs Hub
- [ ] Confirm Hotjar feedback link and Adobe footer script remain present

## Note
Live 26.3.0 HTML must be patched or republished for the banner fix to appear on currently outdated pages; this source change covers future builds from the 26.05 branch.
