### PR TITLE
fix(service): wire Nemotron Parse endpoint into extraction workers

### DIFF
--- a/nemo_retriever/helm/templates/configmap.yaml
+++ b/nemo_retriever/helm/templates/configmap.yaml
@@ -11,6 +11,7 @@ inherits the NIMService resource name, so the mapping is fixed:
   page_elements                          -> nemotron-page-elements-v3                /v1/page-elements
   table_structure                        -> nemotron-table-structure-v1              /v1/table-structure
   ocr                                    -> nemotron-ocr-v2                          /v1/ocr
+  nemotron_parse                         -> nemotron-parse                           /v1/chat/completions
   vlm_embed                              -> llama-nemotron-embed-vl-1b-v2            /v1/embeddings
   nemotron_3_nano_omni_30b_a3b_reasoning -> nemotron-3-nano-omni-30b-a3b-reasoning   /v1/chat/completions
   answer_llm                             -> Values.nimOperator.answer_llm.nimServiceName /v1
@@ -19,6 +20,8 @@ inherits the NIMService resource name, so the mapping is fixed:
 {{- $pageElementsURL := include "nemo-retriever.nim.endpointURL" (dict "context" $ctx "key" "page_elements" "serviceName" "nemotron-page-elements-v3" "configKey" "pageElementsInvokeUrl" "invokePath" "/v1/page-elements") -}}
 {{- $tableStructureURL := include "nemo-retriever.nim.endpointURL" (dict "context" $ctx "key" "table_structure" "serviceName" "nemotron-table-structure-v1" "configKey" "tableStructureInvokeUrl" "invokePath" "/v1/table-structure") -}}
 {{- $ocrURL := include "nemo-retriever.nim.endpointURL" (dict "context" $ctx "key" "ocr" "serviceName" $ctx.Values.nimOperator.ocr.nimServiceName "configKey" "ocrInvokeUrl" "invokePath" "/v1/ocr") -}}
+{{- $nemotronParseURL := include "nemo-retriever.nim.endpointURL" (dict "context" $ctx "key" "nemotron_parse" "serviceName" "nemotron-parse" "configKey" "nemotronParseInvokeUrl" "invokePath" "/v1/chat/completions") -}}
+{{- $nemotronParseModel := $ctx.Values.serviceConfig.nimEndpoints.nemotronParseModel | default "" -}}
 {{- $embedURL := include "nemo-retriever.nim.endpointURL" (dict "context" $ctx "key" "vlm_embed" "serviceName" $ctx.Values.nimOperator.vlm_embed.nimServiceName "configKey" "embedInvokeUrl" "invokePath" "/v1/embeddings") -}}
 {{- $captionURL := include "nemo-retriever.nim.endpointURL" (dict "context" $ctx "key" "nemotron_3_nano_omni_30b_a3b_reasoning" "serviceName" "nemotron-3-nano-omni-30b-a3b-reasoning" "configKey" "captionInvokeUrl" "invokePath" "/v1/chat/completions") -}}
 {{- /*
@@ -73,6 +76,8 @@ nim_endpoints:
   page_elements_invoke_url: {{ .pageElementsURL | quote }}
   table_structure_invoke_url: {{ .tableStructureURL | quote }}
   ocr_invoke_url: {{ .ocrURL | quote }}
+  nemotron_parse_invoke_url: {{ if .nemotronParseURL }}{{ .nemotronParseURL | quote }}{{ else }}null{{ end }}
+  nemotron_parse_model: {{ if .nemotronParseModel }}{{ .nemotronParseModel | quote }}{{ else }}null{{ end }}
   embed_invoke_url: {{ .embedURL | quote }}
   embed_model_name: {{ .Values.serviceConfig.vectordb.embedModel | quote }}
 {{- if .Values.serviceConfig.vectordb.embedModelProviderPrefix }}
@@ -192,7 +197,7 @@ metadata:
 data:
   retriever-service.yaml: |
     mode: standalone
-{{ include "nemo-retriever.configBody" (dict "Values" .Values "gatewaySvc" $gatewaySvc "pageElementsURL" $pageElementsURL "tableStructureURL" $tableStructureURL "ocrURL" $ocrURL "embedURL" $embedURL "captionURL" $captionURL "captionModelName" $captionModelName "audioGrpcEndpoint" $audioGrpcEndpoint "llmEnabled" $llmEnabled "llmModel" $llmModel "llmAPIBase" $llmAPIBase "llmRagSystemPromptPrefix" $llmRagSystemPromptPrefix "vectordbSvc" $vectordbSvc "vectordbPort" $vectordbPort) | indent 4 }}
+{{ include "nemo-retriever.configBody" (dict "Values" .Values "gatewaySvc" $gatewaySvc "pageElementsURL" $pageElementsURL "tableStructureURL" $tableStructureURL "ocrURL" $ocrURL "nemotronParseURL" $nemotronParseURL "nemotronParseModel" $nemotronParseModel "embedURL" $embedURL "captionURL" $captionURL "captionModelName" $captionModelName "audioGrpcEndpoint" $audioGrpcEndpoint "llmEnabled" $llmEnabled "llmModel" $llmModel "llmAPIBase" $llmAPIBase "llmRagSystemPromptPrefix" $llmRagSystemPromptPrefix "vectordbSvc" $vectordbSvc "vectordbPort" $vectordbPort) | indent 4 }}
 {{- else }}
 # =========================================================================
 # Split mode — one ConfigMap per role with the appropriate mode + gateway
@@ -220,6 +225,6 @@ data:
       timeout_s: 300.0
       max_connections: 100
     {{- end }}
-{{ include "nemo-retriever.configBody" (dict "Values" $.Values "gatewaySvc" $gatewaySvc "pageElementsURL" $pageElementsURL "tableStructureURL" $tableStructureURL "ocrURL" $ocrURL "embedURL" $embedURL "captionURL" $captionURL "captionModelName" $captionModelName "audioGrpcEndpoint" $audioGrpcEndpoint "llmEnabled" $llmEnabled "llmModel" $llmModel "llmAPIBase" $llmAPIBase "llmRagSystemPromptPrefix" $llmRagSystemPromptPrefix "vectordbSvc" $vectordbSvc "vectordbPort" $vectordbPort) | indent 4 }}
+{{ include "nemo-retriever.configBody" (dict "Values" $.Values "gatewaySvc" $gatewaySvc "pageElementsURL" $pageElementsURL "tableStructureURL" $tableStructureURL "ocrURL" $ocrURL "nemotronParseURL" $nemotronParseURL "nemotronParseModel" $nemotronParseModel "embedURL" $embedURL "captionURL" $captionURL "captionModelName" $captionModelName "audioGrpcEndpoint" $audioGrpcEndpoint "llmEnabled" $llmEnabled "llmModel" $llmModel "llmAPIBase" $llmAPIBase "llmRagSystemPromptPrefix" $llmRagSystemPromptPrefix "vectordbSvc" $vectordbSvc "vectordbPort" $vectordbPort) | indent 4 }}
 {{- end }}
 {{- end }}

--- a/nemo_retriever/helm/values.yaml
+++ b/nemo_retriever/helm/values.yaml
@@ -544,6 +544,13 @@ serviceConfig:
     pageElementsInvokeUrl: ""
     tableStructureInvokeUrl: ""
     ocrInvokeUrl: ""
+    # Optional Nemotron Parse chat-completions endpoint. When the
+    # operator-managed Parse NIM is enabled, its in-cluster URL is used
+    # unless this explicit endpoint is set.
+    nemotronParseInvokeUrl: ""
+    # Optional model override. Leave empty to infer the hosted
+    # nvidia/nemotron-parse or self-hosted v1.2 contract from the URL.
+    nemotronParseModel: ""
     embedInvokeUrl: ""
     # Optional remote VLM endpoint for image captioning (Nemotron 3 Nano
     # Omni). Auto-wired from the in-cluster Service when

--- a/nemo_retriever/src/nemo_retriever/common/policy.py
+++ b/nemo_retriever/src/nemo_retriever/common/policy.py
@@ -57,6 +57,7 @@ _DENYLIST_KEY_SUBSTRINGS: tuple[str, ...] = (
     "ocr_invoke_url",
     "table_structure_invoke_url",
     "nemotron_parse_invoke_url",
+    "nemotron_parse_model",
     "profile_name",
 )
 

--- a/nemo_retriever/src/nemo_retriever/service/config.py
+++ b/nemo_retriever/src/nemo_retriever/service/config.py
@@ -131,6 +131,23 @@ class NimEndpointsConfig(RichModel):
     page_elements_invoke_url: str | None = None
     ocr_invoke_url: str | None = None
     table_structure_invoke_url: str | None = None
+    nemotron_parse_invoke_url: str | None = Field(
+        default=None,
+        description=(
+            "Remote Nemotron Parse chat-completions endpoint. When set, "
+            "service-mode requests using method='nemotron_parse' call this "
+            "endpoint instead of loading the local Parse model."
+        ),
+    )
+    nemotron_parse_model: str | None = Field(
+        default=None,
+        description=(
+            "Model identifier passed to the remote Nemotron Parse endpoint. "
+            "Use nvidia/nemotron-parse for NVIDIA-hosted inference and "
+            "nvidia/nemotron-parse-v1.2 for a self-hosted NIM. "
+            "Server-owned — clients cannot override the deployed Parse SKU."
+        ),
+    )
     embed_invoke_url: str | None = None
     embed_model_name: str | None = Field(
         default=None,

--- a/nemo_retriever/src/nemo_retriever/service/config.py
+++ b/nemo_retriever/src/nemo_retriever/service/config.py
@@ -197,10 +197,7 @@ class NimEndpointsConfig(RichModel):
         self.nemotron_parse_invoke_url = endpoint or None
         self.nemotron_parse_model = model or None
         if model and not endpoint:
-            raise ValueError(
-                "nim_endpoints.nemotron_parse_model requires "
-                "nim_endpoints.nemotron_parse_invoke_url"
-            )
+            raise ValueError("nim_endpoints.nemotron_parse_model requires " "nim_endpoints.nemotron_parse_invoke_url")
         return self
 
 

--- a/nemo_retriever/src/nemo_retriever/service/config.py
+++ b/nemo_retriever/src/nemo_retriever/service/config.py
@@ -190,6 +190,19 @@ class NimEndpointsConfig(RichModel):
     )
     api_key: str | None = None
 
+    @model_validator(mode="after")
+    def _validate_nemotron_parse_config(self) -> "NimEndpointsConfig":
+        endpoint = (self.nemotron_parse_invoke_url or "").strip()
+        model = (self.nemotron_parse_model or "").strip()
+        self.nemotron_parse_invoke_url = endpoint or None
+        self.nemotron_parse_model = model or None
+        if model and not endpoint:
+            raise ValueError(
+                "nim_endpoints.nemotron_parse_model requires "
+                "nim_endpoints.nemotron_parse_invoke_url"
+            )
+        return self
+
 
 class LLMConfig(RichModel):
     """Remote LLM configuration for service-mode RAG answer generation."""

--- a/nemo_retriever/src/nemo_retriever/service/retriever-service.yaml
+++ b/nemo_retriever/src/nemo_retriever/service/retriever-service.yaml
@@ -33,6 +33,11 @@ nim_endpoints:
   page_elements_invoke_url: null
   table_structure_invoke_url: null
   ocr_invoke_url: null
+  # Remote Nemotron Parse chat-completions endpoint and model. Both are
+  # server-owned; service clients select method="nemotron_parse" but cannot
+  # redirect the endpoint or change the deployed model.
+  nemotron_parse_invoke_url: null
+  nemotron_parse_model: null
   embed_invoke_url: null
   # Model name for the remote embed NIM (server-owned; must match the SKU).
   embed_model_name: null

--- a/nemo_retriever/src/nemo_retriever/service/service_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/service/service_ingestor.py
@@ -223,6 +223,7 @@ _SERVER_OWNED_KEYS: frozenset[str] = frozenset(
         "ocr_api_key",
         "table_structure_invoke_url",
         "nemotron_parse_invoke_url",
+        "nemotron_parse_model",
         "embed_invoke_url",
         "embedding_endpoint",
         "embed_model_provider_prefix",

--- a/nemo_retriever/src/nemo_retriever/service/service_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/service/service_ingestor.py
@@ -76,6 +76,7 @@ import queue
 import threading
 import time
 import warnings
+from contextlib import nullcontext
 from io import BytesIO
 from pathlib import Path
 from typing import Any, AsyncIterator, Iterator, List, Optional, Tuple, Union
@@ -100,6 +101,12 @@ _LEGACY_RESULT_SCHEMA_DEPRECATION = (
     "schema in a future release. Pass result_schema='compact' to opt in now, or "
     "result_schema='legacy' to keep the current GraphIngestor.ingest() column layout "
     "with bulky image/embedding values stripped during the deprecation window."
+)
+
+_RESULT_FETCH_TRANSIENT_ERRORS: tuple[type[Exception], ...] = (
+    httpx.ConnectError,
+    httpx.ReadError,
+    httpx.RemoteProtocolError,
 )
 
 
@@ -447,20 +454,44 @@ class ServiceIngestor(ingestor):
         if name not in order:
             order.append(name)
 
-    def _fetch_document_result_data(self, document_id: str) -> list[dict[str, Any]]:
+    def _new_result_fetch_client(self) -> httpx.Client:
+        """Create a client for retained-result status requests."""
+        return httpx.Client(timeout=self._request_timeout_s, headers=self._auth_headers)
+
+    def _fetch_document_result_data(
+        self,
+        document_id: str,
+        *,
+        client: httpx.Client | None = None,
+    ) -> list[dict[str, Any]]:
         """Fetch ``result_data`` for *document_id* from the status endpoint.
 
         The status endpoint retains ``result_data`` through the job retention
-        window, so retrying this read is safe.
+        window, so retrying this read is safe. When the caller supplies a
+        client it is reused for the first attempt. A transient failure receives
+        one retry through a fresh client so a stale pooled connection cannot be
+        selected again.
         """
         if not document_id:
             raise ValueError("_fetch_document_result_data(): empty document_id")
 
+        if client is None:
+            with self._new_result_fetch_client() as scoped_client:
+                return self._fetch_document_result_data(document_id, client=scoped_client)
+
         url = f"{self._base_url}/v1/ingest/status/{document_id}"
-        with httpx.Client(timeout=self._request_timeout_s, headers=self._auth_headers) as client:
+        try:
             resp = client.get(url)
-            resp.raise_for_status()
-            body = resp.json()
+        except _RESULT_FETCH_TRANSIENT_ERRORS as exc:
+            logger.debug(
+                "Transient %s fetching retained result for %s; retrying on a fresh connection",
+                type(exc).__name__,
+                document_id,
+            )
+            with self._new_result_fetch_client() as retry_client:
+                resp = retry_client.get(url)
+        resp.raise_for_status()
+        body = resp.json()
         return list(body.get("result_data") or [])
 
     def _write_result_data_to_disk(self, document_id: str, result_data: list[dict[str, Any]]) -> Path:
@@ -484,7 +515,12 @@ class ServiceIngestor(ingestor):
             out_path.write_bytes(payload)
         return out_path
 
-    def _save_document_to_disk(self, document_id: str) -> Path:
+    def _save_document_to_disk(
+        self,
+        document_id: str,
+        *,
+        client: httpx.Client | None = None,
+    ) -> Path:
         """Fetch ``result_data`` for *document_id* and write a JSON artifact.
 
         Returns the path that was written. Raises if the document_id is
@@ -492,7 +528,7 @@ class ServiceIngestor(ingestor):
         """
         if self._save_to_disk_dir is None:
             raise RuntimeError("_save_document_to_disk(): save_to_disk was never enabled")
-        result_data = self._fetch_document_result_data(document_id)
+        result_data = self._fetch_document_result_data(document_id, client=client)
         return self._write_result_data_to_disk(document_id, result_data)
 
     def _materialize_completed_document(
@@ -500,11 +536,12 @@ class ServiceIngestor(ingestor):
         document_id: str,
         *,
         return_results: bool,
+        client: httpx.Client | None = None,
     ) -> list[dict[str, Any]] | None:
         """Fetch (once) and optionally persist rows for a completed document."""
         if not return_results and self._save_to_disk_dir is None:
             return None
-        result_data = self._fetch_document_result_data(document_id)
+        result_data = self._fetch_document_result_data(document_id, client=client)
         if self._save_to_disk_dir is not None:
             self._write_result_data_to_disk(document_id, result_data)
         return result_data if return_results else None
@@ -1049,6 +1086,25 @@ class ServiceIngestor(ingestor):
         self._record_stage("webhook")
         return self
 
+    def _ingest_events_with_result_client(
+        self,
+        *,
+        retain_results: bool,
+        result_schema: ResultSchema,
+        return_embeddings: bool,
+        return_images: bool,
+    ) -> Iterator[tuple[dict[str, Any], httpx.Client | None]]:
+        """Yield ingest events while owning the optional shared result client."""
+        client_context = self._new_result_fetch_client() if retain_results else nullcontext(None)
+        with client_context as result_client:
+            for evt in self.ingest_stream(
+                retain_results=retain_results,
+                result_schema=result_schema,
+                return_embeddings=return_embeddings,
+                return_images=return_images,
+            ):
+                yield evt, result_client
+
     # ------------------------------------------------------------------
     # Execution — sync materialized
     # ------------------------------------------------------------------
@@ -1123,7 +1179,7 @@ class ServiceIngestor(ingestor):
         documents_failed = 0
         total_uploaded = 0
 
-        for evt in self.ingest_stream(
+        for evt, result_client in self._ingest_events_with_result_client(
             retain_results=retain_results,
             result_schema=result_schema,
             return_embeddings=return_embeddings,
@@ -1187,6 +1243,7 @@ class ServiceIngestor(ingestor):
                             rows = self._materialize_completed_document(
                                 doc_id,
                                 return_results=return_results,
+                                client=result_client,
                             )
                             if rows is not None and return_results:
                                 rows_by_document[doc_id] = rows

--- a/nemo_retriever/src/nemo_retriever/service/service_ingestor.py
+++ b/nemo_retriever/src/nemo_retriever/service/service_ingestor.py
@@ -76,7 +76,6 @@ import queue
 import threading
 import time
 import warnings
-from contextlib import nullcontext
 from io import BytesIO
 from pathlib import Path
 from typing import Any, AsyncIterator, Iterator, List, Optional, Tuple, Union
@@ -101,12 +100,6 @@ _LEGACY_RESULT_SCHEMA_DEPRECATION = (
     "schema in a future release. Pass result_schema='compact' to opt in now, or "
     "result_schema='legacy' to keep the current GraphIngestor.ingest() column layout "
     "with bulky image/embedding values stripped during the deprecation window."
-)
-
-_RESULT_FETCH_TRANSIENT_ERRORS: tuple[type[Exception], ...] = (
-    httpx.ConnectError,
-    httpx.ReadError,
-    httpx.RemoteProtocolError,
 )
 
 
@@ -454,44 +447,20 @@ class ServiceIngestor(ingestor):
         if name not in order:
             order.append(name)
 
-    def _new_result_fetch_client(self) -> httpx.Client:
-        """Create a client for retained-result status requests."""
-        return httpx.Client(timeout=self._request_timeout_s, headers=self._auth_headers)
-
-    def _fetch_document_result_data(
-        self,
-        document_id: str,
-        *,
-        client: httpx.Client | None = None,
-    ) -> list[dict[str, Any]]:
+    def _fetch_document_result_data(self, document_id: str) -> list[dict[str, Any]]:
         """Fetch ``result_data`` for *document_id* from the status endpoint.
 
         The status endpoint retains ``result_data`` through the job retention
-        window, so retrying this read is safe. When the caller supplies a
-        client it is reused for the first attempt. A transient failure receives
-        one retry through a fresh client so a stale pooled connection cannot be
-        selected again.
+        window, so retrying this read is safe.
         """
         if not document_id:
             raise ValueError("_fetch_document_result_data(): empty document_id")
 
-        if client is None:
-            with self._new_result_fetch_client() as scoped_client:
-                return self._fetch_document_result_data(document_id, client=scoped_client)
-
         url = f"{self._base_url}/v1/ingest/status/{document_id}"
-        try:
+        with httpx.Client(timeout=self._request_timeout_s, headers=self._auth_headers) as client:
             resp = client.get(url)
-        except _RESULT_FETCH_TRANSIENT_ERRORS as exc:
-            logger.debug(
-                "Transient %s fetching retained result for %s; retrying on a fresh connection",
-                type(exc).__name__,
-                document_id,
-            )
-            with self._new_result_fetch_client() as retry_client:
-                resp = retry_client.get(url)
-        resp.raise_for_status()
-        body = resp.json()
+            resp.raise_for_status()
+            body = resp.json()
         return list(body.get("result_data") or [])
 
     def _write_result_data_to_disk(self, document_id: str, result_data: list[dict[str, Any]]) -> Path:
@@ -515,12 +484,7 @@ class ServiceIngestor(ingestor):
             out_path.write_bytes(payload)
         return out_path
 
-    def _save_document_to_disk(
-        self,
-        document_id: str,
-        *,
-        client: httpx.Client | None = None,
-    ) -> Path:
+    def _save_document_to_disk(self, document_id: str) -> Path:
         """Fetch ``result_data`` for *document_id* and write a JSON artifact.
 
         Returns the path that was written. Raises if the document_id is
@@ -528,7 +492,7 @@ class ServiceIngestor(ingestor):
         """
         if self._save_to_disk_dir is None:
             raise RuntimeError("_save_document_to_disk(): save_to_disk was never enabled")
-        result_data = self._fetch_document_result_data(document_id, client=client)
+        result_data = self._fetch_document_result_data(document_id)
         return self._write_result_data_to_disk(document_id, result_data)
 
     def _materialize_completed_document(
@@ -536,12 +500,11 @@ class ServiceIngestor(ingestor):
         document_id: str,
         *,
         return_results: bool,
-        client: httpx.Client | None = None,
     ) -> list[dict[str, Any]] | None:
         """Fetch (once) and optionally persist rows for a completed document."""
         if not return_results and self._save_to_disk_dir is None:
             return None
-        result_data = self._fetch_document_result_data(document_id, client=client)
+        result_data = self._fetch_document_result_data(document_id)
         if self._save_to_disk_dir is not None:
             self._write_result_data_to_disk(document_id, result_data)
         return result_data if return_results else None
@@ -1086,25 +1049,6 @@ class ServiceIngestor(ingestor):
         self._record_stage("webhook")
         return self
 
-    def _ingest_events_with_result_client(
-        self,
-        *,
-        retain_results: bool,
-        result_schema: ResultSchema,
-        return_embeddings: bool,
-        return_images: bool,
-    ) -> Iterator[tuple[dict[str, Any], httpx.Client | None]]:
-        """Yield ingest events while owning the optional shared result client."""
-        client_context = self._new_result_fetch_client() if retain_results else nullcontext(None)
-        with client_context as result_client:
-            for evt in self.ingest_stream(
-                retain_results=retain_results,
-                result_schema=result_schema,
-                return_embeddings=return_embeddings,
-                return_images=return_images,
-            ):
-                yield evt, result_client
-
     # ------------------------------------------------------------------
     # Execution — sync materialized
     # ------------------------------------------------------------------
@@ -1179,7 +1123,7 @@ class ServiceIngestor(ingestor):
         documents_failed = 0
         total_uploaded = 0
 
-        for evt, result_client in self._ingest_events_with_result_client(
+        for evt in self.ingest_stream(
             retain_results=retain_results,
             result_schema=result_schema,
             return_embeddings=return_embeddings,
@@ -1243,7 +1187,6 @@ class ServiceIngestor(ingestor):
                             rows = self._materialize_completed_document(
                                 doc_id,
                                 return_results=return_results,
-                                client=result_client,
                             )
                             if rows is not None and return_results:
                                 rows_by_document[doc_id] = rows

--- a/nemo_retriever/src/nemo_retriever/service/services/pipeline_executor.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/pipeline_executor.py
@@ -322,6 +322,7 @@ _TRUST_OWNED_EXTRACT_KEYS: tuple[str, ...] = (
     "ocr_api_key",
     "table_structure_invoke_url",
     "nemotron_parse_invoke_url",
+    "nemotron_parse_model",
 )
 _TRUST_OWNED_EMBED_KEYS: tuple[str, ...] = (
     "embed_invoke_url",
@@ -786,6 +787,14 @@ def build_extract_params(nim: "NimEndpointsConfig", local: "LocalModelsConfig | 
         kwargs["ocr_invoke_url"] = nim.ocr_invoke_url
     if nim.table_structure_invoke_url:
         kwargs["table_structure_invoke_url"] = nim.table_structure_invoke_url
+    if nim.nemotron_parse_invoke_url or nim.nemotron_parse_model:
+        # ExtractParams validates that Parse-specific configuration and the
+        # extraction method are selected together.
+        kwargs["method"] = "nemotron_parse"
+        if nim.nemotron_parse_invoke_url:
+            kwargs["nemotron_parse_invoke_url"] = nim.nemotron_parse_invoke_url
+        if nim.nemotron_parse_model:
+            kwargs["nemotron_parse_model"] = nim.nemotron_parse_model
     if nim.api_key:
         kwargs["api_key"] = nim.api_key
 

--- a/nemo_retriever/src/nemo_retriever/service/services/pipeline_executor.py
+++ b/nemo_retriever/src/nemo_retriever/service/services/pipeline_executor.py
@@ -361,6 +361,24 @@ def _merge_server_owned(
     return merged
 
 
+def _resolve_extract_params(
+    base_extract: dict[str, Any],
+    extract_override: dict[str, Any] | None,
+) -> Any:
+    """Merge extraction settings while isolating Parse-only server fields."""
+    from nemo_retriever.common.params import ExtractParams
+
+    extract_kwargs = _merge_server_owned(
+        base_extract,
+        extract_override,
+        _TRUST_OWNED_EXTRACT_KEYS,
+    )
+    if extract_kwargs.get("method", "pdfium") != "nemotron_parse":
+        extract_kwargs.pop("nemotron_parse_invoke_url", None)
+        extract_kwargs.pop("nemotron_parse_model", None)
+    return ExtractParams(**extract_kwargs)
+
+
 def _resolve_sidecar_in_spec(spec: dict[str, Any] | None) -> dict[str, Any] | None:
     """Resolve ``vdb_upload_params.meta_dataframe_id`` to in-band bytes.
 
@@ -518,7 +536,6 @@ def _build_graph_ingestor_from_spec(
         ASRParams,
         CaptionParams,
         DedupParams,
-        ExtractParams,
         StoreParams,
         VdbUploadParams,
         WebhookParams,
@@ -528,8 +545,7 @@ def _build_graph_ingestor_from_spec(
     extraction_mode = _resolve_service_extraction_mode(spec.get("extraction_mode", "auto"), filename)
     split_config = spec.get("split_config")
 
-    extract_kwargs = _merge_server_owned(base_extract, spec.get("extract_params"), _TRUST_OWNED_EXTRACT_KEYS)
-    extract_params = ExtractParams(**extract_kwargs)
+    extract_params = _resolve_extract_params(base_extract, spec.get("extract_params"))
 
     embed_override = spec.get("embed_params")
     embed_params = _resolve_embed_params(base_embed, embed_override)
@@ -787,12 +803,11 @@ def build_extract_params(nim: "NimEndpointsConfig", local: "LocalModelsConfig | 
         kwargs["ocr_invoke_url"] = nim.ocr_invoke_url
     if nim.table_structure_invoke_url:
         kwargs["table_structure_invoke_url"] = nim.table_structure_invoke_url
-    if nim.nemotron_parse_invoke_url or nim.nemotron_parse_model:
+    if nim.nemotron_parse_invoke_url:
         # ExtractParams validates that Parse-specific configuration and the
         # extraction method are selected together.
         kwargs["method"] = "nemotron_parse"
-        if nim.nemotron_parse_invoke_url:
-            kwargs["nemotron_parse_invoke_url"] = nim.nemotron_parse_invoke_url
+        kwargs["nemotron_parse_invoke_url"] = nim.nemotron_parse_invoke_url
         if nim.nemotron_parse_model:
             kwargs["nemotron_parse_model"] = nim.nemotron_parse_model
     if nim.api_key:

--- a/nemo_retriever/tests/test_helm_nemotron_parse_endpoint.py
+++ b/nemo_retriever/tests/test_helm_nemotron_parse_endpoint.py
@@ -81,10 +81,7 @@ def test_helm_template_autowires_operator_parse_endpoint() -> None:
         ("--set", "nimOperator.nemotron_parse.enabled=true"),
         api_versions=("apps.nvidia.com/v1alpha1",),
     )
-    assert (
-        f'nemotron_parse_invoke_url: "http://{PARSE_SERVICE}:8000{PARSE_PATH}"'
-        in rendered
-    )
+    assert f'nemotron_parse_invoke_url: "http://{PARSE_SERVICE}:8000{PARSE_PATH}"' in rendered
     assert "nemotron_parse_model: null" in rendered
 
 

--- a/nemo_retriever/tests/test_helm_nemotron_parse_endpoint.py
+++ b/nemo_retriever/tests/test_helm_nemotron_parse_endpoint.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for Nemotron Parse service endpoint Helm wiring."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Sequence
+from unittest import SkipTest
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHART_DIR = REPO_ROOT / "nemo_retriever" / "helm"
+VALUES_PATH = CHART_DIR / "values.yaml"
+CONFIGMAP_PATH = CHART_DIR / "templates" / "configmap.yaml"
+PARSE_SERVICE = "nemotron-parse"
+PARSE_PATH = "/v1/chat/completions"
+
+
+def _helm_template(
+    extra_args: Sequence[str] = (),
+    *,
+    api_versions: Sequence[str] = (),
+) -> str:
+    helm = shutil.which("helm")
+    if helm is None:
+        raise SkipTest("`helm` binary not available")
+    command = [
+        helm,
+        "template",
+        "parse-endpoint",
+        str(CHART_DIR),
+        "--set",
+        "ngcImagePullSecret.create=false",
+        "--set",
+        "ngcApiSecret.create=false",
+    ]
+    for version in api_versions:
+        command += ["--api-versions", version]
+    command += list(extra_args)
+    completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    assert completed.returncode == 0, completed.stderr
+    return completed.stdout
+
+
+def test_values_expose_parse_endpoint_and_model_overrides() -> None:
+    values = yaml.safe_load(VALUES_PATH.read_text())
+    endpoints = values["serviceConfig"]["nimEndpoints"]
+    assert endpoints["nemotronParseInvokeUrl"] == ""
+    assert endpoints["nemotronParseModel"] == ""
+
+
+def test_configmap_resolves_and_renders_parse_fields() -> None:
+    template = CONFIGMAP_PATH.read_text()
+    assert '"key" "nemotron_parse"' in template
+    assert f'"serviceName" "{PARSE_SERVICE}"' in template
+    assert '"configKey" "nemotronParseInvokeUrl"' in template
+    assert f'"invokePath" "{PARSE_PATH}"' in template
+    assert "nemotronParseModel" in template
+    assert "nemotron_parse_invoke_url:" in template
+    assert "nemotron_parse_model:" in template
+
+
+def test_helm_template_parse_null_when_disabled() -> None:
+    rendered = _helm_template(
+        ("--set", "nimOperator.nemotron_parse.enabled=false"),
+        api_versions=("apps.nvidia.com/v1alpha1",),
+    )
+    assert "nemotron_parse_invoke_url: null" in rendered
+    assert "nemotron_parse_model: null" in rendered
+
+
+def test_helm_template_autowires_operator_parse_endpoint() -> None:
+    rendered = _helm_template(
+        ("--set", "nimOperator.nemotron_parse.enabled=true"),
+        api_versions=("apps.nvidia.com/v1alpha1",),
+    )
+    assert (
+        f'nemotron_parse_invoke_url: "http://{PARSE_SERVICE}:8000{PARSE_PATH}"'
+        in rendered
+    )
+    assert "nemotron_parse_model: null" in rendered
+
+
+def test_helm_template_explicit_hosted_endpoint_and_model_win() -> None:
+    hosted_url = "https://integrate.api.nvidia.com/v1/chat/completions"
+    hosted_model = "nvidia/nemotron-parse"
+    rendered = _helm_template(
+        (
+            "--set",
+            "nimOperator.nemotron_parse.enabled=true",
+            "--set",
+            f"serviceConfig.nimEndpoints.nemotronParseInvokeUrl={hosted_url}",
+            "--set",
+            f"serviceConfig.nimEndpoints.nemotronParseModel={hosted_model}",
+        ),
+        api_versions=("apps.nvidia.com/v1alpha1",),
+    )
+    assert f'nemotron_parse_invoke_url: "{hosted_url}"' in rendered
+    assert f'nemotron_parse_model: "{hosted_model}"' in rendered
+
+
+def test_helm_template_parse_endpoint_renders_in_split_mode() -> None:
+    rendered = _helm_template(
+        (
+            "--set",
+            "nimOperator.nemotron_parse.enabled=true",
+            "--set",
+            "topology.mode=split",
+        ),
+        api_versions=("apps.nvidia.com/v1alpha1",),
+    )
+    expected = f"http://{PARSE_SERVICE}:8000{PARSE_PATH}"
+    assert rendered.count(expected) >= 3

--- a/nemo_retriever/tests/test_service_local_models.py
+++ b/nemo_retriever/tests/test_service_local_models.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
+
 from nemo_retriever.service.config import (
     LocalEmbedConfig,
     LocalModelsConfig,
@@ -95,6 +97,21 @@ def test_build_extract_params_from_nemotron_parse_nim_config() -> None:
     assert ep.nemotron_parse_invoke_url == "http://parse-nim/v1/chat/completions"
     assert ep.nemotron_parse_model == "nvidia/nemotron-parse-v1.2"
     assert ep.api_key == "k"
+
+
+def test_nemotron_parse_model_requires_endpoint() -> None:
+    with pytest.raises(ValueError, match="nemotron_parse_model requires"):
+        NimEndpointsConfig(nemotron_parse_model="nvidia/nemotron-parse-v1.2")
+
+
+def test_build_extract_params_accepts_nemotron_parse_endpoint_only() -> None:
+    nim = NimEndpointsConfig(
+        nemotron_parse_invoke_url="https://integrate.api.nvidia.com/v1/chat/completions"
+    )
+    ep = build_extract_params(nim, LocalModelsConfig())
+    assert ep.method == "nemotron_parse"
+    assert ep.nemotron_parse_invoke_url == "https://integrate.api.nvidia.com/v1/chat/completions"
+    assert ep.nemotron_parse_model is None
 
 
 def test_build_asr_params_local_when_enabled() -> None:

--- a/nemo_retriever/tests/test_service_local_models.py
+++ b/nemo_retriever/tests/test_service_local_models.py
@@ -105,9 +105,7 @@ def test_nemotron_parse_model_requires_endpoint() -> None:
 
 
 def test_build_extract_params_accepts_nemotron_parse_endpoint_only() -> None:
-    nim = NimEndpointsConfig(
-        nemotron_parse_invoke_url="https://integrate.api.nvidia.com/v1/chat/completions"
-    )
+    nim = NimEndpointsConfig(nemotron_parse_invoke_url="https://integrate.api.nvidia.com/v1/chat/completions")
     ep = build_extract_params(nim, LocalModelsConfig())
     assert ep.method == "nemotron_parse"
     assert ep.nemotron_parse_invoke_url == "https://integrate.api.nvidia.com/v1/chat/completions"

--- a/nemo_retriever/tests/test_service_local_models.py
+++ b/nemo_retriever/tests/test_service_local_models.py
@@ -84,6 +84,19 @@ def test_build_extract_params_nim_url_wins_over_local_flags() -> None:
     assert ep.use_table_structure is True
 
 
+def test_build_extract_params_from_nemotron_parse_nim_config() -> None:
+    nim = NimEndpointsConfig(
+        nemotron_parse_invoke_url="http://parse-nim/v1/chat/completions",
+        nemotron_parse_model="nvidia/nemotron-parse-v1.2",
+        api_key="k",
+    )
+    ep = build_extract_params(nim, LocalModelsConfig())
+    assert ep.method == "nemotron_parse"
+    assert ep.nemotron_parse_invoke_url == "http://parse-nim/v1/chat/completions"
+    assert ep.nemotron_parse_model == "nvidia/nemotron-parse-v1.2"
+    assert ep.api_key == "k"
+
+
 def test_build_asr_params_local_when_enabled() -> None:
     local = LocalModelsConfig(enabled=True)
     asr = build_asr_params(NimEndpointsConfig(), local)

--- a/nemo_retriever/tests/test_service_pipeline_spec.py
+++ b/nemo_retriever/tests/test_service_pipeline_spec.py
@@ -201,6 +201,15 @@ def test_client_rejects_server_owned_keys() -> None:
         ing.extract(ExtractParams(page_elements_invoke_url="http://attacker/"))
 
 
+def test_policy_rejects_client_nemotron_parse_model_override() -> None:
+    policy = PipelineOverridesConfig().to_policy()
+    spec = PipelineSpec(
+        extract_params={"method": "nemotron_parse", "nemotron_parse_model": "attacker/model"}
+    )
+    with pytest.raises(PolicyError):
+        validate_pipeline_spec(spec, policy)
+
+
 def test_future_phase_methods_raise_informative_error() -> None:
     """Methods deferred to follow-up phases still produce a clear error.
 
@@ -321,14 +330,21 @@ def test_merge_preserves_server_extract_endpoints() -> None:
         "page_elements_invoke_url": "http://server/page_elements",
         "ocr_invoke_url": "http://server/ocr",
         "api_key": "server-token",
+        "nemotron_parse_invoke_url": "http://server/parse",
+        "nemotron_parse_model": "nvidia/nemotron-parse-v1.2",
         "dpi": 150,
     }
-    override = {"dpi": 600, "page_elements_invoke_url": "http://attacker/"}
+    override = {
+        "dpi": 600,
+        "page_elements_invoke_url": "http://attacker/",
+        "nemotron_parse_model": "attacker/model",
+    }
     merged = _merge_server_owned(base, override, _TRUST_OWNED_EXTRACT_KEYS)
     assert merged["dpi"] == 600
     assert merged["page_elements_invoke_url"] == "http://server/page_elements"
     assert merged["ocr_invoke_url"] == "http://server/ocr"
     assert merged["api_key"] == "server-token"
+    assert merged["nemotron_parse_model"] == "nvidia/nemotron-parse-v1.2"
 
 
 def test_merge_preserves_server_embed_endpoints() -> None:

--- a/nemo_retriever/tests/test_service_pipeline_spec.py
+++ b/nemo_retriever/tests/test_service_pipeline_spec.py
@@ -204,9 +204,7 @@ def test_client_rejects_server_owned_keys() -> None:
 
 def test_policy_rejects_client_nemotron_parse_model_override() -> None:
     policy = PipelineOverridesConfig().to_policy()
-    spec = PipelineSpec(
-        extract_params={"method": "nemotron_parse", "nemotron_parse_model": "attacker/model"}
-    )
+    spec = PipelineSpec(extract_params={"method": "nemotron_parse", "nemotron_parse_model": "attacker/model"})
     with pytest.raises(PolicyError):
         validate_pipeline_spec(spec, policy)
 

--- a/nemo_retriever/tests/test_service_pipeline_spec.py
+++ b/nemo_retriever/tests/test_service_pipeline_spec.py
@@ -26,6 +26,7 @@ from nemo_retriever.service.services.pipeline_executor import (
     _build_graph_ingestor_from_spec,
     _merge_server_owned,
     _request_needs_asr_params,
+    _resolve_extract_params,
     _resolve_service_extraction_mode,
     _run_pipeline_in_process,
     _TRUST_OWNED_EMBED_KEYS,
@@ -345,6 +346,33 @@ def test_merge_preserves_server_extract_endpoints() -> None:
     assert merged["ocr_invoke_url"] == "http://server/ocr"
     assert merged["api_key"] == "server-token"
     assert merged["nemotron_parse_model"] == "nvidia/nemotron-parse-v1.2"
+
+
+@pytest.mark.parametrize("method", ["pdfium", "pdfium_hybrid", "ocr"])
+def test_resolve_extract_params_drops_parse_fields_for_other_methods(method: str) -> None:
+    base = {
+        "method": "nemotron_parse",
+        "nemotron_parse_invoke_url": "http://server/parse",
+        "nemotron_parse_model": "nvidia/nemotron-parse-v1.2",
+        "api_key": "server-token",
+    }
+    resolved = _resolve_extract_params(base, {"method": method})
+    assert resolved.method == method
+    assert resolved.nemotron_parse_invoke_url is None
+    assert resolved.nemotron_parse_model is None
+    assert resolved.api_key == "server-token"
+
+
+def test_resolve_extract_params_preserves_parse_fields_for_parse_method() -> None:
+    base = {
+        "method": "nemotron_parse",
+        "nemotron_parse_invoke_url": "http://server/parse",
+        "nemotron_parse_model": "nvidia/nemotron-parse-v1.2",
+    }
+    resolved = _resolve_extract_params(base, {"method": "nemotron_parse"})
+    assert resolved.method == "nemotron_parse"
+    assert resolved.nemotron_parse_invoke_url == "http://server/parse"
+    assert resolved.nemotron_parse_model == "nvidia/nemotron-parse-v1.2"
 
 
 def test_merge_preserves_server_embed_endpoints() -> None:


### PR DESCRIPTION
## Summary

Service-mode clients can select `method="nemotron_parse"`, but the Python
service configuration does not currently expose or inject the remote Nemotron
Parse endpoint and model into worker `ExtractParams`.

Without the remote URL, the Parse operator receives an empty invoke URL and
falls back to local vLLM loading, even when the operator intends to use an
NVIDIA-hosted or self-hosted Parse NIM.

This change:

- adds server-owned `nemotron_parse_invoke_url` and
  `nemotron_parse_model` fields to `NimEndpointsConfig`;
- exposes the fields in the bundled service YAML;
- injects the configured method, endpoint and model into worker
  `ExtractParams`;
- prevents clients from overriding the server-owned Parse model; and
- adds tests for configuration propagation, policy enforcement and
  server-owned worker merging.

## Testing

- Focused service tests pass.
- Self-hosted service-mode validation completed successfully against
  `nvidia/nemotron-parse-v1.2`.
- The service client sent only `method="nemotron_parse"` and extraction flags.
- The server injected the Parse URL/model.
- One-page end-to-end extraction completed with one result row, no failures,
  and `nemotron_parse_v1_2.error = None`.
