### PR TITLE
Update PyTorch version in docs to be 2.11.0

### DIFF
--- a/nemo_retriever/README.md
+++ b/nemo_retriever/README.md
@@ -86,7 +86,7 @@ The `[local]` extra pulls PyTorch from PyPI, which defaults to a CPU build on Li
 
 ```bash
 uv pip uninstall torch torchvision
-uv pip install torch==2.10.0 torchvision -i https://download.pytorch.org/whl/cu130
+uv pip install torch==2.11.0 torchvision==0.26.0 -i https://download.pytorch.org/whl/cu130
 ```
 
 Skip this step if you are using remote NIM inference only.


### PR DESCRIPTION
## Description
pytorch verison within the toml is 2.11.0 but on docs it still seems to be 2.10.0

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Retriever/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
