### PR TITLE
docs(26.05): fix stale LanceDB retrieval example

### DIFF
--- a/docs/sphinx_docs/source/index.rst
+++ b/docs/sphinx_docs/source/index.rst
@@ -94,23 +94,27 @@ To inspect the results, use :func:`~nv_ingest_client.util.process_json_files.ing
     # results blob is directly inspectable
     print(ingest_json_results_to_blob(results[0]))
 
-To query the ingested LanceDB table, use :func:`~nv_ingest_client.util.vdb.lancedb.lancedb_retrieval`
+To query the ingested LanceDB table, use :meth:`~nemo_retriever.common.vdb.lancedb.LanceDB.retrieval`
+(precomputed query vectors) or :meth:`~nemo_retriever.retriever.Retriever.query` (embeds the query string for you).
 
 .. code-block:: python
 
-    from nv_ingest_client.util.vdb.lancedb import lancedb_retrieval
+    from nemo_retriever.common.vdb.lancedb import LanceDB
+    from nemo_retriever.retriever import Retriever
 
     table_path = "./lancedb_data"
     table_name = "test"
 
-    queries = ["Which animal is responsible for the typos?"]
+    # Option 1: precomputed query vectors
+    vdb = LanceDB(uri=table_path, table_name=table_name)
+    query_vectors = [[0.0] * 2048]  # replace with vectors from the same embedder used at ingest
+    retrieved_docs = vdb.retrieval(query_vectors, top_k=1)
 
-    retrieved_docs = lancedb_retrieval(
-        queries,
-        table_path=table_path,
-        table_name=table_name,
-        top_k=1,
+    # Option 2: natural-language query (Retriever embeds the query for you)
+    retriever = Retriever(
+        vdb_kwargs={"uri": table_path, "table_name": table_name},
     )
+    hits = retriever.query("Which animal is responsible for the typos?", top_k=1)
 
 
 .. toctree::

--- a/docs/sphinx_docs/source/index.rst
+++ b/docs/sphinx_docs/source/index.rst
@@ -94,12 +94,12 @@ To inspect the results, use :func:`~nv_ingest_client.util.process_json_files.ing
     # results blob is directly inspectable
     print(ingest_json_results_to_blob(results[0]))
 
-To query the ingested LanceDB table, use :meth:`~nemo_retriever.common.vdb.lancedb.LanceDB.retrieval`
+To query the ingested LanceDB table, use :meth:`~nemo_retriever.vdb.lancedb.LanceDB.retrieval`
 (precomputed query vectors) or :meth:`~nemo_retriever.retriever.Retriever.query` (embeds the query string for you).
 
 .. code-block:: python
 
-    from nemo_retriever.common.vdb.lancedb import LanceDB
+    from nemo_retriever.vdb.lancedb import LanceDB
     from nemo_retriever.retriever import Retriever
 
     table_path = "./lancedb_data"


### PR DESCRIPTION
## Summary

- backport the Sphinx LanceDB retrieval correction to `26.05`
- replace the removed `lancedb_retrieval` helper with `LanceDB.retrieval()` and `Retriever.query()`
- use current `nemo_retriever` import paths

**NVBugs:** https://nvbugspro.nvidia.com/bug/6205401

## Important: partial fix only — do not close NVBugs 6205401

This PR fixes only the stale LanceDB helper in `docs/sphinx_docs/source/index.rst` on `26.05`. It does **not** resolve the entire bug.

The following known issue remains on `26.05` in `examples/building_vdb_operator.ipynb` and requires a separate engineering-owned PR because this PR intentionally excludes Python notebooks and runtime code:

- Notebook JSON lines 126 and 158 still import `VDB` from the removed legacy path `nv_ingest_client.util.vdb.adt_vdb`; the current interface is under `nemo_retriever.common.vdb.adt_vdb`.
- Lines 721–764 describe the in-notebook OpenSearch example as a complete, production-ready, pre-built operator.
- Line 727 points readers to `client/src/nv_ingest_client/util/vdb/opensearch.py`, which does not exist in the 26.05 code tree.
- Line 743 imports `OpenSearch` from `nv_ingest_client.util.vdb.opensearch`, which also does not exist.
- The 26.05 VDB factory registers only `lancedb`; there is no shipped first-party OpenSearch backend.

Required follow-up decision and work:

1. **Recommended:** retain the notebook as a build-your-own custom-operator tutorial, update it to the current `nemo_retriever` `VDB` interface, remove all claims/imports implying that OpenSearch ships with the library, and execute the notebook end to end against a supported OpenSearch setup.
2. **Alternative, only if OpenSearch is intended to ship:** implement and register a maintained OpenSearch backend under the current `nemo_retriever` package, add dependencies and tests, and then document that shipped implementation. This is runtime engineering work and must not be folded into this docs PR.

Until one of those follow-ups lands and QA verifies the notebook, merging this PR should be treated as progress on NVBugs 6205401—not as grounds to close it.

## Scope

Documentation only. Python notebooks and runtime code are intentionally unchanged.

## Test plan

- [x] Confirm no stale `lancedb_retrieval` or `lancedb_hybrid_retrieval` references remain in `.md` or `.rst` files
- [x] Confirm the PR changes only `docs/sphinx_docs/source/index.rst`

## Related

- Main PR: #2402