### PR TITLE
docs(26.05): rename non-FAQ question headings to statement style

### DIFF
--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -16,7 +16,7 @@ This documentation describes two ways to run [NeMo Retriever Library](overview.m
 Supported file types for speech extraction today:
 
 - `mp3`, `wav`
-- `mp4`, `mov`, `mkv`, `avi` — common video containers; the audio track is transcribed (same extensions as in [What is NeMo Retriever Library?](overview.md))
+- `mp4`, `mov`, `mkv`, `avi` — common video containers; the audio track is transcribed (same extensions as in [NeMo Retriever Library overview](overview.md))
 
 [NeMo Retriever Library](overview.md) supports extracting speech from audio for Retrieval Augmented Generation (RAG). Similar to how the multimodal document pipeline uses detection and OCR microservices, NeMo Retriever Library uses the [parakeet-1-1b-ctc-en-us ASR NIM](https://docs.nvidia.com/nim/speech/latest/asr/deploy-asr-models/parakeet-ctc-en-us.html) to transcribe speech to text, then embeddings through the NeMo Retriever embedding path.
 
@@ -129,7 +129,7 @@ For video assets, NeMo Retriever Library can combine audio or speech processing 
 
 For OCR-oriented extract methods on scanned or image-heavy content, refer to [OCR and scanned documents](multimodal-extraction.md#ocr-and-scanned-documents), [text and layout extraction](multimodal-extraction.md#text-and-layout-extraction), and [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse) for advanced visual parsing.
 
-Container formats and early-access video types are listed under [supported file types and formats](multimodal-extraction.md#supported-file-types-and-formats) (refer to [What is NeMo Retriever Library?](overview.md) for the full list).
+Container formats and early-access video types are listed under [supported file types and formats](multimodal-extraction.md#supported-file-types-and-formats) (refer to [NeMo Retriever Library overview](overview.md) for the full list).
 
 For end-to-end RAG stacks that include multimodal ingestion, refer to the [NVIDIA AI Blueprints catalog](https://build.nvidia.com/explore/discover) and related solution pages on [NVIDIA Build](https://build.nvidia.com/).
 

--- a/docs/docs/extraction/audio-video.md
+++ b/docs/docs/extraction/audio-video.md
@@ -16,7 +16,7 @@ This documentation describes two ways to run [NeMo Retriever Library](overview.m
 Supported file types for speech extraction today:
 
 - `mp3`, `wav`
-- `mp4`, `mov`, `mkv`, `avi` — common video containers; the audio track is transcribed (same extensions as in [NeMo Retriever Library overview](overview.md))
+- `mp4`, `mov`, `mkv`, `avi` — common video containers; the audio track is transcribed (same extensions as in [NeMo Retriever Library Overview](overview.md))
 
 [NeMo Retriever Library](overview.md) supports extracting speech from audio for Retrieval Augmented Generation (RAG). Similar to how the multimodal document pipeline uses detection and OCR microservices, NeMo Retriever Library uses the [parakeet-1-1b-ctc-en-us ASR NIM](https://docs.nvidia.com/nim/speech/latest/asr/deploy-asr-models/parakeet-ctc-en-us.html) to transcribe speech to text, then embeddings through the NeMo Retriever embedding path.
 
@@ -129,7 +129,7 @@ For video assets, NeMo Retriever Library can combine audio or speech processing 
 
 For OCR-oriented extract methods on scanned or image-heavy content, refer to [OCR and scanned documents](multimodal-extraction.md#ocr-and-scanned-documents), [text and layout extraction](multimodal-extraction.md#text-and-layout-extraction), and [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse) for advanced visual parsing.
 
-Container formats and early-access video types are listed under [supported file types and formats](multimodal-extraction.md#supported-file-types-and-formats) (refer to [NeMo Retriever Library overview](overview.md) for the full list).
+Container formats and early-access video types are listed under [supported file types and formats](multimodal-extraction.md#supported-file-types-and-formats) (refer to [NeMo Retriever Library Overview](overview.md) for the full list).
 
 For end-to-end RAG stacks that include multimodal ingestion, refer to the [NVIDIA AI Blueprints catalog](https://build.nvidia.com/explore/discover) and related solution pages on [NVIDIA Build](https://build.nvidia.com/).
 

--- a/docs/docs/extraction/getting-started-about.md
+++ b/docs/docs/extraction/getting-started-about.md
@@ -11,4 +11,4 @@ Typical order:
     - **Supported:** [Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) for Kubernetes, plus [NeMo Retriever Library install docs](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the published charts
 4. Explore [Jupyter Notebooks](notebooks/index.md) for end-to-end examples.
 
-If you are new to the product, read [NeMo Retriever Library overview](overview.md) and [Concepts](concepts.md) under **Introduction** first.
+If you are new to the product, read [NeMo Retriever Library Overview](overview.md) and [Concepts](concepts.md) under **Introduction** first.

--- a/docs/docs/extraction/getting-started-about.md
+++ b/docs/docs/extraction/getting-started-about.md
@@ -11,4 +11,4 @@ Typical order:
     - **Supported:** [Helm chart](https://github.com/NVIDIA/NeMo-Retriever/blob/main/nemo_retriever/helm/README.md) for Kubernetes, plus [NeMo Retriever Library install docs](https://docs.nvidia.com/nemo/retriever/latest/extraction/overview/) for the published charts
 4. Explore [Jupyter Notebooks](notebooks/index.md) for end-to-end examples.
 
-If you are new to the product, read [What is NeMo Retriever Library?](overview.md) and [Concepts](concepts.md) under **Introduction** first.
+If you are new to the product, read [NeMo Retriever Library overview](overview.md) and [Concepts](concepts.md) under **Introduction** first.

--- a/docs/docs/extraction/multimodal-extraction.md
+++ b/docs/docs/extraction/multimodal-extraction.md
@@ -15,7 +15,7 @@ NeMo Retriever Library classifies and extracts text, tables, charts, infographic
 
 ## Supported file types and formats { #supported-file-types-and-formats }
 
-NeMo Retriever Library accepts multiple document and media types. A current list (including PDF, Office formats, HTML, images, audio, and video, some early access) appears in [What is NeMo Retriever Library?](overview.md) under **NeMo Retriever Library supports the following file types**.
+NeMo Retriever Library accepts multiple document and media types. A current list (including PDF, Office formats, HTML, images, audio, and video, some early access) appears in [NeMo Retriever Library overview](overview.md) under **NeMo Retriever Library supports the following file types**.
 
 **Related**
 
@@ -31,7 +31,7 @@ For PDFs, NeMo Retriever Library typically uses **pdfium**-based extraction with
 
 **Related**
 
-- [What is NeMo Retriever Library?](overview.md)
+- [NeMo Retriever Library overview](overview.md)
 - [OCR and scanned documents](#ocr-and-scanned-documents)
 - [Chunking](concepts.md#chunking)
 
@@ -41,7 +41,7 @@ NeMo Retriever Library detects tables as structured page elements, processes the
 
 **Related**
 
-- [What is NeMo Retriever Library?](overview.md) for artifact classification
+- [NeMo Retriever Library overview](overview.md) for artifact classification
 - [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse) for advanced visual parsing
 - [Metadata reference](content-metadata.md)
 
@@ -66,7 +66,7 @@ For natural-language infographic descriptions, optionally enable [image captioni
 
 **Related**
 
-- [What is NeMo Retriever Library?](overview.md)
+- [NeMo Retriever Library overview](overview.md)
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
 - [Multimodal embeddings (VLM)](embedding.md) when you treat graphics as images for embedding
 

--- a/docs/docs/extraction/multimodal-extraction.md
+++ b/docs/docs/extraction/multimodal-extraction.md
@@ -15,7 +15,7 @@ NeMo Retriever Library classifies and extracts text, tables, charts, infographic
 
 ## Supported file types and formats { #supported-file-types-and-formats }
 
-NeMo Retriever Library accepts multiple document and media types. A current list (including PDF, Office formats, HTML, images, audio, and video, some early access) appears in [NeMo Retriever Library overview](overview.md) under **NeMo Retriever Library supports the following file types**.
+NeMo Retriever Library accepts multiple document and media types. A current list (including PDF, Office formats, HTML, images, audio, and video, some early access) appears in [NeMo Retriever Library Overview](overview.md) under **NeMo Retriever Library supports the following file types**.
 
 **Related**
 
@@ -31,7 +31,7 @@ For PDFs, NeMo Retriever Library typically uses **pdfium**-based extraction with
 
 **Related**
 
-- [NeMo Retriever Library overview](overview.md)
+- [NeMo Retriever Library Overview](overview.md)
 - [OCR and scanned documents](#ocr-and-scanned-documents)
 - [Chunking](concepts.md#chunking)
 
@@ -41,7 +41,7 @@ NeMo Retriever Library detects tables as structured page elements, processes the
 
 **Related**
 
-- [NeMo Retriever Library overview](overview.md) for artifact classification
+- [NeMo Retriever Library Overview](overview.md) for artifact classification
 - [Nemotron Parse](https://build.nvidia.com/nvidia/nemotron-parse) for advanced visual parsing
 - [Metadata reference](content-metadata.md)
 
@@ -66,7 +66,7 @@ For natural-language infographic descriptions, optionally enable [image captioni
 
 **Related**
 
-- [NeMo Retriever Library overview](overview.md)
+- [NeMo Retriever Library Overview](overview.md)
 - [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md)
 - [Multimodal embeddings (VLM)](embedding.md) when you treat graphics as images for embedding
 

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -1,4 +1,4 @@
-# What is NeMo Retriever Library?
+# NeMo Retriever Library overview { #what-is-nemo-retriever-library }
 
 NVIDIA NeMo Retriever Library (NRL) is a high retrieval accuracy, performant, and scalable framework for content and metadata extraction from various media types (PDFs, HTML, Word docs, Powerpoint, audio, video, and image files). It supports both NVIDIA NIM microservices and a range of models to find, contextualize, and extract text, tables, charts, infographics, and transcripts for use in downstream generative and retrieval-augmented applications.
 

--- a/docs/docs/extraction/overview.md
+++ b/docs/docs/extraction/overview.md
@@ -1,4 +1,4 @@
-# NeMo Retriever Library overview { #what-is-nemo-retriever-library }
+# NeMo Retriever Library Overview { #what-is-nemo-retriever-library }
 
 NVIDIA NeMo Retriever Library (NRL) is a high retrieval accuracy, performant, and scalable framework for content and metadata extraction from various media types (PDFs, HTML, Word docs, Powerpoint, audio, video, and image files). It supports both NVIDIA NIM microservices and a range of models to find, contextualize, and extract text, tables, charts, infographics, and transcripts for use in downstream generative and retrieval-augmented applications.
 

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -126,7 +126,7 @@ For local GPU inference with Nemotron Parse, combine extras:
 pip install "nemo-retriever[local,nemotron-parse]"
 ```
 
-See also [What is NeMo Retriever Library?](overview.md) and [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md#software-requirements).
+See also [NeMo Retriever Library overview](overview.md) and [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md#software-requirements).
 
 ## Extract method nemotron-parse doesn't support image files
 

--- a/docs/docs/extraction/troubleshoot.md
+++ b/docs/docs/extraction/troubleshoot.md
@@ -126,7 +126,7 @@ For local GPU inference with Nemotron Parse, combine extras:
 pip install "nemo-retriever[local,nemotron-parse]"
 ```
 
-See also [NeMo Retriever Library overview](overview.md) and [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md#software-requirements).
+See also [NeMo Retriever Library Overview](overview.md) and [Pre-Requisites & Support Matrix](prerequisites-support-matrix.md#software-requirements).
 
 ## Extract method nemotron-parse doesn't support image files
 

--- a/docs/docs/extraction/vdbs.md
+++ b/docs/docs/extraction/vdbs.md
@@ -5,7 +5,7 @@ Use this documentation to learn how [NeMo Retriever Library](overview.md) stores
 ## On this page { #on-this-page }
 
 - [Overview](#overview)
-- [LanceDB overview](#why-lancedb)
+- [LanceDB Overview](#why-lancedb)
 - [Upload to LanceDB](#upload-to-lancedb)
 - [Semantic retrieval](#semantic-retrieval)
 - [Metadata and filtering](#metadata-and-filtering)
@@ -37,7 +37,7 @@ Currently, data upload is not supported through the [CLI](https://github.com/NVI
 
 
 
-## LanceDB overview { #why-lancedb }
+## LanceDB Overview { #why-lancedb }
 
 LanceDB is optimized for low-latency retrieval in this stack:
 

--- a/docs/docs/extraction/vdbs.md
+++ b/docs/docs/extraction/vdbs.md
@@ -5,7 +5,7 @@ Use this documentation to learn how [NeMo Retriever Library](overview.md) stores
 ## On this page { #on-this-page }
 
 - [Overview](#overview)
-- [Why LanceDB?](#why-lancedb)
+- [LanceDB overview](#why-lancedb)
 - [Upload to LanceDB](#upload-to-lancedb)
 - [Semantic retrieval](#semantic-retrieval)
 - [Metadata and filtering](#metadata-and-filtering)
@@ -37,7 +37,7 @@ Currently, data upload is not supported through the [CLI](https://github.com/NVI
 
 
 
-## Why LanceDB? { #why-lancedb }
+## LanceDB overview { #why-lancedb }
 
 LanceDB is optimized for low-latency retrieval in this stack:
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,4 +1,4 @@
-# What is NVIDIA NeMo Retriever?
+# NVIDIA NeMo Retriever overview { #what-is-nvidia-nemo-retriever }
 
 NVIDIA NeMo Retriever is a collection of microservices 
 for building and scaling multimodal data extraction, embedding, and reranking pipelines 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,4 +1,4 @@
-# NVIDIA NeMo Retriever overview { #what-is-nvidia-nemo-retriever }
+# NVIDIA NeMo Retriever Overview { #what-is-nvidia-nemo-retriever }
 
 NVIDIA NeMo Retriever is a collection of microservices 
 for building and scaling multimodal data extraction, embedding, and reranking pipelines 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -74,7 +74,7 @@ extra_css:
 # bar when there is only one top-level tab.
 nav:
   - "1. Introduction":
-      - "What is NeMo Retriever?": extraction/overview.md
+      - "NeMo Retriever Library overview": extraction/overview.md
       - Key concepts: extraction/concepts.md
       - Release notes: extraction/releasenotes.md
   - "2. Get started":

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -74,7 +74,7 @@ extra_css:
 # bar when there is only one top-level tab.
 nav:
   - "1. Introduction":
-      - "NeMo Retriever Library overview": extraction/overview.md
+      - "NeMo Retriever Library Overview": extraction/overview.md
       - Key concepts: extraction/concepts.md
       - Release notes: extraction/releasenotes.md
   - "2. Get started":


### PR DESCRIPTION
## Summary
- Rename non-FAQ question-style headings to statement-style titles per NVIDIA Template Library guidance (overview H1, root index H1, LanceDB section, MkDocs nav label).
- Update cross-link text to match the new titles; preserve existing heading anchors so deep links keep working.
- Leave FAQ question headings unchanged; do not change numbered TOC section labels.

## Test plan
- [ ] Confirm overview, index, and LanceDB headings are statement-style in the rendered docs.
- [ ] Confirm FAQ page headings remain questions.
- [ ] Spot-check nav label for overview and a few cross-links from multimodal / audio-video / troubleshoot pages.
- [ ] Confirm anchors #what-is-nemo-retriever-library, #what-is-nvidia-nemo-retriever, and #why-lancedb still resolve.