### PR TITLE
docs(26.05): link archived release notes to archive.docs.nvidia.com

### DIFF
--- a/docs/docs/extraction/releasenotes.md
+++ b/docs/docs/extraction/releasenotes.md
@@ -78,9 +78,16 @@ Highlights for the 26.05 release include:
 
 ## Release Notes for Previous Versions
 
-| [26.03](https://docs.nvidia.com/nemo/retriever/26.3.0/extraction/releasenotes-nv-ingest/)
+- [26.03](https://docs.nvidia.com/nemo/retriever/26.3.0/extraction/releasenotes-nv-ingest/)
+- [26.1.2](https://archive.docs.nvidia.com/nemo/retriever/26.1.2/extraction/releasenotes-nv-ingest/)
+- [26.1.1](https://archive.docs.nvidia.com/nemo/retriever/26.1.1/extraction/releasenotes-nv-ingest/)
+- [25.9.0](https://archive.docs.nvidia.com/nemo/retriever/25.9.0/extraction/releasenotes-nv-ingest/)
+- [25.6.3](https://archive.docs.nvidia.com/nemo/retriever/25.6.3/extraction/releasenotes-nv-ingest/)
+- [25.6.2](https://archive.docs.nvidia.com/nemo/retriever/25.6.2/extraction/releasenotes-nv-ingest/)
+- [25.4.2](https://archive.docs.nvidia.com/nemo/retriever/25.4.2/extraction/releasenotes-nv-ingest/)
+- [25.3.0](https://archive.docs.nvidia.com/nemo/retriever/25.3.0/extraction/releasenotes-nv-ingest/)
 
-Release notes for earlier versions (26.1.2, 26.1.1, 25.9.0, 25.6.3, 25.6.2, 25.4.2, 25.3.0, 24.12.1, and 24.12.0) — *These links have been archived.*
+Release notes for 24.12.1 and 24.12.0 are on the [25.3.0 archived release notes](https://archive.docs.nvidia.com/nemo/retriever/25.3.0/extraction/releasenotes-nv-ingest/).
 
 ## Related Topics
 


### PR DESCRIPTION
## Summary
- Replace the archived release-notes placeholder with direct `archive.docs.nvidia.com` links for retired NeMo Retriever doc trains (26.1.2 through 25.3.0).
- Fix the malformed previous-versions list on the 26.05 release-notes page.
- Point 24.12.1 and 24.12.0 to the 25.3.0 archived release-notes page.

## Test plan
- [ ] Verify release notes page renders the previous-versions list after publish
- [ ] Spot-check one archived link (for example 25.6.2) loads with the archive banner
- [ ] Confirm live 26.3.0 link still resolves on docs.nvidia.com