### PR TITLE
Reuse connections for service ingest results

### DIFF
--- a/nemo_retriever/harness/README.md
+++ b/nemo_retriever/harness/README.md
@@ -68,6 +68,14 @@ applies that URL only to service-mode children in a mixed session. Service mode
 uses the product service APIs for ingest and query while preserving the same
 `status.json`, `results.json`, metric gates, and session summary contract.
 
+Service-mode benchmarks wait for remote document completion without downloading
+retained result payloads. Their `rows_processed` value is the sum of
+`result_rows` from successful document-completion events; the independent
+VectorDB coverage checks remain the authoritative end-to-end validation. As a
+result, service `ingest_secs` measures remote ingestion completion rather than
+ingestion plus client-side result materialization. Service timing baselines
+recorded before this behavior changed are not directly comparable.
+
 ## Commands
 
 - `list`: list code-owned benchmarks and optional runsets.

--- a/nemo_retriever/src/nemo_retriever/harness/execution.py
+++ b/nemo_retriever/src/nemo_retriever/harness/execution.py
@@ -443,7 +443,10 @@ def run_prepared_benchmark(
                     writer.path("run.log"), label="service_ingest" if service_mode else "ingest"
                 ):
                     if service_mode:
-                        ingest_summary = execute_service_ingest_request(ingest_request).to_summary_dict()
+                        ingest_summary = execute_service_ingest_request(
+                            ingest_request,
+                            return_results=False,
+                        ).to_summary_dict()
                     else:
                         ingest_summary = run_ingest_workflow(ingest_plan, dry_run=False)
             except Exception as exc:

--- a/nemo_retriever/src/nemo_retriever/ingest/service.py
+++ b/nemo_retriever/src/nemo_retriever/ingest/service.py
@@ -269,10 +269,19 @@ def build_service_ingestor(request: ServiceIngestRequest) -> Any:
     return ingestor
 
 
-def execute_service_ingest_request(request: ServiceIngestRequest) -> ServiceIngestExecutionResult:
-    """Execute a service ingest request and return its structured result."""
+def execute_service_ingest_request(
+    request: ServiceIngestRequest,
+    *,
+    return_results: bool = True,
+) -> ServiceIngestExecutionResult:
+    """Execute a service ingest request and return its structured result.
 
-    result = build_service_ingestor(request).ingest(return_results=False)
+    ``return_results`` defaults to the user-facing service client behavior.
+    Callers that only need completion metadata may disable retained-result
+    downloads explicitly.
+    """
+
+    result = build_service_ingestor(request).ingest(return_results=return_results)
     failures = list(getattr(result, "failures", ()) or ())
     if failures:
         document, detail = failures[0]
@@ -463,6 +472,13 @@ def _sanitize_service_caption_params(caption_params: CaptionParams) -> CaptionPa
 
 
 def _count_service_result_rows(result: object) -> int | None:
+    dataframe = getattr(result, "dataframe", None)
+    if dataframe is not None:
+        try:
+            return len(dataframe)
+        except TypeError:
+            return None
+
     try:
         events = iter(result)
     except TypeError:

--- a/nemo_retriever/src/nemo_retriever/ingest/service.py
+++ b/nemo_retriever/src/nemo_retriever/ingest/service.py
@@ -132,9 +132,10 @@ class ServiceIngestExecutionResult:
     """Structured result from executing a resolved service ingest request.
 
     Service mode does not locally verify the remote vector database after
-    ingest. ``result_n_rows`` counts rows from the service ingest result when
-    available, and ``n_rows`` mirrors that value so root CLI summaries keep the
-    same top-level row-count contract as local ingest results.
+    ingest. ``result_n_rows`` sums the row counts reported by successful
+    document-completion events, and ``n_rows`` mirrors that value so root CLI
+    summaries keep the same top-level row-count contract as local ingest
+    results without downloading retained result payloads.
     """
 
     request: ServiceIngestRequest
@@ -271,7 +272,7 @@ def build_service_ingestor(request: ServiceIngestRequest) -> Any:
 def execute_service_ingest_request(request: ServiceIngestRequest) -> ServiceIngestExecutionResult:
     """Execute a service ingest request and return its structured result."""
 
-    result = build_service_ingestor(request).ingest()
+    result = build_service_ingestor(request).ingest(return_results=False)
     failures = list(getattr(result, "failures", ()) or ())
     if failures:
         document, detail = failures[0]
@@ -462,10 +463,20 @@ def _sanitize_service_caption_params(caption_params: CaptionParams) -> CaptionPa
 
 
 def _count_service_result_rows(result: object) -> int | None:
-    dataframe = getattr(result, "dataframe", None)
-    if dataframe is None:
-        return None
     try:
-        return len(dataframe)
+        events = iter(result)
     except TypeError:
         return None
+
+    total = 0
+    for event in events:
+        if not isinstance(event, dict) or event.get("status") != "completed":
+            continue
+        result_rows = event.get("result_rows", 0)
+        if result_rows is None:
+            continue
+        try:
+            total += int(result_rows)
+        except (TypeError, ValueError):
+            return None
+    return total

--- a/nemo_retriever/src/nemo_retriever/service/service_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/service/service_ingestor.py
@@ -76,6 +76,7 @@ import queue
 import threading
 import time
 import warnings
+from contextlib import nullcontext
 from io import BytesIO
 from pathlib import Path
 from typing import Any, AsyncIterator, Iterator, List, Optional, Tuple, Union
@@ -100,6 +101,12 @@ _LEGACY_RESULT_SCHEMA_DEPRECATION = (
     "schema in a future release. Pass result_schema='compact' to opt in now, or "
     "result_schema='legacy' to keep the current GraphIngestor.ingest() column layout "
     "with bulky image/embedding values stripped during the deprecation window."
+)
+
+_RESULT_FETCH_TRANSIENT_ERRORS: tuple[type[Exception], ...] = (
+    httpx.ConnectError,
+    httpx.ReadError,
+    httpx.RemoteProtocolError,
 )
 
 
@@ -446,20 +453,44 @@ class ServiceIngestor(ingestor):
         if name not in order:
             order.append(name)
 
-    def _fetch_document_result_data(self, document_id: str) -> list[dict[str, Any]]:
+    def _new_result_fetch_client(self) -> httpx.Client:
+        """Create a client for retained-result status requests."""
+        return httpx.Client(timeout=self._request_timeout_s, headers=self._auth_headers)
+
+    def _fetch_document_result_data(
+        self,
+        document_id: str,
+        *,
+        client: httpx.Client | None = None,
+    ) -> list[dict[str, Any]]:
         """Fetch ``result_data`` for *document_id* from the status endpoint.
 
         The status endpoint retains ``result_data`` through the job retention
-        window, so retrying this read is safe.
+        window, so retrying this read is safe. When the caller supplies a
+        client it is reused for the first attempt. A transient failure receives
+        one retry through a fresh client so a stale pooled connection cannot be
+        selected again.
         """
         if not document_id:
             raise ValueError("_fetch_document_result_data(): empty document_id")
 
+        if client is None:
+            with self._new_result_fetch_client() as scoped_client:
+                return self._fetch_document_result_data(document_id, client=scoped_client)
+
         url = f"{self._base_url}/v1/ingest/status/{document_id}"
-        with httpx.Client(timeout=self._request_timeout_s, headers=self._auth_headers) as client:
+        try:
             resp = client.get(url)
-            resp.raise_for_status()
-            body = resp.json()
+        except _RESULT_FETCH_TRANSIENT_ERRORS as exc:
+            logger.debug(
+                "Transient %s fetching retained result for %s; retrying on a fresh connection",
+                type(exc).__name__,
+                document_id,
+            )
+            with self._new_result_fetch_client() as retry_client:
+                resp = retry_client.get(url)
+        resp.raise_for_status()
+        body = resp.json()
         return list(body.get("result_data") or [])
 
     def _write_result_data_to_disk(self, document_id: str, result_data: list[dict[str, Any]]) -> Path:
@@ -483,7 +514,12 @@ class ServiceIngestor(ingestor):
             out_path.write_bytes(payload)
         return out_path
 
-    def _save_document_to_disk(self, document_id: str) -> Path:
+    def _save_document_to_disk(
+        self,
+        document_id: str,
+        *,
+        client: httpx.Client | None = None,
+    ) -> Path:
         """Fetch ``result_data`` for *document_id* and write a JSON artifact.
 
         Returns the path that was written. Raises if the document_id is
@@ -491,7 +527,7 @@ class ServiceIngestor(ingestor):
         """
         if self._save_to_disk_dir is None:
             raise RuntimeError("_save_document_to_disk(): save_to_disk was never enabled")
-        result_data = self._fetch_document_result_data(document_id)
+        result_data = self._fetch_document_result_data(document_id, client=client)
         return self._write_result_data_to_disk(document_id, result_data)
 
     def _materialize_completed_document(
@@ -499,11 +535,12 @@ class ServiceIngestor(ingestor):
         document_id: str,
         *,
         return_results: bool,
+        client: httpx.Client | None = None,
     ) -> list[dict[str, Any]] | None:
         """Fetch (once) and optionally persist rows for a completed document."""
         if not return_results and self._save_to_disk_dir is None:
             return None
-        result_data = self._fetch_document_result_data(document_id)
+        result_data = self._fetch_document_result_data(document_id, client=client)
         if self._save_to_disk_dir is not None:
             self._write_result_data_to_disk(document_id, result_data)
         return result_data if return_results else None
@@ -1048,6 +1085,25 @@ class ServiceIngestor(ingestor):
         self._record_stage("webhook")
         return self
 
+    def _ingest_events_with_result_client(
+        self,
+        *,
+        retain_results: bool,
+        result_schema: ResultSchema,
+        return_embeddings: bool,
+        return_images: bool,
+    ) -> Iterator[tuple[dict[str, Any], httpx.Client | None]]:
+        """Yield ingest events while owning the optional shared result client."""
+        client_context = self._new_result_fetch_client() if retain_results else nullcontext(None)
+        with client_context as result_client:
+            for evt in self.ingest_stream(
+                retain_results=retain_results,
+                result_schema=result_schema,
+                return_embeddings=return_embeddings,
+                return_images=return_images,
+            ):
+                yield evt, result_client
+
     # ------------------------------------------------------------------
     # Execution — sync materialized
     # ------------------------------------------------------------------
@@ -1122,7 +1178,7 @@ class ServiceIngestor(ingestor):
         documents_failed = 0
         total_uploaded = 0
 
-        for evt in self.ingest_stream(
+        for evt, result_client in self._ingest_events_with_result_client(
             retain_results=retain_results,
             result_schema=result_schema,
             return_embeddings=return_embeddings,
@@ -1186,6 +1242,7 @@ class ServiceIngestor(ingestor):
                             rows = self._materialize_completed_document(
                                 doc_id,
                                 return_results=return_results,
+                                client=result_client,
                             )
                             if rows is not None and return_results:
                                 rows_by_document[doc_id] = rows

--- a/nemo_retriever/tests/test_harness_helm_nightly.py
+++ b/nemo_retriever/tests/test_harness_helm_nightly.py
@@ -134,10 +134,12 @@ def test_service_dry_run_writes_plans_without_network(service_execution, monkeyp
 
 
 def test_service_ingest_and_beir_use_shared_results(service_execution, monkeypatch, tmp_path: Path) -> None:
+    ingest_calls = []
     monkeypatch.setattr(
         service_execution,
         "execute_service_ingest_request",
-        lambda _request: SimpleNamespace(to_summary_dict=lambda: {"n_rows": 12}),
+        lambda _request, **kwargs: ingest_calls.append(kwargs)
+        or SimpleNamespace(to_summary_dict=lambda: {"n_rows": 12}),
     )
     monkeypatch.setattr(
         service_execution,
@@ -151,6 +153,7 @@ def test_service_ingest_and_beir_use_shared_results(service_execution, monkeypat
     )
 
     assert outcome.exit_code == 0
+    assert ingest_calls == [{"return_results": False}]
     assert outcome.results["summary_metrics"]["rows_processed"] == 12
     assert outcome.results["summary_metrics"]["query_count"] == 1
     assert outcome.results["summary_metrics"]["recall_5"] == 0.9
@@ -199,7 +202,7 @@ def test_service_metric_gate_failure_uses_standard_exit_code(service_execution, 
     monkeypatch.setattr(
         service_execution,
         "execute_service_ingest_request",
-        lambda _request: SimpleNamespace(to_summary_dict=lambda: {"n_rows": 1}),
+        lambda _request, **_kwargs: SimpleNamespace(to_summary_dict=lambda: {"n_rows": 1}),
     )
     outcome = run_prepared_benchmark(
         _prepared(tmp_path, requirements=("files==2",)),
@@ -211,7 +214,7 @@ def test_service_metric_gate_failure_uses_standard_exit_code(service_execution, 
 
 
 def test_service_ingest_failure_is_concise(service_execution, monkeypatch, tmp_path: Path) -> None:
-    def fail(_request):
+    def fail(_request, **_kwargs):
         raise RuntimeError("service unavailable\ntraceback details")
 
     monkeypatch.setattr(service_execution, "execute_service_ingest_request", fail)

--- a/nemo_retriever/tests/test_ingest_service.py
+++ b/nemo_retriever/tests/test_ingest_service.py
@@ -12,7 +12,7 @@ from nemo_retriever.common.policy import validate_pipeline_spec
 from nemo_retriever.common.schemas.pipeline_spec import PipelineSpec
 from nemo_retriever.ingest.service import ServiceIngestRequest, build_service_ingestor, execute_service_ingest_request
 from nemo_retriever.service.config import PipelineOverridesConfig
-from nemo_retriever.service.service_ingestor import ServiceIngestor
+from nemo_retriever.service.service_ingestor import ServiceIngestor, ServiceIngestResult
 
 
 def test_build_service_ingestor_wires_extract_embed_and_chunking(tmp_path: Path) -> None:
@@ -93,8 +93,39 @@ def test_execute_service_ingest_request_raises_for_document_failures(monkeypatch
     failed_result = SimpleNamespace(failures=[("doc.pdf", "HTTP 400: invalid request")])
     monkeypatch.setattr(
         "nemo_retriever.ingest.service.build_service_ingestor",
-        lambda _request: SimpleNamespace(ingest=lambda: failed_result),
+        lambda _request: SimpleNamespace(ingest=lambda **_kwargs: failed_result),
     )
 
     with pytest.raises(RuntimeError, match=r"failed for 1 document\(s\).+doc.pdf.+HTTP 400"):
         execute_service_ingest_request(request)
+
+
+def test_execute_service_ingest_request_disables_materialization_and_counts_event_rows(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    request = ServiceIngestRequest(documents=[str(tmp_path / "doc.pdf")], input_type="pdf")
+    result = ServiceIngestResult(
+        [
+            {"event": "document_complete", "document_id": "a", "status": "completed", "result_rows": 2},
+            {"event": "document_complete", "document_id": "b", "status": "failed", "result_rows": 99},
+            {"event": "document_complete", "document_id": "c", "status": "completed", "result_rows": 3},
+        ]
+    )
+    captured: dict[str, object] = {}
+
+    def ingest(**kwargs):
+        captured.update(kwargs)
+        return result
+
+    monkeypatch.setattr(
+        "nemo_retriever.ingest.service.build_service_ingestor",
+        lambda _request: SimpleNamespace(ingest=ingest),
+    )
+
+    execution = execute_service_ingest_request(request)
+
+    assert captured == {"return_results": False}
+    assert execution.n_rows == 5
+    assert execution.result_n_rows == 5
+    assert execution.to_summary_dict()["result_n_rows"] == 5

--- a/nemo_retriever/tests/test_ingest_service.py
+++ b/nemo_retriever/tests/test_ingest_service.py
@@ -100,7 +100,31 @@ def test_execute_service_ingest_request_raises_for_document_failures(monkeypatch
         execute_service_ingest_request(request)
 
 
-def test_execute_service_ingest_request_disables_materialization_and_counts_event_rows(
+def test_execute_service_ingest_request_materializes_results_by_default(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    request = ServiceIngestRequest(documents=[str(tmp_path / "doc.pdf")], input_type="pdf")
+    result = SimpleNamespace(dataframe=[{"row": 1}, {"row": 2}], failures=[])
+    captured: dict[str, object] = {}
+
+    def ingest(**kwargs):
+        captured.update(kwargs)
+        return result
+
+    monkeypatch.setattr(
+        "nemo_retriever.ingest.service.build_service_ingestor",
+        lambda _request: SimpleNamespace(ingest=ingest),
+    )
+
+    execution = execute_service_ingest_request(request)
+
+    assert captured == {"return_results": True}
+    assert execution.n_rows == 2
+    assert execution.result_n_rows == 2
+
+
+def test_execute_service_ingest_request_can_disable_materialization_and_count_event_rows(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
@@ -123,7 +147,7 @@ def test_execute_service_ingest_request_disables_materialization_and_counts_even
         lambda _request: SimpleNamespace(ingest=ingest),
     )
 
-    execution = execute_service_ingest_request(request)
+    execution = execute_service_ingest_request(request, return_results=False)
 
     assert captured == {"return_results": False}
     assert execution.n_rows == 5

--- a/nemo_retriever/tests/test_root_cli_workflow.py
+++ b/nemo_retriever/tests/test_root_cli_workflow.py
@@ -242,6 +242,7 @@ def test_root_ingest_service_mode_uses_service_ingest_core(tmp_path, monkeypatch
             return self
 
         def ingest(self, *args: Any, **kwargs: Any):
+            captured["ingest_kwargs"] = kwargs
             return self
 
     monkeypatch.setattr(service_ingestor_module, "ServiceIngestor", _FakeServiceIngestor)
@@ -289,6 +290,7 @@ def test_root_ingest_service_mode_uses_service_ingest_core(tmp_path, monkeypatch
     assert captured["dedup_params"].iou_threshold == 0.6
     assert captured["caption_params"].context_text_max_chars == 12
     assert captured["embed_params"].embed_granularity == "page"
+    assert captured["ingest_kwargs"] == {"return_results": True}
     assert "through retriever service http://retriever-service:7670" in result.output
 
 

--- a/nemo_retriever/tests/test_service_ingest_async.py
+++ b/nemo_retriever/tests/test_service_ingest_async.py
@@ -61,6 +61,7 @@ def _fake_materialize_completed_document(
     document_id: str,
     *,
     return_results: bool,
+    client: Any = None,
 ) -> list[dict[str, Any]] | None:
     if not return_results and self._save_to_disk_dir is None:
         return None
@@ -280,3 +281,14 @@ def test_ingest_async_forwards_return_results(stub_ingestor: ServiceIngestor) ->
     out = future.result(timeout=5.0)
     assert isinstance(out, ServiceIngestResult)
     assert out.dataframe is None
+
+
+def test_ingest_return_results_false_creates_no_result_client(stub_ingestor: ServiceIngestor) -> None:
+    with patch.object(
+        stub_ingestor,
+        "_new_result_fetch_client",
+        side_effect=AssertionError("result client must not be created"),
+    ):
+        result = stub_ingestor.ingest(return_results=False)
+
+    assert result.dataframe is None

--- a/nemo_retriever/tests/test_service_save_to_disk.py
+++ b/nemo_retriever/tests/test_service_save_to_disk.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import httpx
 import pytest
 
 from nemo_retriever.service.service_ingestor import ServiceIngestor
@@ -146,7 +147,12 @@ def test_materialize_fetches_once_when_return_results_and_save_to_disk(tmp_path:
     rows = [{"page": 1, "text": "shared"}]
     fetch_calls = 0
 
-    def _counting_fetch(self: ServiceIngestor, document_id: str) -> list[dict[str, Any]]:
+    def _counting_fetch(
+        self: ServiceIngestor,
+        document_id: str,
+        *,
+        client: httpx.Client | None = None,
+    ) -> list[dict[str, Any]]:
         nonlocal fetch_calls
         fetch_calls += 1
         assert document_id == "doc-1"
@@ -168,3 +174,140 @@ def test_save_document_authorisation_header_sent_when_token_present(tmp_path: Pa
         ing._save_document_to_disk("doc-x")
 
     assert captured["kwargs"]["headers"] == {"Authorization": "Bearer sekret"}
+
+
+# ----------------------------------------------------------------------
+# ingest-scoped result client reuse and retry
+# ----------------------------------------------------------------------
+
+
+def _completion_events(*document_ids: str) -> list[dict[str, Any]]:
+    return [
+        {"event": "job_created", "job_id": "job-1"},
+        *[
+            {
+                "event": "document_complete",
+                "document_id": document_id,
+                "status": "completed",
+                "result_rows": 1,
+            }
+            for document_id in document_ids
+        ],
+        {"event": "job_finalized", "job_id": "job-1"},
+    ]
+
+
+def _result_row(document_id: str) -> dict[str, Any]:
+    return {
+        "path": f"/uploads/{document_id}.pdf",
+        "page_number": 1,
+        "text": f"content-{document_id}",
+        "metadata": {"source_id": document_id},
+    }
+
+
+def test_ingest_reuses_one_result_client_across_documents(monkeypatch: pytest.MonkeyPatch) -> None:
+    ing = ServiceIngestor(base_url="http://example:7670")
+    monkeypatch.setattr(ing, "ingest_stream", lambda **_kwargs: iter(_completion_events("doc-a", "doc-b")))
+    requests: list[httpx.Request] = []
+    clients: list[httpx.Client] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        document_id = request.url.path.rsplit("/", 1)[-1]
+        return httpx.Response(200, json={"result_data": [_result_row(document_id)]})
+
+    def client_factory() -> httpx.Client:
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(ing, "_new_result_fetch_client", client_factory)
+    result = ing.ingest(result_schema="compact")
+
+    assert len(clients) == 1
+    assert clients[0].is_closed
+    assert [request.url.path for request in requests] == [
+        "/v1/ingest/status/doc-a",
+        "/v1/ingest/status/doc-b",
+    ]
+    assert result.dataframe is not None
+    assert len(result.dataframe) == 2
+    assert result.failures == []
+
+
+@pytest.mark.parametrize("error_type", [httpx.ConnectError, httpx.ReadError, httpx.RemoteProtocolError])
+def test_ingest_retries_transient_result_fetch_on_fresh_client(
+    monkeypatch: pytest.MonkeyPatch,
+    error_type: type[Exception],
+) -> None:
+    ing = ServiceIngestor(base_url="http://example:7670")
+    monkeypatch.setattr(ing, "ingest_stream", lambda **_kwargs: iter(_completion_events("doc-a")))
+    clients: list[httpx.Client] = []
+
+    def failing_handler(request: httpx.Request) -> httpx.Response:
+        raise error_type("transient result failure", request=request)
+
+    def success_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"result_data": [_result_row("doc-a")]})
+
+    handlers = [failing_handler, success_handler]
+
+    def client_factory() -> httpx.Client:
+        client = httpx.Client(transport=httpx.MockTransport(handlers[len(clients)]))
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(ing, "_new_result_fetch_client", client_factory)
+    result = ing.ingest(result_schema="compact")
+
+    assert len(clients) == 2
+    assert all(client.is_closed for client in clients)
+    assert result.dataframe is not None
+    assert len(result.dataframe) == 1
+    assert result.failures == []
+
+
+def test_ingest_exhausted_result_retry_remains_visible(monkeypatch: pytest.MonkeyPatch) -> None:
+    ing = ServiceIngestor(base_url="http://example:7670")
+    monkeypatch.setattr(ing, "ingest_stream", lambda **_kwargs: iter(_completion_events("doc-a")))
+    clients: list[httpx.Client] = []
+
+    def failing_handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadError("persistent result failure", request=request)
+
+    def client_factory() -> httpx.Client:
+        client = httpx.Client(transport=httpx.MockTransport(failing_handler))
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(ing, "_new_result_fetch_client", client_factory)
+    result = ing.ingest(result_schema="compact")
+
+    assert len(clients) == 2
+    assert all(client.is_closed for client in clients)
+    assert len(result.failures) == 1
+    assert result.failures[0][0] == "doc-a"
+    assert "persistent result failure" in result.failures[0][1]
+
+
+def test_ingest_does_not_retry_http_status_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    ing = ServiceIngestor(base_url="http://example:7670")
+    monkeypatch.setattr(ing, "ingest_stream", lambda **_kwargs: iter(_completion_events("doc-a")))
+    clients: list[httpx.Client] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"detail": "permanent"})
+
+    def client_factory() -> httpx.Client:
+        client = httpx.Client(transport=httpx.MockTransport(handler))
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(ing, "_new_result_fetch_client", client_factory)
+    result = ing.ingest(result_schema="compact")
+
+    assert len(clients) == 1
+    assert clients[0].is_closed
+    assert len(result.failures) == 1
+    assert "500" in result.failures[0][1]


### PR DESCRIPTION
## Description

Service ingest result materialization previously created a new synchronous `httpx.Client` for every completed document. At benchmark scale this produced O(documents) client instances and short-lived TCP connections. The benchmark execution path also downloaded retained result payloads even though it only needs completion metadata and row counts.

This change:

- reuses one ingest-scoped result client when retained results or `save_to_disk` are requested;
- retries `ConnectError`, `ReadError`, and `RemoteProtocolError` once using a fresh client, avoiding reuse of a potentially stale pooled connection;
- skips retained-result materialization in `execute_service_ingest_request` and derives row totals from successful document-completion events;
- documents the service benchmark timing/row-count behavior; and
- adds coverage for client reuse, transient retry, exhausted retry visibility, permanent HTTP failures, and the no-materialization path.

### Experimental validation

A disposable A/B run compared unmodified `4d9d0d65` with this branch against the same running Minikube service, 100 copies of `data/multimodal_test.pdf`, and concurrency 16. The six benchmark trials alternated `baseline, patched, patched, baseline, baseline, patched`.

| Scenario | Baseline | Patched |
|---|---:|---:|
| Benchmark successful event rows | 800 | 800 |
| Benchmark status GETs, median | 100 | 0 |
| Benchmark retained-result bytes, median | 3,223,966 | 0 |
| Benchmark port-forward connections, median | 118 | 18 |
| Benchmark peak `TIME_WAIT`, median | 118 | 0 |
| Pool-only returned rows (`return_results=True`) | 800 | 800 |
| Pool-only result clients | 100 | 1 |
| Pool-only port-forward connections | 118 | 19 |
| Injected first-GET `ReadError`: returned rows | 72 / 80 | 80 / 80 |
| Injected first-GET `ReadError`: materialization failures | 1 | 0 |

The patched fault trial used two result clients total: the shared client plus one fresh retry client. All authoritative aggregate jobs completed, every port-forward remained alive until deliberate teardown, and the service pod had zero restarts. Timing and RSS were treated as supporting evidence because the fixture payload was small.

### Checks

- `PYTHONPATH=src python -m pytest -q tests/test_ingest_service.py tests/test_service_ingest_async.py tests/test_service_save_to_disk.py` — 40 passed
- `git diff --check`
- Disposable baseline-vs-patched Kubernetes experiment described above

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
